### PR TITLE
feat: add Linux .deb/.rpm package support and improve CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  # Go modules
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      wailsapp:
+        patterns:
+          - "github.com/wailsapp/*"
+      go-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "github.com/wailsapp/*"
+
+  # npm (GUI frontend)
+  - package-ecosystem: npm
+    directory: /internal/gui/frontend
+    schedule:
+      interval: weekly
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/templates/homebrew-formula.rb
+++ b/.github/templates/homebrew-formula.rb
@@ -1,0 +1,36 @@
+class Suve < Formula
+  desc "Git-like CLI for AWS Parameter Store and Secrets Manager"
+  homepage "https://github.com/mpyw/suve"
+  license "MIT"
+  version "${VERSION}"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/mpyw/suve/releases/download/v${VERSION}/suve_${VERSION}_darwin_arm64.tar.gz"
+      sha256 "${SHA256_DARWIN_ARM64}"
+    end
+    on_intel do
+      url "https://github.com/mpyw/suve/releases/download/v${VERSION}/suve_${VERSION}_darwin_amd64.tar.gz"
+      sha256 "${SHA256_DARWIN_AMD64}"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/mpyw/suve/releases/download/v${VERSION}/suve_${VERSION}_linux_arm64.tar.gz"
+      sha256 "${SHA256_LINUX_ARM64}"
+    end
+    on_intel do
+      url "https://github.com/mpyw/suve/releases/download/v${VERSION}/suve_${VERSION}_linux_amd64.tar.gz"
+      sha256 "${SHA256_LINUX_AMD64}"
+    end
+  end
+
+  def install
+    bin.install "suve"
+  end
+
+  test do
+    system bin/"suve", "--version"
+  end
+end

--- a/.github/templates/scoop-manifest.json
+++ b/.github/templates/scoop-manifest.json
@@ -1,0 +1,17 @@
+{
+  "version": "${VERSION}",
+  "description": "Git-like CLI for AWS Parameter Store and Secrets Manager",
+  "homepage": "https://github.com/mpyw/suve",
+  "license": "MIT",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/mpyw/suve/releases/download/v${VERSION}/suve_${VERSION}_windows_amd64.zip",
+      "hash": "${SHA256_WINDOWS_AMD64}"
+    },
+    "arm64": {
+      "url": "https://github.com/mpyw/suve/releases/download/v${VERSION}/suve_${VERSION}_windows_arm64.zip",
+      "hash": "${SHA256_WINDOWS_ARM64}"
+    }
+  },
+  "bin": "suve.exe"
+}

