### PR TITLE
perf(param): batch GetParameters API calls when listing with values

### DIFF
--- a/internal/api/paramapi/api.go
+++ b/internal/api/paramapi/api.go
@@ -10,6 +10,11 @@ type GetParameterAPI interface {
 	GetParameter(ctx context.Context, params *GetParameterInput, optFns ...func(*Options)) (*GetParameterOutput, error)
 }
 
+// GetParametersAPI is the interface for getting multiple parameters in a single call.
+type GetParametersAPI interface {
+	GetParameters(ctx context.Context, params *GetParametersInput, optFns ...func(*Options)) (*GetParametersOutput, error)
+}
+
 // GetParameterHistoryAPI is the interface for getting parameter history.
 type GetParameterHistoryAPI interface {
 	GetParameterHistory(ctx context.Context, params *GetParameterHistoryInput, optFns ...func(*Options)) (*GetParameterHistoryOutput, error)

--- a/internal/api/paramapi/types.go
+++ b/internal/api/paramapi/types.go
@@ -16,6 +16,8 @@ type (
 type (
 	GetParameterInput            = ssm.GetParameterInput
 	GetParameterOutput           = ssm.GetParameterOutput
+	GetParametersInput           = ssm.GetParametersInput
+	GetParametersOutput          = ssm.GetParametersOutput
 	GetParameterHistoryInput     = ssm.GetParameterHistoryInput
 	GetParameterHistoryOutput    = ssm.GetParameterHistoryOutput
 	PutParameterInput            = ssm.PutParameterInput


### PR DESCRIPTION
## Summary
- Replace individual `GetParameter` calls with batched `GetParameters` API calls (up to 10 parameters per request) when `withValue=true`
- Reduces API calls from N to ceil(N/10) when listing parameters with values
- Implements parallel execution of batches using `parallel.ExecuteMap`

## Changes
- Add `GetParametersAPI` interface and types to `paramapi`
- Change `ListClient` to use `GetParametersAPI` instead of `GetParameterAPI`
- Add `fetchValuesBatched` function for batch processing
- Update all tests to use the new batched API

## Test plan
- [x] Unit tests for usecase and CLI command updated
- [x] All tests pass
- [x] Lint passes

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)