### PR TITLE
refactor(model): move AWS-specific fields to metadata structs

### DIFF
--- a/internal/model/parameter.go
+++ b/internal/model/parameter.go
@@ -13,7 +13,6 @@ type TypedParameter[M any] struct {
 	Name         string
 	Value        string
 	Version      string
-	Type         string // Parameter type (e.g., String, SecureString)
 	Description  string
 	LastModified *time.Time
 	Tags         map[string]string
@@ -26,7 +25,6 @@ func (p *TypedParameter[M]) ToBase() *Parameter {
 		Name:         p.Name,
 		Value:        p.Value,
 		Version:      p.Version,
-		Type:         p.Type,
 		Description:  p.Description,
 		LastModified: p.LastModified,
 		Tags:         p.Tags,
@@ -43,11 +41,23 @@ type Parameter struct {
 	Name         string
 	Value        string
 	Version      string
-	Type         string // Parameter type (e.g., String, SecureString)
 	Description  string
 	LastModified *time.Time
 	Tags         map[string]string
-	Metadata     any // Provider-specific metadata (e.g., *AWSParameterMeta)
+	Metadata     any // Provider-specific metadata (e.g., AWSParameterMeta)
+}
+
+// AWSMeta returns the AWS-specific metadata if available.
+func (p *Parameter) AWSMeta() *AWSParameterMeta {
+	if meta, ok := p.Metadata.(AWSParameterMeta); ok {
+		return &meta
+	}
+
+	if meta, ok := p.Metadata.(*AWSParameterMeta); ok {
+		return meta
+	}
+
+	return nil
 }
 
 // TypedMetadata casts Metadata to a specific type.
@@ -63,6 +73,8 @@ func TypedMetadata[M any](p *Parameter) (M, bool) {
 
 // AWSParameterMeta contains AWS SSM Parameter Store-specific metadata.
 type AWSParameterMeta struct {
+	// Type is the parameter type (e.g., String, SecureString, StringList).
+	Type string
 	// ARN is the Amazon Resource Name of the parameter.
 	ARN string
 	// Tier is the parameter tier (Standard, Advanced, Intelligent-Tiering).
@@ -136,8 +148,27 @@ type AWSParameterHistory = TypedParameterHistory[AWSParameterMeta]
 // ParameterListItem represents a parameter in a list (without value).
 type ParameterListItem struct {
 	Name         string
-	Type         string
 	Description  string
 	LastModified *time.Time
 	Tags         map[string]string
+	Metadata     any // Provider-specific metadata (e.g., AWSParameterListItemMeta)
+}
+
+// AWSMeta returns the AWS-specific metadata if available.
+func (p *ParameterListItem) AWSMeta() *AWSParameterListItemMeta {
+	if meta, ok := p.Metadata.(AWSParameterListItemMeta); ok {
+		return &meta
+	}
+
+	if meta, ok := p.Metadata.(*AWSParameterListItemMeta); ok {
+		return meta
+	}
+
+	return nil
+}
+
+// AWSParameterListItemMeta contains AWS SSM-specific metadata for list items.
+type AWSParameterListItemMeta struct {
+	// Type is the parameter type (e.g., String, SecureString, StringList).
+	Type string
 }

--- a/internal/model/parameter_test.go
+++ b/internal/model/parameter_test.go
@@ -17,11 +17,11 @@ func TestTypedParameter_ToBase(t *testing.T) {
 		Name:         "test-param",
 		Value:        "test-value",
 		Version:      "1",
-		Type:         "String",
 		Description:  "test description",
 		LastModified: &now,
 		Tags:         map[string]string{"key": "value"},
 		Metadata: model.AWSParameterMeta{
+			Type: "String",
 			ARN:  "arn:aws:ssm:us-east-1:123456789012:parameter/test-param",
 			Tier: "Standard",
 		},
@@ -32,11 +32,15 @@ func TestTypedParameter_ToBase(t *testing.T) {
 	assert.Equal(t, typed.Name, base.Name)
 	assert.Equal(t, typed.Value, base.Value)
 	assert.Equal(t, typed.Version, base.Version)
-	assert.Equal(t, typed.Type, base.Type)
 	assert.Equal(t, typed.Description, base.Description)
 	assert.Equal(t, typed.LastModified, base.LastModified)
 	assert.Equal(t, typed.Tags, base.Tags)
 	assert.IsType(t, model.AWSParameterMeta{}, base.Metadata)
+
+	// Verify Type is in Metadata
+	meta := base.AWSMeta()
+	assert.NotNil(t, meta)
+	assert.Equal(t, "String", meta.Type)
 }
 
 func TestTypedMetadata(t *testing.T) {

--- a/internal/model/secret_test.go
+++ b/internal/model/secret_test.go
@@ -15,13 +15,13 @@ func TestTypedSecret_ToBase(t *testing.T) {
 	now := time.Now()
 	typed := &model.TypedSecret[model.AWSSecretMeta]{
 		Name:        "test-secret",
-		ARN:         "arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret",
 		Value:       "test-value",
 		VersionID:   "v1",
 		Description: "test description",
 		CreatedDate: &now,
 		Tags:        map[string]string{"key": "value"},
 		Metadata: model.AWSSecretMeta{
+			ARN:             "arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret",
 			VersionStages:   []string{"AWSCURRENT"},
 			KmsKeyID:        "arn:aws:kms:us-east-1:123456789012:key/test",
 			RotationEnabled: true,
@@ -31,13 +31,17 @@ func TestTypedSecret_ToBase(t *testing.T) {
 	base := typed.ToBase()
 
 	assert.Equal(t, typed.Name, base.Name)
-	assert.Equal(t, typed.ARN, base.ARN)
 	assert.Equal(t, typed.Value, base.Value)
 	assert.Equal(t, typed.VersionID, base.VersionID)
 	assert.Equal(t, typed.Description, base.Description)
 	assert.Equal(t, typed.CreatedDate, base.CreatedDate)
 	assert.Equal(t, typed.Tags, base.Tags)
 	assert.IsType(t, model.AWSSecretMeta{}, base.Metadata)
+
+	// Verify ARN is in Metadata
+	meta := base.AWSMeta()
+	assert.NotNil(t, meta)
+	assert.Equal(t, "arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret", meta.ARN)
 }
 
 func TestTypedSecretMetadata(t *testing.T) {

--- a/internal/provider/aws/secret/adapter.go
+++ b/internal/provider/aws/secret/adapter.go
@@ -299,11 +299,11 @@ func convertGetSecretValueOutput(o *secretapi.GetSecretValueOutput) *model.Secre
 
 	return &model.Secret{
 		Name:        lo.FromPtr(o.Name),
-		ARN:         lo.FromPtr(o.ARN),
 		Value:       lo.FromPtr(o.SecretString),
 		VersionID:   lo.FromPtr(o.VersionId),
 		CreatedDate: o.CreatedDate,
 		Metadata: model.AWSSecretMeta{
+			ARN:           lo.FromPtr(o.ARN),
 			VersionStages: o.VersionStages,
 		},
 	}
@@ -330,12 +330,14 @@ func convertSecretListEntry(e *secretapi.SecretListEntry) *model.SecretListItem 
 
 	return &model.SecretListItem{
 		Name:         lo.FromPtr(e.Name),
-		ARN:          lo.FromPtr(e.ARN),
 		Description:  lo.FromPtr(e.Description),
 		CreatedDate:  e.CreatedDate,
 		LastModified: e.LastChangedDate,
 		Tags:         convertFromAWSTags(e.Tags),
-		DeletedDate:  e.DeletedDate,
+		Metadata: model.AWSSecretListItemMeta{
+			ARN:         lo.FromPtr(e.ARN),
+			DeletedDate: e.DeletedDate,
+		},
 	}
 }
 
@@ -346,12 +348,14 @@ func convertDescribeSecretOutput(o *secretapi.DescribeSecretOutput) *model.Secre
 
 	return &model.SecretListItem{
 		Name:         lo.FromPtr(o.Name),
-		ARN:          lo.FromPtr(o.ARN),
 		Description:  lo.FromPtr(o.Description),
 		CreatedDate:  o.CreatedDate,
 		LastModified: o.LastChangedDate,
 		Tags:         convertFromAWSTags(o.Tags),
-		DeletedDate:  o.DeletedDate,
+		Metadata: model.AWSSecretListItemMeta{
+			ARN:         lo.FromPtr(o.ARN),
+			DeletedDate: o.DeletedDate,
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

- Move provider-specific fields from base types to metadata structs for multi-cloud support
- `Parameter.Type` → `AWSParameterMeta.Type`
- `ParameterListItem.Type` → `AWSParameterListItemMeta.Type` (new)
- `Secret.ARN` → `AWSSecretMeta.ARN`
- `SecretListItem.ARN`, `DeletedDate` → `AWSSecretListItemMeta` (new)
- Add `AWSMeta()` helper methods for type-safe metadata access

## Test plan

- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.ai/code)