### PR TITLE
fix(staging): allow stash drop without passphrase for encrypted files

### DIFF
--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -853,9 +853,8 @@ func (a *App) StagingDrop() (*StagingDropResult, error) {
 		return nil, errors.New("no stashed changes to drop")
 	}
 
-	// Drain with keep=false to delete the file (we discard the result)
-	_, err = fileStore.Drain(a.ctx, "", false)
-	if err != nil {
+	// Delete the file directly (no decryption needed for drop)
+	if err := fileStore.Delete(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary
- Add `Delete()` method to file Store for direct file removal without decryption
- Update CLI `stash drop` to handle encrypted files gracefully (show "encrypted stash file" in confirmation for global drop, require passphrase for service-specific drop)
- Update GUI `StagingDrop` to use `Delete()` instead of `Drain()`

Fixes #111

## Test plan
- [x] Unit tests for `Delete()` method added
- [x] All existing tests pass
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)