### PR TITLE
fix(release): add suve-gui-windows and fix workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,35 +9,11 @@ permissions:
   contents: write
 
 jobs:
-  build:
-    strategy:
-      matrix:
-        include:
-          - os: macos-latest
-            goos: darwin
-            goarch: amd64
-            build_id: suve-darwin-amd64
-          - os: macos-latest
-            goos: darwin
-            goarch: arm64
-            build_id: suve-darwin-arm64
-          - os: ubuntu-latest
-            goos: linux
-            goarch: amd64
-            build_id: suve-linux-amd64
-          - os: ubuntu-latest
-            goos: linux
-            goarch: arm64
-            build_id: suve-linux-arm64
-          - os: windows-latest
-            goos: windows
-            goarch: amd64
-            build_id: suve-windows-amd64
-          - os: windows-latest
-            goos: windows
-            goarch: arm64
-            build_id: suve-windows-arm64
-    runs-on: ${{ matrix.os }}
+  # ===========================================================================
+  # suve-cli: No CGO, build all platforms from single runner
+  # ===========================================================================
+  build-cli:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -49,30 +25,211 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install Linux dependencies
-        if: matrix.goos == 'linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev gcc-aarch64-linux-gnu
-
-      - name: Run GoReleaser
+      - name: Build suve-cli (all platforms)
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser
           version: latest
-          args: build --clean --id ${{ matrix.build_id }} --single-target
+          args: build --clean --id suve-cli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: dist-${{ matrix.goos }}-${{ matrix.goarch }}
+          name: dist-cli
           path: dist/
           retention-days: 1
 
+  # ===========================================================================
+  # suve & suve-gui (Darwin): CGO required
+  # ===========================================================================
+  build-darwin:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build frontend
+        run: |
+          cd internal/gui/frontend
+          npm ci
+          npm run build
+
+      - name: Build suve & suve-gui (darwin-arm64)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: build --clean --id suve-darwin --id suve-gui-darwin --single-target
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload arm64 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-darwin-arm64
+          path: dist/
+          retention-days: 1
+
+      - name: Clean dist for amd64 build
+        run: rm -rf dist/
+
+      - name: Build suve & suve-gui (darwin-amd64)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: build --clean --id suve-darwin --id suve-gui-darwin --single-target
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOARCH: amd64
+
+      - name: Upload amd64 artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-darwin-amd64
+          path: dist/
+          retention-days: 1
+
+  # ===========================================================================
+  # suve & suve-gui (Linux amd64): CGO required
+  # ===========================================================================
+  build-linux-amd64:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
+
+      - name: Build frontend
+        run: |
+          cd internal/gui/frontend
+          npm ci
+          npm run build
+
+      - name: Build suve & suve-gui (linux-amd64)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: build --clean --id suve-linux --id suve-gui-linux --single-target
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOARCH: amd64
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-linux-amd64
+          path: dist/
+          retention-days: 1
+
+  # ===========================================================================
+  # suve & suve-gui (Linux arm64): CGO required, native ARM64 runner
+  # ===========================================================================
+  build-linux-arm64:
+    runs-on: ubuntu-24.04-arm64
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+
+      - name: Build frontend
+        run: |
+          cd internal/gui/frontend
+          npm ci
+          npm run build
+
+      - name: Build suve & suve-gui (linux-arm64)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: build --clean --id suve-linux --id suve-gui-linux --single-target
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GOARCH: arm64
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-linux-arm64
+          path: dist/
+          retention-days: 1
+
+  # ===========================================================================
+  # suve & suve-gui (Windows): No CGO required
+  # ===========================================================================
+  build-windows:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build frontend
+        run: |
+          cd internal/gui/frontend
+          npm ci
+          npm run build
+
+      - name: Build suve & suve-gui (windows)
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: build --clean --id suve-windows --id suve-gui-windows
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-windows
+          path: dist/
+          retention-days: 1
+
+  # ===========================================================================
+  # Release: Combine all artifacts and publish
+  # ===========================================================================
   release:
-    needs: build
+    needs: [build-cli, build-darwin, build-linux-amd64, build-linux-arm64, build-windows]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -93,7 +250,7 @@ jobs:
           merge-multiple: true
 
       - name: List dist contents
-        run: find dist -type f
+        run: find dist -type f | sort
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -56,6 +56,21 @@ builds:
     ldflags:
       - -s -w
 
+  - id: suve-gui-windows
+    main: ./cmd/suve-gui
+    binary: suve-gui
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    tags:
+      - production
+    ldflags:
+      - -s -w
+
   # suve: integrated CLI + GUI
   - id: suve-darwin
     main: ./cmd/suve
@@ -132,6 +147,7 @@ archives:
   - id: windows
     builds:
       - suve-cli
+      - suve-gui-windows
       - suve-windows
     formats:
       - zip


### PR DESCRIPTION
## Summary
- Add suve-gui-windows build target (CGO=0, works on Windows)
- Update release.yml to use correct goreleaser build IDs
- Add build-linux-arm64 job with native ARM64 runner

All three binaries now have full platform coverage:

| Binary | darwin | linux | windows |
|--------|:------:|:-----:|:-------:|
| suve | amd64, arm64 | amd64, arm64 | amd64, arm64 |
| suve-cli | amd64, arm64 | amd64, arm64 | amd64, arm64 |
| suve-gui | amd64, arm64 | amd64, arm64 | amd64, arm64 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)