### PR TITLE
fix: add permissions to tag_and_release workflow

### DIFF
--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   tag:
     uses: ./.github/workflows/tag.yml


### PR DESCRIPTION
## Summary
Fix workflow validation error by adding `permissions: contents: write` to the orchestrator workflow.

## Problem
```
Error calling workflow 'mpyw/suve/.github/workflows/tag.yml@...'. 
The workflow is requesting 'contents: write', but is only allowed 'contents: read'.
```

## Solution
Reusable workflows inherit permissions from the caller. The `tag_and_release.yml` orchestrator needs to declare `contents: write` so that `tag.yml` can push tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)