### PR TITLE
ci(github): add issue/PR templates and auto-labeling workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,96 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug!
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug
+      placeholder: Describe the bug...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior
+      placeholder: |
+        1. Run `suve param show /my/param`
+        2. See error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which component is affected?
+      options:
+        - CLI
+        - GUI
+        - Staging
+        - Parameter Store (SSM)
+        - Secrets Manager
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: "Output of `suve --version`"
+      placeholder: "v0.1.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: OS, AWS region, etc.
+      placeholder: |
+        - OS: macOS 14.0
+        - AWS Region: ap-northeast-1
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Error Output
+      description: Paste any relevant logs or error messages
+      render: shell
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context about the problem
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussions
+    url: https://github.com/mpyw/suve/discussions
+    about: Ask questions and share ideas

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,68 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting a feature!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this feature solve?
+      placeholder: I'm always frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like
+      placeholder: |
+        Add a new command `suve param foo` that...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you've considered?
+    validations:
+      required: false
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which component would this affect?
+      options:
+        - CLI
+        - GUI
+        - Staging
+        - Parameter Store (SSM)
+        - Secrets Manager
+        - New Component
+        - Other
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      description: Would you be willing to contribute this feature?
+      options:
+        - label: I'd be willing to submit a PR for this feature
+          required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or examples
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,42 @@
+name: Question
+description: Ask a question about suve
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have a question? We're here to help!
+
+        Before asking, please check:
+        - [README](https://github.com/mpyw/suve#readme)
+        - [Existing issues](https://github.com/mpyw/suve/issues?q=is%3Aissue)
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What would you like to know?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: topic
+    attributes:
+      label: Topic
+      description: What is this question about?
+      options:
+        - Usage / How-to
+        - Configuration
+        - AWS Integration
+        - Installation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Any relevant context that might help answer your question
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- Brief description of what this PR does -->
+
+## Related Issues
+
+<!-- Link to related issues: Fixes #123, Closes #456 -->
+
+## Changes
+
+<!-- List the main changes in this PR -->
+
+-
+
+## Checklist
+
+- [ ] Tests pass (`make test`)
+- [ ] Linter passes (`make lint`)
+- [ ] E2E tests pass if applicable (`make e2e`)
+- [ ] Documentation updated if needed
+- [ ] Breaking changes are documented
+
+## Screenshots / Output
+
+<!-- If applicable, add screenshots or command output -->

--- a/.github/issue-labeler.yml
+++ b/.github/issue-labeler.yml
@@ -1,0 +1,27 @@
+# Issue labeler configuration for github/issue-labeler
+# Labels are applied based on issue title/body content (regex patterns)
+
+cli:
+  - '\b(cli|command|flag|option|terminal|shell)\b'
+  - '\bsuve (param|secret) '
+
+gui:
+  - '\b(gui|ui|frontend|wails|svelte|window|dialog)\b'
+
+staging:
+  - '\b(stag(e|ing)|stash|daemon|apply|reset)\b'
+
+param:
+  - '\b(param(eter)?|ssm|parameter.?store)\b'
+
+secret:
+  - '\b(secret|sm|secrets?.?manager)\b'
+
+security:
+  - '\b(security|vulnerab|cve|exploit|auth|credential|encrypt|decrypt)\b'
+
+performance:
+  - '\b(performance|slow|fast|speed|latency|memory|cpu|optimization)\b'
+
+documentation:
+  - '\b(doc(s|umentation)?|readme|example|tutorial)\b'

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,84 @@
+# Label definitions managed by crazy-max/ghaction-github-labeler
+# Changes here will be synced to GitHub on push to main
+
+# Type labels
+- name: bug
+  color: "d73a4a"
+  description: Something isn't working
+
+- name: enhancement
+  color: "a2eeef"
+  description: New feature or request
+
+- name: documentation
+  color: "0075ca"
+  description: Improvements or additions to documentation
+
+- name: question
+  color: "d876e3"
+  description: Further information is requested
+
+# Status labels
+- name: duplicate
+  color: "cfd3d7"
+  description: This issue or pull request already exists
+
+- name: invalid
+  color: "e4e669"
+  description: This doesn't seem right
+
+- name: wontfix
+  color: "ffffff"
+  description: This will not be worked on
+
+# Component labels
+- name: cli
+  color: "1d76db"
+  description: CLI functionality
+
+- name: gui
+  color: "0e8a16"
+  description: GUI functionality
+
+- name: staging
+  color: "5319e7"
+  description: Staging workflow functionality
+
+# Service labels
+- name: param
+  color: "f9a825"
+  description: AWS Parameter Store related
+
+- name: secret
+  color: "e65100"
+  description: AWS Secrets Manager related
+
+# Impact labels
+- name: security
+  color: "b60205"
+  description: Security related issue or fix
+
+- name: performance
+  color: "fbca04"
+  description: Performance improvement
+
+- name: breaking-change
+  color: "b60205"
+  description: Breaking change that requires attention
+
+# Dependabot labels
+- name: dependencies
+  color: "0366d6"
+  description: Pull requests that update a dependency file
+
+- name: go
+  color: "16e2e2"
+  description: Pull requests that update Go code
+
+- name: github_actions
+  color: "000000"
+  description: Pull requests that update GitHub Actions code
+
+- name: javascript
+  color: "168700"
+  description: Pull requests that update JavaScript code

--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,0 +1,61 @@
+# PR labeler configuration for actions/labeler
+# Labels are applied based on changed file paths
+
+cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "internal/cli/**"
+          - "cmd/suve/**"
+
+gui:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "internal/gui/**"
+
+staging:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "internal/staging/**"
+          - "internal/usecase/staging/**"
+
+param:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "internal/api/paramapi/**"
+          - "internal/cli/commands/param/**"
+          - "internal/usecase/param/**"
+          - "internal/version/paramversion/**"
+
+secret:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "internal/api/secretapi/**"
+          - "internal/cli/commands/secret/**"
+          - "internal/usecase/secret/**"
+          - "internal/version/secretversion/**"
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.md"
+          - "docs/**"
+
+github_actions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/*.yml"
+
+go:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "**/*.go"
+          - "go.mod"
+          - "go.sum"
+
+javascript:
+  - changed-files:
+      - any-glob-to-any-file:
+          - "internal/gui/frontend/**/*.ts"
+          - "internal/gui/frontend/**/*.svelte"
+          - "internal/gui/frontend/package*.json"

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,19 @@
+name: Issue Labeler
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Label issue based on content
+        uses: github/issue-labeler@v3.4
+        with:
+          configuration-path: .github/issue-labeler.yml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          include-title: 1

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,31 @@
+name: Sync Labels
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/labels.yml"
+      - ".github/workflows/labels.yml"
+  pull_request:
+    paths:
+      - ".github/labels.yml"
+      - ".github/workflows/labels.yml"
+  workflow_dispatch:
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Sync labels
+        uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          yaml-file: .github/labels.yml
+          dry-run: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,0 +1,17 @@
+name: PR Labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  labeler:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Label PR based on changed files
+        uses: actions/labeler@v5
+        with:
+          configuration-path: .github/pr-labeler.yml


### PR DESCRIPTION
## Summary

- Add issue templates (bug report, feature request, question)
- Add PR template with checklist
- Add label definitions managed by `crazy-max/ghaction-github-labeler`
- Add PR auto-labeling based on changed file paths (`actions/labeler`)
- Add issue auto-labeling based on title/body keywords (`github/issue-labeler`)

## Labels

| Category | Labels |
|---|---|
| Type | `bug`, `enhancement`, `documentation`, `question` |
| Status | `duplicate`, `invalid`, `wontfix` |
| Component | `cli`, `gui`, `staging` |
| Service | `param`, `secret` |
| Impact | `security`, `performance`, `breaking-change` |
| Dependabot | `dependencies`, `go`, `github_actions`, `javascript` |

## Workflows

| Workflow | Trigger | Action |
|---|---|---|
| `labels.yml` | Push to main (labels.yml changed) | Sync label definitions |
| `pr-labeler.yml` | PR opened/updated | Label based on changed files |
| `issue-labeler.yml` | Issue opened/edited | Label based on content keywords |

## Test plan

- [ ] Verify label sync workflow runs on merge
- [ ] Create test issue to verify auto-labeling
- [ ] Create test PR to verify file-based labeling

🤖 Generated with [Claude Code](https://claude.com/claude-code)