--- a/.github/templates/windows-versioninfo.json
+++ b/.github/templates/windows-versioninfo.json
@@ -1,0 +1,43 @@
+{
+  "FixedFileInfo": {
+    "FileVersion": {
+      "Major": $MAJOR,
+      "Minor": $MINOR,
+      "Patch": $PATCH,
+      "Build": $BUILD
+    },
+    "ProductVersion": {
+      "Major": $MAJOR,
+      "Minor": $MINOR,
+      "Patch": $PATCH,
+      "Build": $BUILD
+    },
+    "FileFlagsMask": "3f",
+    "FileFlags": "00",
+    "FileOS": "040004",
+    "FileType": "01",
+    "FileSubType": "00"
+  },
+  "StringFileInfo": {
+    "Comments": "",
+    "CompanyName": "",
+    "FileDescription": "Git-like CLI/GUI for AWS Parameter Store & Secrets Manager",
+    "FileVersion": "v${VERSION}",
+    "InternalName": "suve",
+    "LegalCopyright": "",
+    "LegalTrademarks": "",
+    "OriginalFilename": "suve.exe",
+    "PrivateBuild": "",
+    "ProductName": "suve",
+    "ProductVersion": "v${VERSION}",
+    "SpecialBuild": ""
+  },
+  "VarFileInfo": {
+    "Translation": {
+      "LangID": "0409",
+      "CharsetID": "04B0"
+    }
+  },
+  "IconPath": "appicon.ico",
+  "ManifestPath": ""
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,72 +181,24 @@ jobs:
           set -e
 
           # Parse version from tag (e.g., v0.5.3 -> 0.5.3)
-          VERSION="${GITHUB_REF_NAME#v}"
-          MAJOR=$(echo "$VERSION" | cut -d. -f1)
-          MINOR=$(echo "$VERSION" | cut -d. -f2)
-          PATCH=$(echo "$VERSION" | cut -d. -f3)
+          export VERSION="${GITHUB_REF_NAME#v}"
+          export MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          export MINOR=$(echo "$VERSION" | cut -d. -f2)
+          export PATCH=$(echo "$VERSION" | cut -d. -f3)
+          export BUILD="${GITHUB_RUN_NUMBER}"
 
           # Generate appicon.ico from appicon.png
           sudo apt-get update
           sudo apt-get install -y imagemagick
           convert internal/gui/appicon.png -define icon:auto-resize=256,128,64,48,32,16 cmd/suve/appicon.ico
 
-          # Generate versioninfo.json
-          cat > cmd/suve/versioninfo.json << 'VERSIONINFO_EOF'
-          {
-            "FixedFileInfo": {
-              "FileVersion": {
-                "Major": __MAJOR__,
-                "Minor": __MINOR__,
-                "Patch": __PATCH__,
-                "Build": __BUILD__
-              },
-              "ProductVersion": {
-                "Major": __MAJOR__,
-                "Minor": __MINOR__,
-                "Patch": __PATCH__,
-                "Build": __BUILD__
-              },
-              "FileFlagsMask": "3f",
-              "FileFlags": "00",
-              "FileOS": "040004",
-              "FileType": "01",
-              "FileSubType": "00"
-            },
-            "StringFileInfo": {
-              "Comments": "",
-              "CompanyName": "",
-              "FileDescription": "Git-like CLI/GUI for AWS Parameter Store & Secrets Manager",
-              "FileVersion": "__VERSION__",
-              "InternalName": "suve",
-              "LegalCopyright": "",
-              "LegalTrademarks": "",
-              "OriginalFilename": "suve.exe",
-              "PrivateBuild": "",
-              "ProductName": "suve",
-              "ProductVersion": "__VERSION__",
-              "SpecialBuild": ""
-            },
-            "VarFileInfo": {
-              "Translation": {
-                "LangID": "0409",
-                "CharsetID": "04B0"
-              }
-            },
-            "IconPath": "appicon.ico",
-            "ManifestPath": ""
-          }
-          VERSIONINFO_EOF
-          # Remove leading whitespace from heredoc (heredoc was indented for YAML compatibility)
-          sed -i 's/^          //' cmd/suve/versioninfo.json
-
-          # Replace placeholders with actual version values
-          sed -i "s/__MAJOR__/${MAJOR}/g; s/__MINOR__/${MINOR}/g; s/__PATCH__/${PATCH}/g; s/__BUILD__/${GITHUB_RUN_NUMBER}/g; s/__VERSION__/v${VERSION}/g" cmd/suve/versioninfo.json
+          # Generate versioninfo.json from template
+          envsubst < .github/templates/windows-versioninfo.json > cmd/suve/versioninfo.json
 
           # Generate resource_windows.syso for both AMD64 and ARM64
           cd cmd/suve
-          go run github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest -64 -o resource_windows_amd64.syso
-          go run github.com/josephspurrier/goversioninfo/cmd/goversioninfo@latest -arm -o resource_windows_arm64.syso
+          go run github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.5.0 -64 -o resource_windows_amd64.syso
+          go run github.com/josephspurrier/goversioninfo/cmd/goversioninfo@v1.5.0 -arm -o resource_windows_arm64.syso
 
       - name: Build suve (windows)
         uses: goreleaser/goreleaser-action@v6
@@ -326,10 +278,77 @@ jobs:
 
           ls -la releases/
 
+      - name: Create Linux packages (.deb, .rpm)
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+
+          # Install nfpm (pinned version for reproducibility)
+          go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.41.1
+          export PATH="$(go env GOPATH)/bin:$PATH"
+
+          for arch in amd64 arm64; do
+            # Find Linux binary
+            linux_dir=$(find dist -type d -name "*linux_${arch}*" | head -n 1)
+            if [[ -z "$linux_dir" ]]; then
+              echo "Error: No Linux ${arch} build found"
+              exit 1
+            fi
+
+            # Map Go arch to package arch names
+            case "$arch" in
+              amd64) deb_arch="amd64"; rpm_arch="x86_64" ;;
+              arm64) deb_arch="arm64"; rpm_arch="aarch64" ;;
+            esac
+
+            # Copy binary to working directory
+            cp "${linux_dir}/suve" ./suve
+
+            # Set environment variables for nfpm
+            export VERSION="${VERSION}"
+            export GOARCH="${arch}"
+
+            # Generate .deb (Debian naming: name_version-revision_arch.deb)
+            deb_file="releases/suve_${VERSION}-1_${deb_arch}.deb"
+            echo "Generating ${deb_file}..."
+            nfpm pkg --packager deb --target "${deb_file}"
+
+            # Generate .rpm (RPM naming: name-version-release.arch.rpm)
+            rpm_file="releases/suve-${VERSION}-1.${rpm_arch}.rpm"
+            echo "Generating ${rpm_file}..."
+            nfpm pkg --packager rpm --target "${rpm_file}"
+
+            rm ./suve
+          done
+
+          echo "=== Generated packages ==="
+          ls -la releases/*.deb releases/*.rpm
+
+          echo "=== Installing verification tools ==="
+          sudo apt-get update && sudo apt-get install -y lintian rpm rpmlint
+
+          echo "=== Verifying .deb packages ==="
+          for deb_pkg in releases/*.deb; do
+            echo "--- ${deb_pkg} ---"
+            dpkg-deb -I "${deb_pkg}"
+            echo "--- lintian ${deb_pkg} ---"
+            lintian --tag-display-limit 0 \
+              --suppress-tags no-changelog,no-manual-page,unknown-field,hardening-no-pie,hardening-no-relro,unstripped-binary-or-object,undeclared-elf-prerequisites \
+              "${deb_pkg}" || true
+          done
+
+          echo "=== Verifying .rpm packages ==="
+          for rpm_pkg in releases/*.rpm; do
+            echo "--- ${rpm_pkg} ---"
+            rpm -qip "${rpm_pkg}"
+            echo "--- rpmlint ${rpm_pkg} ---"
+            rpmlint "${rpm_pkg}" || true  # warnings ok
+          done
+
       - name: Generate checksums
         run: |
           cd releases
-          sha256sum *.tar.gz *.zip > checksums.txt
+          sha256sum *.tar.gz *.zip *.deb *.rpm > checksums.txt
           cat checksums.txt
 
       - name: Create or Update GitHub Release
@@ -378,59 +397,15 @@ jobs:
             exit 0
           fi
 
-          VERSION="${GITHUB_REF_NAME#v}"
+          export VERSION="${GITHUB_REF_NAME#v}"
+          export SHA256_DARWIN_AMD64=$(grep "darwin_amd64.tar.gz" releases/checksums.txt | cut -d' ' -f1)
+          export SHA256_DARWIN_ARM64=$(grep "darwin_arm64.tar.gz" releases/checksums.txt | cut -d' ' -f1)
+          export SHA256_LINUX_AMD64=$(grep "linux_amd64.tar.gz" releases/checksums.txt | cut -d' ' -f1)
+          export SHA256_LINUX_ARM64=$(grep "linux_arm64.tar.gz" releases/checksums.txt | cut -d' ' -f1)
 
-          # Get SHA256 checksums
-          SHA256_DARWIN_AMD64=$(grep "darwin_amd64.tar.gz" releases/checksums.txt | cut -d' ' -f1)
-          SHA256_DARWIN_ARM64=$(grep "darwin_arm64.tar.gz" releases/checksums.txt | cut -d' ' -f1)
-          SHA256_LINUX_AMD64=$(grep "linux_amd64.tar.gz" releases/checksums.txt | cut -d' ' -f1)
-          SHA256_LINUX_ARM64=$(grep "linux_arm64.tar.gz" releases/checksums.txt | cut -d' ' -f1)
-
-          # Generate formula
-          cat > suve.rb <<EOF
-          class Suve < Formula
-            desc "Git-like CLI for AWS Parameter Store and Secrets Manager"
-            homepage "https://github.com/mpyw/suve"
-            license "MIT"
-            version "${VERSION}"
-
-            on_macos do
-              on_arm do
-                url "https://github.com/mpyw/suve/releases/download/v${VERSION}/suve_${VERSION}_darwin_arm64.tar.gz"
-                sha256 "${SHA256_DARWIN_ARM64}"
-              end
-              on_intel do
-                url "https://github.com/mpyw/suve/releases/download/v${VERSION}/suve_${VERSION}_darwin_amd64.tar.gz"
-                sha256 "${SHA256_DARWIN_AMD64}"
-              end
-            end
-
-            on_linux do
-              on_arm do
-                url "https://github.com/mpyw/suve/releases/download/v${VERSION}/suve_${VERSION}_linux_arm64.tar.gz"
-                sha256 "${SHA256_LINUX_ARM64}"
-              end
-              on_intel do
-                url "https://github.com/mpyw/suve/releases/download/v${VERSION}/suve_${VERSION}_linux_amd64.tar.gz"
-                sha256 "${SHA256_LINUX_AMD64}"
-              end
-            end
-
-            def install
-              bin.install "suve"
-            end
-
-            test do
-              system bin/"suve", "--version"
-            end
-          end
-          EOF
-
-          # Remove leading spaces
-          sed -i 's/^          //' suve.rb
+          envsubst < .github/templates/homebrew-formula.rb > suve.rb
           cat suve.rb
 
-          # Push to homebrew-tap
           git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/mpyw/homebrew-tap.git"
           mkdir -p homebrew-tap/Formula
           cp suve.rb homebrew-tap/Formula/
@@ -450,46 +425,19 @@ jobs:
             exit 0
           fi
 
-          VERSION="${GITHUB_REF_NAME#v}"
+          export VERSION="${GITHUB_REF_NAME#v}"
+          export SHA256_WINDOWS_AMD64=$(grep "windows_amd64.zip" releases/checksums.txt | cut -d' ' -f1)
+          export SHA256_WINDOWS_ARM64=$(grep "windows_arm64.zip" releases/checksums.txt | cut -d' ' -f1)
 
-          # Get SHA256 checksums for Windows builds
-          SHA256_WINDOWS_AMD64=$(grep "windows_amd64.zip" releases/checksums.txt | cut -d' ' -f1)
-          SHA256_WINDOWS_ARM64=$(grep "windows_arm64.zip" releases/checksums.txt | cut -d' ' -f1)
-
-          # Validate checksums were found
           if [[ -z "$SHA256_WINDOWS_AMD64" || -z "$SHA256_WINDOWS_ARM64" ]]; then
             echo "Error: Could not find SHA256 checksums for Windows builds"
-            echo "Contents of releases/checksums.txt:"
             cat releases/checksums.txt
             exit 1
           fi
 
-          # Generate Scoop manifest
-          cat > suve.json <<EOF
-          {
-            "version": "${VERSION}",
-            "description": "Git-like CLI for AWS Parameter Store and Secrets Manager",
-            "homepage": "https://github.com/mpyw/suve",
-            "license": "MIT",
-            "architecture": {
-              "64bit": {
-                "url": "https://github.com/mpyw/suve/releases/download/v${VERSION}/suve_${VERSION}_windows_amd64.zip",
-                "hash": "${SHA256_WINDOWS_AMD64}"
-              },
-              "arm64": {
-                "url": "https://github.com/mpyw/suve/releases/download/v${VERSION}/suve_${VERSION}_windows_arm64.zip",
-                "hash": "${SHA256_WINDOWS_ARM64}"
-              }
-            },
-            "bin": "suve.exe"
-          }
-          EOF
-
-          # Remove leading spaces from heredoc
-          sed -i 's/^          //' suve.json
+          envsubst < .github/templates/scoop-manifest.json > suve.json
           cat suve.json
 
-          # Push to scoop-bucket
           git clone "https://x-access-token:${SCOOP_BUCKET_TOKEN}@github.com/mpyw/scoop-bucket.git"
           cp suve.json scoop-bucket/
           cd scoop-bucket

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       localstack:
-        image: localstack/localstack:latest
+        image: localstack/localstack:4
         ports:
           - 4566:4566
         env:
@@ -152,6 +152,61 @@ jobs:
           name: playwright-report-${{ matrix.os }}
           path: internal/gui/frontend/playwright-report/
           retention-days: 30
+
+  linux-package:
+    name: Linux Package Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build test binary
+        run: go build -o suve ./cmd/suve
+
+      - name: Install nfpm
+        run: go install github.com/goreleaser/nfpm/v2/cmd/nfpm@v2.41.1
+
+      - name: Install lintian and rpmlint
+        run: sudo apt-get update && sudo apt-get install -y lintian rpm rpmlint
+
+      - name: Generate and lint .deb package
+        run: |
+          export VERSION="0.0.0-test"
+          export GOARCH="amd64"
+          nfpm pkg --packager deb --target suve_test_amd64.deb
+          echo "=== deb package info ==="
+          dpkg-deb -I suve_test_amd64.deb
+          echo "=== lintian check ==="
+          # Suppress tags expected for Go binaries:
+          # - no-changelog: No Debian-style changelog maintained
+          # - no-manual-page: CLI has --help instead
+          # - unknown-field: nfpm uses License field
+          # - hardening-*: Go binaries don't support PIE/RELRO
+          # - unstripped-binary-or-object: Go needs debug info for stack traces
+          # - undeclared-elf-prerequisites: libc is provided by base system
+          lintian --tag-display-limit 0 \
+            --suppress-tags no-changelog,no-manual-page,unknown-field,hardening-no-pie,hardening-no-relro,unstripped-binary-or-object,undeclared-elf-prerequisites \
+            suve_test_amd64.deb
+
+      - name: Generate and lint .rpm package
+        run: |
+          export VERSION="0.0.0-test"
+          export GOARCH="amd64"
+          nfpm pkg --packager rpm --target suve-test.x86_64.rpm
+          echo "=== rpm package info ==="
+          rpm -qip suve-test.x86_64.rpm
+          echo "=== rpmlint check ==="
+          # rpmlint returns non-zero on warnings; allow warnings for:
+          # - no-signature: Test packages aren't GPG signed
+          # - no-manual-page-for-binary: CLI has --help instead
+          # - no-documentation/no-changelogname-tag: Minimal package
+          # - invalid-license: MIT is valid but rpmlint wants SPDX format
+          rpmlint suve-test.x86_64.rpm || true
 
   gui-test-windows:
     name: GUI Test (Playwright) (Windows)

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -137,23 +137,6 @@ changelog:
       - Merge pull request
       - Merge branch
 
-brews:
-  - name: suve
-    ids:
-      - suve
-    repository:
-      owner: mpyw
-      name: homebrew-tap
-      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
-    directory: Formula
-    homepage: "https://github.com/mpyw/suve"
-    description: "Git-like CLI for AWS Parameter Store and Secrets Manager"
-    license: "MIT"
-    install: |
-      bin.install "suve"
-    test: |
-      system "#{bin}/suve", "--version"
-
 release:
   github:
     owner: mpyw

--- a/README.md
+++ b/README.md
@@ -47,6 +47,46 @@ scoop bucket add mpyw https://github.com/mpyw/scoop-bucket.git
 scoop install suve
 ```
 
+### Debian/Ubuntu (.deb)
+
+Download the `.deb` package from [GitHub Releases](https://github.com/mpyw/suve/releases):
+
+```bash
+# Download (replace VERSION and ARCH as needed)
+curl -LO https://github.com/mpyw/suve/releases/download/vVERSION/suve_VERSION-1_ARCH.deb
+
+# Install
+sudo dpkg -i suve_VERSION-1_ARCH.deb
+```
+
+Available architectures: `amd64`, `arm64`
+
+> [!NOTE]
+> The CLI works standalone. For GUI support (`--gui`), install the recommended dependencies:
+> ```bash
+> sudo apt install libgtk-3-0 libayatana-appindicator3-1
+> ```
+
+### Red Hat/Fedora (.rpm)
+
+Download the `.rpm` package from [GitHub Releases](https://github.com/mpyw/suve/releases):
+
+```bash
+# Download (replace VERSION and ARCH as needed)
+curl -LO https://github.com/mpyw/suve/releases/download/vVERSION/suve-VERSION-1.ARCH.rpm
+
+# Install
+sudo rpm -i suve-VERSION-1.ARCH.rpm
+```
+
+Available architectures: `x86_64`, `aarch64`
+
+> [!NOTE]
+> The CLI works standalone. For GUI support (`--gui`), install GTK3:
+> ```bash
+> sudo dnf install gtk3
+> ```
+
 ### Using [`go install`](https://pkg.go.dev/cmd/go#hdr-Compile_and_install_packages_and_dependencies)
 
 ```bash

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   localstack:
-    image: localstack/localstack:latest
+    image: localstack/localstack:4
     ports:
       - "127.0.0.1:${SUVE_LOCALSTACK_EXTERNAL_PORT:-4566}:4566/tcp"
     environment:

--- a/internal/gui/check_linux.go
+++ b/internal/gui/check_linux.go
@@ -1,0 +1,41 @@
+//go:build (production || dev) && linux
+
+package gui
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+)
+
+// ErrMissingGUILibs is returned when required GUI libraries are not installed.
+var ErrMissingGUILibs = errors.New(`GUI dependencies not found
+
+The GUI requires GTK3 and WebKit2GTK to be installed.
+See: https://wails.io/docs/guides/linux-distro-support/
+
+After installing the dependencies, try running the GUI again.
+Alternatively, use the CLI without the --gui flag`)
+
+// checkGUIDependencies verifies that required GUI libraries are available.
+// Uses ldconfig to query the dynamic linker cache for webkit2gtk.
+// If ldconfig is unavailable, skips the check and lets the runtime handle it.
+func checkGUIDependencies() error {
+	if _, err := exec.LookPath("ldconfig"); err != nil {
+		// ldconfig not available, skip check
+		return nil
+	}
+
+	cmd := exec.Command("ldconfig", "-p")
+	output, err := cmd.Output()
+	if err != nil {
+		// ldconfig failed, skip check
+		return nil
+	}
+
+	if strings.Contains(string(output), "libwebkit2gtk") {
+		return nil
+	}
+
+	return ErrMissingGUILibs
+}

--- a/internal/gui/check_other.go
+++ b/internal/gui/check_other.go
@@ -1,0 +1,11 @@
+//go:build (production || dev) && !linux
+
+package gui
+
+// checkGUIDependencies is a no-op on non-Linux platforms.
+// macOS and Windows handle their dependencies differently:
+// - macOS: WebKit is included in the OS
+// - Windows: WebView2 runtime is auto-installed if missing
+func checkGUIDependencies() error {
+	return nil
+}

--- a/internal/gui/run.go
+++ b/internal/gui/run.go
@@ -10,6 +10,11 @@ import (
 
 // Run starts the GUI application.
 func Run() error {
+	// Check for required GUI dependencies (platform-specific)
+	if err := checkGUIDependencies(); err != nil {
+		return err
+	}
+
 	app := NewApp()
 
 	opts := &options.App{

--- a/nfpm.yaml
+++ b/nfpm.yaml
@@ -1,0 +1,54 @@
+# nfpm configuration for generating .deb and .rpm packages
+# https://nfpm.goreleaser.com/configuration/
+
+name: suve
+arch: "${GOARCH}"
+platform: linux
+version: "${VERSION}"
+release: "1"
+maintainer: "mpyw <mpyw628@gmail.com>"
+description: |
+  Git-like CLI/GUI for AWS Parameter Store and Secrets Manager
+  .
+  Provides familiar commands like show, log, diff, and a staging workflow
+  for safe, reviewable changes to your AWS secrets and parameters.
+homepage: "https://github.com/mpyw/suve"
+license: "MIT"
+
+# RPM uses first line of description as Summary (without trailing dot)
+vendor: "mpyw"
+section: "utils"
+priority: "optional"
+
+# RPM-specific
+rpm:
+  group: "Applications/System"
+
+# No hard dependencies - CLI works without GUI libs
+# GUI dependencies are recommended but not required
+depends: []
+
+# DEB: recommended packages for GUI support
+recommends:
+  - libgtk-3-0
+  - libayatana-appindicator3-1
+
+# RPM overrides
+# Note: RPM only recommends gtk3 because appindicator package names
+# vary across distros (libappindicator-gtk3, ayatana-appindicator, etc.)
+overrides:
+  rpm:
+    recommends:
+      - gtk3
+
+contents:
+  - src: ./suve
+    dst: /usr/bin/suve
+    file_info:
+      mode: 0755
+
+  # Copyright file (required by Debian policy)
+  - src: ./LICENSE
+    dst: /usr/share/doc/suve/copyright
+    file_info:
+      mode: 0644


### PR DESCRIPTION
## Summary

- Add Linux .deb/.rpm package generation to GitHub Releases using nfpm
- Add PR-time package linting with lintian/rpmlint
- Extract inline templates (versioninfo, Homebrew, Scoop) using envsubst
- Pin tool versions for reproducibility (goversioninfo, localstack, nfpm)
- Add runtime webkit2gtk dependency check for Linux GUI
- Add dependabot config for automated dependency updates

## Changes

### Linux Packaging
- `nfpm.yaml`: Configuration for .deb/.rpm generation
- `.github/workflows/test.yml`: Add linux-package job for PR-time linting
- `.github/workflows/release.yml`: Generate and upload .deb/.rpm packages
- `README.md`: Add Linux installation instructions

### Template Extraction
- `.github/templates/windows-versioninfo.json`
- `.github/templates/homebrew-formula.rb`
- `.github/templates/scoop-manifest.json`

### GUI Dependency Check
- `internal/gui/check_linux.go`: Runtime webkit2gtk check using ldconfig
- `internal/gui/check_other.go`: No-op for non-Linux platforms

### Maintenance
- `.github/dependabot.yml`: Automated dependency updates (weekly, grouped)
- `.goreleaser.yaml`: Remove dead `brews` section

## Test plan

- [ ] CI passes (test, lint, linux-package jobs)
- [ ] Release workflow generates .deb/.rpm packages correctly
- [ ] Linux GUI shows friendly error when webkit2gtk is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)