### PR TITLE
refactor(lifecycle): add Execute*0 variants for actions without return values

### DIFF
--- a/internal/cli/commands/stage/apply/apply.go
+++ b/internal/cli/commands/stage/apply/apply.go
@@ -82,26 +82,26 @@ func action(ctx context.Context, cmd *cli.Command) error {
 
 	store := agent.NewStore(identity.AccountID, identity.Region)
 
-	result, err := lifecycle.ExecuteRead(ctx, store, lifecycle.CmdApply, func() (struct{}, error) {
+	result, err := lifecycle.ExecuteRead0(ctx, store, lifecycle.CmdApply, func() error {
 		// Check if there are any staged changes
 		paramStaged, err := store.ListEntries(ctx, staging.ServiceParam)
 		if err != nil {
-			return struct{}{}, err
+			return err
 		}
 
 		secretStaged, err := store.ListEntries(ctx, staging.ServiceSecret)
 		if err != nil {
-			return struct{}{}, err
+			return err
 		}
 
 		paramTagStaged, err := store.ListTags(ctx, staging.ServiceParam)
 		if err != nil {
-			return struct{}{}, err
+			return err
 		}
 
 		secretTagStaged, err := store.ListTags(ctx, staging.ServiceSecret)
 		if err != nil {
-			return struct{}{}, err
+			return err
 		}
 
 		hasParam := len(paramStaged[staging.ServiceParam]) > 0 || len(paramTagStaged[staging.ServiceParam]) > 0
@@ -110,7 +110,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		if !hasParam && !hasSecret {
 			output.Info(cmd.Root().Writer, "No changes staged.")
 
-			return struct{}{}, nil
+			return nil
 		}
 
 		// Count total staged changes
@@ -132,11 +132,11 @@ func action(ctx context.Context, cmd *cli.Command) error {
 
 		confirmed, err := prompter.Confirm(message, skipConfirm)
 		if err != nil {
-			return struct{}{}, err
+			return err
 		}
 
 		if !confirmed {
-			return struct{}{}, nil
+			return nil
 		}
 
 		r := &Runner{
@@ -150,7 +150,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		if hasParam {
 			strategy, err := staging.ParamFactory(ctx)
 			if err != nil {
-				return struct{}{}, err
+				return err
 			}
 
 			r.ParamStrategy = strategy
@@ -159,13 +159,13 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		if hasSecret {
 			strategy, err := staging.SecretFactory(ctx)
 			if err != nil {
-				return struct{}{}, err
+				return err
 			}
 
 			r.SecretStrategy = strategy
 		}
 
-		return struct{}{}, r.Run(ctx)
+		return r.Run(ctx)
 	})
 	if err != nil {
 		return err

--- a/internal/cli/commands/stage/reset/reset.go
+++ b/internal/cli/commands/stage/reset/reset.go
@@ -62,14 +62,14 @@ func action(ctx context.Context, cmd *cli.Command) error {
 
 	store := agent.NewStore(identity.AccountID, identity.Region)
 
-	result, err := lifecycle.ExecuteRead(ctx, store, lifecycle.CmdReset, func() (struct{}, error) {
+	result, err := lifecycle.ExecuteRead0(ctx, store, lifecycle.CmdReset, func() error {
 		r := &Runner{
 			Store:  store,
 			Stdout: cmd.Root().Writer,
 			Stderr: cmd.Root().ErrWriter,
 		}
 
-		return struct{}{}, r.Run(ctx)
+		return r.Run(ctx)
 	})
 	if err != nil {
 		return err

--- a/internal/cli/commands/stage/status/status.go
+++ b/internal/cli/commands/stage/status/status.go
@@ -66,14 +66,14 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		Verbose: cmd.Bool("verbose"),
 	}
 
-	result, err := lifecycle.ExecuteRead(ctx, store, lifecycle.CmdStatus, func() (struct{}, error) {
+	result, err := lifecycle.ExecuteRead0(ctx, store, lifecycle.CmdStatus, func() error {
 		r := &Runner{
 			Store:  store,
 			Stdout: cmd.Root().Writer,
 			Stderr: cmd.Root().ErrWriter,
 		}
 
-		return struct{}{}, r.Run(ctx, opts)
+		return r.Run(ctx, opts)
 	})
 	if err != nil {
 		return err

--- a/internal/staging/cli/stash_pop.go
+++ b/internal/staging/cli/stash_pop.go
@@ -109,7 +109,7 @@ func stashPopAction(service staging.Service) func(context.Context, *cli.Command)
 
 		agentStore := agent.NewStore(identity.AccountID, identity.Region)
 
-		_, err = lifecycle.ExecuteWrite(ctx, agentStore, lifecycle.CmdStashPop, func() (struct{}, error) {
+		err = lifecycle.ExecuteWrite0(ctx, agentStore, lifecycle.CmdStashPop, func() error {
 			r := &StashPopRunner{
 				UseCase: &stagingusecase.StashPopUseCase{
 					FileStore:  fileStore,
@@ -119,7 +119,7 @@ func stashPopAction(service staging.Service) func(context.Context, *cli.Command)
 				Stderr: cmd.Root().ErrWriter,
 			}
 
-			return struct{}{}, r.Run(ctx, StashPopOptions{
+			return r.Run(ctx, StashPopOptions{
 				Service: service,
 				Keep:    cmd.Bool("keep"),
 				Force:   cmd.Bool("force"),

--- a/internal/staging/cli/stash_show.go
+++ b/internal/staging/cli/stash_show.go
@@ -129,10 +129,10 @@ func stashShowAction(service staging.Service) func(context.Context, *cli.Command
 			return fmt.Errorf("failed to get AWS identity: %w", err)
 		}
 
-		_, err = lifecycle.ExecuteFile(ctx, lifecycle.CmdStashShow, func() (struct{}, error) {
+		err = lifecycle.ExecuteFile0(ctx, lifecycle.CmdStashShow, func() error {
 			fileStore, err := fileStoreForReading(cmd, identity.AccountID, identity.Region, true)
 			if err != nil {
-				return struct{}{}, err
+				return err
 			}
 
 			r := &StashShowRunner{
@@ -141,7 +141,7 @@ func stashShowAction(service staging.Service) func(context.Context, *cli.Command
 				Stderr:    cmd.Root().ErrWriter,
 			}
 
-			return struct{}{}, r.Run(ctx, StashShowOptions{
+			return r.Run(ctx, StashShowOptions{
 				Service: service,
 				Verbose: cmd.Bool("verbose"),
 			})

--- a/internal/staging/store/agent/daemon/lifecycle/executor.go
+++ b/internal/staging/store/agent/daemon/lifecycle/executor.go
@@ -62,3 +62,44 @@ func ExecuteFile[T any](
 ) (T, error) {
 	return action()
 }
+
+// ExecuteWrite0 is like ExecuteWrite but for actions that don't return a value.
+func ExecuteWrite0(
+	ctx context.Context,
+	starter Starter,
+	cmd WriteCommand,
+	action func() error,
+) error {
+	_, err := ExecuteWrite(ctx, starter, cmd, func() (struct{}, error) {
+		return struct{}{}, action()
+	})
+
+	return err
+}
+
+// ExecuteRead0 is like ExecuteRead but for actions that don't return a value.
+func ExecuteRead0(
+	ctx context.Context,
+	pinger Pinger,
+	cmd ReadCommand,
+	action func() error,
+) (Result0, error) {
+	result, err := ExecuteRead(ctx, pinger, cmd, func() (struct{}, error) {
+		return struct{}{}, action()
+	})
+
+	return Result0{NothingStaged: result.NothingStaged}, err
+}
+
+// ExecuteFile0 is like ExecuteFile but for actions that don't return a value.
+func ExecuteFile0(
+	ctx context.Context,
+	cmd FileCommand,
+	action func() error,
+) error {
+	_, err := ExecuteFile(ctx, cmd, func() (struct{}, error) {
+		return struct{}{}, action()
+	})
+
+	return err
+}

--- a/internal/staging/store/agent/daemon/lifecycle/result.go
+++ b/internal/staging/store/agent/daemon/lifecycle/result.go
@@ -10,3 +10,10 @@ type Result[T any] struct {
 	// When true, Value should be ignored.
 	NothingStaged bool
 }
+
+// Result0 is like Result but without a value.
+// Used by ExecuteRead0 for actions that don't return a value.
+type Result0 struct {
+	// NothingStaged indicates that the agent was not running, meaning no changes are staged.
+	NothingStaged bool
+}


### PR DESCRIPTION
## Summary
- Add `ExecuteWrite0`, `ExecuteRead0`, `ExecuteFile0` wrapper functions that take `func() error` instead of `func() (T, error)`
- Add `Result0` struct for `ExecuteRead0` results (with `NothingStaged` flag)
- Migrate all call sites from `struct{}{}` pattern to `0` variants

## Details
The `0` variants are thin wrappers around the original generic functions that absorb the `struct{}{}` internally, keeping the original functions as the base implementation.

**Files updated:**
- `internal/staging/store/agent/daemon/lifecycle/executor.go` - new functions
- `internal/staging/store/agent/daemon/lifecycle/result.go` - new `Result0` type
- `internal/staging/store/agent/daemon/lifecycle/executor_test.go` - tests for new functions
- CLI command files migrated to use `0` variants

Closes #114

## Test plan
- [x] All lifecycle tests pass
- [x] Package builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)