### PR TITLE
feat(staging): add Scope type and refactor daemon to scope-independent architecture

### DIFF
--- a/e2e/staging_test.go
+++ b/e2e/staging_test.go
@@ -1134,7 +1134,7 @@ func TestDaemonLauncher_Ping(t *testing.T) {
 	setupTempHome(t)
 
 	// Create launcher for the running test daemon
-	launcher := daemon.NewLauncher("000000000000", "us-east-1", daemon.WithAutoStartDisabled())
+	launcher := daemon.NewLauncher(daemon.WithAutoStartDisabled())
 
 	// Test Ping
 	t.Run("ping-success", func(t *testing.T) {
@@ -1166,7 +1166,7 @@ func TestDaemonLauncher_EnsureRunning(t *testing.T) {
 	setupTempHome(t)
 
 	// Create launcher for the running test daemon
-	launcher := daemon.NewLauncher("000000000000", "us-east-1", daemon.WithAutoStartDisabled())
+	launcher := daemon.NewLauncher(daemon.WithAutoStartDisabled())
 
 	// Test EnsureRunning (daemon is already running from TestMain)
 	t.Run("ensure-running-when-running", func(t *testing.T) {
@@ -1231,13 +1231,21 @@ func TestDaemonLauncher_ViaStore(t *testing.T) {
 	})
 }
 
+// setupIsolatedSocketPath sets TMPDIR to a temp directory, causing the daemon
+// to look for a socket in a different location where no daemon is running.
+// This simulates the "daemon not running" scenario for E2E tests.
+func setupIsolatedSocketPath(t *testing.T) {
+	t.Helper()
+	t.Setenv("TMPDIR", t.TempDir())
+}
+
 // TestDaemonLauncher_NotRunning tests launcher behavior when daemon is not running.
 func TestDaemonLauncher_NotRunning(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
+	setupIsolatedSocketPath(t) // Use different socket path where no daemon exists
 
-	// Create launcher for a different account where no daemon is running
-	launcher := daemon.NewLauncher("999999999999", "ap-northeast-1", daemon.WithAutoStartDisabled())
+	launcher := daemon.NewLauncher(daemon.WithAutoStartDisabled())
 
 	// Test Ping fails when daemon not running
 	t.Run("ping-not-running", func(t *testing.T) {
@@ -1257,9 +1265,9 @@ func TestDaemonLauncher_NotRunning(t *testing.T) {
 func TestAgentStore_NotRunning(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
+	setupIsolatedSocketPath(t) // Use different socket path where no daemon exists
 
-	// Create store for a different account where no daemon is running
-	store := newStoreForAccount("999999999999", "ap-northeast-1")
+	store := newStore()
 
 	// Test GetEntry fails when daemon not running
 	t.Run("get-entry-not-running", func(t *testing.T) {

--- a/internal/cli/commands/stage/agent/command.go
+++ b/internal/cli/commands/stage/agent/command.go
@@ -3,12 +3,10 @@ package agent
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/infra"
 	agentcfg "github.com/mpyw/suve/internal/staging/store/agent"
 	"github.com/mpyw/suve/internal/staging/store/agent/daemon"
 )
@@ -50,14 +48,6 @@ The daemon will automatically shut down when all staged changes are cleared.
 
 Set ` + agentcfg.EnvDaemonManualMode + `=1 to enable manual mode (disables auto-start and auto-shutdown).`,
 		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:  "account",
-				Usage: "AWS account ID (required, usually passed automatically)",
-			},
-			&cli.StringFlag{
-				Name:  "region",
-				Usage: "AWS region (required, usually passed automatically)",
-			},
 			&cli.BoolFlag{
 				Name:   "foreground",
 				Usage:  "Run daemon in foreground (used internally by spawner)",
@@ -65,30 +55,17 @@ Set ` + agentcfg.EnvDaemonManualMode + `=1 to enable manual mode (disables auto-
 			},
 		},
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			accountID := cmd.String("account")
-			region := cmd.String("region")
 			foreground := cmd.Bool("foreground")
-
-			// If not passed via flags, get from AWS identity
-			if accountID == "" || region == "" {
-				identity, err := infra.GetAWSIdentity(ctx)
-				if err != nil {
-					return fmt.Errorf("failed to get AWS identity: %w", err)
-				}
-
-				accountID = identity.AccountID
-				region = identity.Region
-			}
 
 			// Foreground mode: run daemon directly (used by spawner)
 			if foreground {
-				runner := daemon.NewRunner(accountID, region, agentcfg.DaemonOptions()...)
+				runner := daemon.NewRunner(agentcfg.DaemonOptions()...)
 
 				return runner.Run(ctx)
 			}
 
 			// Background mode: spawn daemon via launcher
-			launcher := daemon.NewLauncher(accountID, region)
+			launcher := daemon.NewLauncher()
 
 			// Check if already running
 			if err := launcher.Ping(ctx); err == nil {
@@ -118,12 +95,7 @@ func stopCommand() *cli.Command {
 This command sends a shutdown signal to the running daemon.
 Note: Any staged changes in memory will be lost unless persisted first.`,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
-			identity, err := infra.GetAWSIdentity(ctx)
-			if err != nil {
-				return fmt.Errorf("failed to get AWS identity: %w", err)
-			}
-
-			launcher := daemon.NewLauncher(identity.AccountID, identity.Region)
+			launcher := daemon.NewLauncher()
 
 			// Check if agent is running first
 			if err := launcher.Ping(ctx); err != nil {

--- a/internal/cli/commands/stage/agent/command_internal_test.go
+++ b/internal/cli/commands/stage/agent/command_internal_test.go
@@ -64,8 +64,6 @@ func TestStartCommand_HasExpectedFlags(t *testing.T) {
 		return ""
 	})
 
-	assert.Contains(t, flagNames, "account")
-	assert.Contains(t, flagNames, "region")
 	assert.Contains(t, flagNames, "foreground")
 }
 

--- a/internal/cli/commands/stage/apply/apply.go
+++ b/internal/cli/commands/stage/apply/apply.go
@@ -80,7 +80,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed to get AWS identity: %w", err)
 	}
 
-	store := agent.NewStore(identity.AccountID, identity.Region)
+	store := agent.NewStore(staging.AWSScope(identity.AccountID, identity.Region))
 
 	result, err := lifecycle.ExecuteRead0(ctx, store, lifecycle.CmdApply, func() error {
 		// Check if there are any staged changes

--- a/internal/cli/commands/stage/diff/diff.go
+++ b/internal/cli/commands/stage/diff/diff.go
@@ -93,7 +93,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed to get AWS identity: %w", err)
 	}
 
-	store := agent.NewStore(identity.AccountID, identity.Region)
+	store := agent.NewStore(staging.AWSScope(identity.AccountID, identity.Region))
 
 	opts := Options{
 		ParseJSON: cmd.Bool("parse-json"),

--- a/internal/cli/commands/stage/reset/reset.go
+++ b/internal/cli/commands/stage/reset/reset.go
@@ -60,7 +60,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed to get AWS identity: %w", err)
 	}
 
-	store := agent.NewStore(identity.AccountID, identity.Region)
+	store := agent.NewStore(staging.AWSScope(identity.AccountID, identity.Region))
 
 	result, err := lifecycle.ExecuteRead0(ctx, store, lifecycle.CmdReset, func() error {
 		r := &Runner{

--- a/internal/cli/commands/stage/status/status.go
+++ b/internal/cli/commands/stage/status/status.go
@@ -60,7 +60,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed to get AWS identity: %w", err)
 	}
 
-	store := agent.NewStore(identity.AccountID, identity.Region)
+	store := agent.NewStore(staging.AWSScope(identity.AccountID, identity.Region))
 
 	opts := Options{
 		Verbose: cmd.Bool("verbose"),

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -135,7 +135,7 @@ func (a *App) getAgentStore() (store.AgentStore, error) {
 		return nil, err
 	}
 
-	s := agent.NewStore(identity.AccountID, identity.Region)
+	s := agent.NewStore(staging.AWSScope(identity.AccountID, identity.Region))
 	a.stagingStore = s
 
 	return s, nil

--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -701,7 +701,7 @@ func (a *App) StagingFileStatus() (*StagingFileStatusResult, error) {
 		return nil, err
 	}
 
-	fileStore, err := file.NewStore(identity.AccountID, identity.Region)
+	fileStore, err := file.NewStore(staging.AWSScope(identity.AccountID, identity.Region))
 	if err != nil {
 		return nil, err
 	}
@@ -736,7 +736,7 @@ func (a *App) StagingDrain(service string, passphrase string, keep bool, mode st
 		return nil, err
 	}
 
-	fileStore, err := file.NewStoreWithPassphrase(identity.AccountID, identity.Region, passphrase)
+	fileStore, err := file.NewStoreWithPassphrase(staging.AWSScope(identity.AccountID, identity.Region), passphrase)
 	if err != nil {
 		return nil, err
 	}
@@ -789,7 +789,7 @@ func (a *App) StagingPersist(service string, passphrase string, keep bool, mode 
 		return nil, err
 	}
 
-	fileStore, err := file.NewStoreWithPassphrase(identity.AccountID, identity.Region, passphrase)
+	fileStore, err := file.NewStoreWithPassphrase(staging.AWSScope(identity.AccountID, identity.Region), passphrase)
 	if err != nil {
 		return nil, err
 	}
@@ -845,7 +845,7 @@ func (a *App) StagingDrop() (*StagingDropResult, error) {
 		return nil, err
 	}
 
-	fileStore, err := file.NewStore(identity.AccountID, identity.Region)
+	fileStore, err := file.NewStore(staging.AWSScope(identity.AccountID, identity.Region))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/staging/cli/command.go
+++ b/internal/staging/cli/command.go
@@ -68,7 +68,7 @@ EXAMPLES:
 				return fmt.Errorf("failed to get AWS identity: %w", err)
 			}
 
-			store := agent.NewStore(identity.AccountID, identity.Region)
+			store := agent.NewStore(staging.AWSScope(identity.AccountID, identity.Region))
 
 			opts := StatusOptions{
 				Verbose: cmd.Bool("verbose"),
@@ -155,7 +155,7 @@ EXAMPLES:
 				return fmt.Errorf("failed to get AWS identity: %w", err)
 			}
 
-			store := agent.NewStore(identity.AccountID, identity.Region)
+			store := agent.NewStore(staging.AWSScope(identity.AccountID, identity.Region))
 
 			opts := DiffOptions{
 				Name:      name,
@@ -245,7 +245,7 @@ EXAMPLES:
 				return fmt.Errorf("failed to get AWS identity: %w", err)
 			}
 
-			store := agent.NewStore(identity.AccountID, identity.Region)
+			store := agent.NewStore(staging.AWSScope(identity.AccountID, identity.Region))
 
 			strategy, err := cfg.Factory(ctx)
 			if err != nil {
@@ -322,7 +322,7 @@ EXAMPLES:
 				return fmt.Errorf("failed to get AWS identity: %w", err)
 			}
 
-			store := agent.NewStore(identity.AccountID, identity.Region)
+			store := agent.NewStore(staging.AWSScope(identity.AccountID, identity.Region))
 
 			strategy, err := cfg.Factory(ctx)
 			if err != nil {
@@ -398,7 +398,7 @@ EXAMPLES:
 				return fmt.Errorf("failed to get AWS identity: %w", err)
 			}
 
-			store := agent.NewStore(identity.AccountID, identity.Region)
+			store := agent.NewStore(staging.AWSScope(identity.AccountID, identity.Region))
 			parser := cfg.ParserFactory()
 
 			result, err := lifecycle.ExecuteRead0(ctx, store, lifecycle.CmdApply, func() error {
@@ -553,7 +553,7 @@ EXAMPLES:
 				return fmt.Errorf("failed to get AWS identity: %w", err)
 			}
 
-			store := agent.NewStore(identity.AccountID, identity.Region)
+			store := agent.NewStore(staging.AWSScope(identity.AccountID, identity.Region))
 
 			if hasVersion {
 				// Reset with version spec - write operation, auto-start the agent
@@ -689,7 +689,7 @@ EXAMPLES:
 				return fmt.Errorf("failed to get AWS identity: %w", err)
 			}
 
-			store := agent.NewStore(identity.AccountID, identity.Region)
+			store := agent.NewStore(staging.AWSScope(identity.AccountID, identity.Region))
 
 			strategy, err := cfg.Factory(ctx)
 			if err != nil {
@@ -742,7 +742,7 @@ func tagAction(cfg CommandConfig, usageMsg string, runner tagCommandRunner) func
 			return fmt.Errorf("failed to get AWS identity: %w", err)
 		}
 
-		store := agent.NewStore(identity.AccountID, identity.Region)
+		store := agent.NewStore(staging.AWSScope(identity.AccountID, identity.Region))
 
 		strategy, err := cfg.Factory(ctx)
 		if err != nil {

--- a/internal/staging/cli/stash.go
+++ b/internal/staging/cli/stash.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mpyw/suve/internal/cli/passphrase"
 	"github.com/mpyw/suve/internal/cli/terminal"
+	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store/file"
 )
 
@@ -87,8 +88,8 @@ EXAMPLES:
 // fileStoreForReading creates a file store for reading operations.
 // It handles passphrase prompting if the file is encrypted.
 // If checkExists is true, returns an error if the file doesn't exist.
-func fileStoreForReading(cmd *cli.Command, accountID, region string, checkExists bool) (*file.Store, error) {
-	basicFileStore, err := file.NewStore(accountID, region)
+func fileStoreForReading(cmd *cli.Command, scope staging.Scope, checkExists bool) (*file.Store, error) {
+	basicFileStore, err := file.NewStore(scope)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create file store: %w", err)
 	}
@@ -134,5 +135,5 @@ func fileStoreForReading(cmd *cli.Command, accountID, region string, checkExists
 		}
 	}
 
-	return file.NewStoreWithPassphrase(accountID, region, pass)
+	return file.NewStoreWithPassphrase(scope, pass)
 }

--- a/internal/staging/cli/stash_drop.go
+++ b/internal/staging/cli/stash_drop.go
@@ -121,8 +121,10 @@ func globalStashDropAction() func(context.Context, *cli.Command) error {
 			return fmt.Errorf("failed to get AWS identity: %w", err)
 		}
 
+		scope := staging.AWSScope(identity.AccountID, identity.Region)
+
 		return lifecycle.ExecuteFile0(ctx, lifecycle.CmdStashDrop, func() error {
-			fileStore, err := file.NewStore(identity.AccountID, identity.Region)
+			fileStore, err := file.NewStore(scope)
 			if err != nil {
 				return fmt.Errorf("failed to create file store: %w", err)
 			}
@@ -200,9 +202,11 @@ func serviceStashDropAction(service staging.Service) func(context.Context, *cli.
 			return fmt.Errorf("failed to get AWS identity: %w", err)
 		}
 
+		scope := staging.AWSScope(identity.AccountID, identity.Region)
+
 		return lifecycle.ExecuteFile0(ctx, lifecycle.CmdStashDrop, func() error {
 			// Use fileStoreForReading which handles passphrase prompting for encrypted files
-			fileStore, err := fileStoreForReading(cmd, identity.AccountID, identity.Region, true)
+			fileStore, err := fileStoreForReading(cmd, scope, true)
 			if err != nil {
 				return err
 			}

--- a/internal/staging/cli/stash_pop.go
+++ b/internal/staging/cli/stash_pop.go
@@ -178,12 +178,14 @@ func stashPopAction(service staging.Service) func(context.Context, *cli.Command)
 			return fmt.Errorf("failed to get AWS identity: %w", err)
 		}
 
-		fileStore, err := fileStoreForReading(cmd, identity.AccountID, identity.Region, false)
+		scope := staging.AWSScope(identity.AccountID, identity.Region)
+
+		fileStore, err := fileStoreForReading(cmd, scope, false)
 		if err != nil {
 			return err
 		}
 
-		agentStore := agent.NewStore(identity.AccountID, identity.Region)
+		agentStore := agent.NewStore(scope)
 
 		err = lifecycle.ExecuteWrite0(ctx, agentStore, lifecycle.CmdStashPop, func() error {
 			// Check if agent has existing changes

--- a/internal/staging/cli/stash_push.go
+++ b/internal/staging/cli/stash_push.go
@@ -125,11 +125,12 @@ func stashPushAction(service staging.Service) func(context.Context, *cli.Command
 			return fmt.Errorf("failed to get AWS identity: %w", err)
 		}
 
-		agentStore := agent.NewStore(identity.AccountID, identity.Region)
+		scope := staging.AWSScope(identity.AccountID, identity.Region)
+		agentStore := agent.NewStore(scope)
 
 		result, err := lifecycle.ExecuteRead0(ctx, agentStore, lifecycle.CmdStashPush, func() error {
 			// Check if stash file already exists
-			basicFileStore, err := file.NewStore(identity.AccountID, identity.Region)
+			basicFileStore, err := file.NewStore(scope)
 			if err != nil {
 				return fmt.Errorf("failed to create file store: %w", err)
 			}
@@ -227,7 +228,7 @@ func stashPushAction(service staging.Service) func(context.Context, *cli.Command
 				// pass remains empty = plain text
 			}
 
-			fileStore, err := file.NewStoreWithPassphrase(identity.AccountID, identity.Region, pass)
+			fileStore, err := file.NewStoreWithPassphrase(scope, pass)
 			if err != nil {
 				return fmt.Errorf("failed to create file store: %w", err)
 			}

--- a/internal/staging/cli/stash_show.go
+++ b/internal/staging/cli/stash_show.go
@@ -129,8 +129,9 @@ func stashShowAction(service staging.Service) func(context.Context, *cli.Command
 			return fmt.Errorf("failed to get AWS identity: %w", err)
 		}
 
+		scope := staging.AWSScope(identity.AccountID, identity.Region)
 		err = lifecycle.ExecuteFile0(ctx, lifecycle.CmdStashShow, func() error {
-			fileStore, err := fileStoreForReading(cmd, identity.AccountID, identity.Region, true)
+			fileStore, err := fileStoreForReading(cmd, scope, true)
 			if err != nil {
 				return err
 			}

--- a/internal/staging/scope.go
+++ b/internal/staging/scope.go
@@ -1,0 +1,110 @@
+package staging
+
+import "fmt"
+
+// Provider represents a cloud provider.
+type Provider string
+
+const (
+	// ProviderAWS represents Amazon Web Services.
+	ProviderAWS Provider = "aws"
+	// ProviderGoogleCloud represents Google Cloud Platform.
+	ProviderGoogleCloud Provider = "googlecloud"
+	// ProviderAzure represents Microsoft Azure.
+	ProviderAzure Provider = "azure"
+)
+
+// Scope represents the staging scope.
+// Required fields vary by provider:
+//   - AWS: AccountID + Region (shared for param/secret)
+//   - GoogleCloud: ProjectID (secret only)
+//   - Azure: SubscriptionID + ResourceGroup + VaultName or StoreName
+type Scope struct {
+	Provider Provider `json:"provider"`
+
+	// AWS fields
+	AccountID string `json:"accountId,omitempty"`
+	Region    string `json:"region,omitempty"`
+
+	// GoogleCloud fields
+	ProjectID string `json:"projectId,omitempty"`
+
+	// Azure fields
+	SubscriptionID string `json:"subscriptionId,omitempty"`
+	ResourceGroup  string `json:"resourceGroup,omitempty"`
+	VaultName      string `json:"vaultName,omitempty"` // KeyVault (secret)
+	StoreName      string `json:"storeName,omitempty"` // AppConfig (param)
+}
+
+// Key returns a unique key for file paths.
+func (s Scope) Key() string {
+	switch s.Provider {
+	case ProviderAWS:
+		return fmt.Sprintf("aws/%s/%s", s.AccountID, s.Region)
+	case ProviderGoogleCloud:
+		return fmt.Sprintf("googlecloud/%s", s.ProjectID)
+	case ProviderAzure:
+		if s.VaultName != "" {
+			return fmt.Sprintf("azure/%s/%s/keyvault/%s", s.SubscriptionID, s.ResourceGroup, s.VaultName)
+		}
+
+		return fmt.Sprintf("azure/%s/%s/appconfig/%s", s.SubscriptionID, s.ResourceGroup, s.StoreName)
+	default:
+		return ""
+	}
+}
+
+// SupportsService returns true if the scope supports the given service type.
+func (s Scope) SupportsService(svc Service) bool {
+	switch s.Provider {
+	case ProviderAWS:
+		return true // supports both param and secret
+	case ProviderGoogleCloud:
+		return svc == ServiceSecret // Secret Manager only
+	case ProviderAzure:
+		if s.VaultName != "" {
+			return svc == ServiceSecret
+		}
+
+		return svc == ServiceParam
+	default:
+		return false
+	}
+}
+
+// AWSScope creates a Scope for AWS.
+func AWSScope(accountID, region string) Scope {
+	return Scope{
+		Provider:  ProviderAWS,
+		AccountID: accountID,
+		Region:    region,
+	}
+}
+
+// GoogleCloudScope creates a Scope for Google Cloud.
+func GoogleCloudScope(projectID string) Scope {
+	return Scope{
+		Provider:  ProviderGoogleCloud,
+		ProjectID: projectID,
+	}
+}
+
+// AzureKeyVaultScope creates a Scope for Azure Key Vault.
+func AzureKeyVaultScope(subscriptionID, resourceGroup, vaultName string) Scope {
+	return Scope{
+		Provider:       ProviderAzure,
+		SubscriptionID: subscriptionID,
+		ResourceGroup:  resourceGroup,
+		VaultName:      vaultName,
+	}
+}
+
+// AzureAppConfigScope creates a Scope for Azure App Configuration.
+func AzureAppConfigScope(subscriptionID, resourceGroup, storeName string) Scope {
+	return Scope{
+		Provider:       ProviderAzure,
+		SubscriptionID: subscriptionID,
+		ResourceGroup:  resourceGroup,
+		StoreName:      storeName,
+	}
+}

--- a/internal/staging/store/agent/daemon/internal/ipc/client.go
+++ b/internal/staging/store/agent/daemon/internal/ipc/client.go
@@ -23,15 +23,17 @@ const (
 var ErrNotConnected = errors.New("daemon not connected")
 
 // Client provides low-level IPC communication with the daemon.
+// A single client communicates with the scope-independent daemon.
 type Client struct {
 	socketPath string
 	mu         sync.Mutex
 }
 
-// NewClient creates a new IPC client for a specific AWS account and region.
-func NewClient(accountID, region string) *Client {
+// NewClient creates a new IPC client.
+// The client connects to the scope-independent daemon; scope is passed with each request.
+func NewClient() *Client {
 	return &Client{
-		socketPath: protocol.SocketPathForAccount(accountID, region),
+		socketPath: protocol.SocketPath(),
 	}
 }
 

--- a/internal/staging/store/agent/daemon/internal/ipc/client_internal_test.go
+++ b/internal/staging/store/agent/daemon/internal/ipc/client_internal_test.go
@@ -17,17 +17,17 @@ import (
 func TestNewClient(t *testing.T) {
 	t.Parallel()
 
-	c := NewClient(testAccountID, testRegion)
+	c := NewClient()
 	require.NotNil(t, c)
 	assert.NotEmpty(t, c.socketPath)
-	assert.Contains(t, c.socketPath, testAccountID)
-	assert.Contains(t, c.socketPath, testRegion)
+	assert.Contains(t, c.socketPath, "agent.sock")
 }
 
 func TestClient_SendRequest_NotConnected(t *testing.T) {
 	t.Parallel()
 
-	c := NewClient("nonexistent", "nonexistent")
+	// Use a non-existent socket path
+	c := &Client{socketPath: "/nonexistent/path/to/socket.sock"}
 	resp, err := c.SendRequest(t.Context(), &protocol.Request{Method: protocol.MethodPing})
 
 	require.Error(t, err)
@@ -38,7 +38,8 @@ func TestClient_SendRequest_NotConnected(t *testing.T) {
 func TestClient_Ping_NotConnected(t *testing.T) {
 	t.Parallel()
 
-	c := NewClient("nonexistent", "nonexistent")
+	// Use a non-existent socket path
+	c := &Client{socketPath: "/nonexistent/path/to/socket.sock"}
 	err := c.Ping(t.Context())
 
 	require.Error(t, err)

--- a/internal/staging/store/agent/daemon/runner.go
+++ b/internal/staging/store/agent/daemon/runner.go
@@ -22,27 +22,25 @@ func WithAutoShutdownDisabled() RunnerOption {
 }
 
 // Runner represents the staging agent daemon process.
+// A single daemon handles requests for all scopes.
 type Runner struct {
-	accountID            string
-	region               string
 	server               *ipc.Server
 	handler              *server.Handler
 	autoShutdownDisabled bool
 	cancel               context.CancelFunc
 }
 
-// NewRunner creates a new daemon runner for a specific AWS account and region.
-func NewRunner(accountID, region string, opts ...RunnerOption) *Runner {
+// NewRunner creates a new daemon runner.
+// The runner is scope-independent; scope is passed with each request.
+func NewRunner(opts ...RunnerOption) *Runner {
 	r := &Runner{
-		accountID: accountID,
-		region:    region,
-		handler:   server.NewHandler(),
+		handler: server.NewHandler(),
 	}
 	for _, opt := range opts {
 		opt(r)
 	}
 
-	r.server = ipc.NewServer(accountID, region, r.handler.HandleRequest, r.checkAutoShutdown, r.Shutdown)
+	r.server = ipc.NewServer(r.handler.HandleRequest, r.checkAutoShutdown, r.Shutdown)
 
 	return r
 }

--- a/internal/staging/store/agent/daemon/runner_internal_test.go
+++ b/internal/staging/store/agent/daemon/runner_internal_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/mpyw/suve/internal/staging/store/agent/internal/protocol"
 )
 
-const (
-	testRunnerAccountID = "123456789012"
-	testRunnerRegion    = "us-east-1"
-)
+// testScope is used in protocol requests that need a scope.
+//
+//nolint:gochecknoglobals // Test-only constant
+var testScope = staging.AWSScope("123456789012", "us-east-1")
 
 func TestNewRunner(t *testing.T) {
 	t.Parallel()
@@ -25,19 +25,17 @@ func TestNewRunner(t *testing.T) {
 	t.Run("default options", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 		require.NotNil(t, r)
 		assert.NotNil(t, r.server)
 		assert.NotNil(t, r.handler)
-		assert.Equal(t, testRunnerAccountID, r.accountID)
-		assert.Equal(t, testRunnerRegion, r.region)
 		assert.False(t, r.autoShutdownDisabled)
 	})
 
 	t.Run("with auto shutdown disabled", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion, WithAutoShutdownDisabled())
+		r := NewRunner(WithAutoShutdownDisabled())
 		require.NotNil(t, r)
 		assert.True(t, r.autoShutdownDisabled)
 	})
@@ -49,7 +47,7 @@ func TestRunner_Shutdown(t *testing.T) {
 	t.Run("shutdown without running server", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 		// This should not panic
 		r.Shutdown()
 	})
@@ -61,7 +59,7 @@ func TestRunner_checkAutoShutdown(t *testing.T) {
 	t.Run("does not set WillShutdown when auto shutdown disabled", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion, WithAutoShutdownDisabled())
+		r := NewRunner(WithAutoShutdownDisabled())
 
 		req := &protocol.Request{Method: protocol.MethodUnstageAll}
 		resp := &protocol.Response{Success: true}
@@ -74,7 +72,7 @@ func TestRunner_checkAutoShutdown(t *testing.T) {
 	t.Run("does not set WillShutdown on non-unstage methods", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 
 		req := &protocol.Request{Method: protocol.MethodPing}
 		resp := &protocol.Response{Success: true}
@@ -87,7 +85,7 @@ func TestRunner_checkAutoShutdown(t *testing.T) {
 	t.Run("does not set WillShutdown on failed response", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 
 		req := &protocol.Request{Method: protocol.MethodUnstageAll}
 		resp := &protocol.Response{Success: false}
@@ -106,7 +104,7 @@ func TestRunner_checkAutoShutdown_ShutdownReasons(t *testing.T) {
 	t.Run("UnstageEntry with no hint returns empty reason", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 
 		req := &protocol.Request{Method: protocol.MethodUnstageEntry}
 		resp := &protocol.Response{Success: true}
@@ -119,7 +117,7 @@ func TestRunner_checkAutoShutdown_ShutdownReasons(t *testing.T) {
 	t.Run("UnstageEntry with apply hint returns applied reason", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 
 		req := &protocol.Request{Method: protocol.MethodUnstageEntry, Hint: protocol.HintApply}
 		resp := &protocol.Response{Success: true}
@@ -132,7 +130,7 @@ func TestRunner_checkAutoShutdown_ShutdownReasons(t *testing.T) {
 	t.Run("UnstageEntry with reset hint returns unstaged reason", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 
 		req := &protocol.Request{Method: protocol.MethodUnstageEntry, Hint: protocol.HintReset}
 		resp := &protocol.Response{Success: true}
@@ -145,7 +143,7 @@ func TestRunner_checkAutoShutdown_ShutdownReasons(t *testing.T) {
 	t.Run("UnstageEntry with persist hint returns persisted reason", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 
 		req := &protocol.Request{Method: protocol.MethodUnstageEntry, Hint: protocol.HintPersist}
 		resp := &protocol.Response{Success: true}
@@ -159,7 +157,7 @@ func TestRunner_checkAutoShutdown_ShutdownReasons(t *testing.T) {
 	t.Run("UnstageTag with no hint returns empty reason", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 
 		req := &protocol.Request{Method: protocol.MethodUnstageTag}
 		resp := &protocol.Response{Success: true}
@@ -172,7 +170,7 @@ func TestRunner_checkAutoShutdown_ShutdownReasons(t *testing.T) {
 	t.Run("UnstageTag with apply hint returns applied reason", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 
 		req := &protocol.Request{Method: protocol.MethodUnstageTag, Hint: protocol.HintApply}
 		resp := &protocol.Response{Success: true}
@@ -185,7 +183,7 @@ func TestRunner_checkAutoShutdown_ShutdownReasons(t *testing.T) {
 	t.Run("UnstageTag with reset hint returns unstaged reason", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 
 		req := &protocol.Request{Method: protocol.MethodUnstageTag, Hint: protocol.HintReset}
 		resp := &protocol.Response{Success: true}
@@ -198,7 +196,7 @@ func TestRunner_checkAutoShutdown_ShutdownReasons(t *testing.T) {
 	t.Run("UnstageTag with persist hint returns persisted reason", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 
 		req := &protocol.Request{Method: protocol.MethodUnstageTag, Hint: protocol.HintPersist}
 		resp := &protocol.Response{Success: true}
@@ -212,7 +210,7 @@ func TestRunner_checkAutoShutdown_ShutdownReasons(t *testing.T) {
 	t.Run("UnstageAll with no hint returns unstaged reason", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 
 		req := &protocol.Request{Method: protocol.MethodUnstageAll}
 		resp := &protocol.Response{Success: true}
@@ -225,7 +223,7 @@ func TestRunner_checkAutoShutdown_ShutdownReasons(t *testing.T) {
 	t.Run("UnstageAll with apply hint returns applied reason", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 
 		req := &protocol.Request{Method: protocol.MethodUnstageAll, Hint: protocol.HintApply}
 		resp := &protocol.Response{Success: true}
@@ -238,7 +236,7 @@ func TestRunner_checkAutoShutdown_ShutdownReasons(t *testing.T) {
 	t.Run("UnstageAll with reset hint returns unstaged reason", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 
 		req := &protocol.Request{Method: protocol.MethodUnstageAll, Hint: protocol.HintReset}
 		resp := &protocol.Response{Success: true}
@@ -251,7 +249,7 @@ func TestRunner_checkAutoShutdown_ShutdownReasons(t *testing.T) {
 	t.Run("UnstageAll with persist hint returns persisted reason", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 
 		req := &protocol.Request{Method: protocol.MethodUnstageAll, Hint: protocol.HintPersist}
 		resp := &protocol.Response{Success: true}
@@ -265,7 +263,7 @@ func TestRunner_checkAutoShutdown_ShutdownReasons(t *testing.T) {
 	t.Run("SetState returns cleared reason", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 
 		req := &protocol.Request{Method: protocol.MethodSetState}
 		resp := &protocol.Response{Success: true}
@@ -284,15 +282,14 @@ func TestRunner_checkAutoShutdown_NonEmptyState(t *testing.T) {
 	t.Run("UnstageEntry does not shutdown when state not empty", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 
 		// Stage an entry to make state non-empty
 		stageReq := protocol.Request{
-			Method:    protocol.MethodStageEntry,
-			AccountID: testRunnerAccountID,
-			Region:    testRunnerRegion,
-			Service:   staging.ServiceParam,
-			Name:      "/test/param",
+			Method:  protocol.MethodStageEntry,
+			Scope:   testScope,
+			Service: staging.ServiceParam,
+			Name:    "/test/param",
 			Entry: &staging.Entry{
 				Value:     lo.ToPtr("value"),
 				Operation: staging.OperationCreate,
@@ -303,11 +300,10 @@ func TestRunner_checkAutoShutdown_NonEmptyState(t *testing.T) {
 
 		// Stage another entry
 		stageReq2 := protocol.Request{
-			Method:    protocol.MethodStageEntry,
-			AccountID: testRunnerAccountID,
-			Region:    testRunnerRegion,
-			Service:   staging.ServiceParam,
-			Name:      "/test/param2",
+			Method:  protocol.MethodStageEntry,
+			Scope:   testScope,
+			Service: staging.ServiceParam,
+			Name:    "/test/param2",
 			Entry: &staging.Entry{
 				Value:     lo.ToPtr("value2"),
 				Operation: staging.OperationCreate,
@@ -318,11 +314,10 @@ func TestRunner_checkAutoShutdown_NonEmptyState(t *testing.T) {
 
 		// Unstage one entry - state should not be empty
 		unstageReq := protocol.Request{
-			Method:    protocol.MethodUnstageEntry,
-			AccountID: testRunnerAccountID,
-			Region:    testRunnerRegion,
-			Service:   staging.ServiceParam,
-			Name:      "/test/param",
+			Method:  protocol.MethodUnstageEntry,
+			Scope:   testScope,
+			Service: staging.ServiceParam,
+			Name:    "/test/param",
 		}
 		resp = r.handler.HandleRequest(&unstageReq)
 		require.True(t, resp.Success)
@@ -336,15 +331,14 @@ func TestRunner_checkAutoShutdown_NonEmptyState(t *testing.T) {
 	t.Run("UnstageTag does not shutdown when state not empty", func(t *testing.T) {
 		t.Parallel()
 
-		r := NewRunner(testRunnerAccountID, testRunnerRegion)
+		r := NewRunner()
 
 		// Stage an entry
 		stageReq := protocol.Request{
-			Method:    protocol.MethodStageEntry,
-			AccountID: testRunnerAccountID,
-			Region:    testRunnerRegion,
-			Service:   staging.ServiceParam,
-			Name:      "/test/param",
+			Method:  protocol.MethodStageEntry,
+			Scope:   testScope,
+			Service: staging.ServiceParam,
+			Name:    "/test/param",
 			Entry: &staging.Entry{
 				Value:     lo.ToPtr("value"),
 				Operation: staging.OperationCreate,
@@ -355,11 +349,10 @@ func TestRunner_checkAutoShutdown_NonEmptyState(t *testing.T) {
 
 		// UnstageTag should not trigger shutdown since there's still an entry
 		unstageReq := protocol.Request{
-			Method:    protocol.MethodUnstageTag,
-			AccountID: testRunnerAccountID,
-			Region:    testRunnerRegion,
-			Service:   staging.ServiceParam,
-			Name:      "/test/another",
+			Method:  protocol.MethodUnstageTag,
+			Scope:   testScope,
+			Service: staging.ServiceParam,
+			Name:    "/test/another",
 		}
 		checkResp := &protocol.Response{Success: true}
 		r.checkAutoShutdown(&unstageReq, checkResp)
@@ -377,10 +370,7 @@ func TestRunner_Run_ContextCancellation(t *testing.T) {
 	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
 	t.Setenv("TMPDIR", tmpDir)
 
-	accountID := "c1"
-	region := "r1"
-
-	runner := NewRunner(accountID, region, WithAutoShutdownDisabled())
+	runner := NewRunner(WithAutoShutdownDisabled())
 
 	// Create a cancellable context
 	ctx, cancel := context.WithCancel(t.Context())
@@ -392,7 +382,7 @@ func TestRunner_Run_ContextCancellation(t *testing.T) {
 	}()
 
 	// Wait for daemon to be ready
-	launcher := NewLauncher(accountID, region, WithAutoStartDisabled())
+	launcher := NewLauncher(WithAutoStartDisabled())
 
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
@@ -421,9 +411,7 @@ func TestRunner_Run_ContextCancellation(t *testing.T) {
 func TestRunner_MultipleOptions(t *testing.T) {
 	t.Parallel()
 
-	r := NewRunner(testRunnerAccountID, testRunnerRegion,
-		WithAutoShutdownDisabled(),
-	)
+	r := NewRunner(WithAutoShutdownDisabled())
 	require.NotNil(t, r)
 	assert.True(t, r.autoShutdownDisabled)
 }
@@ -450,7 +438,7 @@ func TestRunner_checkAutoShutdown_AllMethods(t *testing.T) {
 		t.Run(method, func(t *testing.T) {
 			t.Parallel()
 
-			r := NewRunner(testRunnerAccountID, testRunnerRegion)
+			r := NewRunner()
 
 			req := &protocol.Request{Method: method}
 			resp := &protocol.Response{Success: true}
@@ -469,10 +457,7 @@ func TestRunner_Run_StartError(t *testing.T) {
 	// /proc/1/root is typically not writable on Linux
 	t.Setenv("TMPDIR", "/proc/1/root/nonexistent")
 
-	accountID := "run-start-err"
-	region := "r1"
-
-	runner := NewRunner(accountID, region)
+	runner := NewRunner()
 
 	// Use a short timeout context in case the server unexpectedly starts
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)

--- a/internal/staging/store/agent/internal/protocol/protocol.go
+++ b/internal/staging/store/agent/internal/protocol/protocol.go
@@ -47,15 +47,14 @@ const (
 //
 //nolint:tagliatelle // JSON field names use snake_case for consistency with IPC protocol
 type Request struct {
-	Method    string            `json:"method"`
-	AccountID string            `json:"account_id"`
-	Region    string            `json:"region"`
-	Service   staging.Service   `json:"service,omitempty"`
-	Name      string            `json:"name,omitempty"`
-	Entry     *staging.Entry    `json:"entry,omitempty"`
-	TagEntry  *staging.TagEntry `json:"tag_entry,omitempty"`
-	State     *staging.State    `json:"state,omitempty"`
-	Hint      string            `json:"hint,omitempty"` // Optional context hint for shutdown messages (HintApply, HintReset, HintPersist)
+	Method   string            `json:"method"`
+	Scope    staging.Scope     `json:"scope"`
+	Service  staging.Service   `json:"service,omitempty"`
+	Name     string            `json:"name,omitempty"`
+	Entry    *staging.Entry    `json:"entry,omitempty"`
+	TagEntry *staging.TagEntry `json:"tag_entry,omitempty"`
+	State    *staging.State    `json:"state,omitempty"`
+	Hint     string            `json:"hint,omitempty"` // Optional context hint for shutdown messages (HintApply, HintReset, HintPersist)
 }
 
 // Response represents a JSON-RPC response from the daemon.

--- a/internal/staging/store/agent/internal/protocol/protocol_test.go
+++ b/internal/staging/store/agent/internal/protocol/protocol_test.go
@@ -46,45 +46,22 @@ func TestResponse_Err(t *testing.T) {
 	})
 }
 
-func TestSocketPathForAccount(t *testing.T) {
+func TestSocketPath(t *testing.T) {
 	t.Parallel()
 
-	const (
-		testAccountID = "123456789012"
-		testRegion    = "us-east-1"
-	)
-
-	t.Run("returns valid path with account and region", func(t *testing.T) {
+	t.Run("returns valid path", func(t *testing.T) {
 		t.Parallel()
 
-		path := protocol.SocketPathForAccount(testAccountID, testRegion)
+		path := protocol.SocketPath()
 		assert.NotEmpty(t, path)
-		assert.Contains(t, path, testAccountID)
-		assert.Contains(t, path, testRegion)
 		assert.Contains(t, path, "agent.sock")
-	})
-
-	t.Run("different accounts have different paths", func(t *testing.T) {
-		t.Parallel()
-
-		path1 := protocol.SocketPathForAccount("111111111111", "us-east-1")
-		path2 := protocol.SocketPathForAccount("222222222222", "us-east-1")
-		assert.NotEqual(t, path1, path2)
-	})
-
-	t.Run("different regions have different paths", func(t *testing.T) {
-		t.Parallel()
-
-		path1 := protocol.SocketPathForAccount(testAccountID, "us-east-1")
-		path2 := protocol.SocketPathForAccount(testAccountID, "us-west-2")
-		assert.NotEqual(t, path1, path2)
 	})
 
 	//nolint:paralleltest // Reads TMPDIR environment variable which should not be modified by parallel tests
 	t.Run("uses TMPDIR on darwin when set", func(t *testing.T) {
 		// This test only runs on darwin - on other platforms TMPDIR may not be used
 		if tmpdir := os.Getenv("TMPDIR"); tmpdir != "" {
-			path := protocol.SocketPathForAccount(testAccountID, testRegion)
+			path := protocol.SocketPath()
 			// On darwin with TMPDIR set, the path should contain the TMPDIR
 			assert.True(t, strings.HasPrefix(path, tmpdir) || strings.Contains(path, "suve"))
 		}

--- a/internal/staging/store/agent/internal/protocol/socket.go
+++ b/internal/staging/store/agent/internal/protocol/socket.go
@@ -7,8 +7,8 @@ const (
 	socketFileName = "agent.sock"
 )
 
-// SocketPathForAccount returns the socket path for a specific AWS account and region.
-// This ensures each account/region combination has its own daemon instance.
-func SocketPathForAccount(accountID, region string) string {
-	return socketPathForAccount(accountID, region)
+// SocketPath returns the socket path for the agent daemon.
+// A single daemon handles all scopes, so the path is scope-independent.
+func SocketPath() string {
+	return socketPath()
 }

--- a/internal/staging/store/agent/internal/protocol/socket_darwin.go
+++ b/internal/staging/store/agent/internal/protocol/socket_darwin.go
@@ -7,11 +7,11 @@ import (
 	"path/filepath"
 )
 
-// socketPathForAccount returns the path for the daemon socket on macOS for a specific account/region.
-func socketPathForAccount(accountID, region string) string {
+// socketPath returns the path for the daemon socket on macOS.
+func socketPath() string {
 	if tmpdir := os.Getenv("TMPDIR"); tmpdir != "" {
-		return filepath.Join(tmpdir, socketDirName, accountID, region, socketFileName)
+		return filepath.Join(tmpdir, socketDirName, socketFileName)
 	}
 
-	return socketPathFallback(accountID, region)
+	return socketPathFallback()
 }

--- a/internal/staging/store/agent/internal/protocol/socket_linux.go
+++ b/internal/staging/store/agent/internal/protocol/socket_linux.go
@@ -7,11 +7,11 @@ import (
 	"path/filepath"
 )
 
-// socketPathForAccount returns the path for the daemon socket on Linux for a specific account/region.
-func socketPathForAccount(accountID, region string) string {
+// socketPath returns the path for the daemon socket on Linux.
+func socketPath() string {
 	if xdgRuntime := os.Getenv("XDG_RUNTIME_DIR"); xdgRuntime != "" {
-		return filepath.Join(xdgRuntime, socketDirName, accountID, region, socketFileName)
+		return filepath.Join(xdgRuntime, socketDirName, socketFileName)
 	}
 
-	return socketPathFallback(accountID, region)
+	return socketPathFallback()
 }

--- a/internal/staging/store/agent/internal/protocol/socket_other.go
+++ b/internal/staging/store/agent/internal/protocol/socket_other.go
@@ -2,7 +2,7 @@
 
 package protocol
 
-// socketPathForAccount returns the path for the daemon socket for a specific account/region.
-func socketPathForAccount(accountID, region string) string {
-	return socketPathFallback(accountID, region)
+// socketPath returns the path for the daemon socket.
+func socketPath() string {
+	return socketPathFallback()
 }

--- a/internal/staging/store/agent/internal/protocol/socket_unix.go
+++ b/internal/staging/store/agent/internal/protocol/socket_unix.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 )
 
-// socketPathFallback returns the fallback socket path for a specific account/region.
+// socketPathFallback returns the fallback socket path.
 // Used by darwin, linux, and other Unix-like platforms when preferred paths are unavailable.
-func socketPathFallback(accountID, region string) string {
-	return filepath.Join(fmt.Sprintf("/tmp/%s-%d", socketDirName, os.Getuid()), accountID, region, socketFileName)
+func socketPathFallback() string {
+	return filepath.Join(fmt.Sprintf("/tmp/%s-%d", socketDirName, os.Getuid()), socketFileName)
 }

--- a/internal/staging/store/agent/internal/protocol/socket_windows.go
+++ b/internal/staging/store/agent/internal/protocol/socket_windows.go
@@ -7,17 +7,17 @@ import (
 	"path/filepath"
 )
 
-// socketPathForAccount returns the path for the daemon socket on Windows for a specific account/region.
-func socketPathForAccount(accountID, region string) string {
+// socketPath returns the path for the daemon socket on Windows.
+func socketPath() string {
 	if localAppData := os.Getenv("LOCALAPPDATA"); localAppData != "" {
-		return filepath.Join(localAppData, socketDirName, accountID, region, socketFileName)
+		return filepath.Join(localAppData, socketDirName, socketFileName)
 	}
 
 	// Fallback to user's home directory
 	if home, err := os.UserHomeDir(); err == nil {
-		return filepath.Join(home, "."+socketDirName, accountID, region, socketFileName)
+		return filepath.Join(home, "."+socketDirName, socketFileName)
 	}
 
 	// Last resort: use temp directory
-	return filepath.Join(os.TempDir(), socketDirName, accountID, region, socketFileName)
+	return filepath.Join(os.TempDir(), socketDirName, socketFileName)
 }

--- a/internal/staging/store/agent/internal/server/handler.go
+++ b/internal/staging/store/agent/internal/server/handler.go
@@ -101,7 +101,7 @@ func (h *Handler) handlePing() *protocol.Response {
 
 // handleGetEntry handles the GetEntry method.
 func (h *Handler) handleGetEntry(req *protocol.Request) *protocol.Response {
-	state, err := h.state.get(req.AccountID, req.Region)
+	state, err := h.state.get(req.Scope)
 	if err != nil {
 		return errorResponse(err)
 	}
@@ -119,7 +119,7 @@ func (h *Handler) handleGetEntry(req *protocol.Request) *protocol.Response {
 
 // handleGetTag handles the GetTag method.
 func (h *Handler) handleGetTag(req *protocol.Request) *protocol.Response {
-	state, err := h.state.get(req.AccountID, req.Region)
+	state, err := h.state.get(req.Scope)
 	if err != nil {
 		return errorResponse(err)
 	}
@@ -137,7 +137,7 @@ func (h *Handler) handleGetTag(req *protocol.Request) *protocol.Response {
 
 // handleListEntries handles the ListEntries method.
 func (h *Handler) handleListEntries(req *protocol.Request) *protocol.Response {
-	state, err := h.state.get(req.AccountID, req.Region)
+	state, err := h.state.get(req.Scope)
 	if err != nil {
 		return errorResponse(err)
 	}
@@ -157,7 +157,7 @@ func (h *Handler) handleListEntries(req *protocol.Request) *protocol.Response {
 
 // handleListTags handles the ListTags method.
 func (h *Handler) handleListTags(req *protocol.Request) *protocol.Response {
-	state, err := h.state.get(req.AccountID, req.Region)
+	state, err := h.state.get(req.Scope)
 	if err != nil {
 		return errorResponse(err)
 	}
@@ -182,7 +182,7 @@ func (h *Handler) handleLoad(req *protocol.Request) *protocol.Response {
 
 // handleStageEntry handles the StageEntry method.
 func (h *Handler) handleStageEntry(req *protocol.Request) *protocol.Response {
-	state, err := h.state.get(req.AccountID, req.Region)
+	state, err := h.state.get(req.Scope)
 	if err != nil {
 		return errorResponse(err)
 	}
@@ -193,7 +193,7 @@ func (h *Handler) handleStageEntry(req *protocol.Request) *protocol.Response {
 
 	state.Entries[req.Service][req.Name] = *req.Entry
 
-	if err := h.state.set(req.AccountID, req.Region, state); err != nil {
+	if err := h.state.set(req.Scope, state); err != nil {
 		return errorResponse(err)
 	}
 
@@ -202,7 +202,7 @@ func (h *Handler) handleStageEntry(req *protocol.Request) *protocol.Response {
 
 // handleStageTag handles the StageTag method.
 func (h *Handler) handleStageTag(req *protocol.Request) *protocol.Response {
-	state, err := h.state.get(req.AccountID, req.Region)
+	state, err := h.state.get(req.Scope)
 	if err != nil {
 		return errorResponse(err)
 	}
@@ -213,7 +213,7 @@ func (h *Handler) handleStageTag(req *protocol.Request) *protocol.Response {
 
 	state.Tags[req.Service][req.Name] = *req.TagEntry
 
-	if err := h.state.set(req.AccountID, req.Region, state); err != nil {
+	if err := h.state.set(req.Scope, state); err != nil {
 		return errorResponse(err)
 	}
 
@@ -222,7 +222,7 @@ func (h *Handler) handleStageTag(req *protocol.Request) *protocol.Response {
 
 // handleUnstageEntry handles the UnstageEntry method.
 func (h *Handler) handleUnstageEntry(req *protocol.Request) *protocol.Response {
-	state, err := h.state.get(req.AccountID, req.Region)
+	state, err := h.state.get(req.Scope)
 	if err != nil {
 		return errorResponse(err)
 	}
@@ -231,7 +231,7 @@ func (h *Handler) handleUnstageEntry(req *protocol.Request) *protocol.Response {
 		if _, ok := entries[req.Name]; ok {
 			delete(entries, req.Name)
 
-			if err := h.state.set(req.AccountID, req.Region, state); err != nil {
+			if err := h.state.set(req.Scope, state); err != nil {
 				return errorResponse(err)
 			}
 
@@ -244,7 +244,7 @@ func (h *Handler) handleUnstageEntry(req *protocol.Request) *protocol.Response {
 
 // handleUnstageTag handles the UnstageTag method.
 func (h *Handler) handleUnstageTag(req *protocol.Request) *protocol.Response {
-	state, err := h.state.get(req.AccountID, req.Region)
+	state, err := h.state.get(req.Scope)
 	if err != nil {
 		return errorResponse(err)
 	}
@@ -253,7 +253,7 @@ func (h *Handler) handleUnstageTag(req *protocol.Request) *protocol.Response {
 		if _, ok := tags[req.Name]; ok {
 			delete(tags, req.Name)
 
-			if err := h.state.set(req.AccountID, req.Region, state); err != nil {
+			if err := h.state.set(req.Scope, state); err != nil {
 				return errorResponse(err)
 			}
 
@@ -266,7 +266,7 @@ func (h *Handler) handleUnstageTag(req *protocol.Request) *protocol.Response {
 
 // handleUnstageAll handles the UnstageAll method.
 func (h *Handler) handleUnstageAll(req *protocol.Request) *protocol.Response {
-	state, err := h.state.get(req.AccountID, req.Region)
+	state, err := h.state.get(req.Scope)
 	if err != nil {
 		return errorResponse(err)
 	}
@@ -287,7 +287,7 @@ func (h *Handler) handleUnstageAll(req *protocol.Request) *protocol.Response {
 		state.Tags[req.Service] = make(map[string]staging.TagEntry)
 	}
 
-	if err := h.state.set(req.AccountID, req.Region, state); err != nil {
+	if err := h.state.set(req.Scope, state); err != nil {
 		return errorResponse(err)
 	}
 
@@ -296,7 +296,7 @@ func (h *Handler) handleUnstageAll(req *protocol.Request) *protocol.Response {
 
 // handleGetState handles the GetState method (for persist).
 func (h *Handler) handleGetState(req *protocol.Request) *protocol.Response {
-	state, err := h.state.get(req.AccountID, req.Region)
+	state, err := h.state.get(req.Scope)
 	if err != nil {
 		return errorResponse(err)
 	}
@@ -310,7 +310,7 @@ func (h *Handler) handleSetState(req *protocol.Request) *protocol.Response {
 		return errorMessageResponse("state is required")
 	}
 
-	if err := h.state.set(req.AccountID, req.Region, req.State); err != nil {
+	if err := h.state.set(req.Scope, req.State); err != nil {
 		return errorResponse(err)
 	}
 

--- a/internal/staging/store/agent/internal/server/handler_test.go
+++ b/internal/staging/store/agent/internal/server/handler_test.go
@@ -63,22 +63,20 @@ func TestHandler_HandleRequest(t *testing.T) {
 
 		// Stage entry
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageEntry,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
-			Entry:     &entry,
+			Method:  protocol.MethodStageEntry,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config",
+			Entry:   &entry,
 		})
 		assert.True(t, resp.Success)
 
 		// Get entry
 		resp = h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodGetEntry,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
+			Method:  protocol.MethodGetEntry,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config",
 		})
 		assert.True(t, resp.Success)
 
@@ -97,11 +95,10 @@ func TestHandler_HandleRequest(t *testing.T) {
 		defer h.Destroy()
 
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodGetEntry,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/nonexistent",
+			Method:  protocol.MethodGetEntry,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/nonexistent",
 		})
 		assert.True(t, resp.Success)
 
@@ -125,22 +122,20 @@ func TestHandler_HandleRequest(t *testing.T) {
 
 		// Stage tag
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageTag,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
-			TagEntry:  &tagEntry,
+			Method:   protocol.MethodStageTag,
+			Scope:    staging.AWSScope("123456789012", "us-east-1"),
+			Service:  staging.ServiceParam,
+			Name:     "/app/config",
+			TagEntry: &tagEntry,
 		})
 		assert.True(t, resp.Success)
 
 		// Get tag
 		resp = h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodGetTag,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
+			Method:  protocol.MethodGetTag,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config",
 		})
 		assert.True(t, resp.Success)
 
@@ -159,11 +154,10 @@ func TestHandler_HandleRequest(t *testing.T) {
 		defer h.Destroy()
 
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodGetTag,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/nonexistent",
+			Method:  protocol.MethodGetTag,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/nonexistent",
 		})
 		assert.True(t, resp.Success)
 
@@ -182,27 +176,24 @@ func TestHandler_HandleRequest(t *testing.T) {
 
 		// Stage entries
 		h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageEntry,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config1",
-			Entry:     &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value1"), StagedAt: time.Now()},
+			Method:  protocol.MethodStageEntry,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config1",
+			Entry:   &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value1"), StagedAt: time.Now()},
 		})
 		h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageEntry,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config2",
-			Entry:     &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value2"), StagedAt: time.Now()},
+			Method:  protocol.MethodStageEntry,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config2",
+			Entry:   &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value2"), StagedAt: time.Now()},
 		})
 
 		// List all entries
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodListEntries,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
+			Method: protocol.MethodListEntries,
+			Scope:  staging.AWSScope("123456789012", "us-east-1"),
 		})
 		assert.True(t, resp.Success)
 
@@ -221,28 +212,25 @@ func TestHandler_HandleRequest(t *testing.T) {
 
 		// Stage entries in different services
 		h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageEntry,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
-			Entry:     &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("param-value"), StagedAt: time.Now()},
+			Method:  protocol.MethodStageEntry,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config",
+			Entry:   &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("param-value"), StagedAt: time.Now()},
 		})
 		h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageEntry,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceSecret,
-			Name:      "my-secret",
-			Entry:     &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("secret-value"), StagedAt: time.Now()},
+			Method:  protocol.MethodStageEntry,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceSecret,
+			Name:    "my-secret",
+			Entry:   &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("secret-value"), StagedAt: time.Now()},
 		})
 
 		// List param entries only
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodListEntries,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
+			Method:  protocol.MethodListEntries,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
 		})
 		assert.True(t, resp.Success)
 
@@ -262,19 +250,17 @@ func TestHandler_HandleRequest(t *testing.T) {
 
 		// Stage tags
 		h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageTag,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
-			TagEntry:  &staging.TagEntry{Add: map[string]string{"env": "prod"}, StagedAt: time.Now()},
+			Method:   protocol.MethodStageTag,
+			Scope:    staging.AWSScope("123456789012", "us-east-1"),
+			Service:  staging.ServiceParam,
+			Name:     "/app/config",
+			TagEntry: &staging.TagEntry{Add: map[string]string{"env": "prod"}, StagedAt: time.Now()},
 		})
 
 		// List tags
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodListTags,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
+			Method: protocol.MethodListTags,
+			Scope:  staging.AWSScope("123456789012", "us-east-1"),
 		})
 		assert.True(t, resp.Success)
 
@@ -293,28 +279,25 @@ func TestHandler_HandleRequest(t *testing.T) {
 
 		// Stage tags in different services
 		h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageTag,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
-			TagEntry:  &staging.TagEntry{Add: map[string]string{"env": "prod"}, StagedAt: time.Now()},
+			Method:   protocol.MethodStageTag,
+			Scope:    staging.AWSScope("123456789012", "us-east-1"),
+			Service:  staging.ServiceParam,
+			Name:     "/app/config",
+			TagEntry: &staging.TagEntry{Add: map[string]string{"env": "prod"}, StagedAt: time.Now()},
 		})
 		h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageTag,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceSecret,
-			Name:      "my-secret",
-			TagEntry:  &staging.TagEntry{Add: map[string]string{"team": "backend"}, StagedAt: time.Now()},
+			Method:   protocol.MethodStageTag,
+			Scope:    staging.AWSScope("123456789012", "us-east-1"),
+			Service:  staging.ServiceSecret,
+			Name:     "my-secret",
+			TagEntry: &staging.TagEntry{Add: map[string]string{"team": "backend"}, StagedAt: time.Now()},
 		})
 
 		// List secret tags only
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodListTags,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceSecret,
+			Method:  protocol.MethodListTags,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceSecret,
 		})
 		assert.True(t, resp.Success)
 
@@ -334,31 +317,28 @@ func TestHandler_HandleRequest(t *testing.T) {
 
 		// Stage entry
 		h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageEntry,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
-			Entry:     &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value"), StagedAt: time.Now()},
+			Method:  protocol.MethodStageEntry,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config",
+			Entry:   &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value"), StagedAt: time.Now()},
 		})
 
 		// Unstage entry
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodUnstageEntry,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
+			Method:  protocol.MethodUnstageEntry,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config",
 		})
 		assert.True(t, resp.Success)
 
 		// Verify entry is gone
 		resp = h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodGetEntry,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
+			Method:  protocol.MethodGetEntry,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config",
 		})
 
 		var result protocol.EntryResponse
@@ -374,11 +354,10 @@ func TestHandler_HandleRequest(t *testing.T) {
 		defer h.Destroy()
 
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodUnstageEntry,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/nonexistent",
+			Method:  protocol.MethodUnstageEntry,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/nonexistent",
 		})
 		assert.False(t, resp.Success)
 		assert.Equal(t, staging.ErrNotStaged.Error(), resp.Error)
@@ -392,31 +371,28 @@ func TestHandler_HandleRequest(t *testing.T) {
 
 		// Stage tag
 		h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageTag,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
-			TagEntry:  &staging.TagEntry{Add: map[string]string{"env": "prod"}, StagedAt: time.Now()},
+			Method:   protocol.MethodStageTag,
+			Scope:    staging.AWSScope("123456789012", "us-east-1"),
+			Service:  staging.ServiceParam,
+			Name:     "/app/config",
+			TagEntry: &staging.TagEntry{Add: map[string]string{"env": "prod"}, StagedAt: time.Now()},
 		})
 
 		// Unstage tag
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodUnstageTag,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
+			Method:  protocol.MethodUnstageTag,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config",
 		})
 		assert.True(t, resp.Success)
 
 		// Verify tag is gone
 		resp = h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodGetTag,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
+			Method:  protocol.MethodGetTag,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config",
 		})
 
 		var result protocol.TagResponse
@@ -432,11 +408,10 @@ func TestHandler_HandleRequest(t *testing.T) {
 		defer h.Destroy()
 
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodUnstageTag,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/nonexistent",
+			Method:  protocol.MethodUnstageTag,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/nonexistent",
 		})
 		assert.False(t, resp.Success)
 		assert.Equal(t, staging.ErrNotStaged.Error(), resp.Error)
@@ -450,36 +425,32 @@ func TestHandler_HandleRequest(t *testing.T) {
 
 		// Stage entries in both services
 		h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageEntry,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
-			Entry:     &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value"), StagedAt: time.Now()},
+			Method:  protocol.MethodStageEntry,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config",
+			Entry:   &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value"), StagedAt: time.Now()},
 		})
 		h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageEntry,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceSecret,
-			Name:      "my-secret",
-			Entry:     &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value"), StagedAt: time.Now()},
+			Method:  protocol.MethodStageEntry,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceSecret,
+			Name:    "my-secret",
+			Entry:   &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value"), StagedAt: time.Now()},
 		})
 
 		// Unstage all
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodUnstageAll,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   "",
+			Method:  protocol.MethodUnstageAll,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: "",
 		})
 		assert.True(t, resp.Success)
 
 		// Verify all entries are gone
 		resp = h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodListEntries,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
+			Method: protocol.MethodListEntries,
+			Scope:  staging.AWSScope("123456789012", "us-east-1"),
 		})
 
 		var result protocol.ListEntriesResponse
@@ -497,36 +468,32 @@ func TestHandler_HandleRequest(t *testing.T) {
 
 		// Stage entries in both services
 		h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageEntry,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
-			Entry:     &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value"), StagedAt: time.Now()},
+			Method:  protocol.MethodStageEntry,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config",
+			Entry:   &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value"), StagedAt: time.Now()},
 		})
 		h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageEntry,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceSecret,
-			Name:      "my-secret",
-			Entry:     &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value"), StagedAt: time.Now()},
+			Method:  protocol.MethodStageEntry,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceSecret,
+			Name:    "my-secret",
+			Entry:   &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value"), StagedAt: time.Now()},
 		})
 
 		// Unstage only param service
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodUnstageAll,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
+			Method:  protocol.MethodUnstageAll,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
 		})
 		assert.True(t, resp.Success)
 
 		// Verify param is empty but secret still exists
 		resp = h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodListEntries,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
+			Method: protocol.MethodListEntries,
+			Scope:  staging.AWSScope("123456789012", "us-east-1"),
 		})
 
 		var result protocol.ListEntriesResponse
@@ -551,18 +518,16 @@ func TestHandler_HandleRequest(t *testing.T) {
 
 		// Set state
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodSetState,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			State:     state,
+			Method: protocol.MethodSetState,
+			Scope:  staging.AWSScope("123456789012", "us-east-1"),
+			State:  state,
 		})
 		assert.True(t, resp.Success)
 
 		// Get state
 		resp = h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodGetState,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
+			Method: protocol.MethodGetState,
+			Scope:  staging.AWSScope("123456789012", "us-east-1"),
 		})
 		assert.True(t, resp.Success)
 
@@ -581,10 +546,9 @@ func TestHandler_HandleRequest(t *testing.T) {
 		defer h.Destroy()
 
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodSetState,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			State:     nil,
+			Method: protocol.MethodSetState,
+			Scope:  staging.AWSScope("123456789012", "us-east-1"),
+			State:  nil,
 		})
 		assert.False(t, resp.Success)
 		assert.Contains(t, resp.Error, "state is required")
@@ -598,19 +562,17 @@ func TestHandler_HandleRequest(t *testing.T) {
 
 		// Stage an entry
 		h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageEntry,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
-			Entry:     &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value"), StagedAt: time.Now()},
+			Method:  protocol.MethodStageEntry,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config",
+			Entry:   &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value"), StagedAt: time.Now()},
 		})
 
 		// Load
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodLoad,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
+			Method: protocol.MethodLoad,
+			Scope:  staging.AWSScope("123456789012", "us-east-1"),
 		})
 		assert.True(t, resp.Success)
 
@@ -648,12 +610,11 @@ func TestHandler_HandleRequest(t *testing.T) {
 
 		// Stage an entry
 		h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageEntry,
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
-			Entry:     &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value"), StagedAt: time.Now()},
+			Method:  protocol.MethodStageEntry,
+			Scope:   staging.AWSScope("123456789012", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config",
+			Entry:   &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("value"), StagedAt: time.Now()},
 		})
 
 		assert.False(t, h.IsEmpty())
@@ -674,31 +635,28 @@ func TestHandler_HandleRequest(t *testing.T) {
 
 		// Stage entry in account 1
 		h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageEntry,
-			AccountID: "111111111111",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
-			Entry:     &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("account1-value"), StagedAt: time.Now()},
+			Method:  protocol.MethodStageEntry,
+			Scope:   staging.AWSScope("111111111111", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config",
+			Entry:   &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("account1-value"), StagedAt: time.Now()},
 		})
 
 		// Stage entry in account 2
 		h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodStageEntry,
-			AccountID: "222222222222",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
-			Entry:     &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("account2-value"), StagedAt: time.Now()},
+			Method:  protocol.MethodStageEntry,
+			Scope:   staging.AWSScope("222222222222", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config",
+			Entry:   &staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("account2-value"), StagedAt: time.Now()},
 		})
 
 		// Get entry from account 1
 		resp := h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodGetEntry,
-			AccountID: "111111111111",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
+			Method:  protocol.MethodGetEntry,
+			Scope:   staging.AWSScope("111111111111", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config",
 		})
 
 		var result1 protocol.EntryResponse
@@ -708,11 +666,10 @@ func TestHandler_HandleRequest(t *testing.T) {
 
 		// Get entry from account 2
 		resp = h.HandleRequest(&protocol.Request{
-			Method:    protocol.MethodGetEntry,
-			AccountID: "222222222222",
-			Region:    "us-east-1",
-			Service:   staging.ServiceParam,
-			Name:      "/app/config",
+			Method:  protocol.MethodGetEntry,
+			Scope:   staging.AWSScope("222222222222", "us-east-1"),
+			Service: staging.ServiceParam,
+			Name:    "/app/config",
 		})
 
 		var result2 protocol.EntryResponse

--- a/internal/staging/store/agent/store.go
+++ b/internal/staging/store/agent/store.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store"
 	"github.com/mpyw/suve/internal/staging/store/agent/internal/client"
 )
@@ -11,8 +12,8 @@ type StoreOption = client.StoreOption
 // NewStore creates an AgentStore using the agent daemon.
 // The agent daemon is started automatically if not running, unless
 // manual mode is enabled (see [EnvDaemonManualMode]).
-func NewStore(accountID, region string, opts ...StoreOption) store.AgentStore {
+func NewStore(scope staging.Scope, opts ...StoreOption) store.AgentStore {
 	opts = append(ClientOptions(), opts...)
 
-	return client.NewStore(accountID, region, opts...)
+	return client.NewStore(scope, opts...)
 }

--- a/internal/staging/store/file/store_internal_test.go
+++ b/internal/staging/store/file/store_internal_test.go
@@ -102,7 +102,7 @@ func TestNewStore_UserHomeDirError(t *testing.T) {
 		return "", errors.New("home directory not available")
 	}
 
-	store, err := NewStore("123456789012", "ap-northeast-1")
+	store, err := NewStore(staging.AWSScope("123456789012", "ap-northeast-1"))
 	assert.Nil(t, store)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get home directory")
@@ -122,7 +122,7 @@ func TestNewStoreWithPassphrase_UserHomeDirError(t *testing.T) {
 		return "", errors.New("home directory not available")
 	}
 
-	store, err := NewStoreWithPassphrase("123456789012", "ap-northeast-1", "secret")
+	store, err := NewStoreWithPassphrase(staging.AWSScope("123456789012", "ap-northeast-1"), "secret")
 	assert.Nil(t, store)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to get home directory")

--- a/internal/staging/store/file/store_test.go
+++ b/internal/staging/store/file/store_test.go
@@ -17,7 +17,7 @@ import (
 func TestNewStore(t *testing.T) {
 	t.Parallel()
 
-	store, err := file.NewStore("123456789012", "ap-northeast-1")
+	store, err := file.NewStore(staging.AWSScope("123456789012", "ap-northeast-1"))
 	require.NoError(t, err)
 	assert.NotNil(t, store)
 }
@@ -77,7 +77,7 @@ func TestStore_Exists(t *testing.T) {
 func TestNewStoreWithPassphrase(t *testing.T) {
 	t.Parallel()
 
-	store, err := file.NewStoreWithPassphrase("123456789012", "ap-northeast-1", "secret")
+	store, err := file.NewStoreWithPassphrase(staging.AWSScope("123456789012", "ap-northeast-1"), "secret")
 	require.NoError(t, err)
 	assert.NotNil(t, store)
 }


### PR DESCRIPTION
## Summary
- Add `staging.Scope` type with Provider enum (AWS, GoogleCloud, Azure) for multi-cloud support
- Refactor daemon architecture from "one daemon per scope" to "single daemon handles all scopes"
- Update all stores (agent, file) to accept Scope parameter at request time, not initialization

## Changes

### New Files
- `internal/staging/scope.go` - Scope type with Provider constants and helper constructors

### Architecture Change
Before: Daemon initialized with (accountID, region), one daemon per scope
After: Daemon scope-independent at startup, scope passed per-request via protocol.Request

This change enables:
1. Future multi-cloud support with different scope structures per provider
2. Single daemon process serving requests for any scope

### Modified Components
- **protocol**: Add `Scope` field to `Request`
- **server state**: Route by `(Scope, Service)` instead of `(accountID, region, Service)`
- **client store**: Accept `Scope` at construction, not daemon initialization
- **daemon runner/launcher**: Remove scope from constructors
- **file store**: Accept `Scope` for path determination
- **CLI commands**: Pass `Scope` to stores

## Test plan
- [x] All unit tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [ ] E2E tests pass (`make e2e` - requires localstack)

## Notes
Splitting `stage.json` into `param.json` and `secret.json` will be done in a separate PR as mentioned in the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)