### PR TITLE
ci/e2e: port cross-platform setupIsolatedSocketPath fix from multicloud branch

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -43,10 +43,17 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	// Set TMPDIR so protocol.SocketPath() uses our isolated directory
-	if err := os.Setenv("TMPDIR", tmpDir); err != nil {
-		output.Printf(os.Stderr, "failed to set TMPDIR: %v\n", err)
-		os.Exit(1)
+	// Point every platform's socket-path env var at our isolated directory so
+	// protocol.SocketPath() resolves there regardless of OS: TMPDIR on macOS,
+	// XDG_RUNTIME_DIR on Linux, LOCALAPPDATA on Windows. Without this the Linux
+	// daemon socket escapes to the host's XDG_RUNTIME_DIR when it is set.
+	// (Ported from the multicloud branch's setupIsolatedSocketPath fix; the
+	// short /tmp path is kept to stay under macOS's 104-byte socket limit.)
+	for _, key := range []string{"TMPDIR", "XDG_RUNTIME_DIR", "LOCALAPPDATA"} {
+		if err := os.Setenv(key, tmpDir); err != nil {
+			output.Printf(os.Stderr, "failed to set %s: %v\n", key, err)
+			os.Exit(1)
+		}
 	}
 
 	// Enable manual mode to prevent fork bomb from test binary


### PR DESCRIPTION
Closes #193 (Part of #189, Phase 0)

## Summary

Ports the **cross-platform socket-path isolation** portion of the `multicloud` branch's `setupIsolatedSocketPath` fix (PR #142) into the e2e `TestMain`.

`TestMain` set only `TMPDIR`, which isolates `protocol.SocketPath()` on macOS but **not** on Linux (`XDG_RUNTIME_DIR`) or Windows (`LOCALAPPDATA`):

| OS | `socketPathForAccount` reads | main before | now |
|----|------------------------------|-------------|-----|
| macOS | `TMPDIR` | isolated ✅ | isolated ✅ |
| Linux | `XDG_RUNTIME_DIR` (else fallback) | escapes to host's `XDG_RUNTIME_DIR` when set ⚠️ | isolated ✅ |
| Windows | `LOCALAPPDATA` (else fallback) | not isolated ⚠️ | isolated ✅ |

CI's E2E job runs on `ubuntu-latest` where `XDG_RUNTIME_DIR` happens to be unset (so it fell back to the isolated dir by luck); a Linux dev box with a login session set has it, and the daemon socket would then escape the temp dir. The fix sets all three env vars to the same isolated directory. The short `/tmp` path is preserved to stay under macOS's 104-byte Unix-socket limit (so `t.TempDir()`, used by the branch's helper, is deliberately **not** adopted here — it would blow that limit for the bound daemon socket).

## Scoping decisions (per the issue's caveats)

- **Excluded the provider-abstraction changes.** The `multicloud` diff of `e2e/e2e_test.go` is almost entirely the `Scope`-type refactor (`daemon.NewRunner(agent.DaemonOptions()...)`, `agent.NewStore(testScope)`, `staging.AWSScope(...)`). That is explicitly out of scope here and is redesigned/ported via #199/#200 — none of it was taken.
- **Did not rewire the daemon-not-running tests.** `TestDaemonLauncher_NotRunning` / `TestAgentStore_NotRunning` on main already simulate "not running" via a distinct account/region, which is cross-platform already, so the branch's `setupIsolatedSocketPath` *helper* (used only by those tests on the branch) was not needed — only its cross-platform env-var essence was ported, into `TestMain`.
- **Interaction with #194.** This socket-path handling is removed together with the daemon in #194. It is ported now because #193 is sequenced before #194 in Phase 0 and the fix is a real cross-platform correctness improvement for anyone running `make e2e` in the meantime.

## Verification

```
$ go test -tags e2e -run xxxNoMatch ./e2e/...   # compile check
ok  github.com/mpyw/suve/e2e  [no tests to run]

$ make lint    # 0 issues
$ make test    # green (e2e/gui excluded by the target)
```

Full cross-platform e2e run is validated by CI's **E2E Test** job (ubuntu + localstack).

## Acceptance criteria

- [x] Ported e2e code compiles and the e2e suite is runnable cross-platform
- [x] `make test` is green
- [x] `make lint` is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)