### PR TITLE
refactor: split release workflow into reusable components

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,13 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to release (e.g., v0.6.3)"
+        description: "Version to release (e.g., v1.2.3) - tag must already exist"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to release (e.g., v1.2.3) - tag must already exist"
         required: true
         type: string
 
@@ -13,7 +19,7 @@ permissions:
 
 jobs:
   # ===========================================================================
-  # Validate version format before any builds
+  # Validate that tag exists before any builds
   # ===========================================================================
   validate:
     runs-on: ubuntu-latest
@@ -24,20 +30,22 @@ jobs:
         run: |
           if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "Error: Invalid version format '$VERSION'"
-            echo "Expected format: vX.Y.Z (e.g., v0.6.3)"
+            echo "Expected format: vX.Y.Z (e.g., v1.2.3)"
             exit 1
           fi
           echo "Version format valid: $VERSION"
 
-      - name: Check tag does not exist
+      - name: Check tag exists
         env:
           VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          if git ls-remote --tags origin | grep -q "refs/tags/${VERSION}$"; then
-            echo "Error: Tag '$VERSION' already exists"
+          if ! git ls-remote --tags https://github.com/${{ github.repository }} | grep -q "refs/tags/${VERSION}$"; then
+            echo "Error: Tag '$VERSION' does not exist"
+            echo "Please create the tag first using the 'Tag' workflow"
             exit 1
           fi
-          echo "Tag does not exist: $VERSION"
+          echo "Tag exists: $VERSION"
 
   # ===========================================================================
   # Darwin: CGO required for GUI, build both archs on ARM64 runner
@@ -49,6 +57,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.version }}
           fetch-depth: 0
 
       - name: Set up Go
@@ -114,6 +123,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.version }}
           fetch-depth: 0
 
       - name: Set up Go
@@ -167,6 +177,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.version }}
           fetch-depth: 0
 
       - name: Set up Go
@@ -215,6 +226,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.version }}
           fetch-depth: 0
 
       - name: Set up Go
@@ -248,6 +260,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.version }}
           fetch-depth: 0
 
       - name: Set up Go
@@ -312,6 +325,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.version }}
           fetch-depth: 0
 
       - name: Download all artifacts
@@ -484,15 +498,6 @@ jobs:
           cd releases
           sha256sum *.tar.gz *.zip *.deb *.rpm > checksums.txt
           cat checksums.txt
-
-      - name: Create tag
-        env:
-          TAG: ${{ inputs.version }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "$TAG" -m "Release $TAG"
-          git push origin "$TAG"
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,58 @@
+name: Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to tag (e.g., v1.2.3)"
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: "Version to tag (e.g., v1.2.3)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Invalid version format '$VERSION'"
+            echo "Expected format: vX.Y.Z (e.g., v1.2.3)"
+            exit 1
+          fi
+          echo "Version format valid: $VERSION"
+
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check tag does not exist
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if git ls-remote --tags origin | grep -q "refs/tags/${VERSION}$"; then
+            echo "Error: Tag '$VERSION' already exists"
+            exit 1
+          fi
+          echo "Tag does not exist: $VERSION"
+
+      - name: Create and push tag
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$VERSION" -m "Release $VERSION"
+          git push origin "$VERSION"
+          echo "Tag '$VERSION' created and pushed successfully"

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -1,0 +1,22 @@
+name: Tag and Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g., v1.2.3)"
+        required: true
+        type: string
+
+jobs:
+  tag:
+    uses: ./.github/workflows/tag.yml
+    with:
+      version: ${{ inputs.version }}
+
+  release:
+    needs: [tag]
+    uses: ./.github/workflows/release.yml
+    with:
+      version: ${{ inputs.version }}
+    secrets: inherit


### PR DESCRIPTION
## Summary
- Split monolithic release workflow into 3 reusable workflows
- Fix GoReleaser "tag not made against commit" error by ensuring tag exists before build

## Changes
| Workflow | Purpose |
|----------|---------|
| `tag.yml` | Create and push git tag (reusable) |
| `release.yml` | Build & publish release (requires existing tag) |
| `tag_and_release.yml` | Orchestrator: tag → release |

## Usage
- **Normal release**: Run `Tag and Release` workflow with version (e.g., `v1.2.3`)
- **Tag only**: Run `Tag` workflow standalone
- **Re-release existing tag**: Run `Release` workflow standalone

## Root cause of CI failure
GoReleaser expects to run on a tagged commit. The previous workflow created the tag *after* builds, causing:
```
error=git tag v0.6.2 was not made against commit ab72447...
```

Now tags are created first, and builds checkout the tag ref directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)