### PR TITLE
feat: add Linux GUI test environment with Docker and X11 forwarding

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -12,3 +12,26 @@ services:
       timeout: 5s
       retries: 10
       start_period: 15s
+
+  linux-gui:
+    profiles:
+      - linux-gui
+    build:
+      context: .
+      dockerfile: docker/linux-gui/Dockerfile
+    environment:
+      - DISPLAY=${HOST_DISPLAY:-host.docker.internal:0}
+    volumes:
+      - .:/app
+      - go-cache:/root/go
+      - go-build-cache:/root/.cache/go-build
+    working_dir: /app
+    stdin_open: true
+    tty: true
+    # For X11 forwarding
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+volumes:
+  go-cache:
+  go-build-cache:

--- a/docker/linux-gui/Dockerfile
+++ b/docker/linux-gui/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Asia/Tokyo
+
+# Install dependencies for Wails GUI app
+RUN apt-get update && apt-get install -y \
+    # X11 and GUI dependencies
+    libgtk-3-0 \
+    libwebkit2gtk-4.1-0 \
+    libayatana-appindicator3-1 \
+    # X11 utilities
+    x11-apps \
+    xauth \
+    dbus-x11 \
+    # Build tools (for development)
+    build-essential \
+    pkg-config \
+    libgtk-3-dev \
+    libwebkit2gtk-4.1-dev \
+    # Go
+    golang-go \
+    # Utilities
+    curl \
+    git \
+    ca-certificates \
+    # Clean up
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Wails
+RUN go install github.com/wailsapp/wails/v2/cmd/wails@latest
+
+# Set working directory
+WORKDIR /app
+
+# Add Go bin to PATH
+ENV PATH="/root/go/bin:${PATH}"
+
+# Default command
+CMD ["/bin/bash"]

--- a/docker/linux-gui/start.sh
+++ b/docker/linux-gui/start.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Script to start Linux GUI container with X11 forwarding on macOS
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo -e "${GREEN}=== Linux GUI Test Environment ===${NC}"
+
+# Check XQuartz
+if ! command -v xquartz &> /dev/null && [ ! -d "/Applications/Utilities/XQuartz.app" ]; then
+    echo -e "${RED}Error: XQuartz is not installed${NC}"
+    echo "Install with: brew install --cask xquartz"
+    exit 1
+fi
+
+# Check if XQuartz is running
+if ! pgrep -x "XQuartz" > /dev/null && ! pgrep -x "X11.bin" > /dev/null; then
+    echo -e "${YELLOW}Starting XQuartz...${NC}"
+    open -a XQuartz
+    sleep 3
+fi
+
+# Allow connections from localhost
+echo -e "${YELLOW}Allowing X11 connections from localhost...${NC}"
+xhost +localhost 2>/dev/null || xhost + 2>/dev/null || true
+
+# Get host IP for Docker
+HOST_IP=$(ifconfig en0 | grep 'inet ' | awk '{print $2}')
+if [ -z "$HOST_IP" ]; then
+    HOST_IP="host.docker.internal"
+fi
+
+echo -e "${GREEN}Host IP: $HOST_IP${NC}"
+echo -e "${GREEN}DISPLAY will be set to: $HOST_IP:0${NC}"
+
+# Export for docker compose
+export HOST_DISPLAY="$HOST_IP:0"
+
+echo ""
+echo -e "${GREEN}Environment ready! You can now run:${NC}"
+echo "  make linux-gui        # Start interactive shell"
+echo "  make linux-gui-build  # Build GUI in Linux"
+echo "  make linux-gui-test   # Run GUI tests"


### PR DESCRIPTION
## Summary
- Add Docker-based Linux GUI environment for testing Wails apps on macOS
- Use XQuartz X11 forwarding to display Linux GUI applications
- New make targets: `linux-gui`, `linux-gui-build`, `linux-gui-test`
- Use Docker Compose profiles (`--profile linux-gui`) to keep it separate from default services

## Test plan
- [ ] Install XQuartz: `brew install --cask xquartz`
- [ ] Enable "Allow connections from network clients" in XQuartz preferences
- [ ] Run `make linux-gui` to verify container starts and X11 forwarding works
- [ ] Run `xeyes` in the container to test display

🤖 Generated with [Claude Code](https://claude.com/claude-code)