### PR TITLE
refactor: add Store interfaces for usecase layer testability

### DIFF
--- a/internal/staging/store_interface.go
+++ b/internal/staging/store_interface.go
@@ -1,0 +1,25 @@
+package staging
+
+// StoreReader provides read-only access to staging state.
+type StoreReader interface {
+	// Get retrieves a staged change.
+	Get(service Service, name string) (*Entry, error)
+	// List returns all staged changes for a service.
+	List(service Service) (map[Service]map[string]Entry, error)
+}
+
+// StoreWriter provides write access to staging state.
+type StoreWriter interface {
+	// Stage adds or updates a staged change.
+	Stage(service Service, name string, entry Entry) error
+	// Unstage removes a staged change.
+	Unstage(service Service, name string) error
+	// UnstageAll removes all staged changes for a service.
+	UnstageAll(service Service) error
+}
+
+// StoreReadWriter combines read and write access to staging state.
+type StoreReadWriter interface {
+	StoreReader
+	StoreWriter
+}

--- a/internal/usecase/staging/add.go
+++ b/internal/usecase/staging/add.go
@@ -26,7 +26,7 @@ type AddOutput struct {
 // AddUseCase executes add operations.
 type AddUseCase struct {
 	Strategy staging.Parser
-	Store    *staging.Store
+	Store    staging.StoreReadWriter
 }
 
 // Execute runs the add use case.

--- a/internal/usecase/staging/add_test.go
+++ b/internal/usecase/staging/add_test.go
@@ -182,3 +182,38 @@ func TestAddUseCase_Draft_ParseError(t *testing.T) {
 	_, err := uc.Draft(context.Background(), usecasestaging.DraftInput{Name: "invalid"})
 	assert.Error(t, err)
 }
+
+func TestAddUseCase_Execute_StageError(t *testing.T) {
+	t.Parallel()
+
+	store := newMockStore()
+	store.stageErr = errors.New("stage error")
+
+	uc := &usecasestaging.AddUseCase{
+		Strategy: newMockParser(),
+		Store:    store,
+	}
+
+	_, err := uc.Execute(context.Background(), usecasestaging.AddInput{
+		Name:  "/app/config",
+		Value: "value",
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "stage error")
+}
+
+func TestAddUseCase_Draft_GetError(t *testing.T) {
+	t.Parallel()
+
+	store := newMockStore()
+	store.getErr = errors.New("get error")
+
+	uc := &usecasestaging.AddUseCase{
+		Strategy: newMockParser(),
+		Store:    store,
+	}
+
+	_, err := uc.Draft(context.Background(), usecasestaging.DraftInput{Name: "/app/config"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "get error")
+}

--- a/internal/usecase/staging/apply.go
+++ b/internal/usecase/staging/apply.go
@@ -44,7 +44,7 @@ type ApplyOutput struct {
 // ApplyUseCase executes apply operations.
 type ApplyUseCase struct {
 	Strategy staging.ApplyStrategy
-	Store    *staging.Store
+	Store    staging.StoreReadWriter
 }
 
 // Execute runs the apply use case.

--- a/internal/usecase/staging/delete.go
+++ b/internal/usecase/staging/delete.go
@@ -27,7 +27,7 @@ type DeleteOutput struct {
 // DeleteUseCase executes delete staging operations.
 type DeleteUseCase struct {
 	Strategy staging.DeleteStrategy
-	Store    *staging.Store
+	Store    staging.StoreWriter
 }
 
 // Execute runs the delete use case.

--- a/internal/usecase/staging/diff.go
+++ b/internal/usecase/staging/diff.go
@@ -47,7 +47,7 @@ type DiffOutput struct {
 // DiffUseCase executes diff operations.
 type DiffUseCase struct {
 	Strategy staging.DiffStrategy
-	Store    *staging.Store
+	Store    staging.StoreReadWriter
 }
 
 // Execute runs the diff use case.

--- a/internal/usecase/staging/edit.go
+++ b/internal/usecase/staging/edit.go
@@ -26,7 +26,7 @@ type EditOutput struct {
 // EditUseCase executes edit operations.
 type EditUseCase struct {
 	Strategy staging.EditStrategy
-	Store    *staging.Store
+	Store    staging.StoreReadWriter
 }
 
 // Execute runs the edit use case.

--- a/internal/usecase/staging/reset.go
+++ b/internal/usecase/staging/reset.go
@@ -41,7 +41,7 @@ type ResetOutput struct {
 type ResetUseCase struct {
 	Parser  staging.Parser
 	Fetcher staging.ResetStrategy
-	Store   *staging.Store
+	Store   staging.StoreReadWriter
 }
 
 // Execute runs the reset use case.

--- a/internal/usecase/staging/status.go
+++ b/internal/usecase/staging/status.go
@@ -38,7 +38,7 @@ type StatusOutput struct {
 // StatusUseCase executes status operations.
 type StatusUseCase struct {
 	Strategy staging.ServiceStrategy
-	Store    *staging.Store
+	Store    staging.StoreReader
 }
 
 // Execute runs the status use case.

--- a/internal/usecase/staging/status_test.go
+++ b/internal/usecase/staging/status_test.go
@@ -2,6 +2,7 @@ package staging_test
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -143,4 +144,36 @@ func TestStatusUseCase_Execute_SecretWithDeleteOptions(t *testing.T) {
 	assert.True(t, output.Entries[0].ShowDeleteOptions)
 	assert.NotNil(t, output.Entries[0].DeleteOptions)
 	assert.Equal(t, 14, output.Entries[0].DeleteOptions.RecoveryWindow)
+}
+
+func TestStatusUseCase_Execute_GetError(t *testing.T) {
+	t.Parallel()
+
+	store := newMockStore()
+	store.getErr = errors.New("store error")
+
+	uc := &usecasestaging.StatusUseCase{
+		Strategy: newParamStrategy(),
+		Store:    store,
+	}
+
+	_, err := uc.Execute(context.Background(), usecasestaging.StatusInput{Name: "/app/config"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "store error")
+}
+
+func TestStatusUseCase_Execute_ListError(t *testing.T) {
+	t.Parallel()
+
+	store := newMockStore()
+	store.listErr = errors.New("list error")
+
+	uc := &usecasestaging.StatusUseCase{
+		Strategy: newParamStrategy(),
+		Store:    store,
+	}
+
+	_, err := uc.Execute(context.Background(), usecasestaging.StatusInput{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "list error")
 }

--- a/internal/usecase/staging/store_mock_test.go
+++ b/internal/usecase/staging/store_mock_test.go
@@ -1,0 +1,100 @@
+package staging_test
+
+import (
+	"github.com/mpyw/suve/internal/staging"
+)
+
+// mockStore implements staging.StoreReadWriter for testing.
+type mockStore struct {
+	entries       map[staging.Service]map[string]staging.Entry
+	getErr        error
+	listErr       error
+	stageErr      error
+	unstageErr    error
+	unstageAllErr error
+}
+
+func newMockStore() *mockStore {
+	return &mockStore{
+		entries: map[staging.Service]map[string]staging.Entry{
+			staging.ServiceParam:  {},
+			staging.ServiceSecret: {},
+		},
+	}
+}
+
+func (m *mockStore) Get(service staging.Service, name string) (*staging.Entry, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	if entries, ok := m.entries[service]; ok {
+		if entry, ok := entries[name]; ok {
+			return &entry, nil
+		}
+	}
+	return nil, staging.ErrNotStaged
+}
+
+func (m *mockStore) List(service staging.Service) (map[staging.Service]map[string]staging.Entry, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	result := make(map[staging.Service]map[string]staging.Entry)
+	if service == "" {
+		for s, entries := range m.entries {
+			if len(entries) > 0 {
+				result[s] = entries
+			}
+		}
+	} else if entries, ok := m.entries[service]; ok && len(entries) > 0 {
+		result[service] = entries
+	}
+	return result, nil
+}
+
+func (m *mockStore) Stage(service staging.Service, name string, entry staging.Entry) error {
+	if m.stageErr != nil {
+		return m.stageErr
+	}
+	if _, ok := m.entries[service]; !ok {
+		m.entries[service] = make(map[string]staging.Entry)
+	}
+	m.entries[service][name] = entry
+	return nil
+}
+
+func (m *mockStore) Unstage(service staging.Service, name string) error {
+	if m.unstageErr != nil {
+		return m.unstageErr
+	}
+	if entries, ok := m.entries[service]; ok {
+		if _, ok := entries[name]; ok {
+			delete(entries, name)
+			return nil
+		}
+	}
+	return staging.ErrNotStaged
+}
+
+func (m *mockStore) UnstageAll(service staging.Service) error {
+	if m.unstageAllErr != nil {
+		return m.unstageAllErr
+	}
+	if service == "" {
+		m.entries = map[staging.Service]map[string]staging.Entry{
+			staging.ServiceParam:  {},
+			staging.ServiceSecret: {},
+		}
+	} else {
+		m.entries[service] = make(map[string]staging.Entry)
+	}
+	return nil
+}
+
+// Helper to add entries directly for testing
+func (m *mockStore) addEntry(service staging.Service, name string, entry staging.Entry) {
+	if _, ok := m.entries[service]; !ok {
+		m.entries[service] = make(map[string]staging.Entry)
+	}
+	m.entries[service][name] = entry
+}


### PR DESCRIPTION
## Summary
- Define `StoreReader`, `StoreWriter`, `StoreReadWriter` interfaces in staging package
- Update usecase layer to use interfaces instead of concrete `*Store` type
- Add mock store implementation for testing error paths
- Achieve **100% test coverage** for usecase/staging package

## Changes
### New Files
- `internal/staging/store_interface.go` - Interface definitions
- `internal/usecase/staging/store_mock_test.go` - Mock implementation for tests

### Interface Design
```go
// StoreReader provides read-only access to staging state.
type StoreReader interface {
    Get(service Service, name string) (*Entry, error)
    List(service Service) (map[Service]map[string]Entry, error)
}

// StoreWriter provides write access to staging state.
type StoreWriter interface {
    Stage(service Service, name string, entry Entry) error
    Unstage(service Service, name string) error
    UnstageAll(service Service) error
}

// StoreReadWriter combines read and write access to staging state.
type StoreReadWriter interface {
    StoreReader
    StoreWriter
}
```

### Usecase Interface Usage
- `StatusUseCase.Store` → `StoreReader`
- `DeleteUseCase.Store` → `StoreWriter`
- Others → `StoreReadWriter`

## Test plan
- [x] `make test` passes
- [x] `make lint` passes
- [x] usecase/staging coverage: 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)