### PR TITLE
docs: add missing deletion example to stage diff output

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,11 @@ Output will look like:
 +++ /app/config/new-param (staged for creation)
 @@ -0,0 +1 @@
 +my-value
+
+--- /app/config/old-param#2 (AWS)
++++ /app/config/old-param (staged for deletion)
+@@ -1 +0,0 @@
+-deprecated-value
 ```
 
 **3. Apply changes**:


### PR DESCRIPTION
## Summary
- Add missing deletion diff example to `suve stage diff` output in README
- The `stage status` example showed `D /app/config/old-param` but the `stage diff` output was missing the corresponding deletion diff

## Test plan
- [x] Documentation-only change, no implementation changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)