### PR TITLE
fix(e2e): support all platforms in setupIsolatedSocketPath

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -390,6 +390,7 @@ jobs:
     runs-on: windows-latest
     if: >-
       github.ref == 'refs/heads/main' ||
+      github.ref == 'refs/heads/multicloud' ||
       contains(github.event.head_commit.message, '[CI: windows]')
     defaults:
       run:

--- a/e2e/staging_test.go
+++ b/e2e/staging_test.go
@@ -1231,12 +1231,16 @@ func TestDaemonLauncher_ViaStore(t *testing.T) {
 	})
 }
 
-// setupIsolatedSocketPath sets TMPDIR to a temp directory, causing the daemon
-// to look for a socket in a different location where no daemon is running.
+// setupIsolatedSocketPath sets socket-related environment variables to a temp directory,
+// causing the daemon to look for a socket in a different location where no daemon is running.
 // This simulates the "daemon not running" scenario for E2E tests.
+// Darwin uses TMPDIR, Linux uses XDG_RUNTIME_DIR, Windows uses LOCALAPPDATA.
 func setupIsolatedSocketPath(t *testing.T) {
 	t.Helper()
-	t.Setenv("TMPDIR", t.TempDir())
+	tempDir := t.TempDir()
+	t.Setenv("TMPDIR", tempDir)
+	t.Setenv("XDG_RUNTIME_DIR", tempDir)
+	t.Setenv("LOCALAPPDATA", tempDir)
 }
 
 // TestDaemonLauncher_NotRunning tests launcher behavior when daemon is not running.


### PR DESCRIPTION
## Summary
- Fix E2E tests failing on Linux by setting `XDG_RUNTIME_DIR`
- Add Windows support by setting `LOCALAPPDATA`
- Enable Windows GUI tests on multicloud branch

## Changes
- `setupIsolatedSocketPath` now sets all platform-specific env vars:
  - `TMPDIR` for Darwin
  - `XDG_RUNTIME_DIR` for Linux
  - `LOCALAPPDATA` for Windows

## Test plan
- [x] Lint passes locally
- [ ] E2E tests pass on Linux (CI)
- [ ] E2E tests pass on Windows (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)