### PR TITLE
refactor: simplify errors.As pattern with inline variable declaration

### DIFF
--- a/internal/gui/param.go
+++ b/internal/gui/param.go
@@ -243,8 +243,7 @@ func (a *App) ParamSet(name, value, paramType string) (*ParamSetResult, error) {
 	}
 
 	// If parameter already exists, update it
-	var pae *paramapi.ParameterAlreadyExists
-	if errors.As(err, &pae) {
+	if pae := (*paramapi.ParameterAlreadyExists)(nil); errors.As(err, &pae) {
 		updateUC := &param.UpdateUseCase{Client: client}
 		updateResult, err := updateUC.Execute(a.ctx, param.UpdateInput{
 			Name:  name,

--- a/internal/staging/param.go
+++ b/internal/staging/param.go
@@ -101,8 +101,7 @@ func (s *ParamStrategy) applyUpdate(ctx context.Context, name string, entry Entr
 		Name: lo.ToPtr(name),
 	})
 	if err != nil {
-		var pnf *paramapi.ParameterNotFound
-		if errors.As(err, &pnf) {
+		if pnf := (*paramapi.ParameterNotFound)(nil); errors.As(err, &pnf) {
 			return fmt.Errorf("parameter not found: %s", name)
 		}
 		return fmt.Errorf("failed to get existing parameter: %w", err)
@@ -152,8 +151,7 @@ func (s *ParamStrategy) applyDelete(ctx context.Context, name string) error {
 	})
 	if err != nil {
 		// Already deleted is considered success
-		var pnf *paramapi.ParameterNotFound
-		if errors.As(err, &pnf) {
+		if pnf := (*paramapi.ParameterNotFound)(nil); errors.As(err, &pnf) {
 			return nil
 		}
 		return fmt.Errorf("failed to delete parameter: %w", err)
@@ -168,8 +166,7 @@ func (s *ParamStrategy) FetchLastModified(ctx context.Context, name string) (tim
 		Name: lo.ToPtr(name),
 	})
 	if err != nil {
-		var pnf *paramapi.ParameterNotFound
-		if errors.As(err, &pnf) {
+		if pnf := (*paramapi.ParameterNotFound)(nil); errors.As(err, &pnf) {
 			return time.Time{}, nil
 		}
 		return time.Time{}, fmt.Errorf("failed to get parameter: %w", err)
@@ -211,8 +208,7 @@ func (s *ParamStrategy) FetchCurrentValue(ctx context.Context, name string) (*Ed
 	spec := &paramversion.Spec{Name: name}
 	param, err := paramversion.GetParameterWithVersion(ctx, s.Client, spec)
 	if err != nil {
-		var pnf *paramapi.ParameterNotFound
-		if errors.As(err, &pnf) {
+		if pnf := (*paramapi.ParameterNotFound)(nil); errors.As(err, &pnf) {
 			return nil, &ResourceNotFoundError{Err: err}
 		}
 		return nil, err

--- a/internal/staging/secret.go
+++ b/internal/staging/secret.go
@@ -143,8 +143,7 @@ func (s *SecretStrategy) applyDelete(ctx context.Context, name string, entry Ent
 	_, err := s.Client.DeleteSecret(ctx, input)
 	if err != nil {
 		// Already deleted is considered success
-		var rnf *secretapi.ResourceNotFoundException
-		if errors.As(err, &rnf) {
+		if rnf := (*secretapi.ResourceNotFoundException)(nil); errors.As(err, &rnf) {
 			return nil
 		}
 		return fmt.Errorf("failed to delete secret: %w", err)
@@ -159,8 +158,7 @@ func (s *SecretStrategy) FetchLastModified(ctx context.Context, name string) (ti
 		SecretId: lo.ToPtr(name),
 	})
 	if err != nil {
-		var rnf *secretapi.ResourceNotFoundException
-		if errors.As(err, &rnf) {
+		if rnf := (*secretapi.ResourceNotFoundException)(nil); errors.As(err, &rnf) {
 			return time.Time{}, nil
 		}
 		return time.Time{}, fmt.Errorf("failed to get secret: %w", err)
@@ -203,8 +201,7 @@ func (s *SecretStrategy) FetchCurrentValue(ctx context.Context, name string) (*E
 	spec := &secretversion.Spec{Name: name}
 	secret, err := secretversion.GetSecretWithVersion(ctx, s.Client, spec)
 	if err != nil {
-		var rnf *secretapi.ResourceNotFoundException
-		if errors.As(err, &rnf) {
+		if rnf := (*secretapi.ResourceNotFoundException)(nil); errors.As(err, &rnf) {
 			return nil, &ResourceNotFoundError{Err: err}
 		}
 		return nil, err

--- a/internal/usecase/param/delete.go
+++ b/internal/usecase/param/delete.go
@@ -38,8 +38,7 @@ func (u *DeleteUseCase) GetCurrentValue(ctx context.Context, name string) (strin
 		WithDecryption: lo.ToPtr(true),
 	})
 	if err != nil {
-		var pnf *paramapi.ParameterNotFound
-		if errors.As(err, &pnf) {
+		if pnf := (*paramapi.ParameterNotFound)(nil); errors.As(err, &pnf) {
 			return "", nil
 		}
 		return "", err

--- a/internal/usecase/param/update.go
+++ b/internal/usecase/param/update.go
@@ -41,8 +41,7 @@ func (u *UpdateUseCase) Exists(ctx context.Context, name string) (bool, error) {
 		Name: lo.ToPtr(name),
 	})
 	if err != nil {
-		var pnf *paramapi.ParameterNotFound
-		if errors.As(err, &pnf) {
+		if pnf := (*paramapi.ParameterNotFound)(nil); errors.As(err, &pnf) {
 			return false, nil
 		}
 		return false, err

--- a/internal/usecase/secret/delete.go
+++ b/internal/usecase/secret/delete.go
@@ -42,8 +42,7 @@ func (u *DeleteUseCase) GetCurrentValue(ctx context.Context, name string) (strin
 		SecretId: lo.ToPtr(name),
 	})
 	if err != nil {
-		var rnf *secretapi.ResourceNotFoundException
-		if errors.As(err, &rnf) {
+		if rnf := (*secretapi.ResourceNotFoundException)(nil); errors.As(err, &rnf) {
 			return "", nil
 		}
 		return "", err

--- a/internal/usecase/staging/add.go
+++ b/internal/usecase/staging/add.go
@@ -43,8 +43,7 @@ func (u *AddUseCase) Execute(ctx context.Context, input AddInput) (*AddOutput, e
 	result, err := u.Strategy.FetchCurrentValue(ctx, name)
 	if err != nil {
 		// ResourceNotFoundError means resource doesn't exist - that's expected for add
-		var notFoundErr *staging.ResourceNotFoundError
-		if !errors.As(err, &notFoundErr) {
+		if notFoundErr := (*staging.ResourceNotFoundError)(nil); !errors.As(err, &notFoundErr) {
 			return nil, err
 		}
 		// Resource doesn't exist, currentValue remains nil

--- a/internal/usecase/staging/tag.go
+++ b/internal/usecase/staging/tag.go
@@ -95,8 +95,7 @@ func (u *TagUseCase) fetchAWSCurrentValue(ctx context.Context, name string) (*st
 	result, err := u.Strategy.FetchCurrentValue(ctx, name)
 	if err != nil {
 		// If resource doesn't exist, return nil
-		var notFoundErr *staging.ResourceNotFoundError
-		if errors.As(err, &notFoundErr) {
+		if notFoundErr := (*staging.ResourceNotFoundError)(nil); errors.As(err, &notFoundErr) {
 			return nil, nil, nil
 		}
 		return nil, nil, err


### PR DESCRIPTION
## Summary
- Combine variable declaration and `errors.As` check into a single line using Go's if-statement initialization syntax
- Reduces 13 lines of boilerplate across 8 files while maintaining the same functionality

## Changes
```go
// Before
var pnf *paramapi.ParameterNotFound
if errors.As(err, &pnf) {

// After  
if pnf := (*paramapi.ParameterNotFound)(nil); errors.As(err, &pnf) {
```

## Test plan
- [ ] `make test` passes
- [ ] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)