### PR TITLE
docs: fix stage.json path in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Output will look like:
 > For detailed state transition rules, see [Staging State Transitions](docs/staging-state-transitions.md).
 
 > [!CAUTION]
-> Staged values are stored in plain text at `~/.suve/stage.json`. If you no longer need pending changes, run `suve stage reset --all` to clear them.
+> Staged values are stored in plain text at `~/.suve/<ACCOUNT_ID>/<REGION>/stage.json`. If you no longer need pending changes, run `suve stage reset --all` to clear them.
 
 **1. Stage changes** (opens editor or accepts value directly):
 

--- a/docs/param.md
+++ b/docs/param.md
@@ -624,7 +624,7 @@ The staging workflow allows you to prepare changes locally before applying them 
 > [!IMPORTANT]
 > The staging workflow lets you prepare changes locally, review them, and apply when ready--just like `git add` -> `git diff --staged` -> `git commit`.
 
-The stage file is stored at `~/.suve/stage.json`.
+The stage file is stored at `~/.suve/<ACCOUNT_ID>/<REGION>/stage.json`.
 
 ### Workflow Overview
 

--- a/docs/secret.md
+++ b/docs/secret.md
@@ -667,7 +667,7 @@ The staging workflow allows you to prepare changes locally before applying them 
 > [!IMPORTANT]
 > The staging workflow lets you prepare changes locally, review them, and apply when ready--just like `git add` -> `git diff --staged` -> `git commit`.
 
-The stage file is stored at `~/.suve/stage.json`.
+The stage file is stored at `~/.suve/<ACCOUNT_ID>/<REGION>/stage.json`.
 
 ### Workflow Overview
 


### PR DESCRIPTION
Update the stage file path from `~/.suve/stage.json` to `~/.suve/<ACCOUNT_ID>/<REGION>/stage.json` to reflect the actual implementation that stores staging data per AWS account and region.

🤖 Generated with [Claude Code](https://claude.com/claude-code)