### PR TITLE
fix(staging): validate resource existence before staging operations

### DIFF
--- a/internal/staging/param.go
+++ b/internal/staging/param.go
@@ -176,10 +176,15 @@ func (s *ParamStrategy) ParseName(input string) (string, error) {
 }
 
 // FetchCurrentValue fetches the current value from AWS SSM Parameter Store for editing.
+// Returns *ResourceNotFoundError if the parameter doesn't exist.
 func (s *ParamStrategy) FetchCurrentValue(ctx context.Context, name string) (*EditFetchResult, error) {
 	spec := &paramversion.Spec{Name: name}
 	param, err := paramversion.GetParameterWithVersion(ctx, s.Client, spec)
 	if err != nil {
+		var pnf *paramapi.ParameterNotFound
+		if errors.As(err, &pnf) {
+			return nil, &ResourceNotFoundError{Err: err}
+		}
 		return nil, err
 	}
 	result := &EditFetchResult{

--- a/internal/staging/runner/add_test.go
+++ b/internal/staging/runner/add_test.go
@@ -169,7 +169,7 @@ func TestAddRunner_Run(t *testing.T) {
 	})
 }
 
-// mockStrategy implements staging.Parser for testing.
+// mockStrategy implements staging.EditStrategy for testing.
 type mockStrategy struct {
 	service      staging.Service
 	parseNameErr error
@@ -187,6 +187,11 @@ func (m *mockStrategy) ParseName(input string) (string, error) {
 }
 func (m *mockStrategy) ParseSpec(input string) (string, bool, error) {
 	return input, false, nil
+}
+
+// FetchCurrentValue returns not-found for add scenarios (new resource)
+func (m *mockStrategy) FetchCurrentValue(_ context.Context, _ string) (*staging.EditFetchResult, error) {
+	return nil, &staging.ResourceNotFoundError{Err: errors.New("resource not found")}
 }
 
 func TestAddRunner_ErrorCases(t *testing.T) {

--- a/internal/staging/runner/command.go
+++ b/internal/staging/runner/command.go
@@ -223,7 +223,10 @@ EXAMPLES:
 				return fmt.Errorf("failed to initialize stage store: %w", err)
 			}
 
-			strat := cfg.ParserFactory()
+			strat, err := cfg.Factory(ctx)
+			if err != nil {
+				return fmt.Errorf("failed to initialize strategy: %w", err)
+			}
 
 			r := &AddRunner{
 				UseCase: &stagingusecase.AddUseCase{

--- a/internal/staging/service.go
+++ b/internal/staging/service.go
@@ -6,6 +6,22 @@ import (
 	"time"
 )
 
+// ResourceNotFoundError indicates a resource was not found in AWS.
+type ResourceNotFoundError struct {
+	Err error
+}
+
+func (e *ResourceNotFoundError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "resource not found"
+}
+
+func (e *ResourceNotFoundError) Unwrap() error {
+	return e.Err
+}
+
 // ServiceStrategy defines the common interface for service-specific operations.
 // This enables Strategy Pattern to consolidate duplicate code across SSM Parameter Store and Secrets Manager commands.
 type ServiceStrategy interface {

--- a/internal/staging/transition/executor.go
+++ b/internal/staging/transition/executor.go
@@ -51,7 +51,7 @@ func (e *Executor) ExecuteEntry(service staging.Service, name string, state Entr
 }
 
 // ExecuteTag executes a tag action and persists the result.
-func (e *Executor) ExecuteTag(service staging.Service, name string, entryState EntryStagedState, stagedTags StagedTags, action TagAction, baseModifiedAt *time.Time) (TagTransitionResult, error) {
+func (e *Executor) ExecuteTag(service staging.Service, name string, entryState EntryState, stagedTags StagedTags, action TagAction, baseModifiedAt *time.Time) (TagTransitionResult, error) {
 	result := ReduceTag(entryState, stagedTags, action)
 	if result.Error != nil {
 		return result, result.Error

--- a/internal/staging/transition/executor_test.go
+++ b/internal/staging/transition/executor_test.go
@@ -373,8 +373,10 @@ func TestExecuteTag_Add(t *testing.T) {
 		Tags:           map[string]string{"env": "prod"},
 		CurrentAWSTags: nil, // nil disables auto-skip
 	}
+	existingValue := "existing-value"
+	entryState := EntryState{CurrentValue: &existingValue, StagedState: EntryStagedStateNotStaged{}}
 
-	result, err := executor.ExecuteTag(staging.ServiceParam, "/app/config", EntryStagedStateNotStaged{}, StagedTags{}, action, &baseTime)
+	result, err := executor.ExecuteTag(staging.ServiceParam, "/app/config", entryState, StagedTags{}, action, &baseTime)
 	require.NoError(t, err)
 
 	assert.Equal(t, "prod", result.NewStagedTags.ToSet["env"])
@@ -396,8 +398,10 @@ func TestExecuteTag_Remove(t *testing.T) {
 		Keys:              maputil.NewSet("deprecated"),
 		CurrentAWSTagKeys: nil, // nil disables auto-skip
 	}
+	existingValue := "existing-value"
+	entryState := EntryState{CurrentValue: &existingValue, StagedState: EntryStagedStateNotStaged{}}
 
-	result, err := executor.ExecuteTag(staging.ServiceParam, "/app/config", EntryStagedStateNotStaged{}, StagedTags{}, action, nil)
+	result, err := executor.ExecuteTag(staging.ServiceParam, "/app/config", entryState, StagedTags{}, action, nil)
 	require.NoError(t, err)
 
 	assert.True(t, result.NewStagedTags.ToUnset.Contains("deprecated"))
@@ -417,9 +421,11 @@ func TestExecuteTag_Error(t *testing.T) {
 	action := TagActionTag{
 		Tags: map[string]string{"env": "prod"},
 	}
+	existingValue := "existing-value"
+	entryState := EntryState{CurrentValue: &existingValue, StagedState: EntryStagedStateDelete{}}
 
 	// Tag on DELETE should error
-	result, err := executor.ExecuteTag(staging.ServiceParam, "/app/config", EntryStagedStateDelete{}, StagedTags{}, action, nil)
+	result, err := executor.ExecuteTag(staging.ServiceParam, "/app/config", entryState, StagedTags{}, action, nil)
 	assert.ErrorIs(t, err, ErrCannotTagDelete)
 	assert.Equal(t, ErrCannotTagDelete, result.Error)
 }
@@ -445,8 +451,10 @@ func TestExecuteTag_UnstageWhenEmpty(t *testing.T) {
 		Keys:              maputil.NewSet("env"),
 		CurrentAWSTagKeys: maputil.NewSet("env"),
 	}
+	existingValue := "existing-value"
+	entryState := EntryState{CurrentValue: &existingValue, StagedState: EntryStagedStateNotStaged{}}
 
-	result, err := executor.ExecuteTag(staging.ServiceParam, "/app/config", EntryStagedStateNotStaged{}, existingTags, action, nil)
+	result, err := executor.ExecuteTag(staging.ServiceParam, "/app/config", entryState, existingTags, action, nil)
 	require.NoError(t, err)
 
 	// Result should have only ToUnset, no ToSet
@@ -481,8 +489,10 @@ func TestExecuteTag_UnstageWhenCompletelyEmpty(t *testing.T) {
 		Tags:           map[string]string{"env": "prod"},
 		CurrentAWSTags: map[string]string{"env": "prod"}, // Same value on AWS - auto-skip
 	}
+	existingValue := "existing-value"
+	entryState := EntryState{CurrentValue: &existingValue, StagedState: EntryStagedStateNotStaged{}}
 
-	result, err := executor.ExecuteTag(staging.ServiceParam, "/app/config", EntryStagedStateNotStaged{}, existingTags, action, nil)
+	result, err := executor.ExecuteTag(staging.ServiceParam, "/app/config", entryState, existingTags, action, nil)
 	require.NoError(t, err)
 
 	// Result should be completely empty (no ToSet, no ToUnset)
@@ -507,8 +517,10 @@ func TestExecuteTag_UnstageWhenAlreadyNotStaged(t *testing.T) {
 		Tags:           map[string]string{"env": "prod"},
 		CurrentAWSTags: map[string]string{"env": "prod"}, // Same value on AWS - auto-skip
 	}
+	existingValue := "existing-value"
+	entryState := EntryState{CurrentValue: &existingValue, StagedState: EntryStagedStateNotStaged{}}
 
-	result, err := executor.ExecuteTag(staging.ServiceParam, "/app/config", EntryStagedStateNotStaged{}, existingTags, action, nil)
+	result, err := executor.ExecuteTag(staging.ServiceParam, "/app/config", entryState, existingTags, action, nil)
 	require.NoError(t, err)
 
 	// Result is empty, and unstaging non-existing tags should not error
@@ -662,9 +674,11 @@ func TestExecuteTag_PersistError(t *testing.T) {
 		Tags:           map[string]string{"env": "prod"},
 		CurrentAWSTags: nil, // nil disables auto-skip
 	}
+	existingValue := "existing-value"
+	entryState := EntryState{CurrentValue: &existingValue, StagedState: EntryStagedStateNotStaged{}}
 
 	// Tag should fail due to StageTag error
-	_, err := executor.ExecuteTag(staging.ServiceParam, "/app/config", EntryStagedStateNotStaged{}, StagedTags{}, action, nil)
+	_, err := executor.ExecuteTag(staging.ServiceParam, "/app/config", entryState, StagedTags{}, action, nil)
 	assert.ErrorIs(t, err, errMock)
 }
 

--- a/internal/usecase/staging/edit_test.go
+++ b/internal/usecase/staging/edit_test.go
@@ -38,6 +38,14 @@ func newMockEditStrategy() *mockEditStrategy {
 	}
 }
 
+// newMockEditStrategyNotFound creates a mock that returns ResourceNotFoundError.
+func newMockEditStrategyNotFound() *mockEditStrategy {
+	return &mockEditStrategy{
+		mockParser: newMockParser(),
+		fetchErr:   &staging.ResourceNotFoundError{Err: errors.New("resource not found")},
+	}
+}
+
 func TestEditUseCase_Execute(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Add resource existence checks to prevent invalid staging operations
- `stage add` now errors if the resource already exists in AWS (should use `stage edit` instead)
- `stage delete` now errors if the resource doesn't exist (unless already staged as CREATE)
- `stage tag`/`stage untag` now errors if the resource doesn't exist (unless already staged as CREATE)

## Changes

- Add `NotFoundError` interface and `NewResourceNotFoundError` wrapper in `service.go`
- Update `FetchCurrentValue` in `param.go`/`secret.go` to return `NotFoundError` for AWS not-found errors
- Add existence checks in `reducer.go` following the state machine pattern
- Update `ReduceTag`/`ExecuteTag` signatures to accept `EntryState` for existence checks
- Add comprehensive unit tests for all new error cases
- Add E2E tests for existence check scenarios

## State Transition Rules

```
ADD:
  AWS Exists = true   → ERROR "cannot add: resource already exists, use edit instead"

DELETE:
  AWS Exists = false && !Create → ERROR "cannot delete: resource not found"

TAG/UNTAG:
  AWS Exists = false && !Create → ERROR "cannot tag/untag: resource not found"
```

## Test plan

- [x] Unit tests pass (`go test ./...`)
- [x] Lint passes (`make lint`)
- [x] E2E tests pass (`make e2e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)