### PR TITLE
docs: update param log truncation description

### DIFF
--- a/docs/param.md
+++ b/docs/param.md
@@ -140,6 +140,7 @@ suve param log [options] <name>
 | `--until` | - | - | Show versions modified before this date (RFC3339 format) |
 | `--no-pager` | - | `false` | Disable pager output |
 | `--output` | - | `text` | Output format: `text` (default) or `json` |
+| `--max-value-length` | - | `0` | Maximum value preview length (0 = auto) |
 
 **Examples:**
 
@@ -161,7 +162,7 @@ postgres://localhost:5432/myapp...
 ```
 
 > [!NOTE]
-> Values are truncated at 50 characters with `...` suffix.
+> In normal mode, full values are shown. In `--oneline` mode, values are truncated to fit terminal width (default 50 if unavailable). Use `--max-value-length` to override.
 
 With `--patch` to see what changed:
 


### PR DESCRIPTION
## Summary
- Fix outdated note about 50-character truncation
- Add `--max-value-length` option to Options table
- Clarify normal mode shows full value, oneline truncates to terminal width

This fixes documentation that was outdated after #12 changed the truncation behavior.

## Test plan
- [x] Verified docs match actual `--help` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)