### PR TITLE
refactor: remove --decrypt flag and Decrypted output field

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ user@host:~$ suve param show /app/config/database-url
 Name: /app/config/database-url
 Version: 3
 Type: SecureString
-Decrypted: true
 Modified: 2024-01-15T10:30:45Z
 
   postgres://db.example.com:5432/myapp
@@ -297,7 +296,7 @@ where ~SHIFT = ~ | ~N  (repeatable, cumulative)
 
 | Command | Options | Description |
 |---------|---------|-------------|
-| [`suve param show`](docs/param.md#show) | `--raw`<br>`--decrypt`<br>`--parse-json` (`-j`)<br>`--no-pager`<br>`--output=<FORMAT>` | Display parameter with metadata |
+| [`suve param show`](docs/param.md#show) | `--raw`<br>`--parse-json` (`-j`)<br>`--no-pager`<br>`--output=<FORMAT>` | Display parameter with metadata |
 | [`suve param log`](docs/param.md#log) | `--number=<N>` (`-n`)<br>`--patch` (`-p`)<br>`--parse-json` (`-j`)<br>`--oneline`<br>`--reverse`<br>`--since=<DATE>`<br>`--until=<DATE>`<br>`--no-pager`<br>`--output=<FORMAT>` | Show version history |
 | [`suve param diff`](docs/param.md#diff) | `--parse-json` (`-j`)<br>`--no-pager`<br>`--output=<FORMAT>` | Compare versions |
 | [`suve param list`](docs/param.md#list) | `--recursive` (`-R`)<br>`--filter=<REGEX>`<br>`--show`<br>`--output=<FORMAT>` | List parameters |

--- a/docs/param.md
+++ b/docs/param.md
@@ -23,7 +23,6 @@ suve param show [options] <name[#VERSION][~SHIFT]*>
 
 | Option | Alias | Default | Description |
 |--------|-------|---------|-------------|
-| `--decrypt` | - | `true` | Decrypt SecureString values. Use `--decrypt=false` to disable. |
 | `--parse-json` | `-j` | `false` | Pretty-print JSON values with indentation |
 | `--no-pager` | - | `false` | Disable pager output |
 | `--raw` | - | `false` | Output raw value only without metadata (for piping) |
@@ -36,7 +35,6 @@ user@host:~$ suve param show /app/config/database-url
 Name: /app/config/database-url
 Version: 3
 Type: SecureString
-Decrypted: true
 Modified: 2024-01-15T10:30:45Z
 
   postgres://db.example.com:5432/myapp
@@ -49,7 +47,6 @@ user@host:~$ suve param show --parse-json /app/config/credentials
 Name: /app/config/credentials
 Version: 2
 Type: SecureString
-Decrypted: true
 JsonParsed: true
 Modified: 2024-01-15T10:30:45Z
 
@@ -83,7 +80,6 @@ user@host:~$ suve param show --output=json /app/config/database-url
   "name": "/app/config/database-url",
   "version": 3,
   "type": "SecureString",
-  "decrypted": true,
   "modified": "2024-01-15T10:30:45Z",
   "value": "postgres://db.example.com:5432/myapp"
 }
@@ -102,9 +98,6 @@ suve param show /app/config/database-url#3
 
 # Show previous version
 suve param show /app/config/database-url~1
-
-# Show without decryption (displays encrypted value)
-suve param show --decrypt=false /app/config/database-url
 
 # Use in scripts
 DB_URL=$(suve param show --raw /app/config/database-url)

--- a/internal/cli/commands/param/log/log.go
+++ b/internal/cli/commands/param/log/log.go
@@ -11,10 +11,8 @@ import (
 	"io"
 	"time"
 
-	"github.com/samber/lo"
 	"github.com/urfave/cli/v3"
 
-	"github.com/mpyw/suve/internal/api/paramapi"
 	"github.com/mpyw/suve/internal/cli/colors"
 	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/cli/pager"
@@ -47,11 +45,10 @@ type Options struct {
 
 // JSONOutputItem represents a single version entry in JSON output.
 type JSONOutputItem struct {
-	Version   int64  `json:"version"`
-	Type      string `json:"type"`
-	Decrypted *bool  `json:"decrypted,omitempty"` // Only for SecureString
-	Modified  string `json:"modified,omitempty"`
-	Value     string `json:"value"`
+	Version  int64  `json:"version"`
+	Type     string `json:"type"`
+	Modified string `json:"modified,omitempty"`
+	Value    string `json:"value"`
 }
 
 // Command returns the log command.
@@ -230,10 +227,6 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 				Version: entry.Version,
 				Type:    string(entry.Type),
 				Value:   entry.Value,
-			}
-			// Show decrypted status only for SecureString (always true for log command)
-			if entry.Type == paramapi.ParameterTypeSecureString {
-				items[i].Decrypted = lo.ToPtr(true)
 			}
 			if entry.LastModified != nil {
 				items[i].Modified = timeutil.FormatRFC3339(*entry.LastModified)

--- a/internal/cli/commands/param/log/log_test.go
+++ b/internal/cli/commands/param/log/log_test.go
@@ -410,7 +410,6 @@ func TestRun(t *testing.T) {
 				assert.Contains(t, output, `"value"`)
 				assert.Contains(t, output, `"type"`)
 				assert.Contains(t, output, `"SecureString"`)
-				assert.Contains(t, output, `"decrypted"`)
 			},
 		},
 		{

--- a/internal/cli/commands/param/show/show_test.go
+++ b/internal/cli/commands/param/show/show_test.go
@@ -189,7 +189,6 @@ func TestRun(t *testing.T) {
 			name: "json flag with encrypted SecureString warns",
 			opts: show.Options{
 				Spec:      &paramversion.Spec{Name: "/my/param"},
-				Decrypt:   false,
 				ParseJSON: true,
 			},
 			mock: &mockClient{
@@ -234,9 +233,8 @@ func TestRun(t *testing.T) {
 		{
 			name: "raw mode outputs only value",
 			opts: show.Options{
-				Spec:    &paramversion.Spec{Name: "/my/param"},
-				Decrypt: true,
-				Raw:     true,
+				Spec: &paramversion.Spec{Name: "/my/param"},
+				Raw:  true,
 			},
 			mock: &mockClient{
 				getParameterFunc: func(_ context.Context, _ *paramapi.GetParameterInput, _ ...func(*paramapi.Options)) (*paramapi.GetParameterOutput, error) {
@@ -258,9 +256,8 @@ func TestRun(t *testing.T) {
 		{
 			name: "raw mode with shift",
 			opts: show.Options{
-				Spec:    &paramversion.Spec{Name: "/my/param", Shift: 1},
-				Decrypt: true,
-				Raw:     true,
+				Spec: &paramversion.Spec{Name: "/my/param", Shift: 1},
+				Raw:  true,
 			},
 			mock: &mockClient{
 				getParameterHistoryFunc: func(_ context.Context, _ *paramapi.GetParameterHistoryInput, _ ...func(*paramapi.Options)) (*paramapi.GetParameterHistoryOutput, error) {
@@ -280,7 +277,6 @@ func TestRun(t *testing.T) {
 			name: "raw mode with JSON formatting",
 			opts: show.Options{
 				Spec:      &paramversion.Spec{Name: "/my/param"},
-				Decrypt:   true,
 				ParseJSON: true,
 				Raw:       true,
 			},

--- a/internal/cli/commands/stage/diff/diff.go
+++ b/internal/cli/commands/stage/diff/diff.go
@@ -152,7 +152,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 	// Fetch all values in parallel
 	paramResults := parallel.ExecuteMap(ctx, paramEntries, func(ctx context.Context, name string, _ staging.Entry) (*paramapi.ParameterHistory, error) {
 		spec := &paramversion.Spec{Name: name}
-		return paramversion.GetParameterWithVersion(ctx, r.ParamClient, spec, true)
+		return paramversion.GetParameterWithVersion(ctx, r.ParamClient, spec)
 	})
 
 	secretResults := parallel.ExecuteMap(ctx, secretEntries, func(ctx context.Context, name string, _ staging.Entry) (*secretapi.GetSecretValueOutput, error) {

--- a/internal/staging/param.go
+++ b/internal/staging/param.go
@@ -149,7 +149,7 @@ func (s *ParamStrategy) FetchLastModified(ctx context.Context, name string) (tim
 // FetchCurrent fetches the current value from AWS SSM Parameter Store for diffing.
 func (s *ParamStrategy) FetchCurrent(ctx context.Context, name string) (*FetchResult, error) {
 	spec := &paramversion.Spec{Name: name}
-	param, err := paramversion.GetParameterWithVersion(ctx, s.Client, spec, true)
+	param, err := paramversion.GetParameterWithVersion(ctx, s.Client, spec)
 	if err != nil {
 		return nil, err
 	}
@@ -174,7 +174,7 @@ func (s *ParamStrategy) ParseName(input string) (string, error) {
 // FetchCurrentValue fetches the current value from AWS SSM Parameter Store for editing.
 func (s *ParamStrategy) FetchCurrentValue(ctx context.Context, name string) (*EditFetchResult, error) {
 	spec := &paramversion.Spec{Name: name}
-	param, err := paramversion.GetParameterWithVersion(ctx, s.Client, spec, true)
+	param, err := paramversion.GetParameterWithVersion(ctx, s.Client, spec)
 	if err != nil {
 		return nil, err
 	}
@@ -203,7 +203,7 @@ func (s *ParamStrategy) FetchVersion(ctx context.Context, input string) (value s
 	if err != nil {
 		return "", "", err
 	}
-	param, err := paramversion.GetParameterWithVersion(ctx, s.Client, spec, true)
+	param, err := paramversion.GetParameterWithVersion(ctx, s.Client, spec)
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/usecase/param/diff.go
+++ b/internal/usecase/param/diff.go
@@ -38,12 +38,12 @@ type DiffUseCase struct {
 
 // Execute runs the diff use case.
 func (u *DiffUseCase) Execute(ctx context.Context, input DiffInput) (*DiffOutput, error) {
-	param1, err := paramversion.GetParameterWithVersion(ctx, u.Client, input.Spec1, true)
+	param1, err := paramversion.GetParameterWithVersion(ctx, u.Client, input.Spec1)
 	if err != nil {
 		return nil, err
 	}
 
-	param2, err := paramversion.GetParameterWithVersion(ctx, u.Client, input.Spec2, true)
+	param2, err := paramversion.GetParameterWithVersion(ctx, u.Client, input.Spec2)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usecase/param/show.go
+++ b/internal/usecase/param/show.go
@@ -19,8 +19,7 @@ type ShowClient interface {
 
 // ShowInput holds input for the show use case.
 type ShowInput struct {
-	Spec    *paramversion.Spec
-	Decrypt bool
+	Spec *paramversion.Spec
 }
 
 // ShowOutput holds the result of the show use case.
@@ -39,7 +38,7 @@ type ShowUseCase struct {
 
 // Execute runs the show use case.
 func (u *ShowUseCase) Execute(ctx context.Context, input ShowInput) (*ShowOutput, error) {
-	param, err := paramversion.GetParameterWithVersion(ctx, u.Client, input.Spec, input.Decrypt)
+	param, err := paramversion.GetParameterWithVersion(ctx, u.Client, input.Spec)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usecase/param/show_test.go
+++ b/internal/usecase/param/show_test.go
@@ -61,8 +61,7 @@ func TestShowUseCase_Execute(t *testing.T) {
 	require.NoError(t, err)
 
 	output, err := uc.Execute(context.Background(), param.ShowInput{
-		Spec:    spec,
-		Decrypt: true,
+		Spec: spec,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "/app/config", output.Name)
@@ -93,8 +92,7 @@ func TestShowUseCase_Execute_WithVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	output, err := uc.Execute(context.Background(), param.ShowInput{
-		Spec:    spec,
-		Decrypt: true,
+		Spec: spec,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "/app/config", output.Name)
@@ -122,8 +120,7 @@ func TestShowUseCase_Execute_WithShift(t *testing.T) {
 	require.NoError(t, err)
 
 	output, err := uc.Execute(context.Background(), param.ShowInput{
-		Spec:    spec,
-		Decrypt: true,
+		Spec: spec,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "/app/config", output.Name)
@@ -144,8 +141,7 @@ func TestShowUseCase_Execute_Error(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = uc.Execute(context.Background(), param.ShowInput{
-		Spec:    spec,
-		Decrypt: true,
+		Spec: spec,
 	})
 	assert.Error(t, err)
 }
@@ -170,8 +166,7 @@ func TestShowUseCase_Execute_NoLastModified(t *testing.T) {
 	require.NoError(t, err)
 
 	output, err := uc.Execute(context.Background(), param.ShowInput{
-		Spec:    spec,
-		Decrypt: true,
+		Spec: spec,
 	})
 	require.NoError(t, err)
 	assert.Nil(t, output.LastModified)


### PR DESCRIPTION
## Summary

- Remove `--decrypt` flag from `param show` command
- Remove `Decrypted` output field from `param show` and `param log` commands
- SecureString values are now always decrypted automatically

## Changes

- `param show` no longer has `--decrypt` flag
- JSON/text output no longer includes `decrypted` field
- `GetParameterWithVersion` always uses `WithDecryption: true`
- Updated documentation (README.md, docs/param.md)

## Rationale

The `--decrypt` flag was only available in `param show` but not in other commands like `param log`. This created an inconsistent user experience. Since the decrypted output is what users typically need, we simplified by always decrypting.

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)