### PR TITLE
fix(release): use correct ARM64 runner label

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
   # suve & suve-gui (Linux arm64): CGO required, native ARM64 runner
   # ===========================================================================
   build-linux-arm64:
-    runs-on: ubuntu-24.04-arm64
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Use `ubuntu-24.04-arm` instead of `ubuntu-24.04-arm64`