### PR TITLE
ci: add multicloud branch to workflow triggers

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - multicloud
     paths:
       - ".github/labels.yml"
       - ".github/workflows/labels.yml"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [main]
+    branches: [main, multicloud]
   pull_request:
-    branches: [main]
+    branches: [main, multicloud]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Add `multicloud` branch to test.yml push and pull_request triggers
- Add `multicloud` branch to labels.yml push trigger

This enables CI to run on the multicloud feature branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)