### PR TITLE
docs: add Fedora build dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ go install -tags production github.com/mpyw/suve/cmd/suve@latest
 > On Linux, install the appropriate dev package first:
 > - Ubuntu 22.04/Debian: `sudo apt install libgtk-3-dev libwebkit2gtk-4.0-dev`
 > - Ubuntu 24.04+: `sudo apt install libgtk-3-dev libwebkit2gtk-4.1-dev` (use `-tags production,webkit2_41`)
+> - Fedora 39: `sudo dnf install gtk3-devel webkit2gtk4.0-devel`
+> - Fedora 40+: `sudo dnf install gtk3-devel webkit2gtk4.1-devel` (use `-tags production,webkit2_41`)
 
 ### Using [`go tool`](https://pkg.go.dev/cmd/go#hdr-Run_specified_go_tool) (Go 1.24+)
 


### PR DESCRIPTION
## Summary

- Add Fedora build dependencies (`gtk3-devel`, `webkit2gtk4.0-devel`/`webkit2gtk4.1-devel`) to README for `go install` users

## Test plan

- [ ] README displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)