### PR TITLE
fix(lint): make `make lint` green again

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,6 +126,7 @@ jobs:
       - name: Run golangci-lint (default build)
         uses: golangci/golangci-lint-action@v9
         with:
+          version: v2.11.4
           args: --timeout=5m
 
       - name: Create dummy frontend dist for production lint
@@ -139,6 +140,7 @@ jobs:
       - name: Run golangci-lint (production build)
         uses: golangci/golangci-lint-action@v9
         with:
+          version: v2.11.4
           args: --timeout=5m --build-tags=production,webkit2_41
 
       - name: Run goroutinectx
@@ -508,6 +510,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
+          version: v2.11.4
           args: --timeout=5m
 
   platform-build:

--- a/internal/cli/pager/pager.go
+++ b/internal/cli/pager/pager.go
@@ -38,7 +38,7 @@ func WithPagerWriter(stdout io.Writer, noPager bool, fn func(w io.Writer) error)
 	}
 
 	// Check if output fits in terminal
-	if fitsInTerminal(int(f.Fd()), buf.String()) {
+	if fitsInTerminal(terminal.FdToInt(f.Fd()), buf.String()) {
 		_, err := stdout.Write(buf.Bytes())
 
 		return err

--- a/internal/cli/passphrase/passphrase.go
+++ b/internal/cli/passphrase/passphrase.go
@@ -129,7 +129,7 @@ func (p *Prompter) confirmPlainText() bool {
 func (p *Prompter) readPassword() (string, error) {
 	// Try to get file descriptor for secure password reading
 	if f, ok := p.Stdin.(terminal.Fder); ok && terminal.IsTTY(f.Fd()) {
-		pass, err := term.ReadPassword(int(f.Fd()))
+		pass, err := term.ReadPassword(terminal.FdToInt(f.Fd()))
 		if err != nil {
 			return "", err
 		}

--- a/internal/cli/terminal/terminal.go
+++ b/internal/cli/terminal/terminal.go
@@ -3,6 +3,7 @@ package terminal
 
 import (
 	"io"
+	"math"
 
 	"github.com/mattn/go-isatty"
 	"golang.org/x/term"
@@ -14,6 +15,18 @@ const DefaultWidth = 50
 // Fder is an interface for types that have a file descriptor.
 type Fder interface {
 	Fd() uintptr
+}
+
+// FdToInt safely converts a file descriptor from uintptr to int.
+// File descriptors are always small non-negative values, so this only
+// guards against a theoretical overflow on 32-bit platforms; on overflow
+// it returns -1, which callers treat as an invalid descriptor.
+func FdToInt(fd uintptr) int {
+	if fd > uintptr(math.MaxInt) {
+		return -1
+	}
+
+	return int(fd)
 }
 
 // GetSize returns the terminal width and height for the given file descriptor.
@@ -36,7 +49,7 @@ func GetWidthFromWriter(w io.Writer) int {
 		return DefaultWidth
 	}
 
-	width, _, err := GetSize(int(f.Fd()))
+	width, _, err := GetSize(FdToInt(f.Fd()))
 	if err != nil || width <= 0 {
 		return DefaultWidth
 	}

--- a/internal/cli/terminal/terminal_test.go
+++ b/internal/cli/terminal/terminal_test.go
@@ -2,12 +2,36 @@ package terminal_test
 
 import (
 	"bytes"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
 	"github.com/mpyw/suve/internal/cli/terminal"
 )
+
+func TestFdToInt(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		fd   uintptr
+		want int
+	}{
+		{name: "typical fd", fd: 3, want: 3},
+		{name: "zero", fd: 0, want: 0},
+		{name: "max int", fd: uintptr(math.MaxInt), want: math.MaxInt},
+		{name: "overflow returns -1", fd: uintptr(math.MaxUint), want: -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, terminal.FdToInt(tt.fd))
+		})
+	}
+}
 
 func TestGetWidthFromWriter_NonFder(t *testing.T) {
 	t.Parallel()

--- a/internal/parallel/parallel_test.go
+++ b/internal/parallel/parallel_test.go
@@ -83,12 +83,12 @@ func TestExecuteMap(t *testing.T) {
 		}
 
 		var (
-			running       int32
+			running       atomic.Int32
 			maxConcurrent int32
 		)
 
 		results := parallel.ExecuteMap(t.Context(), entries, func(_ context.Context, _ int, _ string) (bool, error) {
-			current := atomic.AddInt32(&running, 1)
+			current := running.Add(1)
 			// Update maxConcurrent if current is higher
 			for {
 				oldMax := atomic.LoadInt32(&maxConcurrent)
@@ -98,7 +98,7 @@ func TestExecuteMap(t *testing.T) {
 			}
 
 			time.Sleep(10 * time.Millisecond)
-			atomic.AddInt32(&running, -1)
+			running.Add(-1)
 
 			return true, nil
 		})
@@ -125,11 +125,11 @@ func TestExecuteMapWithLimit(t *testing.T) {
 
 		var (
 			maxConcurrent int32
-			running       int32
+			running       atomic.Int32
 		)
 
 		results := parallel.ExecuteMapWithLimit(t.Context(), entries, 2, func(_ context.Context, _ int, _ string) (bool, error) {
-			current := atomic.AddInt32(&running, 1)
+			current := running.Add(1)
 
 			for {
 				oldMax := atomic.LoadInt32(&maxConcurrent)
@@ -139,7 +139,7 @@ func TestExecuteMapWithLimit(t *testing.T) {
 			}
 
 			time.Sleep(20 * time.Millisecond)
-			atomic.AddInt32(&running, -1)
+			running.Add(-1)
 
 			return true, nil
 		})
@@ -160,11 +160,11 @@ func TestExecuteMapWithLimit(t *testing.T) {
 
 		var (
 			maxConcurrent int32
-			running       int32
+			running       atomic.Int32
 		)
 
 		results := parallel.ExecuteMapWithLimit(t.Context(), entries, 1, func(_ context.Context, _ int, _ string) (bool, error) {
-			current := atomic.AddInt32(&running, 1)
+			current := running.Add(1)
 
 			for {
 				oldMax := atomic.LoadInt32(&maxConcurrent)
@@ -174,7 +174,7 @@ func TestExecuteMapWithLimit(t *testing.T) {
 			}
 
 			time.Sleep(5 * time.Millisecond)
-			atomic.AddInt32(&running, -1)
+			running.Add(-1)
 
 			return true, nil
 		})

--- a/internal/staging/store/agent/internal/server/security/peer_darwin.go
+++ b/internal/staging/store/agent/internal/server/security/peer_darwin.go
@@ -30,6 +30,7 @@ func VerifyPeerCredentials(conn net.Conn) error {
 	var credErr error
 
 	controlErr := rawConn.Control(func(fd uintptr) {
+		//nolint:gosec // G115: fd is a valid socket descriptor (small non-negative); file removed in #194.
 		cred, err := unix.GetsockoptXucred(int(fd), unix.SOL_LOCAL, unix.LOCAL_PEERCRED)
 		if err != nil {
 			credErr = fmt.Errorf("failed to get peer credentials: %w", err)

--- a/internal/staging/store/agent/internal/server/security/peer_linux.go
+++ b/internal/staging/store/agent/internal/server/security/peer_linux.go
@@ -30,6 +30,7 @@ func VerifyPeerCredentials(conn net.Conn) error {
 	var credErr error
 
 	controlErr := rawConn.Control(func(fd uintptr) {
+		//nolint:gosec // G115: fd is a valid socket descriptor (small non-negative); file removed in #194.
 		cred, err := unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
 		if err != nil {
 			credErr = fmt.Errorf("failed to get peer credentials: %w", err)

--- a/internal/staging/store/file/internal/crypt/crypt.go
+++ b/internal/staging/store/file/internal/crypt/crypt.go
@@ -16,9 +16,9 @@ import (
 //
 //nolint:gochecknoglobals // Testing hooks to inject errors into crypto operations.
 var (
-	randReader    io.Reader                                      = rand.Reader
-	newCipherFunc func(key []byte) (cipher.Block, error)         = aes.NewCipher
-	newGCMFunc    func(cipher cipher.Block) (cipher.AEAD, error) = cipher.NewGCM
+	randReader    = rand.Reader
+	newCipherFunc = aes.NewCipher
+	newGCMFunc    = cipher.NewGCM
 )
 
 // SetRandReader sets the random reader for testing purposes.

--- a/internal/staging/store/file/internal/crypt/crypt_test.go
+++ b/internal/staging/store/file/internal/crypt/crypt_test.go
@@ -33,7 +33,7 @@ func TestEncryptDecrypt(t *testing.T) {
 			data:       []byte(`{"version":2,"entries":{}}`),
 			passphrase: "my-passphrase",
 		},
-		{
+		{ //nolint:gosec // G101: test fixture passphrase, not a real credential.
 			name:       "unicode passphrase",
 			data:       []byte("test data"),
 			passphrase: "パスワード123",

--- a/internal/version/paramversion/spec.go
+++ b/internal/version/paramversion/spec.go
@@ -45,6 +45,7 @@ var parser = version.AbsoluteParser[AbsoluteSpec]{
 				if err != nil {
 					return abs, err
 				}
+
 				abs.Version = lo.ToPtr(v)
 
 				return abs, nil


### PR DESCRIPTION
Closes #190 (Part of #189, Phase 0)

## Summary

Bring the lint baseline back to green. `make lint` reported **11 violations**; this PR resolves all of them, and additionally pins CI's golangci-lint so the CI Lint gate actually agrees with `make lint`. No behavioral changes to CLI/staging commands.

### 1. The 11 `make lint` violations (#190 scope)

| Linter | Count | Fix |
|--------|-------|-----|
| gosec **G115** (uintptr->int fd) | 3 | Bounds-checked `terminal.FdToInt` helper for `terminal.go`, `pager.go`, `passphrase.go`; `//nolint` for `peer_darwin.go` (removed in #194) |
| gosec **G101** (hardcoded creds) | 1 | `//nolint` -- test-fixture passphrase false positive in `crypt_test.go` |
| **modernize** (atomic) | 3 | `running int32` -> `atomic.Int32` in `parallel_test.go` (x3) |
| **revive** (var-declaration) | 3 | Omit inferred types from test-hook vars in `crypt.go` |
| **wsl_v5** (whitespace) | 1 | Blank line before assignment in `paramversion/spec.go` |

### 2. CI Lint gate was red for a different reason (version drift)

While verifying CI, the **Lint** job was failing on ~40 `goconst` findings in test files that `make lint` does **not** report. Root cause: `golangci-lint-action` installed `latest` (now **v2.12.2**), which drifted away from the local toolchain / `make lint` (**v2.11.4**). This had already turned `main`'s Lint gate red (the 2026-07-04 run on `9ed5ee6` failed) with no code change -- pure linter-version rot.

Fix: pin the action to **v2.11.4** in all three `test.yml` steps so CI == `make lint`. Addressing the goconst wave itself, or a deliberate linter upgrade, is intentionally left to a follow-up (out of #190's scope, which also forbids wholesale rule disabling).

### Notes on choices

- **G115 real fix vs. nolint.** Real fixes preferred per the issue. The three keeper conversions convert an OS fd `uintptr` to the `int` that `x/term`/`isatty` require -> shared bounds-checked `terminal.FdToInt` (guards the theoretical 32-bit overflow, returns `-1` otherwise). `peer_darwin.go:33` gets `//nolint` with a note it is removed in #194, as the issue suggests.
- **`maxConcurrent` left as `int32`** in `parallel_test.go`: read directly in asserts, so modernize does not flag it; only the flagged `running` was converted.
- **Audit drift:** the audit named `terminal.go:39` for a G115, but live `make lint` flagged `pager.go:41` / `passphrase.go:132` (same `int(f.Fd())` pattern). `terminal.go` is a listed file, so all three route through the new helper.

## Test evidence

```
$ make lint      # golangci-lint v2.11.4
0 issues.

$ make test
all packages pass; no FAIL/panic
```
CI green pending after the v2.11.4 pin.

## Acceptance criteria

- [x] `make lint` is green (0 violations)
- [x] `make test` is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
