### PR TITLE
feat: add aqua package manager support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,32 @@ scoop bucket add mpyw https://github.com/mpyw/scoop-bucket.git
 scoop install suve
 ```
 
+### Using [aqua](https://aquaproj.github.io/)
+
+Add to your `aqua.yaml`:
+
+```yaml
+registries:
+  - type: standard
+    ref: v4.311.0
+  - name: mpyw
+    type: github_content
+    repo_owner: mpyw
+    repo_name: suve
+    ref: v0.5.3  # use the version you want
+    path: registry.yaml
+
+packages:
+  - name: mpyw/suve
+    registry: mpyw
+```
+
+Then run:
+
+```bash
+aqua i
+```
+
 ### Using [`go install`](https://pkg.go.dev/cmd/go#hdr-Compile_and_install_packages_and_dependencies)
 
 ```bash

--- a/registry.yaml
+++ b/registry.yaml
@@ -1,0 +1,15 @@
+packages:
+  - type: github_release
+    repo_owner: mpyw
+    repo_name: suve
+    description: Git-like CLI for AWS Parameter Store and Secrets Manager
+    asset: suve_{{trimV .Version}}_{{.OS}}_{{.Arch}}.tar.gz
+    format: tar.gz
+    overrides:
+      - goos: windows
+        format: zip
+        asset: suve_{{trimV .Version}}_{{.OS}}_{{.Arch}}.zip
+    supported_envs:
+      - darwin
+      - linux
+      - windows


### PR DESCRIPTION
## Summary

- Add `registry.yaml` for aqua package manager
- Update README with aqua installation instructions

Users can now install suve via aqua by adding the custom registry to their `aqua.yaml`:

```yaml
registries:
  - type: standard
    ref: v4.311.0
  - name: mpyw
    type: github_content
    repo_owner: mpyw
    repo_name: suve
    ref: v0.5.3
    path: registry.yaml

packages:
  - name: mpyw/suve
    registry: mpyw
```

## Test plan

- [ ] Verify registry.yaml syntax is valid
- [ ] Test installation via aqua after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)