### PR TITLE
refactor(model): unify field names for multi-cloud compatibility

### DIFF
--- a/internal/cli/commands/param/diff/diff.go
+++ b/internal/cli/commands/param/diff/diff.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/cli/pager"
-	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/jsonutil"
+	awsparam "github.com/mpyw/suve/internal/provider/aws/param"
 	"github.com/mpyw/suve/internal/usecase/param"
 	"github.com/mpyw/suve/internal/version/paramversion"
 )
@@ -94,7 +94,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	client, err := infra.NewParamClient(ctx)
+	adapter, err := awsparam.NewAdapter(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to initialize AWS client: %w", err)
 	}
@@ -112,7 +112,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 
 	return pager.WithPagerWriter(cmd.Root().Writer, noPager, func(w io.Writer) error {
 		r := &Runner{
-			UseCase: &param.DiffUseCase{Client: client},
+			UseCase: &param.DiffUseCase{Client: adapter},
 			Stdout:  w,
 			Stderr:  cmd.Root().ErrWriter,
 		}

--- a/internal/cli/commands/param/show/show.go
+++ b/internal/cli/commands/param/show/show.go
@@ -185,8 +185,8 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 			jsonOut.JSONParsed = lo.ToPtr(true)
 		}
 
-		if result.LastModified != nil {
-			jsonOut.Modified = timeutil.FormatRFC3339(*result.LastModified)
+		if result.UpdatedAt != nil {
+			jsonOut.Modified = timeutil.FormatRFC3339(*result.UpdatedAt)
 		}
 
 		jsonOut.Tags = make(map[string]string)
@@ -210,8 +210,8 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 		out.Field("JsonParsed", "true")
 	}
 
-	if result.LastModified != nil {
-		out.Field("Modified", timeutil.FormatRFC3339(*result.LastModified))
+	if result.UpdatedAt != nil {
+		out.Field("Modified", timeutil.FormatRFC3339(*result.UpdatedAt))
 	}
 
 	if len(result.Tags) > 0 {

--- a/internal/cli/commands/param/show/show_test.go
+++ b/internal/cli/commands/param/show/show_test.go
@@ -116,10 +116,10 @@ func TestRun(t *testing.T) {
 			},
 			mock: &mockClient{
 				getParameterResult: &model.Parameter{
-					Name:         "/my/param",
-					Value:        "test-value",
-					Version:      "3",
-					LastModified: &now,
+					Name:      "/my/param",
+					Value:     "test-value",
+					Version:   "3",
+					UpdatedAt: &now,
 					Metadata: model.AWSParameterMeta{
 						Type: "String",
 					},
@@ -140,12 +140,12 @@ func TestRun(t *testing.T) {
 				getHistoryResult: &model.ParameterHistory{
 					Name: "/my/param",
 					Parameters: []*model.Parameter{
-						{Name: "/my/param", Value: "v3", Version: "3", LastModified: &now, Metadata: model.AWSParameterMeta{Type: "String"}},
-						{Name: "/my/param", Value: "v2", Version: "2", LastModified: timePtr(now.Add(-time.Hour)), Metadata: model.AWSParameterMeta{Type: "String"}},
+						{Name: "/my/param", Value: "v3", Version: "3", UpdatedAt: &now, Metadata: model.AWSParameterMeta{Type: "String"}},
+						{Name: "/my/param", Value: "v2", Version: "2", UpdatedAt: timePtr(now.Add(-time.Hour)), Metadata: model.AWSParameterMeta{Type: "String"}},
 						{
 							Name: "/my/param", Value: "v1", Version: "1",
-							LastModified: timePtr(now.Add(-2 * time.Hour)),
-							Metadata:     model.AWSParameterMeta{Type: "String"},
+							UpdatedAt: timePtr(now.Add(-2 * time.Hour)),
+							Metadata:  model.AWSParameterMeta{Type: "String"},
 						},
 					},
 				},
@@ -163,10 +163,10 @@ func TestRun(t *testing.T) {
 			},
 			mock: &mockClient{
 				getParameterResult: &model.Parameter{
-					Name:         "/my/param",
-					Value:        `{"zebra":"last","apple":"first"}`,
-					Version:      "1",
-					LastModified: &now,
+					Name:      "/my/param",
+					Value:     `{"zebra":"last","apple":"first"}`,
+					Version:   "1",
+					UpdatedAt: &now,
 					Metadata: model.AWSParameterMeta{
 						Type: "String",
 					},
@@ -283,10 +283,10 @@ func TestRun(t *testing.T) {
 			},
 			mock: &mockClient{
 				getParameterResult: &model.Parameter{
-					Name:         "/my/param",
-					Value:        "raw-value",
-					Version:      "1",
-					LastModified: &now,
+					Name:      "/my/param",
+					Value:     "raw-value",
+					Version:   "1",
+					UpdatedAt: &now,
 					Metadata: model.AWSParameterMeta{
 						Type: "String",
 					},
@@ -308,8 +308,8 @@ func TestRun(t *testing.T) {
 				getHistoryResult: &model.ParameterHistory{
 					Name: "/my/param",
 					Parameters: []*model.Parameter{
-						{Name: "/my/param", Value: "v1", Version: "1", LastModified: timePtr(now.Add(-time.Hour)), Metadata: model.AWSParameterMeta{Type: "String"}},
-						{Name: "/my/param", Value: "v2", Version: "2", LastModified: &now, Metadata: model.AWSParameterMeta{Type: "String"}},
+						{Name: "/my/param", Value: "v1", Version: "1", UpdatedAt: timePtr(now.Add(-time.Hour)), Metadata: model.AWSParameterMeta{Type: "String"}},
+						{Name: "/my/param", Value: "v2", Version: "2", UpdatedAt: &now, Metadata: model.AWSParameterMeta{Type: "String"}},
 					},
 				},
 			},
@@ -328,10 +328,10 @@ func TestRun(t *testing.T) {
 			},
 			mock: &mockClient{
 				getParameterResult: &model.Parameter{
-					Name:         "/my/param",
-					Value:        `{"zebra":"last","apple":"first"}`,
-					Version:      "1",
-					LastModified: &now,
+					Name:      "/my/param",
+					Value:     `{"zebra":"last","apple":"first"}`,
+					Version:   "1",
+					UpdatedAt: &now,
 					Metadata: model.AWSParameterMeta{
 						Type: "String",
 					},
@@ -355,10 +355,10 @@ func TestRun(t *testing.T) {
 			},
 			mock: &mockClient{
 				getParameterResult: &model.Parameter{
-					Name:         "/my/param",
-					Value:        "test-value",
-					Version:      "1",
-					LastModified: &now,
+					Name:      "/my/param",
+					Value:     "test-value",
+					Version:   "1",
+					UpdatedAt: &now,
 					Metadata: model.AWSParameterMeta{
 						Type: "String",
 					},
@@ -387,10 +387,10 @@ func TestRun(t *testing.T) {
 			},
 			mock: &mockClient{
 				getParameterResult: &model.Parameter{
-					Name:         "/my/param",
-					Value:        "test-value",
-					Version:      "1",
-					LastModified: &now,
+					Name:      "/my/param",
+					Value:     "test-value",
+					Version:   "1",
+					UpdatedAt: &now,
 					Metadata: model.AWSParameterMeta{
 						Type: "String",
 					},

--- a/internal/gui/param.go
+++ b/internal/gui/param.go
@@ -220,7 +220,9 @@ func (a *App) ParamDiff(spec1Str, spec2Str string) (*ParamDiffResult, error) {
 		return nil, err
 	}
 
-	uc := &param.DiffUseCase{Client: client}
+	// Create adapter that implements provider.ParameterReader
+	adapter := awsparam.New(client)
+	uc := &param.DiffUseCase{Client: adapter}
 
 	result, err := uc.Execute(a.ctx, param.DiffInput{
 		Spec1: spec1,

--- a/internal/model/parameter.go
+++ b/internal/model/parameter.go
@@ -10,25 +10,27 @@ import "time"
 // TypedParameter is a parameter with provider-specific metadata.
 // This type is used at the Provider layer for type-safe access to metadata.
 type TypedParameter[M any] struct {
-	Name         string
-	Value        string
-	Version      string
-	Description  string
-	LastModified *time.Time
-	Tags         map[string]string
-	Metadata     M
+	Name        string
+	Value       string
+	Version     string
+	Description string
+	CreatedAt   *time.Time
+	UpdatedAt   *time.Time
+	Tags        map[string]string
+	Metadata    M
 }
 
 // ToBase converts to a UseCase layer type.
 func (p *TypedParameter[M]) ToBase() *Parameter {
 	return &Parameter{
-		Name:         p.Name,
-		Value:        p.Value,
-		Version:      p.Version,
-		Description:  p.Description,
-		LastModified: p.LastModified,
-		Tags:         p.Tags,
-		Metadata:     p.Metadata,
+		Name:        p.Name,
+		Value:       p.Value,
+		Version:     p.Version,
+		Description: p.Description,
+		CreatedAt:   p.CreatedAt,
+		UpdatedAt:   p.UpdatedAt,
+		Tags:        p.Tags,
+		Metadata:    p.Metadata,
 	}
 }
 
@@ -38,13 +40,14 @@ func (p *TypedParameter[M]) ToBase() *Parameter {
 
 // Parameter is a provider-agnostic parameter for the UseCase layer.
 type Parameter struct {
-	Name         string
-	Value        string
-	Version      string
-	Description  string
-	LastModified *time.Time
-	Tags         map[string]string
-	Metadata     any // Provider-specific metadata (e.g., AWSParameterMeta)
+	Name        string
+	Value       string
+	Version     string
+	Description string
+	CreatedAt   *time.Time
+	UpdatedAt   *time.Time
+	Tags        map[string]string
+	Metadata    any // Provider-specific metadata (e.g., AWSParameterMeta)
 }
 
 // AWSMeta returns the AWS-specific metadata if available.
@@ -147,11 +150,12 @@ type AWSParameterHistory = TypedParameterHistory[AWSParameterMeta]
 
 // ParameterListItem represents a parameter in a list (without value).
 type ParameterListItem struct {
-	Name         string
-	Description  string
-	LastModified *time.Time
-	Tags         map[string]string
-	Metadata     any // Provider-specific metadata (e.g., AWSParameterListItemMeta)
+	Name        string
+	Description string
+	CreatedAt   *time.Time
+	UpdatedAt   *time.Time
+	Tags        map[string]string
+	Metadata    any // Provider-specific metadata (e.g., AWSParameterListItemMeta)
 }
 
 // AWSMeta returns the AWS-specific metadata if available.

--- a/internal/model/parameter_test.go
+++ b/internal/model/parameter_test.go
@@ -14,12 +14,13 @@ func TestTypedParameter_ToBase(t *testing.T) {
 
 	now := time.Now()
 	typed := &model.TypedParameter[model.AWSParameterMeta]{
-		Name:         "test-param",
-		Value:        "test-value",
-		Version:      "1",
-		Description:  "test description",
-		LastModified: &now,
-		Tags:         map[string]string{"key": "value"},
+		Name:        "test-param",
+		Value:       "test-value",
+		Version:     "1",
+		Description: "test description",
+		CreatedAt:   &now,
+		UpdatedAt:   &now,
+		Tags:        map[string]string{"key": "value"},
 		Metadata: model.AWSParameterMeta{
 			Type: "String",
 			ARN:  "arn:aws:ssm:us-east-1:123456789012:parameter/test-param",
@@ -33,7 +34,8 @@ func TestTypedParameter_ToBase(t *testing.T) {
 	assert.Equal(t, typed.Value, base.Value)
 	assert.Equal(t, typed.Version, base.Version)
 	assert.Equal(t, typed.Description, base.Description)
-	assert.Equal(t, typed.LastModified, base.LastModified)
+	assert.Equal(t, typed.CreatedAt, base.CreatedAt)
+	assert.Equal(t, typed.UpdatedAt, base.UpdatedAt)
 	assert.Equal(t, typed.Tags, base.Tags)
 	assert.IsType(t, model.AWSParameterMeta{}, base.Metadata)
 
@@ -86,18 +88,18 @@ func TestTypedParameterHistory_ToBase(t *testing.T) {
 		Name: "test-param",
 		Parameters: []*model.TypedParameter[model.AWSParameterMeta]{
 			{
-				Name:         "test-param",
-				Value:        "value1",
-				Version:      "1",
-				LastModified: &now,
-				Metadata:     model.AWSParameterMeta{Tier: "Standard"},
+				Name:      "test-param",
+				Value:     "value1",
+				Version:   "1",
+				UpdatedAt: &now,
+				Metadata:  model.AWSParameterMeta{Tier: "Standard"},
 			},
 			{
-				Name:         "test-param",
-				Value:        "value2",
-				Version:      "2",
-				LastModified: &now,
-				Metadata:     model.AWSParameterMeta{Tier: "Advanced"},
+				Name:      "test-param",
+				Value:     "value2",
+				Version:   "2",
+				UpdatedAt: &now,
+				Metadata:  model.AWSParameterMeta{Tier: "Advanced"},
 			},
 		},
 	}

--- a/internal/model/secret.go
+++ b/internal/model/secret.go
@@ -11,9 +11,10 @@ import "time"
 type TypedSecret[M any] struct {
 	Name        string
 	Value       string
-	VersionID   string
+	Version     string
 	Description string
-	CreatedDate *time.Time
+	CreatedAt   *time.Time
+	UpdatedAt   *time.Time
 	Tags        map[string]string
 	Metadata    M
 }
@@ -23,9 +24,10 @@ func (s *TypedSecret[M]) ToBase() *Secret {
 	return &Secret{
 		Name:        s.Name,
 		Value:       s.Value,
-		VersionID:   s.VersionID,
+		Version:     s.Version,
 		Description: s.Description,
-		CreatedDate: s.CreatedDate,
+		CreatedAt:   s.CreatedAt,
+		UpdatedAt:   s.UpdatedAt,
 		Tags:        s.Tags,
 		Metadata:    s.Metadata,
 	}
@@ -39,9 +41,10 @@ func (s *TypedSecret[M]) ToBase() *Secret {
 type Secret struct {
 	Name        string
 	Value       string
-	VersionID   string
+	Version     string
 	Description string
-	CreatedDate *time.Time
+	CreatedAt   *time.Time
+	UpdatedAt   *time.Time
 	Tags        map[string]string
 	Metadata    any // Provider-specific metadata (e.g., AWSSecretMeta)
 }
@@ -136,25 +139,25 @@ type AzureSecret = TypedSecret[AzureKeyVaultMeta]
 
 // TypedSecretVersion represents a version of a typed secret.
 type TypedSecretVersion[M any] struct {
-	VersionID   string
-	CreatedDate *time.Time
-	Metadata    M
+	Version   string
+	CreatedAt *time.Time
+	Metadata  M
 }
 
 // ToBase converts to a UseCase layer type.
 func (v *TypedSecretVersion[M]) ToBase() *SecretVersion {
 	return &SecretVersion{
-		VersionID:   v.VersionID,
-		CreatedDate: v.CreatedDate,
-		Metadata:    v.Metadata,
+		Version:   v.Version,
+		CreatedAt: v.CreatedAt,
+		Metadata:  v.Metadata,
 	}
 }
 
 // SecretVersion represents a version of a secret.
 type SecretVersion struct {
-	VersionID   string
-	CreatedDate *time.Time
-	Metadata    any // Provider-specific metadata
+	Version   string
+	CreatedAt *time.Time
+	Metadata  any // Provider-specific metadata
 }
 
 // AWSSecretVersionMeta contains AWS-specific version metadata.
@@ -171,12 +174,12 @@ type AWSSecretVersion = TypedSecretVersion[AWSSecretVersionMeta]
 
 // SecretListItem represents a secret in a list (without value).
 type SecretListItem struct {
-	Name         string
-	Description  string
-	CreatedDate  *time.Time
-	LastModified *time.Time
-	Tags         map[string]string
-	Metadata     any // Provider-specific metadata (e.g., AWSSecretListItemMeta)
+	Name        string
+	Description string
+	CreatedAt   *time.Time
+	UpdatedAt   *time.Time
+	Tags        map[string]string
+	Metadata    any // Provider-specific metadata (e.g., AWSSecretListItemMeta)
 }
 
 // AWSMeta returns the AWS-specific metadata if available.

--- a/internal/model/secret_test.go
+++ b/internal/model/secret_test.go
@@ -16,9 +16,10 @@ func TestTypedSecret_ToBase(t *testing.T) {
 	typed := &model.TypedSecret[model.AWSSecretMeta]{
 		Name:        "test-secret",
 		Value:       "test-value",
-		VersionID:   "v1",
+		Version:     "v1",
 		Description: "test description",
-		CreatedDate: &now,
+		CreatedAt:   &now,
+		UpdatedAt:   &now,
 		Tags:        map[string]string{"key": "value"},
 		Metadata: model.AWSSecretMeta{
 			ARN:             "arn:aws:secretsmanager:us-east-1:123456789012:secret:test-secret",
@@ -32,9 +33,10 @@ func TestTypedSecret_ToBase(t *testing.T) {
 
 	assert.Equal(t, typed.Name, base.Name)
 	assert.Equal(t, typed.Value, base.Value)
-	assert.Equal(t, typed.VersionID, base.VersionID)
+	assert.Equal(t, typed.Version, base.Version)
 	assert.Equal(t, typed.Description, base.Description)
-	assert.Equal(t, typed.CreatedDate, base.CreatedDate)
+	assert.Equal(t, typed.CreatedAt, base.CreatedAt)
+	assert.Equal(t, typed.UpdatedAt, base.UpdatedAt)
 	assert.Equal(t, typed.Tags, base.Tags)
 	assert.IsType(t, model.AWSSecretMeta{}, base.Metadata)
 
@@ -84,8 +86,8 @@ func TestTypedSecretVersion_ToBase(t *testing.T) {
 
 	now := time.Now()
 	typed := &model.TypedSecretVersion[model.AWSSecretVersionMeta]{
-		VersionID:   "v1",
-		CreatedDate: &now,
+		Version:   "v1",
+		CreatedAt: &now,
 		Metadata: model.AWSSecretVersionMeta{
 			VersionStages: []string{"AWSCURRENT"},
 		},
@@ -93,7 +95,7 @@ func TestTypedSecretVersion_ToBase(t *testing.T) {
 
 	base := typed.ToBase()
 
-	assert.Equal(t, typed.VersionID, base.VersionID)
-	assert.Equal(t, typed.CreatedDate, base.CreatedDate)
+	assert.Equal(t, typed.Version, base.Version)
+	assert.Equal(t, typed.CreatedAt, base.CreatedAt)
 	assert.IsType(t, model.AWSSecretVersionMeta{}, base.Metadata)
 }

--- a/internal/provider/aws/param/adapter.go
+++ b/internal/provider/aws/param/adapter.go
@@ -287,10 +287,10 @@ func convertParameter(p *paramapi.Parameter) *model.Parameter {
 	}
 
 	return &model.Parameter{
-		Name:         lo.FromPtr(p.Name),
-		Value:        lo.FromPtr(p.Value),
-		Version:      version,
-		LastModified: p.LastModifiedDate,
+		Name:      lo.FromPtr(p.Name),
+		Value:     lo.FromPtr(p.Value),
+		Version:   version,
+		UpdatedAt: p.LastModifiedDate,
 		Metadata: model.AWSParameterMeta{
 			Type:     string(p.Type),
 			ARN:      lo.FromPtr(p.ARN),
@@ -308,11 +308,11 @@ func convertParameterHistory(name string, history []paramapi.ParameterHistory) *
 		}
 
 		params[i] = &model.Parameter{
-			Name:         name,
-			Value:        lo.FromPtr(h.Value),
-			Version:      version,
-			Description:  lo.FromPtr(h.Description),
-			LastModified: h.LastModifiedDate,
+			Name:        name,
+			Value:       lo.FromPtr(h.Value),
+			Version:     version,
+			Description: lo.FromPtr(h.Description),
+			UpdatedAt:   h.LastModifiedDate,
 			Metadata: model.AWSParameterMeta{
 				Type:           string(h.Type),
 				Tier:           string(h.Tier),
@@ -334,9 +334,9 @@ func convertParameterMetadata(m *paramapi.ParameterMetadata) *model.ParameterLis
 	}
 
 	return &model.ParameterListItem{
-		Name:         lo.FromPtr(m.Name),
-		Description:  lo.FromPtr(m.Description),
-		LastModified: m.LastModifiedDate,
+		Name:        lo.FromPtr(m.Name),
+		Description: lo.FromPtr(m.Description),
+		UpdatedAt:   m.LastModifiedDate,
 		Metadata: model.AWSParameterListItemMeta{
 			Type: string(m.Type),
 		},

--- a/internal/provider/aws/secret/adapter.go
+++ b/internal/provider/aws/secret/adapter.go
@@ -298,10 +298,10 @@ func convertGetSecretValueOutput(o *secretapi.GetSecretValueOutput) *model.Secre
 	}
 
 	return &model.Secret{
-		Name:        lo.FromPtr(o.Name),
-		Value:       lo.FromPtr(o.SecretString),
-		VersionID:   lo.FromPtr(o.VersionId),
-		CreatedDate: o.CreatedDate,
+		Name:      lo.FromPtr(o.Name),
+		Value:     lo.FromPtr(o.SecretString),
+		Version:   lo.FromPtr(o.VersionId),
+		CreatedAt: o.CreatedDate,
 		Metadata: model.AWSSecretMeta{
 			ARN:           lo.FromPtr(o.ARN),
 			VersionStages: o.VersionStages,
@@ -315,8 +315,8 @@ func convertSecretVersion(v *secretapi.SecretVersionsListEntry) *model.SecretVer
 	}
 
 	return &model.SecretVersion{
-		VersionID:   lo.FromPtr(v.VersionId),
-		CreatedDate: v.CreatedDate,
+		Version:   lo.FromPtr(v.VersionId),
+		CreatedAt: v.CreatedDate,
 		Metadata: model.AWSSecretVersionMeta{
 			VersionStages: v.VersionStages,
 		},
@@ -329,11 +329,11 @@ func convertSecretListEntry(e *secretapi.SecretListEntry) *model.SecretListItem 
 	}
 
 	return &model.SecretListItem{
-		Name:         lo.FromPtr(e.Name),
-		Description:  lo.FromPtr(e.Description),
-		CreatedDate:  e.CreatedDate,
-		LastModified: e.LastChangedDate,
-		Tags:         convertFromAWSTags(e.Tags),
+		Name:        lo.FromPtr(e.Name),
+		Description: lo.FromPtr(e.Description),
+		CreatedAt:   e.CreatedDate,
+		UpdatedAt:   e.LastChangedDate,
+		Tags:        convertFromAWSTags(e.Tags),
 		Metadata: model.AWSSecretListItemMeta{
 			ARN:         lo.FromPtr(e.ARN),
 			DeletedDate: e.DeletedDate,
@@ -347,11 +347,11 @@ func convertDescribeSecretOutput(o *secretapi.DescribeSecretOutput) *model.Secre
 	}
 
 	return &model.SecretListItem{
-		Name:         lo.FromPtr(o.Name),
-		Description:  lo.FromPtr(o.Description),
-		CreatedDate:  o.CreatedDate,
-		LastModified: o.LastChangedDate,
-		Tags:         convertFromAWSTags(o.Tags),
+		Name:        lo.FromPtr(o.Name),
+		Description: lo.FromPtr(o.Description),
+		CreatedAt:   o.CreatedDate,
+		UpdatedAt:   o.LastChangedDate,
+		Tags:        convertFromAWSTags(o.Tags),
 		Metadata: model.AWSSecretListItemMeta{
 			ARN:         lo.FromPtr(o.ARN),
 			DeletedDate: o.DeletedDate,

--- a/internal/provider/secret_test.go
+++ b/internal/provider/secret_test.go
@@ -32,9 +32,9 @@ func TestWrapTypedSecretReader_GetSecret(t *testing.T) {
 		mock := &mockTypedSecretReader{
 			getTypedSecretFunc: func(_ context.Context, name, versionID, _ string) (*model.TypedSecret[model.AWSSecretMeta], error) {
 				return &model.TypedSecret[model.AWSSecretMeta]{
-					Name:      name,
-					Value:     "test-value",
-					VersionID: versionID,
+					Name:    name,
+					Value:   "test-value",
+					Version: versionID,
 					Metadata: model.AWSSecretMeta{
 						VersionStages: []string{"AWSCURRENT"},
 					},
@@ -48,7 +48,7 @@ func TestWrapTypedSecretReader_GetSecret(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "test-secret", secret.Name)
 		assert.Equal(t, "test-value", secret.Value)
-		assert.Equal(t, "v1", secret.VersionID)
+		assert.Equal(t, "v1", secret.Version)
 	})
 
 	t.Run("error", func(t *testing.T) {

--- a/internal/usecase/param/diff.go
+++ b/internal/usecase/param/diff.go
@@ -2,17 +2,17 @@ package param
 
 import (
 	"context"
+	"strconv"
 
-	"github.com/samber/lo"
-
-	"github.com/mpyw/suve/internal/api/paramapi"
+	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/version/paramversion"
 )
 
 // DiffClient is the interface for the diff use case.
+//
+//nolint:iface // Intentionally aliases ParameterReader for type clarity in DiffUseCase.
 type DiffClient interface {
-	paramapi.GetParameterAPI
-	paramapi.GetParameterHistoryAPI
+	provider.ParameterReader
 }
 
 // DiffInput holds input for the diff use case.
@@ -48,12 +48,15 @@ func (u *DiffUseCase) Execute(ctx context.Context, input DiffInput) (*DiffOutput
 		return nil, err
 	}
 
+	oldVersion, _ := strconv.ParseInt(param1.Version, 10, 64)
+	newVersion, _ := strconv.ParseInt(param2.Version, 10, 64)
+
 	return &DiffOutput{
-		OldName:    lo.FromPtr(param1.Name),
-		OldVersion: param1.Version,
-		OldValue:   lo.FromPtr(param1.Value),
-		NewName:    lo.FromPtr(param2.Name),
-		NewVersion: param2.Version,
-		NewValue:   lo.FromPtr(param2.Value),
+		OldName:    param1.Name,
+		OldVersion: oldVersion,
+		OldValue:   param1.Value,
+		NewName:    param2.Name,
+		NewVersion: newVersion,
+		NewValue:   param2.Value,
 	}, nil
 }

--- a/internal/usecase/param/helper_test.go
+++ b/internal/usecase/param/helper_test.go
@@ -12,5 +12,4 @@ var (
 	errAddTagsFailed    = errors.New("add tags failed")
 	errRemoveTagsFailed = errors.New("remove tags failed")
 	errAccessDenied     = errors.New("access denied")
-	errUnexpectedCall   = errors.New("unexpected GetParameter call")
 )

--- a/internal/usecase/param/log.go
+++ b/internal/usecase/param/log.go
@@ -12,6 +12,8 @@ import (
 )
 
 // LogClient is the interface for the log use case.
+//
+//nolint:iface // Intentionally aliases ParameterReader for type clarity in LogUseCase.
 type LogClient interface {
 	provider.ParameterReader
 }

--- a/internal/usecase/param/show.go
+++ b/internal/usecase/param/show.go
@@ -3,12 +3,8 @@ package param
 
 import (
 	"context"
-	"fmt"
-	"slices"
-	"strconv"
 	"time"
 
-	"github.com/mpyw/suve/internal/model"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/version/paramversion"
 )
@@ -48,7 +44,7 @@ type ShowUseCase struct {
 
 // Execute runs the show use case.
 func (u *ShowUseCase) Execute(ctx context.Context, input ShowInput) (*ShowOutput, error) {
-	param, err := u.getParameterWithVersion(ctx, input.Spec)
+	param, err := paramversion.GetParameterWithVersion(ctx, u.Client, input.Spec)
 	if err != nil {
 		return nil, err
 	}
@@ -75,76 +71,4 @@ func (u *ShowUseCase) Execute(ctx context.Context, input ShowInput) (*ShowOutput
 	}
 
 	return output, nil
-}
-
-// getParameterWithVersion retrieves a parameter with version/shift support.
-func (u *ShowUseCase) getParameterWithVersion(
-	ctx context.Context, spec *paramversion.Spec,
-) (*model.Parameter, error) {
-	if spec.HasShift() {
-		return u.getParameterWithShift(ctx, spec)
-	}
-
-	return u.getParameterDirect(ctx, spec)
-}
-
-func (u *ShowUseCase) getParameterWithShift(
-	ctx context.Context, spec *paramversion.Spec,
-) (*model.Parameter, error) {
-	history, err := u.Client.GetParameterHistory(ctx, spec.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get parameter history: %w", err)
-	}
-
-	if len(history.Parameters) == 0 {
-		return nil, fmt.Errorf("parameter not found: %s", spec.Name)
-	}
-
-	// Copy and reverse to get newest first
-	params := make([]*model.Parameter, len(history.Parameters))
-	copy(params, history.Parameters)
-	slices.Reverse(params)
-
-	baseIdx := 0
-
-	if spec.Absolute.Version != nil {
-		targetVersion := strconv.FormatInt(*spec.Absolute.Version, 10)
-		found := false
-
-		for i, p := range params {
-			if p.Version == targetVersion {
-				baseIdx = i
-				found = true
-
-				break
-			}
-		}
-
-		if !found {
-			return nil, fmt.Errorf("version %d not found", *spec.Absolute.Version)
-		}
-	}
-
-	targetIdx := baseIdx + spec.Shift
-	if targetIdx >= len(params) {
-		return nil, fmt.Errorf("version shift out of range: ~%d", spec.Shift)
-	}
-
-	return params[targetIdx], nil
-}
-
-func (u *ShowUseCase) getParameterDirect(
-	ctx context.Context, spec *paramversion.Spec,
-) (*model.Parameter, error) {
-	version := ""
-	if spec.Absolute.Version != nil {
-		version = strconv.FormatInt(*spec.Absolute.Version, 10)
-	}
-
-	param, err := u.Client.GetParameter(ctx, spec.Name, version)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get parameter: %w", err)
-	}
-
-	return param, nil
 }

--- a/internal/usecase/param/show.go
+++ b/internal/usecase/param/show.go
@@ -32,13 +32,13 @@ type ShowTag struct {
 
 // ShowOutput holds the result of the show use case.
 type ShowOutput struct {
-	Name         string
-	Value        string
-	Version      string
-	Type         string // Parameter type (e.g., "String", "SecureString")
-	Description  string
-	LastModified *time.Time
-	Tags         []ShowTag
+	Name        string
+	Value       string
+	Version     string
+	Type        string // Parameter type (e.g., "String", "SecureString")
+	Description string
+	UpdatedAt   *time.Time
+	Tags        []ShowTag
 }
 
 // ShowUseCase executes show operations.
@@ -54,11 +54,11 @@ func (u *ShowUseCase) Execute(ctx context.Context, input ShowInput) (*ShowOutput
 	}
 
 	output := &ShowOutput{
-		Name:         param.Name,
-		Value:        param.Value,
-		Version:      param.Version,
-		Description:  param.Description,
-		LastModified: param.LastModified,
+		Name:        param.Name,
+		Value:       param.Value,
+		Version:     param.Version,
+		Description: param.Description,
+		UpdatedAt:   param.UpdatedAt,
 	}
 
 	// Extract Type from AWS metadata if available

--- a/internal/usecase/param/show.go
+++ b/internal/usecase/param/show.go
@@ -3,19 +3,20 @@ package param
 
 import (
 	"context"
+	"fmt"
+	"slices"
+	"strconv"
 	"time"
 
-	"github.com/samber/lo"
-
-	"github.com/mpyw/suve/internal/api/paramapi"
+	"github.com/mpyw/suve/internal/model"
+	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/version/paramversion"
 )
 
 // ShowClient is the interface for the show use case.
 type ShowClient interface {
-	paramapi.GetParameterAPI
-	paramapi.GetParameterHistoryAPI
-	paramapi.ListTagsForResourceAPI
+	provider.ParameterReader
+	provider.ParameterTagger
 }
 
 // ShowInput holds input for the show use case.
@@ -33,8 +34,8 @@ type ShowTag struct {
 type ShowOutput struct {
 	Name         string
 	Value        string
-	Version      int64
-	Type         paramapi.ParameterType
+	Version      string
+	Type         string // Parameter type (e.g., "String", "SecureString")
 	Description  string
 	LastModified *time.Time
 	Tags         []ShowTag
@@ -47,35 +48,103 @@ type ShowUseCase struct {
 
 // Execute runs the show use case.
 func (u *ShowUseCase) Execute(ctx context.Context, input ShowInput) (*ShowOutput, error) {
-	param, err := paramversion.GetParameterWithVersion(ctx, u.Client, input.Spec)
+	param, err := u.getParameterWithVersion(ctx, input.Spec)
 	if err != nil {
 		return nil, err
 	}
 
 	output := &ShowOutput{
-		Name:        lo.FromPtr(param.Name),
-		Value:       lo.FromPtr(param.Value),
-		Version:     param.Version,
-		Type:        param.Type,
-		Description: lo.FromPtr(param.Description),
+		Name:         param.Name,
+		Value:        param.Value,
+		Version:      param.Version,
+		Description:  param.Description,
+		LastModified: param.LastModified,
 	}
-	if param.LastModifiedDate != nil {
-		output.LastModified = param.LastModifiedDate
+
+	// Extract Type from AWS metadata if available
+	if meta := param.AWSMeta(); meta != nil {
+		output.Type = meta.Type
 	}
 
 	// Fetch tags
-	tagsOutput, err := u.Client.ListTagsForResource(ctx, &paramapi.ListTagsForResourceInput{
-		ResourceType: paramapi.ResourceTypeForTaggingParameter,
-		ResourceId:   param.Name,
-	})
-	if err == nil && tagsOutput != nil {
-		output.Tags = lo.Map(tagsOutput.TagList, func(tag paramapi.Tag, _ int) ShowTag {
-			return ShowTag{
-				Key:   lo.FromPtr(tag.Key),
-				Value: lo.FromPtr(tag.Value),
-			}
-		})
+	tags, err := u.Client.GetTags(ctx, param.Name)
+	if err == nil && tags != nil {
+		for k, v := range tags {
+			output.Tags = append(output.Tags, ShowTag{Key: k, Value: v})
+		}
 	}
 
 	return output, nil
+}
+
+// getParameterWithVersion retrieves a parameter with version/shift support.
+func (u *ShowUseCase) getParameterWithVersion(
+	ctx context.Context, spec *paramversion.Spec,
+) (*model.Parameter, error) {
+	if spec.HasShift() {
+		return u.getParameterWithShift(ctx, spec)
+	}
+
+	return u.getParameterDirect(ctx, spec)
+}
+
+func (u *ShowUseCase) getParameterWithShift(
+	ctx context.Context, spec *paramversion.Spec,
+) (*model.Parameter, error) {
+	history, err := u.Client.GetParameterHistory(ctx, spec.Name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get parameter history: %w", err)
+	}
+
+	if len(history.Parameters) == 0 {
+		return nil, fmt.Errorf("parameter not found: %s", spec.Name)
+	}
+
+	// Copy and reverse to get newest first
+	params := make([]*model.Parameter, len(history.Parameters))
+	copy(params, history.Parameters)
+	slices.Reverse(params)
+
+	baseIdx := 0
+
+	if spec.Absolute.Version != nil {
+		targetVersion := strconv.FormatInt(*spec.Absolute.Version, 10)
+		found := false
+
+		for i, p := range params {
+			if p.Version == targetVersion {
+				baseIdx = i
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			return nil, fmt.Errorf("version %d not found", *spec.Absolute.Version)
+		}
+	}
+
+	targetIdx := baseIdx + spec.Shift
+	if targetIdx >= len(params) {
+		return nil, fmt.Errorf("version shift out of range: ~%d", spec.Shift)
+	}
+
+	return params[targetIdx], nil
+}
+
+func (u *ShowUseCase) getParameterDirect(
+	ctx context.Context, spec *paramversion.Spec,
+) (*model.Parameter, error) {
+	version := ""
+	if spec.Absolute.Version != nil {
+		version = strconv.FormatInt(*spec.Absolute.Version, 10)
+	}
+
+	param, err := u.Client.GetParameter(ctx, spec.Name, version)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get parameter: %w", err)
+	}
+
+	return param, nil
 }

--- a/internal/usecase/param/show_test.go
+++ b/internal/usecase/param/show_test.go
@@ -73,10 +73,10 @@ func TestShowUseCase_Execute(t *testing.T) {
 	now := time.Now()
 	client := &mockShowClient{
 		getParameterResult: &model.Parameter{
-			Name:         "/app/config",
-			Value:        "secret-value",
-			Version:      "5",
-			LastModified: &now,
+			Name:      "/app/config",
+			Value:     "secret-value",
+			Version:   "5",
+			UpdatedAt: &now,
 			Metadata: model.AWSParameterMeta{
 				Type: "SecureString",
 			},
@@ -96,7 +96,7 @@ func TestShowUseCase_Execute(t *testing.T) {
 	assert.Equal(t, "secret-value", output.Value)
 	assert.Equal(t, "5", output.Version)
 	assert.Equal(t, "SecureString", output.Type)
-	assert.NotNil(t, output.LastModified)
+	assert.NotNil(t, output.UpdatedAt)
 }
 
 func TestShowUseCase_Execute_WithVersion(t *testing.T) {
@@ -175,7 +175,7 @@ func TestShowUseCase_Execute_Error(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestShowUseCase_Execute_NoLastModified(t *testing.T) {
+func TestShowUseCase_Execute_NoUpdatedAt(t *testing.T) {
 	t.Parallel()
 
 	client := &mockShowClient{
@@ -198,7 +198,7 @@ func TestShowUseCase_Execute_NoLastModified(t *testing.T) {
 		Spec: spec,
 	})
 	require.NoError(t, err)
-	assert.Nil(t, output.LastModified)
+	assert.Nil(t, output.UpdatedAt)
 }
 
 func TestShowUseCase_Execute_WithTags(t *testing.T) {


### PR DESCRIPTION
## Summary
- Rename `Secret.VersionID` → `Version` (consistent with Parameter)
- Rename `Parameter.LastModified` → `UpdatedAt`
- Rename `Secret.CreatedDate` → `CreatedAt`
- Add `UpdatedAt` field to Secret for providers that track both dates
- Update all layers: model, provider, usecase, cli, gui

## Motivation
The previous model types were too AWS-centric. This change makes the model layer truly provider-agnostic, supporting AWS, Azure, and GCP field semantics uniformly.

## Test plan
- [x] `go test ./...` passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)