### PR TITLE
fix(gui): StagingApply dereferences result before error check

### DIFF
--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -239,9 +239,13 @@ func (a *App) StagingApply(service string, ignoreConflicts bool) (*StagingApplyR
 		Strategy: strategy,
 		Store:    store,
 	}
+
 	result, err := uc.Execute(a.ctx, stagingusecase.ApplyInput{
 		IgnoreConflicts: ignoreConflicts,
 	})
+	if err != nil {
+		return nil, err
+	}
 
 	output := &StagingApplyResult{
 		ServiceName:    result.ServiceName,
@@ -286,7 +290,7 @@ func (a *App) StagingApply(service string, ignoreConflicts bool) (*StagingApplyR
 		output.TagResults = append(output.TagResults, tagResult)
 	}
 
-	return output, err
+	return output, nil
 }
 
 // StagingReset resets (unstages) all staged changes for a service.

--- a/internal/gui/staging_integration_internal_test.go
+++ b/internal/gui/staging_integration_internal_test.go
@@ -4,6 +4,7 @@ package gui
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -1117,4 +1118,40 @@ func TestApp_StagingReset_ResetBothEntriesAndTags(t *testing.T) {
 		assert.Empty(t, status.Param)
 		assert.Empty(t, status.ParamTags)
 	})
+}
+
+// stubParamClient satisfies the ParamClient interface without any real
+// behavior. It is used by tests that must reach StagingApply's Execute call
+// but never actually invoke a client method (the embedded nil interface would
+// panic if a method were called, which must not happen).
+type stubParamClient struct {
+	ParamClient
+}
+
+// TestApp_StagingApply_ExecuteError is a regression test: StagingApply used to
+// read result.* fields before checking the error returned by Execute, so a
+// (nil, err) return panicked with a nil dereference. It must now return the
+// error cleanly without panicking.
+func TestApp_StagingApply_ExecuteError(t *testing.T) {
+	t.Parallel()
+
+	app := setupTestApp(t)
+	app.paramClient = stubParamClient{}
+
+	mockStore := testutil.NewMockStore()
+	mockStore.ListEntriesErr = errors.New("list boom")
+	app.stagingStore = mockStore
+
+	var (
+		result *StagingApplyResult
+		err    error
+	)
+
+	require.NotPanics(t, func() {
+		result, err = app.StagingApply(string(staging.ServiceParam), false)
+	})
+
+	require.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "list boom")
 }


### PR DESCRIPTION
Closes #192 (Part of #189, Phase 0)

## Summary

`internal/gui/staging.go`'s `StagingApply` called `uc.Execute(...)` and then immediately read `result.ServiceName` (and other `result.*` fields) **before** checking the returned error. When `Execute` returns `(nil, err)`, this panicked with a nil dereference. Every other GUI binding method in the file guards the error first — this was an isolated oversight.

## Changes

- **`StagingApply`**: added the missing `if err != nil { return nil, err }` guard immediately after `Execute`, before any dereference of `result`; the tail `return output, err` becomes `return output, nil`, matching the sibling methods (e.g. `StagingReset`). Also added the blank line the sibling pattern uses between the usecase construction and the `Execute` call (keeps `wsl_v5` happy now that the `if` is cuddled).
- **Regression test** (`staging_integration_internal_test.go`): `TestApp_StagingApply_ExecuteError` injects a stub `ParamClient` and a `MockStore` whose `ListEntriesErr` forces `Execute` to return `(nil, err)`, then asserts `StagingApply` returns the error **without panicking**.

## Verification

The regression test was confirmed to fail before the fix and pass after:

```
# without the fix (staging.go reverted to main):
--- FAIL: TestApp_StagingApply_ExecuteError
    Panic value: runtime error: invalid memory address or nil pointer dereference

# with the fix:
ok  github.com/mpyw/suve/internal/gui  0.334s
```

```
$ make lint    # golangci-lint v2.11.4
0 issues.

$ make test    # (excludes internal/gui by design)
all packages ok, no FAIL/panic

$ CGO_ENABLED=1 go test -tags=production ./internal/gui/...
ok  github.com/mpyw/suve/internal/gui
```

## Scope

Only `StagingApply` and a new test. No provider-abstraction changes, no other binding methods touched, no frontend changes — per the issue's out-of-scope list.

## Acceptance criteria

- [x] `StagingApply` returns the error (no panic) when `Execute` returns `(nil, err)`
- [x] Regression test present and passing (and confirmed to catch the bug)
- [x] `make test` is green
- [x] `make lint` is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)