### PR TITLE
fix(gui): use correct service strings in StagingStatus

### DIFF
--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -148,8 +148,8 @@ func (a *App) StagingStatus() (*StagingStatusResult, error) {
 		return nil, err
 	}
 
-	paramParser, _ := a.getParser("ssm")
-	secretParser, _ := a.getParser("sm")
+	paramParser, _ := a.getParser(string(staging.ServiceParam))
+	secretParser, _ := a.getParser(string(staging.ServiceSecret))
 
 	// SSM Parameter Store status
 	paramUC := &stagingusecase.StatusUseCase{


### PR DESCRIPTION
## Summary

Fix nil pointer dereference on GUI startup caused by incorrect service strings.

**Bug**: `getParser("ssm")` and `getParser("sm")` were used, but `getParser` expects `"param"` and `"secret"`.

**Fix**: Use `string(staging.ServiceParam)` and `string(staging.ServiceSecret)`.

## Test plan

- [x] Build succeeds
- [ ] GUI starts without nil pointer dereference

🤖 Generated with [Claude Code](https://claude.com/claude-code)