### PR TITLE
feat: update CLI description to CLI/GUI when GUI is available

### DIFF
--- a/cmd/suve/gui.go
+++ b/cmd/suve/gui.go
@@ -5,6 +5,7 @@ package main
 import (
 	"log"
 	"os"
+	"strings"
 
 	"github.com/urfave/cli/v3"
 
@@ -29,4 +30,8 @@ func registerGUIFlag() {
 		Name:  "gui",
 		Usage: "Launch GUI mode",
 	})
+}
+
+func registerGUIDescription() {
+	commands.App.Usage = strings.Replace(commands.App.Usage, "CLI", "CLI/GUI", 1)
 }

--- a/cmd/suve/gui_stub.go
+++ b/cmd/suve/gui_stub.go
@@ -9,3 +9,6 @@ func runGUIIfRequested() bool {
 
 // registerGUIFlag is a no-op when GUI is not available.
 func registerGUIFlag() {}
+
+// registerGUIDescription is a no-op when GUI is not available.
+func registerGUIDescription() {}

--- a/cmd/suve/main.go
+++ b/cmd/suve/main.go
@@ -16,6 +16,7 @@ func main() {
 
 	// Run CLI
 	registerGUIFlag()
+	registerGUIDescription()
 	if err := commands.App.Run(context.Background(), os.Args); err != nil {
 		output.Error(os.Stderr, "%v", err)
 		os.Exit(1)


### PR DESCRIPTION
## Summary
- Add `registerGUIDescription` function to update app usage description when GUI is available
- Changes "Git-like CLI for AWS..." to "Git-like CLI/GUI for AWS..." when built with `production` or `dev` tags
- Follows same pattern as existing `registerGUIFlag`

## Test plan
- [x] `make test` passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)