### PR TITLE
refactor(usecase): migrate show operations to provider interfaces

### DIFF
--- a/internal/cli/commands/secret/show/show.go
+++ b/internal/cli/commands/secret/show/show.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/cli/pager"
-	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/jsonutil"
+	awssecret "github.com/mpyw/suve/internal/provider/aws/secret"
 	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/usecase/secret"
 	"github.com/mpyw/suve/internal/version/secretversion"
@@ -110,7 +110,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("--raw and --output=json cannot be used together")
 	}
 
-	client, err := infra.NewSecretClient(ctx)
+	adapter, err := awssecret.NewAdapter(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to initialize AWS client: %w", err)
 	}
@@ -128,7 +128,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 
 	return pager.WithPagerWriter(cmd.Root().Writer, noPager, func(w io.Writer) error {
 		r := &Runner{
-			UseCase: &secret.ShowUseCase{Client: client},
+			UseCase: &secret.ShowUseCase{Client: adapter},
 			Stdout:  w,
 			Stderr:  cmd.Root().ErrWriter,
 		}

--- a/internal/gui/param.go
+++ b/internal/gui/param.go
@@ -124,12 +124,12 @@ func (a *App) ParamShow(specStr string) (*ParamShowResult, error) {
 		return nil, err
 	}
 
-	client, err := a.getParamClient()
+	adapter, err := awsparam.NewAdapter(a.ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	uc := &param.ShowUseCase{Client: client}
+	uc := &param.ShowUseCase{Client: adapter}
 
 	result, err := uc.Execute(a.ctx, param.ShowInput{Spec: spec})
 	if err != nil {
@@ -140,7 +140,7 @@ func (a *App) ParamShow(specStr string) (*ParamShowResult, error) {
 		Name:        result.Name,
 		Value:       result.Value,
 		Version:     result.Version,
-		Type:        string(result.Type),
+		Type:        result.Type,
 		Description: result.Description,
 		Tags:        make([]ParamShowTag, 0, len(result.Tags)),
 	}

--- a/internal/gui/secret.go
+++ b/internal/gui/secret.go
@@ -136,12 +136,12 @@ func (a *App) SecretShow(specStr string) (*SecretShowResult, error) {
 		return nil, err
 	}
 
-	client, err := a.getSecretClient()
+	adapter, err := awssecret.NewAdapter(a.ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	uc := &secret.ShowUseCase{Client: client}
+	uc := &secret.ShowUseCase{Client: adapter}
 
 	result, err := uc.Execute(a.ctx, secret.ShowInput{Spec: spec})
 	if err != nil {

--- a/internal/model/resource.go
+++ b/internal/model/resource.go
@@ -1,0 +1,69 @@
+package model
+
+import "time"
+
+// ResourceKind identifies the type of resource.
+type ResourceKind string
+
+const (
+	// KindParameter represents an SSM Parameter Store parameter.
+	KindParameter ResourceKind = "parameter"
+	// KindSecret represents a Secrets Manager secret.
+	KindSecret ResourceKind = "secret"
+)
+
+// Resource is a unified versioned resource (parameter or secret) for the UseCase layer.
+// This type abstracts common fields from Parameter and Secret to enable unified usecase logic.
+type Resource struct {
+	// Kind identifies whether this is a parameter or secret.
+	Kind ResourceKind
+	// Name is the resource name/identifier.
+	Name string
+	// ARN is the resource ARN (primarily for secrets, empty for parameters).
+	ARN string
+	// Value is the resource value/content.
+	Value string
+	// Version is the version identifier (param.Version or secret.VersionID).
+	Version string
+	// Type is the resource type (e.g., String, SecureString for parameters).
+	// This is empty for secrets which don't have a type concept.
+	Type string
+	// Description is the resource description.
+	Description string
+	// ModifiedAt is when the resource was last modified (LastModified or CreatedDate).
+	ModifiedAt *time.Time
+	// Tags are key-value tags associated with the resource.
+	Tags map[string]string
+	// Metadata contains provider-specific metadata (e.g., AWSParameterMeta, AWSSecretMeta).
+	Metadata any
+}
+
+// ToResource converts a Parameter to a unified Resource.
+func (p *Parameter) ToResource() *Resource {
+	return &Resource{
+		Kind:        KindParameter,
+		Name:        p.Name,
+		Value:       p.Value,
+		Version:     p.Version,
+		Type:        p.Type,
+		Description: p.Description,
+		ModifiedAt:  p.LastModified,
+		Tags:        p.Tags,
+		Metadata:    p.Metadata,
+	}
+}
+
+// ToResource converts a Secret to a unified Resource.
+func (s *Secret) ToResource() *Resource {
+	return &Resource{
+		Kind:        KindSecret,
+		Name:        s.Name,
+		ARN:         s.ARN,
+		Value:       s.Value,
+		Version:     s.VersionID,
+		Description: s.Description,
+		ModifiedAt:  s.CreatedDate,
+		Tags:        s.Tags,
+		Metadata:    s.Metadata,
+	}
+}

--- a/internal/model/resource_test.go
+++ b/internal/model/resource_test.go
@@ -1,0 +1,70 @@
+package model_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mpyw/suve/internal/model"
+)
+
+func TestParameter_ToResource(t *testing.T) {
+	t.Parallel()
+
+	modified := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	meta := model.AWSParameterMeta{ARN: "arn:aws:ssm:us-east-1:123456789012:parameter/test"}
+
+	param := &model.Parameter{
+		Name:         "/app/config",
+		Value:        "secret-value",
+		Version:      "5",
+		Type:         "SecureString",
+		Description:  "Test parameter",
+		LastModified: &modified,
+		Tags:         map[string]string{"env": "prod"},
+		Metadata:     meta,
+	}
+
+	resource := param.ToResource()
+
+	assert.Equal(t, model.KindParameter, resource.Kind)
+	assert.Equal(t, param.Name, resource.Name)
+	assert.Equal(t, param.Value, resource.Value)
+	assert.Equal(t, param.Version, resource.Version)
+	assert.Equal(t, param.Type, resource.Type)
+	assert.Equal(t, param.Description, resource.Description)
+	assert.Equal(t, param.LastModified, resource.ModifiedAt)
+	assert.Equal(t, param.Tags, resource.Tags)
+	assert.Equal(t, meta, resource.Metadata)
+}
+
+func TestSecret_ToResource(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	meta := model.AWSSecretMeta{VersionStages: []string{"AWSCURRENT"}}
+
+	secret := &model.Secret{
+		Name:        "my-secret",
+		ARN:         "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret",
+		Value:       "secret-value",
+		VersionID:   "abc123",
+		Description: "Test secret",
+		CreatedDate: &created,
+		Tags:        map[string]string{"env": "prod"},
+		Metadata:    meta,
+	}
+
+	resource := secret.ToResource()
+
+	assert.Equal(t, model.KindSecret, resource.Kind)
+	assert.Equal(t, secret.Name, resource.Name)
+	assert.Equal(t, secret.ARN, resource.ARN)
+	assert.Equal(t, secret.Value, resource.Value)
+	assert.Equal(t, secret.VersionID, resource.Version)
+	assert.Equal(t, secret.Description, resource.Description)
+	assert.Equal(t, secret.CreatedDate, resource.ModifiedAt)
+	assert.Equal(t, secret.Tags, resource.Tags)
+	assert.Equal(t, meta, resource.Metadata)
+}

--- a/internal/provider/resource.go
+++ b/internal/provider/resource.go
@@ -1,0 +1,27 @@
+package provider
+
+import "context"
+
+// Tagger provides tag management operations for resources.
+// This is a unified interface that both ParameterTagger and SecretTagger satisfy.
+//
+// All provider adapters implementing either ParameterTagger or SecretTagger
+// automatically satisfy this interface since the method signatures are identical.
+//
+//nolint:iface // Intentionally identical to ParameterTagger/SecretTagger for unified access.
+type Tagger interface {
+	// GetTags retrieves all tags for a resource.
+	GetTags(ctx context.Context, name string) (map[string]string, error)
+
+	// AddTags adds or updates tags on a resource.
+	AddTags(ctx context.Context, name string, tags map[string]string) error
+
+	// RemoveTags removes tags from a resource by key names.
+	RemoveTags(ctx context.Context, name string, keys []string) error
+}
+
+// Ensure ParameterTagger and SecretTagger satisfy Tagger interface.
+var (
+	_ Tagger = (ParameterTagger)(nil)
+	_ Tagger = (SecretTagger)(nil)
+)

--- a/internal/usecase/param/show_test.go
+++ b/internal/usecase/param/show_test.go
@@ -5,26 +5,24 @@ import (
 	"testing"
 	"time"
 
-	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/mpyw/suve/internal/api/paramapi"
+	"github.com/mpyw/suve/internal/model"
 	"github.com/mpyw/suve/internal/usecase/param"
 	"github.com/mpyw/suve/internal/version/paramversion"
 )
 
 type mockShowClient struct {
-	getParameterResult *paramapi.GetParameterOutput
+	getParameterResult *model.Parameter
 	getParameterErr    error
-	getHistoryResult   *paramapi.GetParameterHistoryOutput
+	getHistoryResult   *model.ParameterHistory
 	getHistoryErr      error
-	listTagsResult     *paramapi.ListTagsForResourceOutput
-	listTagsErr        error
+	getTagsResult      map[string]string
+	getTagsErr         error
 }
 
-//nolint:lll // mock function signature must match AWS SDK interface
-func (m *mockShowClient) GetParameter(_ context.Context, _ *paramapi.GetParameterInput, _ ...func(*paramapi.Options)) (*paramapi.GetParameterOutput, error) {
+func (m *mockShowClient) GetParameter(_ context.Context, _ string, _ string) (*model.Parameter, error) {
 	if m.getParameterErr != nil {
 		return nil, m.getParameterErr
 	}
@@ -32,30 +30,36 @@ func (m *mockShowClient) GetParameter(_ context.Context, _ *paramapi.GetParamete
 	return m.getParameterResult, nil
 }
 
-//nolint:lll // mock function signature must match AWS SDK interface
-func (m *mockShowClient) GetParameterHistory(_ context.Context, _ *paramapi.GetParameterHistoryInput, _ ...func(*paramapi.Options)) (*paramapi.GetParameterHistoryOutput, error) {
+func (m *mockShowClient) GetParameterHistory(_ context.Context, _ string) (*model.ParameterHistory, error) {
 	if m.getHistoryErr != nil {
 		return nil, m.getHistoryErr
 	}
 
 	if m.getHistoryResult == nil {
-		return &paramapi.GetParameterHistoryOutput{}, nil
+		return &model.ParameterHistory{}, nil
 	}
 
 	return m.getHistoryResult, nil
 }
 
-//nolint:lll // mock function signature must match AWS SDK interface
-func (m *mockShowClient) ListTagsForResource(_ context.Context, _ *paramapi.ListTagsForResourceInput, _ ...func(*paramapi.Options)) (*paramapi.ListTagsForResourceOutput, error) {
-	if m.listTagsErr != nil {
-		return nil, m.listTagsErr
+func (m *mockShowClient) ListParameters(_ context.Context, _ string, _ bool) ([]*model.ParameterListItem, error) {
+	return nil, nil
+}
+
+func (m *mockShowClient) GetTags(_ context.Context, _ string) (map[string]string, error) {
+	if m.getTagsErr != nil {
+		return nil, m.getTagsErr
 	}
 
-	if m.listTagsResult != nil {
-		return m.listTagsResult, nil
-	}
+	return m.getTagsResult, nil
+}
 
-	return &paramapi.ListTagsForResourceOutput{}, nil
+func (m *mockShowClient) AddTags(_ context.Context, _ string, _ map[string]string) error {
+	return nil
+}
+
+func (m *mockShowClient) RemoveTags(_ context.Context, _ string, _ []string) error {
+	return nil
 }
 
 func TestShowUseCase_Execute(t *testing.T) {
@@ -63,14 +67,12 @@ func TestShowUseCase_Execute(t *testing.T) {
 
 	now := time.Now()
 	client := &mockShowClient{
-		getParameterResult: &paramapi.GetParameterOutput{
-			Parameter: &paramapi.Parameter{
-				Name:             lo.ToPtr("/app/config"),
-				Value:            lo.ToPtr("secret-value"),
-				Version:          5,
-				Type:             paramapi.ParameterTypeSecureString,
-				LastModifiedDate: &now,
-			},
+		getParameterResult: &model.Parameter{
+			Name:         "/app/config",
+			Value:        "secret-value",
+			Version:      "5",
+			Type:         "SecureString",
+			LastModified: &now,
 		},
 	}
 
@@ -86,7 +88,7 @@ func TestShowUseCase_Execute(t *testing.T) {
 	assert.Equal(t, "/app/config", output.Name)
 	assert.Equal(t, "secret-value", output.Value)
 	assert.Equal(t, int64(5), output.Version)
-	assert.Equal(t, paramapi.ParameterTypeSecureString, output.Type)
+	assert.Equal(t, "SecureString", output.Type)
 	assert.NotNil(t, output.LastModified)
 }
 
@@ -95,13 +97,11 @@ func TestShowUseCase_Execute_WithVersion(t *testing.T) {
 
 	// #VERSION spec without shift uses GetParameter (SSM supports name:version format)
 	client := &mockShowClient{
-		getParameterResult: &paramapi.GetParameterOutput{
-			Parameter: &paramapi.Parameter{
-				Name:    lo.ToPtr("/app/config"),
-				Value:   lo.ToPtr("old-value"),
-				Version: 3,
-				Type:    paramapi.ParameterTypeString,
-			},
+		getParameterResult: &model.Parameter{
+			Name:    "/app/config",
+			Value:   "old-value",
+			Version: "3",
+			Type:    "String",
 		},
 	}
 
@@ -124,11 +124,12 @@ func TestShowUseCase_Execute_WithShift(t *testing.T) {
 
 	// Spec with shift uses GetParameterHistory
 	client := &mockShowClient{
-		getHistoryResult: &paramapi.GetParameterHistoryOutput{
-			Parameters: []paramapi.ParameterHistory{
-				{Name: lo.ToPtr("/app/config"), Value: lo.ToPtr("v1"), Version: 1, Type: paramapi.ParameterTypeString},
-				{Name: lo.ToPtr("/app/config"), Value: lo.ToPtr("v2"), Version: 2, Type: paramapi.ParameterTypeString},
-				{Name: lo.ToPtr("/app/config"), Value: lo.ToPtr("v3"), Version: 3, Type: paramapi.ParameterTypeString},
+		getHistoryResult: &model.ParameterHistory{
+			Name: "/app/config",
+			Parameters: []*model.Parameter{
+				{Name: "/app/config", Value: "v1", Version: "1", Type: "String"},
+				{Name: "/app/config", Value: "v2", Version: "2", Type: "String"},
+				{Name: "/app/config", Value: "v3", Version: "3", Type: "String"},
 			},
 		},
 	}
@@ -169,13 +170,11 @@ func TestShowUseCase_Execute_NoLastModified(t *testing.T) {
 	t.Parallel()
 
 	client := &mockShowClient{
-		getParameterResult: &paramapi.GetParameterOutput{
-			Parameter: &paramapi.Parameter{
-				Name:    lo.ToPtr("/app/config"),
-				Value:   lo.ToPtr("value"),
-				Version: 1,
-				Type:    paramapi.ParameterTypeString,
-			},
+		getParameterResult: &model.Parameter{
+			Name:    "/app/config",
+			Value:   "value",
+			Version: "1",
+			Type:    "String",
 		},
 	}
 
@@ -195,19 +194,15 @@ func TestShowUseCase_Execute_WithTags(t *testing.T) {
 	t.Parallel()
 
 	client := &mockShowClient{
-		getParameterResult: &paramapi.GetParameterOutput{
-			Parameter: &paramapi.Parameter{
-				Name:    lo.ToPtr("/app/config"),
-				Value:   lo.ToPtr("value"),
-				Version: 1,
-				Type:    paramapi.ParameterTypeString,
-			},
+		getParameterResult: &model.Parameter{
+			Name:    "/app/config",
+			Value:   "value",
+			Version: "1",
+			Type:    "String",
 		},
-		listTagsResult: &paramapi.ListTagsForResourceOutput{
-			TagList: []paramapi.Tag{
-				{Key: lo.ToPtr("env"), Value: lo.ToPtr("prod")},
-				{Key: lo.ToPtr("team"), Value: lo.ToPtr("backend")},
-			},
+		getTagsResult: map[string]string{
+			"env":  "prod",
+			"team": "backend",
 		},
 	}
 
@@ -221,8 +216,13 @@ func TestShowUseCase_Execute_WithTags(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Len(t, output.Tags, 2)
-	assert.Equal(t, "env", output.Tags[0].Key)
-	assert.Equal(t, "prod", output.Tags[0].Value)
-	assert.Equal(t, "team", output.Tags[1].Key)
-	assert.Equal(t, "backend", output.Tags[1].Value)
+
+	// Convert to map for easier testing (order not guaranteed)
+	tagMap := make(map[string]string)
+	for _, tag := range output.Tags {
+		tagMap[tag.Key] = tag.Value
+	}
+
+	assert.Equal(t, "prod", tagMap["env"])
+	assert.Equal(t, "backend", tagMap["team"])
 }

--- a/internal/usecase/resource/show.go
+++ b/internal/usecase/resource/show.go
@@ -1,0 +1,93 @@
+// Package resource provides unified use cases for versioned resources (parameters and secrets).
+package resource
+
+import (
+	"context"
+	"time"
+
+	"github.com/mpyw/suve/internal/model"
+	"github.com/mpyw/suve/internal/provider"
+)
+
+// ShowClient is the interface for the show use case.
+// It requires tag fetching capability.
+type ShowClient interface {
+	provider.Tagger
+}
+
+// ShowInput holds input for the show use case.
+// The Resource should be pre-resolved from a version specification.
+type ShowInput struct {
+	// Resource is the resolved resource to display.
+	// Use paramversion.Resolve or secretversion.Resolve to obtain this.
+	Resource *model.Resource
+}
+
+// ShowTag represents a tag key-value pair in the output.
+type ShowTag struct {
+	Key   string
+	Value string
+}
+
+// ShowOutput holds the result of the show use case.
+type ShowOutput struct {
+	// Kind identifies whether this is a parameter or secret.
+	Kind model.ResourceKind
+	// Name is the resource name/identifier.
+	Name string
+	// ARN is the resource ARN (primarily for secrets, empty for parameters).
+	ARN string
+	// Value is the resource value/content.
+	Value string
+	// Version is the version identifier.
+	Version string
+	// Type is the resource type (e.g., String, SecureString for parameters).
+	// This is empty for secrets which don't have a type concept.
+	Type string
+	// Description is the resource description.
+	Description string
+	// ModifiedAt is when the resource was last modified.
+	ModifiedAt *time.Time
+	// Tags are key-value tags associated with the resource.
+	Tags []ShowTag
+	// Metadata contains provider-specific metadata for additional display.
+	// CLI/GUI layers can type-assert this to extract provider-specific fields.
+	Metadata any
+}
+
+// ShowUseCase executes show operations for versioned resources.
+type ShowUseCase struct {
+	Client ShowClient
+}
+
+// Execute runs the show use case.
+// It takes a pre-resolved resource and fetches its tags.
+func (u *ShowUseCase) Execute(ctx context.Context, input ShowInput) (*ShowOutput, error) {
+	res := input.Resource
+
+	output := &ShowOutput{
+		Kind:        res.Kind,
+		Name:        res.Name,
+		ARN:         res.ARN,
+		Value:       res.Value,
+		Version:     res.Version,
+		Type:        res.Type,
+		Description: res.Description,
+		ModifiedAt:  res.ModifiedAt,
+		Metadata:    res.Metadata,
+	}
+
+	// Fetch tags
+	tags, err := u.Client.GetTags(ctx, res.Name)
+	if err == nil && tags != nil {
+		output.Tags = make([]ShowTag, 0, len(tags))
+		for k, v := range tags {
+			output.Tags = append(output.Tags, ShowTag{
+				Key:   k,
+				Value: v,
+			})
+		}
+	}
+
+	return output, nil
+}

--- a/internal/usecase/resource/show_test.go
+++ b/internal/usecase/resource/show_test.go
@@ -1,0 +1,154 @@
+package resource_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/model"
+	"github.com/mpyw/suve/internal/usecase/resource"
+)
+
+type mockTagger struct {
+	getTags    func(ctx context.Context, name string) (map[string]string, error)
+	addTags    func(ctx context.Context, name string, tags map[string]string) error
+	removeTags func(ctx context.Context, name string, keys []string) error
+}
+
+func (m *mockTagger) GetTags(ctx context.Context, name string) (map[string]string, error) {
+	if m.getTags != nil {
+		return m.getTags(ctx, name)
+	}
+
+	return map[string]string{}, nil
+}
+
+func (m *mockTagger) AddTags(ctx context.Context, name string, tags map[string]string) error {
+	if m.addTags != nil {
+		return m.addTags(ctx, name, tags)
+	}
+
+	return nil
+}
+
+func (m *mockTagger) RemoveTags(ctx context.Context, name string, keys []string) error {
+	if m.removeTags != nil {
+		return m.removeTags(ctx, name, keys)
+	}
+
+	return nil
+}
+
+func TestShowUseCase_Execute(t *testing.T) {
+	t.Parallel()
+
+	modified := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		resource *model.Resource
+		tags     map[string]string
+		tagErr   error
+		wantTags []resource.ShowTag
+	}{
+		{
+			name: "parameter resource with tags",
+			resource: &model.Resource{
+				Kind:        model.KindParameter,
+				Name:        "/app/config",
+				Value:       "secret-value",
+				Version:     "5",
+				Type:        "SecureString",
+				Description: "Test parameter",
+				ModifiedAt:  &modified,
+				Metadata:    model.AWSParameterMeta{ARN: "arn:aws:ssm:us-east-1:123456789012:parameter/app/config"},
+			},
+			tags: map[string]string{"env": "prod", "team": "platform"},
+			wantTags: []resource.ShowTag{
+				{Key: "env", Value: "prod"},
+				{Key: "team", Value: "platform"},
+			},
+		},
+		{
+			name: "secret resource with tags",
+			resource: &model.Resource{
+				Kind:        model.KindSecret,
+				Name:        "my-secret",
+				ARN:         "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret",
+				Value:       "secret-value",
+				Version:     "abc123",
+				Description: "Test secret",
+				ModifiedAt:  &modified,
+				Metadata:    model.AWSSecretMeta{VersionStages: []string{"AWSCURRENT"}},
+			},
+			tags: map[string]string{"env": "staging"},
+			wantTags: []resource.ShowTag{
+				{Key: "env", Value: "staging"},
+			},
+		},
+		{
+			name: "resource without tags",
+			resource: &model.Resource{
+				Kind:        model.KindParameter,
+				Name:        "/app/config",
+				Value:       "value",
+				Version:     "1",
+				Description: "",
+				ModifiedAt:  &modified,
+			},
+			tags:     nil,
+			wantTags: nil,
+		},
+		{
+			name: "tag fetch error is ignored",
+			resource: &model.Resource{
+				Kind:        model.KindParameter,
+				Name:        "/app/config",
+				Value:       "value",
+				Version:     "1",
+				Description: "",
+				ModifiedAt:  &modified,
+			},
+			tagErr:   errors.New("access denied"),
+			wantTags: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			client := &mockTagger{
+				getTags: func(_ context.Context, _ string) (map[string]string, error) {
+					return tt.tags, tt.tagErr
+				},
+			}
+
+			uc := &resource.ShowUseCase{Client: client}
+			output, err := uc.Execute(context.Background(), resource.ShowInput{
+				Resource: tt.resource,
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.resource.Kind, output.Kind)
+			assert.Equal(t, tt.resource.Name, output.Name)
+			assert.Equal(t, tt.resource.ARN, output.ARN)
+			assert.Equal(t, tt.resource.Value, output.Value)
+			assert.Equal(t, tt.resource.Version, output.Version)
+			assert.Equal(t, tt.resource.Type, output.Type)
+			assert.Equal(t, tt.resource.Description, output.Description)
+			assert.Equal(t, tt.resource.ModifiedAt, output.ModifiedAt)
+			assert.Equal(t, tt.resource.Metadata, output.Metadata)
+
+			if tt.wantTags == nil {
+				assert.Nil(t, output.Tags)
+			} else {
+				assert.ElementsMatch(t, tt.wantTags, output.Tags)
+			}
+		})
+	}
+}

--- a/internal/usecase/secret/show.go
+++ b/internal/usecase/secret/show.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mpyw/suve/internal/model"
 	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/usecase/resource"
 	"github.com/mpyw/suve/internal/version/secretversion"
 )
 
@@ -22,10 +23,7 @@ type ShowInput struct {
 }
 
 // ShowTag represents a tag key-value pair.
-type ShowTag struct {
-	Key   string
-	Value string
-}
+type ShowTag = resource.ShowTag
 
 // ShowOutput holds the result of the show use case.
 type ShowOutput struct {
@@ -46,35 +44,36 @@ type ShowUseCase struct {
 
 // Execute runs the show use case.
 func (u *ShowUseCase) Execute(ctx context.Context, input ShowInput) (*ShowOutput, error) {
+	// Resolve secret version
 	secret, err := secretversion.Resolve(ctx, u.Client, input.Spec)
 	if err != nil {
 		return nil, err
 	}
 
+	// Use unified resource usecase for common logic (tag fetching)
+	uc := &resource.ShowUseCase{Client: u.Client}
+
+	result, err := uc.Execute(ctx, resource.ShowInput{
+		Resource: secret.ToResource(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert to secret-specific output
 	output := &ShowOutput{
-		Name:        secret.Name,
-		ARN:         secret.ARN,
-		Value:       secret.Value,
-		VersionID:   secret.VersionID,
-		Description: secret.Description,
-		CreatedDate: secret.CreatedDate,
+		Name:        result.Name,
+		ARN:         result.ARN,
+		Value:       result.Value,
+		VersionID:   result.Version,
+		Description: result.Description,
+		CreatedDate: result.ModifiedAt,
+		Tags:        result.Tags,
 	}
 
 	// Extract version stages from metadata if available
-	if meta, ok := secret.Metadata.(model.AWSSecretMeta); ok {
+	if meta, ok := result.Metadata.(model.AWSSecretMeta); ok {
 		output.VersionStage = meta.VersionStages
-	}
-
-	// Fetch tags
-	tags, err := u.Client.GetTags(ctx, secret.Name)
-	if err == nil && tags != nil {
-		output.Tags = make([]ShowTag, 0, len(tags))
-		for k, v := range tags {
-			output.Tags = append(output.Tags, ShowTag{
-				Key:   k,
-				Value: v,
-			})
-		}
 	}
 
 	return output, nil

--- a/internal/usecase/secret/version_resolver.go
+++ b/internal/usecase/secret/version_resolver.go
@@ -4,6 +4,8 @@ import "github.com/mpyw/suve/internal/api/secretapi"
 
 // VersionResolverClient is the shared interface for use cases that need
 // secret version resolution (listing versions and fetching values).
+//
+// Deprecated: Use provider.SecretReader instead.
 type VersionResolverClient interface {
 	secretapi.GetSecretValueAPI
 	secretapi.ListSecretVersionIDsAPI

--- a/internal/version/internal/resolve.go
+++ b/internal/version/internal/resolve.go
@@ -1,0 +1,15 @@
+package internal
+
+import "fmt"
+
+// ApplyShift applies a shift to a base index and returns the target index.
+// It validates that the target index is within bounds [0, length).
+// baseIdx is the starting index (0-indexed), shift is how many versions to go back.
+func ApplyShift(baseIdx, shift, length int) (int, error) {
+	targetIdx := baseIdx + shift
+	if targetIdx < 0 || targetIdx >= length {
+		return 0, fmt.Errorf("version shift out of range: ~%d", shift)
+	}
+
+	return targetIdx, nil
+}

--- a/internal/version/paramversion/resolve.go
+++ b/internal/version/paramversion/resolve.go
@@ -1,0 +1,106 @@
+package paramversion
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strconv"
+
+	"github.com/mpyw/suve/internal/model"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/version/internal"
+)
+
+// Resolve resolves a parameter version specification to a concrete parameter.
+// It fetches the parameter value, applying shift if specified.
+func Resolve(
+	ctx context.Context,
+	client provider.ParameterReader,
+	spec *Spec,
+) (*model.Parameter, error) {
+	if spec.HasShift() {
+		return resolveWithShift(ctx, client, spec)
+	}
+
+	return resolveDirect(ctx, client, spec)
+}
+
+func resolveWithShift(
+	ctx context.Context,
+	client provider.ParameterReader,
+	spec *Spec,
+) (*model.Parameter, error) {
+	history, err := client.GetParameterHistory(ctx, spec.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get parameter history: %w", err)
+	}
+
+	if len(history.Parameters) == 0 {
+		return nil, fmt.Errorf("parameter not found: %s", spec.Name)
+	}
+
+	// Sort by version descending (newest first)
+	params := history.Parameters
+	slices.SortFunc(params, func(a, b *model.Parameter) int {
+		va, _ := parseVersionString(a.Version)
+		vb, _ := parseVersionString(b.Version)
+
+		return int(vb - va) // Descending order
+	})
+
+	baseIdx := 0
+
+	if spec.Absolute.Version != nil {
+		var found bool
+
+		targetVersion := *spec.Absolute.Version
+
+		for i, p := range params {
+			v, _ := parseVersionString(p.Version)
+			if v == targetVersion {
+				baseIdx = i
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			return nil, fmt.Errorf("version %d not found", targetVersion)
+		}
+	}
+
+	targetIdx, err := internal.ApplyShift(baseIdx, spec.Shift, len(params))
+	if err != nil {
+		return nil, err
+	}
+
+	return params[targetIdx], nil
+}
+
+func resolveDirect(
+	ctx context.Context,
+	client provider.ParameterReader,
+	spec *Spec,
+) (*model.Parameter, error) {
+	version := ""
+	if spec.Absolute.Version != nil {
+		version = strconv.FormatInt(*spec.Absolute.Version, 10)
+	}
+
+	param, err := client.GetParameter(ctx, spec.Name, version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get parameter: %w", err)
+	}
+
+	return param, nil
+}
+
+// parseVersionString converts a version string to int64.
+func parseVersionString(version string) (int64, error) {
+	if version == "" {
+		return 0, nil
+	}
+
+	return strconv.ParseInt(version, 10, 64)
+}

--- a/internal/version/secretversion/resolve.go
+++ b/internal/version/secretversion/resolve.go
@@ -1,0 +1,124 @@
+package secretversion
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/mpyw/suve/internal/model"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/version/internal"
+)
+
+// Resolve resolves a secret version specification to a concrete secret.
+// It fetches the secret value, applying shift if specified.
+func Resolve(
+	ctx context.Context,
+	client provider.SecretReader,
+	spec *Spec,
+) (*model.Secret, error) {
+	if spec.HasShift() {
+		return resolveWithShift(ctx, client, spec)
+	}
+
+	return resolveDirect(ctx, client, spec)
+}
+
+func resolveWithShift(
+	ctx context.Context,
+	client provider.SecretReader,
+	spec *Spec,
+) (*model.Secret, error) {
+	versions, err := client.GetSecretVersions(ctx, spec.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret versions: %w", err)
+	}
+
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("secret not found: %s", spec.Name)
+	}
+
+	// Sort by created date descending (newest first)
+	slices.SortFunc(versions, func(a, b *model.SecretVersion) int {
+		if a.CreatedDate == nil && b.CreatedDate == nil {
+			return 0
+		}
+
+		if a.CreatedDate == nil {
+			return 1
+		}
+
+		if b.CreatedDate == nil {
+			return -1
+		}
+
+		return b.CreatedDate.Compare(*a.CreatedDate)
+	})
+
+	baseIdx, err := findBaseIndex(versions, spec)
+	if err != nil {
+		return nil, err
+	}
+
+	targetIdx, err := internal.ApplyShift(baseIdx, spec.Shift, len(versions))
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the full secret value for the resolved version
+	return client.GetSecret(ctx, spec.Name, versions[targetIdx].VersionID, "")
+}
+
+func findBaseIndex(versions []*model.SecretVersion, spec *Spec) (int, error) {
+	// Default to latest (index 0)
+	if spec.Absolute.ID == nil && spec.Absolute.Label == nil {
+		return 0, nil
+	}
+
+	for i, v := range versions {
+		// Match by version ID
+		if spec.Absolute.ID != nil && v.VersionID == *spec.Absolute.ID {
+			return i, nil
+		}
+
+		// Match by label (AWS-specific: check VersionStages in metadata)
+		if spec.Absolute.Label != nil {
+			if meta, ok := v.Metadata.(model.AWSSecretMeta); ok {
+				if slices.Contains(meta.VersionStages, *spec.Absolute.Label) {
+					return i, nil
+				}
+			}
+		}
+	}
+
+	// Not found
+	if spec.Absolute.ID != nil {
+		return 0, fmt.Errorf("version ID %s not found", *spec.Absolute.ID)
+	}
+
+	return 0, fmt.Errorf("staging label %s not found", *spec.Absolute.Label)
+}
+
+func resolveDirect(
+	ctx context.Context,
+	client provider.SecretReader,
+	spec *Spec,
+) (*model.Secret, error) {
+	versionID := ""
+	versionStage := ""
+
+	if spec.Absolute.ID != nil {
+		versionID = *spec.Absolute.ID
+	}
+
+	if spec.Absolute.Label != nil {
+		versionStage = *spec.Absolute.Label
+	}
+
+	secret, err := client.GetSecret(ctx, spec.Name, versionID, versionStage)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret: %w", err)
+	}
+
+	return secret, nil
+}


### PR DESCRIPTION
## Summary

- Migrate `show` usecases to use provider interfaces
- Move version resolution logic to `paramversion` and `secretversion` packages
- Add shared shift resolution helper in `version/internal`

## Changes

### Version Package Updates
- `version/internal/resolve.go`: New `ApplyShift` helper for shared shift logic
- `paramversion/resolve.go`: New `Resolve` function using `provider.ParameterReader`
- `secretversion/resolve.go`: New `Resolve` function using `provider.SecretReader`

### Show Migration  
- `usecase/param/show.go`: Use `paramversion.Resolve` instead of local resolver
- `usecase/secret/show.go`: Use `secretversion.Resolve` instead of local resolver
- Remove `usecase/param/version_resolver.go` (moved to paramversion)
- Simplify `usecase/secret/version_resolver.go` (keep only `VersionResolverClient` for diff/log)

### Unchanged (for future PRs)
- `diff.go` and `log.go` still use old AWS SDK types
- `VersionResolverClient` kept for backward compatibility

## Test plan

- [x] `make test` passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)