### PR TITLE
feat: add Linux desktop environment with Openbox for GUI testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint e2e up down clean coverage coverage-e2e coverage-all gui-dev gui-build gui-bindings linux-gui linux-gui-build linux-gui-test linux-gui-setup help
+.PHONY: build test lint e2e up down clean coverage coverage-e2e coverage-all gui-dev gui-build gui-bindings linux-gui linux-gui-build linux-gui-test linux-gui-setup linux-desktop help
 
 .DEFAULT_GOAL := help
 
@@ -92,3 +92,7 @@ linux-gui-build: linux-gui-setup ## Build GUI in Linux container
 linux-gui-test: linux-gui-setup ## Run GUI tests in Linux container
 	@echo "Running GUI tests in Linux container..."
 	HOST_DISPLAY=host.docker.internal:0 docker compose --profile linux-gui run --rm linux-gui bash -c "go test -tags=production ./internal/gui/..."
+
+linux-desktop: linux-gui-setup ## Start Linux XFCE desktop (requires XQuartz)
+	@echo "Starting Linux XFCE desktop..."
+	HOST_DISPLAY=host.docker.internal:0 docker compose --profile linux-desktop run --rm linux-desktop

--- a/compose.yaml
+++ b/compose.yaml
@@ -32,6 +32,24 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
+  linux-desktop:
+    profiles:
+      - linux-desktop
+    build:
+      context: .
+      dockerfile: docker/linux-desktop/Dockerfile
+    environment:
+      - DISPLAY=${HOST_DISPLAY:-host.docker.internal:0}
+    volumes:
+      - .:/app
+      - go-cache:/root/go
+      - go-build-cache:/root/.cache/go-build
+    working_dir: /app
+    stdin_open: true
+    tty: true
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
 volumes:
   go-cache:
   go-build-cache:

--- a/docker/linux-desktop/Dockerfile
+++ b/docker/linux-desktop/Dockerfile
@@ -1,0 +1,58 @@
+# Linux desktop environment for GUI testing
+# Runs Openbox window manager via X11 forwarding to macOS XQuartz
+#
+# Prerequisites (macOS):
+#   1. brew install --cask xquartz
+#   2. XQuartz preferences -> Security -> "Allow connections from network clients"
+#   3. Restart XQuartz after changing the setting
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=Asia/Tokyo
+
+# Install Openbox and dependencies
+RUN apt-get update && apt-get install -y \
+    # Window manager and desktop components
+    openbox \
+    tint2 \
+    pcmanfm \
+    lxterminal \
+    feh \
+    # Wails GUI dependencies
+    libgtk-3-0 \
+    libwebkit2gtk-4.1-0 \
+    libayatana-appindicator3-1 \
+    # Build tools
+    build-essential \
+    pkg-config \
+    libgtk-3-dev \
+    libwebkit2gtk-4.1-dev \
+    # Go
+    golang-go \
+    # Utilities
+    curl \
+    git \
+    ca-certificates \
+    dbus-x11 \
+    x11-xserver-utils \
+    # Clean up
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Wails
+RUN go install github.com/wailsapp/wails/v2/cmd/wails@latest
+
+# Create startup script
+RUN echo '#!/bin/bash\n\
+openbox &\n\
+tint2 &\n\
+lxterminal\n\
+' > /usr/local/bin/start-desktop && chmod +x /usr/local/bin/start-desktop
+
+# Set working directory
+WORKDIR /app
+
+# Add Go bin to PATH
+ENV PATH="/root/go/bin:${PATH}"
+
+# Start desktop
+CMD ["/usr/local/bin/start-desktop"]


### PR DESCRIPTION
## Summary
- Add full Linux desktop environment using Openbox window manager
- For testing GUI behavior (minimize, maximize, taskbar icons, etc.)
- New `make linux-desktop` target

## Components
- **Openbox** - lightweight window manager
- **tint2** - taskbar (shows minimized windows)
- **lxterminal** - terminal emulator
- **pcmanfm** - file manager

## Usage
```bash
make linux-desktop
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)