### PR TITLE
fix(release): use ubuntu-22.04-arm for ARM64 Linux builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,9 +145,10 @@ jobs:
 
   # ===========================================================================
   # suve & suve-gui (Linux arm64): CGO required, native ARM64 runner
+  # Ubuntu 22.04 needed for libwebkit2gtk-4.0-dev
   # ===========================================================================
   build-linux-arm64:
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-22.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -162,7 +163,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.0-dev
 
       - name: Build frontend
         run: |


### PR DESCRIPTION
Ubuntu 22.04 has libwebkit2gtk-4.0-dev which Wails requires. Ubuntu 24.04 only has 4.1 which is not compatible.