### PR TITLE
docs: fix incorrect --force flag references in stash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,10 +524,10 @@ where ~SHIFT = ~ | ~N  (repeatable, cumulative)
 | Command | Options | Description |
 |---------|---------|-------------|
 | `suve stage stash` | | Save staged changes to file (alias for `push`) |
-| `suve stage stash push` | `--keep`<br>`--force`<br>`--merge`<br>`--passphrase-stdin` | Save staged changes from memory to file |
-| `suve stage stash pop` | `--keep`<br>`--force`<br>`--merge`<br>`--passphrase-stdin` | Restore staged changes from file |
+| `suve stage stash push` | `--keep`<br>`--yes`<br>`--merge`<br>`--overwrite`<br>`--passphrase-stdin` | Save staged changes from memory to file |
+| `suve stage stash pop` | `--keep`<br>`--yes`<br>`--merge`<br>`--overwrite`<br>`--passphrase-stdin` | Restore staged changes from file |
 | `suve stage stash show` | `--verbose` (`-v`)<br>`--passphrase-stdin` | Preview stashed changes |
-| `suve stage stash drop` | `--force`<br>`--passphrase-stdin` | Delete stash file |
+| `suve stage stash drop` | `--yes`<br>`--passphrase-stdin` | Delete stash file |
 
 ### Agent Commands
 

--- a/docs/staging-agent.md
+++ b/docs/staging-agent.md
@@ -140,8 +140,8 @@ suve stage stash pop
 # Restore but keep file
 suve stage stash pop --keep
 
-# Force overwrite existing memory (no prompt)
-suve stage stash pop --force
+# Overwrite existing memory (no prompt)
+suve stage stash pop --overwrite
 
 # Merge with existing memory
 suve stage stash pop --merge
@@ -159,7 +159,7 @@ suve stage stash show -v  # Verbose mode
 
 # Delete stash file
 suve stage stash drop
-suve stage stash drop --force  # Skip confirmation
+suve stage stash drop --yes  # Skip confirmation
 ```
 
 ### Service-Specific Stash
@@ -199,7 +199,7 @@ When restoring stashed changes with `stash pop`:
 | Scenario | Default Behavior | Options |
 |----------|-----------------|---------|
 | Agent memory is empty | Restore directly | N/A |
-| Agent has changes | Prompt for action | `--force` (overwrite), `--merge` (combine) |
+| Agent has changes | Prompt for action | `--overwrite` (replace), `--merge` (combine) |
 | File has conflicts | User chooses | Interactive prompt in TTY |
 
 When using `--merge`:


### PR DESCRIPTION
## Summary

- Fix incorrect `--force` flag references in stash command documentation
- The actual flags are `--overwrite` (replace data) and `--yes` (skip confirmation)
- `--force` only exists for `secret delete` command

## Changes

| File | Fix |
|------|-----|
| README.md | Replace `--force` with `--yes` and `--overwrite` in stash commands table |
| docs/staging-agent.md | Fix 3 incorrect `--force` usages in examples and table |

## Test plan

- [x] Verify documentation matches actual CLI implementation
- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)