### PR TITLE
fix: correct YAML indentation in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -512,7 +512,7 @@ jobs:
 
           FINAL_BODY="${NEW_NOTES}
 
-${DOWNLOAD_TABLE}"
+          ${DOWNLOAD_TABLE}"
 
           gh release create "$TAG" \
             --title "$TAG" \


### PR DESCRIPTION
Line 515 was missing indentation in the multiline bash script, causing YAML syntax validation to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)