### PR TITLE
feat(staging): OS-keychain-backed encryption for staging state

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/mpyw/suve
 go 1.24.0
 
 require (
-	github.com/awnumar/memguard v0.23.0
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.1
@@ -17,9 +16,9 @@ require (
 	github.com/urfave/cli/v3 v3.6.1
 	github.com/wailsapp/wails/v2 v2.11.0
 	github.com/walles/moor/v2 v2.10.1
+	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/crypto v0.47.0
 	golang.org/x/sync v0.19.0
-	golang.org/x/sys v0.40.0
 	golang.org/x/term v0.39.0
 	gopkg.in/ini.v1 v1.67.1
 )
@@ -27,7 +26,6 @@ require (
 require (
 	github.com/adrg/xdg v0.5.3 // indirect
 	github.com/alecthomas/chroma/v2 v2.21.1 // indirect
-	github.com/awnumar/memcall v0.4.0 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.7 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.17 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 // indirect
@@ -41,10 +39,11 @@ require (
 	github.com/aws/smithy-go v1.24.0 // indirect
 	github.com/bep/debounce v1.2.1 // indirect
 	github.com/charlievieth/strcase v0.0.5 // indirect
+	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
-	github.com/godbus/dbus/v5 v5.1.0 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/jchv/go-winloader v0.0.0-20210711035445-715c2860da7e // indirect
@@ -71,6 +70,7 @@ require (
 	github.com/wailsapp/mimetype v1.4.1 // indirect
 	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc // indirect
 	golang.org/x/net v0.48.0 // indirect
+	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,10 +6,6 @@ github.com/alecthomas/chroma/v2 v2.21.1 h1:FaSDrp6N+3pphkNKU6HPCiYLgm8dbe5UXIXco
 github.com/alecthomas/chroma/v2 v2.21.1/go.mod h1:NqVhfBR0lte5Ouh3DcthuUCTUpDC9cxBOfyMbMQPs3o=
 github.com/alecthomas/repr v0.5.2 h1:SU73FTI9D1P5UNtvseffFSGmdNci/O6RsqzeXJtP0Qs=
 github.com/alecthomas/repr v0.5.2/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
-github.com/awnumar/memcall v0.4.0 h1:B7hgZYdfH6Ot1Goaz8jGne/7i8xD4taZie/PNSFZ29g=
-github.com/awnumar/memcall v0.4.0/go.mod h1:8xOx1YbfyuCg3Fy6TO8DK0kZUua3V42/goA5Ru47E8w=
-github.com/awnumar/memguard v0.23.0 h1:sJ3a1/SWlcuKIQ7MV+R9p0Pvo9CWsMbGZvcZQtmc68A=
-github.com/awnumar/memguard v0.23.0/go.mod h1:olVofBrsPdITtJ2HgxQKrEYEMyIBAIciVG4wNnZhW9M=
 github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
 github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
 github.com/aws/aws-sdk-go-v2/config v1.32.7 h1:vxUyWGUwmkQ2g19n7JY/9YL8MfAIl7bTesIUykECXmY=
@@ -49,6 +45,8 @@ github.com/bep/debounce v1.2.1/go.mod h1:H8yggRPQKLUhUoqrJC1bO2xNya7vanpDl7xR3IS
 github.com/charlievieth/strcase v0.0.5 h1:gV4iXVyD6eI5KdfOV+/vIVCKXZwtCWOmDMcu7Uy00Rs=
 github.com/charlievieth/strcase v0.0.5/go.mod h1:FIOYY1aDBMSIOFqmVomHBpoK+bteGlESRsgsdWjrhx8=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -58,8 +56,8 @@ github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
-github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
-github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -121,6 +119,7 @@ github.com/sirupsen/logrus v1.8.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVs
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -146,6 +145,8 @@ github.com/wailsapp/wails/v2 v2.11.0 h1:seLacV8pqupq32IjS4Y7V8ucab0WZwtK6VvUVxSB
 github.com/wailsapp/wails/v2 v2.11.0/go.mod h1:jrf0ZaM6+GBc1wRmXsM8cIvzlg0karYin3erahI4+0k=
 github.com/walles/moor/v2 v2.10.1 h1:r6DugbwL6j+QifqrsnfFJ73D4Ob8QIcD4wpW/ZsA5Ys=
 github.com/walles/moor/v2 v2.10.1/go.mod h1:CW/q6fKzBKCMVbIOe/tjVjMMSF5imGfCBin+n+hfgKI=
+github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
+github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
 golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
 golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc h1:ao2WRsKSzW6KuUY9IWPwWahcHCgR0s52IfwutMfEbdM=

--- a/internal/cli/commands/stage/apply/apply.go
+++ b/internal/cli/commands/stage/apply/apply.go
@@ -79,7 +79,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed to get AWS identity: %w", err)
 	}
 
-	store, err := file.NewStore(identity.AccountID, identity.Region)
+	store, err := file.NewWorkingStore(identity.AccountID, identity.Region)
 	if err != nil {
 		return fmt.Errorf("failed to create staging store: %w", err)
 	}

--- a/internal/cli/commands/stage/diff/diff.go
+++ b/internal/cli/commands/stage/diff/diff.go
@@ -92,7 +92,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed to get AWS identity: %w", err)
 	}
 
-	store, err := file.NewStore(identity.AccountID, identity.Region)
+	store, err := file.NewWorkingStore(identity.AccountID, identity.Region)
 	if err != nil {
 		return fmt.Errorf("failed to create staging store: %w", err)
 	}

--- a/internal/cli/commands/stage/reset/reset.go
+++ b/internal/cli/commands/stage/reset/reset.go
@@ -59,7 +59,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed to get AWS identity: %w", err)
 	}
 
-	store, err := file.NewStore(identity.AccountID, identity.Region)
+	store, err := file.NewWorkingStore(identity.AccountID, identity.Region)
 	if err != nil {
 		return fmt.Errorf("failed to create staging store: %w", err)
 	}

--- a/internal/cli/commands/stage/status/status.go
+++ b/internal/cli/commands/stage/status/status.go
@@ -59,7 +59,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("failed to get AWS identity: %w", err)
 	}
 
-	store, err := file.NewStore(identity.AccountID, identity.Region)
+	store, err := file.NewWorkingStore(identity.AccountID, identity.Region)
 	if err != nil {
 		return fmt.Errorf("failed to create staging store: %w", err)
 	}

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -126,7 +126,7 @@ func (a *App) getStagingStore() (store.ReadWriteOperator, error) {
 		return nil, err
 	}
 
-	s, err := file.NewStore(identity.AccountID, identity.Region)
+	s, err := file.NewWorkingStore(identity.AccountID, identity.Region)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -745,7 +745,7 @@ func (a *App) StagingDrain(service string, passphrase string, keep bool, mode st
 		return nil, err
 	}
 
-	working, err := file.NewStore(identity.AccountID, identity.Region)
+	working, err := file.NewWorkingStore(identity.AccountID, identity.Region)
 	if err != nil {
 		return nil, err
 	}
@@ -798,7 +798,7 @@ func (a *App) StagingPersist(service string, passphrase string, keep bool, mode 
 		return nil, err
 	}
 
-	working, err := file.NewStore(identity.AccountID, identity.Region)
+	working, err := file.NewWorkingStore(identity.AccountID, identity.Region)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/staging/cli/command.go
+++ b/internal/staging/cli/command.go
@@ -67,7 +67,7 @@ EXAMPLES:
 				return fmt.Errorf("failed to get AWS identity: %w", err)
 			}
 
-			store, err := file.NewStore(identity.AccountID, identity.Region)
+			store, err := file.NewWorkingStore(identity.AccountID, identity.Region)
 			if err != nil {
 				return fmt.Errorf("failed to create staging store: %w", err)
 			}
@@ -146,7 +146,7 @@ EXAMPLES:
 				return fmt.Errorf("failed to get AWS identity: %w", err)
 			}
 
-			store, err := file.NewStore(identity.AccountID, identity.Region)
+			store, err := file.NewWorkingStore(identity.AccountID, identity.Region)
 			if err != nil {
 				return fmt.Errorf("failed to create staging store: %w", err)
 			}
@@ -228,7 +228,7 @@ EXAMPLES:
 				return fmt.Errorf("failed to get AWS identity: %w", err)
 			}
 
-			store, err := file.NewStore(identity.AccountID, identity.Region)
+			store, err := file.NewWorkingStore(identity.AccountID, identity.Region)
 			if err != nil {
 				return fmt.Errorf("failed to create staging store: %w", err)
 			}
@@ -308,7 +308,7 @@ EXAMPLES:
 				return fmt.Errorf("failed to get AWS identity: %w", err)
 			}
 
-			store, err := file.NewStore(identity.AccountID, identity.Region)
+			store, err := file.NewWorkingStore(identity.AccountID, identity.Region)
 			if err != nil {
 				return fmt.Errorf("failed to create staging store: %w", err)
 			}
@@ -387,7 +387,7 @@ EXAMPLES:
 				return fmt.Errorf("failed to get AWS identity: %w", err)
 			}
 
-			store, err := file.NewStore(identity.AccountID, identity.Region)
+			store, err := file.NewWorkingStore(identity.AccountID, identity.Region)
 			if err != nil {
 				return fmt.Errorf("failed to create staging store: %w", err)
 			}
@@ -535,7 +535,7 @@ EXAMPLES:
 				return fmt.Errorf("failed to get AWS identity: %w", err)
 			}
 
-			store, err := file.NewStore(identity.AccountID, identity.Region)
+			store, err := file.NewWorkingStore(identity.AccountID, identity.Region)
 			if err != nil {
 				return fmt.Errorf("failed to create staging store: %w", err)
 			}
@@ -649,7 +649,7 @@ EXAMPLES:
 				return fmt.Errorf("failed to get AWS identity: %w", err)
 			}
 
-			store, err := file.NewStore(identity.AccountID, identity.Region)
+			store, err := file.NewWorkingStore(identity.AccountID, identity.Region)
 			if err != nil {
 				return fmt.Errorf("failed to create staging store: %w", err)
 			}
@@ -705,7 +705,7 @@ func tagAction(cfg CommandConfig, usageMsg string, runner tagCommandRunner) func
 			return fmt.Errorf("failed to get AWS identity: %w", err)
 		}
 
-		store, err := file.NewStore(identity.AccountID, identity.Region)
+		store, err := file.NewWorkingStore(identity.AccountID, identity.Region)
 		if err != nil {
 			return fmt.Errorf("failed to create staging store: %w", err)
 		}

--- a/internal/staging/cli/stash_pop.go
+++ b/internal/staging/cli/stash_pop.go
@@ -182,7 +182,7 @@ func stashPopAction(service staging.Service) func(context.Context, *cli.Command)
 			return err
 		}
 
-		working, err := file.NewStore(identity.AccountID, identity.Region)
+		working, err := file.NewWorkingStore(identity.AccountID, identity.Region)
 		if err != nil {
 			return fmt.Errorf("failed to create staging store: %w", err)
 		}

--- a/internal/staging/cli/stash_push.go
+++ b/internal/staging/cli/stash_push.go
@@ -124,7 +124,7 @@ func stashPushAction(service staging.Service) func(context.Context, *cli.Command
 		}
 
 		// Working staging area is the source of the push.
-		working, err := file.NewStore(identity.AccountID, identity.Region)
+		working, err := file.NewWorkingStore(identity.AccountID, identity.Region)
 		if err != nil {
 			return fmt.Errorf("failed to create staging store: %w", err)
 		}

--- a/internal/staging/store/file/internal/crypt/crypt.go
+++ b/internal/staging/store/file/internal/crypt/crypt.go
@@ -1,4 +1,11 @@
-// Package crypt provides passphrase-based encryption for staging files.
+// Package crypt provides encryption for staging files.
+//
+// Two on-disk formats are supported:
+//
+//	v1 (passphrase): magic(8) + version(1)=1 + salt(32) + nonce(12) + ciphertext
+//	                 key derived from the passphrase via Argon2id.
+//	v2 (raw key):    magic(8) + version(1)=2 + nonce(12) + ciphertext
+//	                 the supplied 32-byte key is used directly as the AES-256-GCM key.
 package crypt
 
 import (
@@ -48,26 +55,49 @@ func ResetCipherFuncs() {
 const (
 	// MagicHeader identifies encrypted files.
 	MagicHeader = "SUVE_ENC"
-	// Version is the current encryption format version.
+	// Version is the passphrase-based (Argon2id) encryption format version.
 	Version = byte(1)
-
-	// Argon2 parameters (OWASP recommended for sensitive data).
-	argonTime    = 3
-	argonMemory  = 64 * 1024 // 64 MB
-	argonThreads = 4
-	argonKeyLen  = 32 // AES-256
+	// VersionRawKey is the raw-key encryption format version.
+	// It stores no salt and performs no KDF; the supplied 32-byte key is used
+	// directly as the AES-256-GCM key.
+	VersionRawKey = byte(2)
 
 	saltLen  = 32
 	nonceLen = 12 // AES-GCM standard nonce size
+
+	// RawKeyLen is the required length (in bytes) of a raw AES-256 key.
+	RawKeyLen = 32
 )
+
+// argonParams holds the Argon2id parameters for a passphrase-based format version.
+type argonParams struct {
+	time    uint32
+	memory  uint32
+	threads uint8
+	keyLen  uint32
+}
+
+// kdfParamsByVersion maps a passphrase-format version byte to its Argon2id
+// parameters. Decrypt looks up parameters by the version byte read from the
+// file, so a future parameter change is expressed as a new version while old
+// files continue to decrypt with the parameters they were written with.
+//
+//nolint:gochecknoglobals // immutable lookup table keyed by format version.
+var kdfParamsByVersion = map[byte]argonParams{
+	// v1 uses OWASP-recommended parameters for sensitive data.
+	//nolint:mnd // Argon2id parameters (OWASP recommended); a change means a new version.
+	1: {time: 3, memory: 64 * 1024, threads: 4, keyLen: 32},
+}
 
 var (
 	// ErrInvalidFormat is returned when the data format is invalid.
 	ErrInvalidFormat = errors.New("invalid encrypted format")
-	// ErrDecryptionFailed is returned when decryption fails (wrong passphrase or corrupted data).
+	// ErrDecryptionFailed is returned when decryption fails (wrong passphrase/key or corrupted data).
 	ErrDecryptionFailed = errors.New("decryption failed: wrong passphrase or corrupted data")
 	// ErrNotEncrypted is returned when trying to decrypt unencrypted data.
 	ErrNotEncrypted = errors.New("data is not encrypted")
+	// ErrInvalidKeyLength is returned when a raw key is not exactly RawKeyLen bytes.
+	ErrInvalidKeyLength = errors.New("invalid key length: must be 32 bytes")
 )
 
 // headerLen is the total header length: magic (8) + version (1).
@@ -76,9 +106,26 @@ const headerLen = len(MagicHeader) + 1
 // gcmAuthTagLen is the minimum GCM authentication tag length in bytes.
 const gcmAuthTagLen = 16
 
+// newGCM creates an AES-GCM AEAD from the given key using the (overridable) cipher hooks.
+func newGCM(key []byte) (cipher.AEAD, error) {
+	block, err := newCipherFunc(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cipher: %w", err)
+	}
+
+	gcm, err := newGCMFunc(block)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create GCM: %w", err)
+	}
+
+	return gcm, nil
+}
+
 // Encrypt encrypts data with the given passphrase using AES-256-GCM with Argon2id key derivation.
-// Returns encrypted data in format: magic header + version + salt + nonce + ciphertext.
+// Returns encrypted data in format: magic header + version(1) + salt + nonce + ciphertext.
 func Encrypt(data []byte, passphrase string) ([]byte, error) {
+	params := kdfParamsByVersion[Version]
+
 	// Generate random salt
 	salt := make([]byte, saltLen)
 	if _, err := io.ReadFull(randReader, salt); err != nil {
@@ -86,18 +133,11 @@ func Encrypt(data []byte, passphrase string) ([]byte, error) {
 	}
 
 	// Derive key using Argon2id
-	key := argon2.IDKey([]byte(passphrase), salt, argonTime, argonMemory, argonThreads, argonKeyLen)
+	key := argon2.IDKey([]byte(passphrase), salt, params.time, params.memory, params.threads, params.keyLen)
 
-	// Create AES cipher
-	block, err := newCipherFunc(key)
+	gcm, err := newGCM(key)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create cipher: %w", err)
-	}
-
-	// Create GCM mode
-	gcm, err := newGCMFunc(block)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create GCM: %w", err)
+		return nil, err
 	}
 
 	// Generate random nonce
@@ -120,23 +160,33 @@ func Encrypt(data []byte, passphrase string) ([]byte, error) {
 	return result, nil
 }
 
-// Decrypt decrypts data with the given passphrase.
-// Returns ErrNotEncrypted if data doesn't have encryption header.
-// Returns ErrDecryptionFailed if passphrase is wrong or data is corrupted.
+// Decrypt decrypts passphrase-based (v1) data with the given passphrase.
+// Returns ErrNotEncrypted if data doesn't have the encryption header.
+// Returns ErrInvalidFormat for raw-key (v2) or unknown-version data.
+// Returns ErrDecryptionFailed if the passphrase is wrong or data is corrupted.
 func Decrypt(data []byte, passphrase string) ([]byte, error) {
 	if !IsEncrypted(data) {
 		return nil, ErrNotEncrypted
 	}
 
-	minLen := headerLen + saltLen + nonceLen + gcmAuthTagLen
-	if len(data) < minLen {
+	if len(data) < headerLen {
 		return nil, ErrInvalidFormat
 	}
 
-	// Check version
 	version := data[len(MagicHeader)]
-	if version != Version {
+
+	if version == VersionRawKey {
+		return nil, fmt.Errorf("%w: data uses raw-key format (v2); a passphrase cannot decrypt it", ErrInvalidFormat)
+	}
+
+	params, ok := kdfParamsByVersion[version]
+	if !ok {
 		return nil, fmt.Errorf("%w: unsupported version %d", ErrInvalidFormat, version)
+	}
+
+	minLen := headerLen + saltLen + nonceLen + gcmAuthTagLen
+	if len(data) < minLen {
+		return nil, ErrInvalidFormat
 	}
 
 	// Extract components
@@ -147,22 +197,90 @@ func Decrypt(data []byte, passphrase string) ([]byte, error) {
 	offset += nonceLen
 	ciphertext := data[offset:]
 
-	// Derive key using same parameters
-	key := argon2.IDKey([]byte(passphrase), salt, argonTime, argonMemory, argonThreads, argonKeyLen)
+	// Derive key using the parameters for this version
+	key := argon2.IDKey([]byte(passphrase), salt, params.time, params.memory, params.threads, params.keyLen)
 
-	// Create AES cipher
-	block, err := newCipherFunc(key)
+	gcm, err := newGCM(key)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create cipher: %w", err)
+		return nil, err
 	}
 
-	// Create GCM mode
-	gcm, err := newGCMFunc(block)
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create GCM: %w", err)
+		return nil, ErrDecryptionFailed
 	}
 
-	// Decrypt
+	return plaintext, nil
+}
+
+// EncryptWithKey encrypts data using AES-256-GCM with the supplied 32-byte key
+// used directly as the key (no KDF). Returns raw-key (v2) format:
+// magic header + version(1)=2 + nonce + ciphertext.
+func EncryptWithKey(data, key []byte) ([]byte, error) {
+	if len(key) != RawKeyLen {
+		return nil, ErrInvalidKeyLength
+	}
+
+	gcm, err := newGCM(key)
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate random nonce
+	nonce := make([]byte, nonceLen)
+	if _, err := io.ReadFull(randReader, nonce); err != nil {
+		return nil, fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	ciphertext := gcm.Seal(nil, nonce, data, nil)
+
+	// Build output: header + nonce + ciphertext (no salt)
+	result := make([]byte, 0, headerLen+nonceLen+len(ciphertext))
+	result = append(result, []byte(MagicHeader)...)
+	result = append(result, VersionRawKey)
+	result = append(result, nonce...)
+	result = append(result, ciphertext...)
+
+	return result, nil
+}
+
+// DecryptWithKey decrypts raw-key (v2) data using the supplied 32-byte key.
+// Returns ErrNotEncrypted if data doesn't have the encryption header.
+// Returns ErrInvalidFormat if the data is not raw-key (v2) format.
+// Returns ErrDecryptionFailed if the key is wrong or data is corrupted.
+func DecryptWithKey(data, key []byte) ([]byte, error) {
+	if len(key) != RawKeyLen {
+		return nil, ErrInvalidKeyLength
+	}
+
+	if !IsEncrypted(data) {
+		return nil, ErrNotEncrypted
+	}
+
+	if len(data) < headerLen {
+		return nil, ErrInvalidFormat
+	}
+
+	version := data[len(MagicHeader)]
+	if version != VersionRawKey {
+		return nil, fmt.Errorf("%w: expected raw-key format (v2), got version %d", ErrInvalidFormat, version)
+	}
+
+	minLen := headerLen + nonceLen + gcmAuthTagLen
+	if len(data) < minLen {
+		return nil, ErrInvalidFormat
+	}
+
+	offset := headerLen
+	nonce := data[offset : offset+nonceLen]
+	offset += nonceLen
+	ciphertext := data[offset:]
+
+	gcm, err := newGCM(key)
+	if err != nil {
+		return nil, err
+	}
+
 	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
 	if err != nil {
 		return nil, ErrDecryptionFailed

--- a/internal/staging/store/file/internal/crypt/crypt_test.go
+++ b/internal/staging/store/file/internal/crypt/crypt_test.go
@@ -2,6 +2,7 @@ package crypt_test
 
 import (
 	"bytes"
+	"encoding/base64"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -219,4 +220,133 @@ func TestDecrypt_UnsupportedVersion(t *testing.T) {
 	_, err := crypt.Decrypt(data, "any-passphrase")
 	require.ErrorIs(t, err, crypt.ErrInvalidFormat)
 	assert.Contains(t, err.Error(), "unsupported version 99")
+}
+
+func TestEncryptDecryptWithKey(t *testing.T) {
+	t.Parallel()
+
+	key := make([]byte, crypt.RawKeyLen)
+	for i := range key {
+		key[i] = byte(i)
+	}
+
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{name: "simple text", data: []byte("hello world")},
+		{name: "empty data", data: []byte{}},
+		{name: "JSON data", data: []byte(`{"version":2,"entries":{}}`)},
+		{name: "binary data", data: []byte{0x00, 0x01, 0x02, 0xff, 0xfe, 0xfd}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			encrypted, err := crypt.EncryptWithKey(tt.data, key)
+			require.NoError(t, err)
+
+			// v2 must still be recognized as encrypted.
+			assert.True(t, crypt.IsEncrypted(encrypted))
+			// Version byte must be the raw-key version.
+			assert.Equal(t, crypt.VersionRawKey, encrypted[len(crypt.MagicHeader)])
+
+			if len(tt.data) > 0 {
+				assert.False(t, bytes.Contains(encrypted, tt.data))
+			}
+
+			decrypted, err := crypt.DecryptWithKey(encrypted, key)
+			require.NoError(t, err)
+
+			if len(tt.data) != 0 || len(decrypted) != 0 {
+				assert.Equal(t, tt.data, decrypted)
+			}
+		})
+	}
+}
+
+func TestEncryptWithKey_InvalidKeyLength(t *testing.T) {
+	t.Parallel()
+
+	_, err := crypt.EncryptWithKey([]byte("data"), make([]byte, 16))
+	assert.ErrorIs(t, err, crypt.ErrInvalidKeyLength)
+}
+
+func TestDecryptWithKey_InvalidKeyLength(t *testing.T) {
+	t.Parallel()
+
+	_, err := crypt.DecryptWithKey([]byte("data"), make([]byte, 16))
+	assert.ErrorIs(t, err, crypt.ErrInvalidKeyLength)
+}
+
+func TestDecryptWithKey_WrongKey(t *testing.T) {
+	t.Parallel()
+
+	key := make([]byte, crypt.RawKeyLen)
+	wrongKey := make([]byte, crypt.RawKeyLen)
+	wrongKey[0] = 0xff
+
+	encrypted, err := crypt.EncryptWithKey([]byte("secret"), key)
+	require.NoError(t, err)
+
+	_, err = crypt.DecryptWithKey(encrypted, wrongKey)
+	assert.ErrorIs(t, err, crypt.ErrDecryptionFailed)
+}
+
+// TestCrossReject verifies the two formats reject each other's data.
+func TestCrossReject(t *testing.T) {
+	t.Parallel()
+
+	key := make([]byte, crypt.RawKeyLen)
+
+	t.Run("Decrypt (passphrase) rejects v2 data", func(t *testing.T) {
+		t.Parallel()
+
+		v2, err := crypt.EncryptWithKey([]byte("data"), key)
+		require.NoError(t, err)
+
+		_, err = crypt.Decrypt(v2, "any-passphrase")
+		require.ErrorIs(t, err, crypt.ErrInvalidFormat)
+		assert.Contains(t, err.Error(), "raw-key")
+	})
+
+	t.Run("DecryptWithKey rejects v1 data", func(t *testing.T) {
+		t.Parallel()
+
+		v1, err := crypt.Encrypt([]byte("data"), "passphrase")
+		require.NoError(t, err)
+
+		_, err = crypt.DecryptWithKey(v1, key)
+		require.ErrorIs(t, err, crypt.ErrInvalidFormat)
+		assert.Contains(t, err.Error(), "version 1")
+	})
+}
+
+func TestDecryptWithKey_NotEncrypted(t *testing.T) {
+	t.Parallel()
+
+	_, err := crypt.DecryptWithKey([]byte(`{"plain":true}`), make([]byte, crypt.RawKeyLen))
+	assert.ErrorIs(t, err, crypt.ErrNotEncrypted)
+}
+
+// TestDecrypt_V1BackwardCompat verifies a v1 blob produced by an earlier build
+// still decrypts. This is a golden fixture: the salt/nonce are embedded, so the
+// Argon2 parameters must be resolved from the version byte via the params
+// table for this to succeed.
+func TestDecrypt_V1BackwardCompat(t *testing.T) {
+	t.Parallel()
+
+	const goldenV1 = "U1VWRV9FTkMBMV+dH6A0LNn0lG8s9emCVJeLMiC2iSLX+G+ASrVwRHB4n4g+ir2sxHh6dm/WXWFWlY86eisG0WKEolYqnEFBy9EG2OWIQtiNs96Zkas="
+
+	blob, err := base64.StdEncoding.DecodeString(goldenV1)
+	require.NoError(t, err)
+
+	// Sanity: it is a v1 blob.
+	require.True(t, crypt.IsEncrypted(blob))
+	require.Equal(t, crypt.Version, blob[len(crypt.MagicHeader)])
+
+	decrypted, err := crypt.Decrypt(blob, "golden-passphrase")
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"hello":"world"}`, string(decrypted))
 }

--- a/internal/staging/store/file/internal/keyprovider/keyprovider.go
+++ b/internal/staging/store/file/internal/keyprovider/keyprovider.go
@@ -1,0 +1,134 @@
+// Package keyprovider resolves the AES-256 data key used to encrypt the
+// working staging state file (stage.json).
+//
+// The resolution follows a fixed fallback chain:
+//
+//  1. SUVE_STAGING_KEY env var, if set: base64-standard of exactly 32 bytes.
+//     If set but invalid, a clear error is returned (no silent fall-through).
+//  2. Otherwise the OS keychain (get-or-create): fetch the stored key, or
+//     generate 32 random bytes, store them, and use them.
+//  3. Otherwise (keychain unavailable/errors and no env var): plaintext, with
+//     the caller expected to warn the user once.
+//
+// No passphrase prompt is used for the working store: prompting on every
+// staging operation would defeat the purpose of the keychain. This is an
+// intentional omission (the stash flow still uses a passphrase).
+package keyprovider
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/zalando/go-keyring"
+)
+
+const (
+	// EnvStagingKey is the environment variable holding a base64-standard
+	// encoded 32-byte key that overrides the keychain.
+	EnvStagingKey = "SUVE_STAGING_KEY"
+
+	// keychainService is the OS keychain service name.
+	keychainService = "suve"
+	// keychainAccount is the OS keychain account/user name for the data key.
+	keychainAccount = "staging-data-key"
+
+	// keyLen is the required AES-256 key length in bytes.
+	keyLen = 32
+)
+
+// Hooks for testing - these allow tests to override environment and keychain
+// access without touching the real environment or OS keychain.
+//
+//nolint:gochecknoglobals // test hooks for dependency injection.
+var (
+	lookupEnvFunc  = os.LookupEnv
+	keyringGetFunc = keyring.Get
+	keyringSetFunc = keyring.Set
+	randReader     = rand.Reader
+)
+
+// Resolve returns the data key for the working staging store.
+//
+// The returned key is 32 bytes when plaintext is false. When plaintext is
+// true, key is nil and the caller should operate without encryption (and warn
+// the user once). err is non-nil only for unrecoverable configuration errors
+// (currently: an invalid SUVE_STAGING_KEY value).
+func Resolve() (key []byte, plaintext bool, err error) {
+	// 1. Environment variable override.
+	if raw, ok := lookupEnvFunc(EnvStagingKey); ok {
+		envKey, decErr := decodeEnvKey(raw)
+		if decErr != nil {
+			return nil, false, decErr
+		}
+
+		return envKey, false, nil
+	}
+
+	// 2. OS keychain get-or-create.
+	k, kcErr := getOrCreateKeychainKey()
+	if kcErr == nil {
+		return k, false, nil
+	}
+
+	// 3. Plaintext fallback.
+	return nil, true, nil
+}
+
+// decodeEnvKey decodes and validates the env-var key.
+func decodeEnvKey(raw string) ([]byte, error) {
+	decoded, err := base64.StdEncoding.DecodeString(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%s must be base64-standard encoded: %w", EnvStagingKey, err)
+	}
+
+	if len(decoded) != keyLen {
+		return nil, fmt.Errorf("%s must decode to exactly %d bytes, got %d", EnvStagingKey, keyLen, len(decoded))
+	}
+
+	return decoded, nil
+}
+
+// getOrCreateKeychainKey fetches the stored key from the OS keychain, or
+// generates, stores, and returns a new 32-byte key if none exists.
+func getOrCreateKeychainKey() ([]byte, error) {
+	stored, err := keyringGetFunc(keychainService, keychainAccount)
+	switch {
+	case err == nil:
+		key, decErr := base64.StdEncoding.DecodeString(stored)
+		if decErr != nil {
+			return nil, fmt.Errorf("stored keychain key is corrupted: %w", decErr)
+		}
+
+		if len(key) != keyLen {
+			return nil, fmt.Errorf("stored keychain key has wrong length %d", len(key))
+		}
+
+		return key, nil
+
+	case errors.Is(err, keyring.ErrNotFound):
+		return generateAndStoreKey()
+
+	default:
+		return nil, fmt.Errorf("failed to read key from keychain: %w", err)
+	}
+}
+
+// generateAndStoreKey creates a new random 32-byte key and stores it in the
+// OS keychain.
+func generateAndStoreKey() ([]byte, error) {
+	key := make([]byte, keyLen)
+	if _, err := io.ReadFull(randReader, key); err != nil {
+		return nil, fmt.Errorf("failed to generate data key: %w", err)
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(key)
+	if err := keyringSetFunc(keychainService, keychainAccount, encoded); err != nil {
+		return nil, fmt.Errorf("failed to store key in keychain: %w", err)
+	}
+
+	return key, nil
+}

--- a/internal/staging/store/file/internal/keyprovider/keyprovider_test.go
+++ b/internal/staging/store/file/internal/keyprovider/keyprovider_test.go
@@ -1,0 +1,139 @@
+package keyprovider //nolint:testpackage // tests override unexported hook vars.
+
+import (
+	"encoding/base64"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zalando/go-keyring"
+)
+
+// withHooks saves and restores the package-level hook vars around a test body.
+func withHooks(t *testing.T, fn func()) {
+	t.Helper()
+
+	origLookup := lookupEnvFunc
+	origGet := keyringGetFunc
+	origSet := keyringSetFunc
+
+	t.Cleanup(func() {
+		lookupEnvFunc = origLookup
+		keyringGetFunc = origGet
+		keyringSetFunc = origSet
+	})
+
+	fn()
+}
+
+//nolint:paralleltest // overrides package-level hook vars.
+func TestResolve_EnvVar_Valid(t *testing.T) {
+	withHooks(t, func() {
+		want := make([]byte, 32)
+		for i := range want {
+			want[i] = byte(i)
+		}
+
+		encoded := base64.StdEncoding.EncodeToString(want)
+
+		lookupEnvFunc = func(key string) (string, bool) {
+			if key == EnvStagingKey {
+				return encoded, true
+			}
+
+			return "", false
+		}
+
+		key, plaintext, err := Resolve()
+		require.NoError(t, err)
+		assert.False(t, plaintext)
+		assert.Equal(t, want, key)
+	})
+}
+
+//nolint:paralleltest // overrides package-level hook vars.
+func TestResolve_EnvVar_InvalidBase64(t *testing.T) {
+	withHooks(t, func() {
+		lookupEnvFunc = func(string) (string, bool) {
+			return "not!valid!base64!", true
+		}
+
+		_, _, err := Resolve()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "base64")
+	})
+}
+
+//nolint:paralleltest // overrides package-level hook vars.
+func TestResolve_EnvVar_WrongLength(t *testing.T) {
+	withHooks(t, func() {
+		// 16 bytes, not 32.
+		lookupEnvFunc = func(string) (string, bool) {
+			return base64.StdEncoding.EncodeToString(make([]byte, 16)), true
+		}
+
+		_, _, err := Resolve()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "32 bytes")
+	})
+}
+
+//nolint:paralleltest // uses global keyring.MockInit and overrides hook vars.
+func TestResolve_Keychain_GetOrCreate(t *testing.T) {
+	keyring.MockInit()
+
+	withHooks(t, func() {
+		lookupEnvFunc = func(string) (string, bool) { return "", false }
+		keyringGetFunc = keyring.Get
+		keyringSetFunc = keyring.Set
+
+		// First call: no key stored -> generate and store.
+		key1, plaintext, err := Resolve()
+		require.NoError(t, err)
+		assert.False(t, plaintext)
+		assert.Len(t, key1, 32)
+
+		// Second call: must return the same stored key.
+		key2, plaintext, err := Resolve()
+		require.NoError(t, err)
+		assert.False(t, plaintext)
+		assert.Equal(t, key1, key2)
+	})
+}
+
+//nolint:paralleltest // overrides package-level hook vars.
+func TestResolve_PlaintextFallback(t *testing.T) {
+	withHooks(t, func() {
+		lookupEnvFunc = func(string) (string, bool) { return "", false }
+		keyringGetFunc = func(string, string) (string, error) {
+			return "", errors.New("keychain unavailable")
+		}
+		keyringSetFunc = func(string, string, string) error {
+			return errors.New("keychain unavailable")
+		}
+
+		key, plaintext, err := Resolve()
+		require.NoError(t, err)
+		assert.True(t, plaintext)
+		assert.Nil(t, key)
+	})
+}
+
+//nolint:paralleltest // overrides package-level hook vars.
+func TestResolve_Keychain_SetError_FallsBackToPlaintext(t *testing.T) {
+	withHooks(t, func() {
+		lookupEnvFunc = func(string) (string, bool) { return "", false }
+		keyringGetFunc = func(string, string) (string, error) {
+			return "", keyring.ErrNotFound
+		}
+		keyringSetFunc = func(string, string, string) error {
+			return errors.New("cannot write to keychain")
+		}
+
+		key, plaintext, err := Resolve()
+		require.NoError(t, err)
+		assert.True(t, plaintext)
+		assert.Nil(t, key)
+	})
+}

--- a/internal/staging/store/file/store.go
+++ b/internal/staging/store/file/store.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store"
 	"github.com/mpyw/suve/internal/staging/store/file/internal/crypt"
+	"github.com/mpyw/suve/internal/staging/store/file/internal/keyprovider"
 )
 
 const (
@@ -31,11 +32,25 @@ var fileMu sync.Mutex
 //nolint:gochecknoglobals // test hook for dependency injection
 var userHomeDirFunc = os.UserHomeDir
 
+// resolveKeyFunc resolves the working-store data key. Overridable for testing.
+//
+//nolint:gochecknoglobals // test hook for dependency injection
+var resolveKeyFunc = keyprovider.Resolve
+
+// plaintextWarnOnce ensures the plaintext fallback warning is emitted only once
+// per process.
+//
+//nolint:gochecknoglobals // process-wide one-time warning guard.
+var plaintextWarnOnce sync.Once
+
 // Store manages the staging state using the filesystem.
 // It implements StateIO interface for drain/persist operations.
 type Store struct {
 	stateFilePath string
 	passphrase    string
+	// key, when non-nil, is a 32-byte AES-256 key used for raw-key (v2)
+	// encryption of the working store. It takes precedence over passphrase.
+	key []byte
 }
 
 // newStore creates a new file Store using the given file name under
@@ -59,6 +74,43 @@ func newStore(accountID, region, fileName string) (*Store, error) {
 // This is the working staging area used by stage add/edit/delete/status/diff/apply/reset.
 func NewStore(accountID, region string) (*Store, error) {
 	return newStore(accountID, region, stateFileName)
+}
+
+// NewWorkingStore creates the working staging-area Store (stage.json) with its
+// encryption key resolved via the key provider fallback chain:
+// SUVE_STAGING_KEY env var -> OS keychain (get-or-create) -> plaintext.
+//
+// When falling back to plaintext, a one-time warning is emitted to stderr.
+// This is the constructor to use for all working-area (stage.json) operations
+// (stage add/edit/delete/status/diff/apply/reset and the working side of
+// stash push/pop). The stash file (stash.json) keeps its passphrase flow.
+func NewWorkingStore(accountID, region string) (*Store, error) {
+	s, err := NewStore(accountID, region)
+	if err != nil {
+		return nil, err
+	}
+
+	key, plaintext, err := resolveKeyFunc()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve staging encryption key: %w", err)
+	}
+
+	if plaintext {
+		plaintextWarnOnce.Do(func() {
+			// Direct stderr write: this low-level store package intentionally
+			// avoids depending on the cli/output package.
+			//nolint:forbidigo // one-time operator warning to stderr.
+			fmt.Fprintln(os.Stderr,
+				"warning: staging state is stored UNENCRYPTED; "+
+					"set SUVE_STAGING_KEY or enable an OS keychain to encrypt")
+		})
+
+		return s, nil
+	}
+
+	s.key = key
+
+	return s, nil
 }
 
 // NewStoreWithPath creates a new file Store with a custom state file path.
@@ -147,13 +199,18 @@ func (s *Store) readStateLocked() (*staging.State, error) {
 		return nil, fmt.Errorf("failed to read state file: %w", err)
 	}
 
-	// Decrypt if encrypted
+	// Decrypt if encrypted. Reading an unencrypted (plaintext/legacy) file is
+	// always allowed so migration from an older/plaintext state works.
 	if crypt.IsEncrypted(data) {
-		if s.passphrase == "" {
+		switch {
+		case s.key != nil:
+			data, err = crypt.DecryptWithKey(data, s.key)
+		case s.passphrase != "":
+			data, err = crypt.Decrypt(data, s.passphrase)
+		default:
 			return nil, crypt.ErrDecryptionFailed
 		}
 
-		data, err = crypt.Decrypt(data, s.passphrase)
 		if err != nil {
 			return nil, err
 		}
@@ -195,8 +252,15 @@ func (s *Store) writeStateLocked(state *staging.State) error {
 		return fmt.Errorf("failed to marshal state: %w", err)
 	}
 
-	// Encrypt if passphrase is provided
-	if s.passphrase != "" {
+	// Encrypt: prefer the raw key (v2) when configured, else fall back to the
+	// passphrase (v1); otherwise write plaintext.
+	switch {
+	case s.key != nil:
+		data, err = crypt.EncryptWithKey(data, s.key)
+		if err != nil {
+			return fmt.Errorf("failed to encrypt state: %w", err)
+		}
+	case s.passphrase != "":
 		data, err = crypt.Encrypt(data, s.passphrase)
 		if err != nil {
 			return fmt.Errorf("failed to encrypt state: %w", err)

--- a/internal/staging/store/file/store_key_internal_test.go
+++ b/internal/staging/store/file/store_key_internal_test.go
@@ -1,0 +1,166 @@
+package file
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/staging"
+	"github.com/mpyw/suve/internal/staging/store/file/internal/crypt"
+)
+
+func newTestKey() []byte {
+	key := make([]byte, crypt.RawKeyLen)
+	for i := range key {
+		key[i] = byte(i + 1)
+	}
+
+	return key
+}
+
+func TestStore_KeyRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "stage.json")
+
+	store := NewStoreWithPath(path)
+	store.key = newTestKey()
+
+	state := staging.NewEmptyState()
+	state.Entries[staging.ServiceParam]["/app/secret"] = staging.Entry{
+		Operation: staging.OperationCreate,
+		Value:     lo.ToPtr("raw-key-value"),
+	}
+
+	require.NoError(t, store.WriteState(t.Context(), "", state))
+
+	// File must be encrypted using the raw-key (v2) format.
+	raw, err := os.ReadFile(path) //nolint:gosec // test temp path
+	require.NoError(t, err)
+	require.True(t, crypt.IsEncrypted(raw))
+	assert.Equal(t, crypt.VersionRawKey, raw[len(crypt.MagicHeader)])
+
+	// Read back with the same key.
+	got, err := store.Drain(t.Context(), "", true)
+	require.NoError(t, err)
+	assert.Equal(t, "raw-key-value", lo.FromPtr(got.Entries[staging.ServiceParam]["/app/secret"].Value))
+}
+
+func TestStore_KeyReadsLegacyPlaintext(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "stage.json")
+
+	// A legacy, unencrypted stage.json must still be readable by a
+	// key-configured store (migration path).
+	plain := `{"version":2,"entries":{"param":{"/legacy":{"operation":"create","value":"plain"}},"secret":{}},"tags":{"param":{},"secret":{}}}`
+	require.NoError(t, os.WriteFile(path, []byte(plain), 0o600))
+
+	store := NewStoreWithPath(path)
+	store.key = newTestKey()
+
+	got, err := store.Drain(t.Context(), "", true)
+	require.NoError(t, err)
+	assert.Equal(t, "plain", lo.FromPtr(got.Entries[staging.ServiceParam]["/legacy"].Value))
+}
+
+func TestStore_KeyWrongKeyFails(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "stage.json")
+
+	store := NewStoreWithPath(path)
+	store.key = newTestKey()
+
+	state := staging.NewEmptyState()
+	state.Entries[staging.ServiceParam]["/app/secret"] = staging.Entry{
+		Operation: staging.OperationCreate,
+		Value:     lo.ToPtr("v"),
+	}
+	require.NoError(t, store.WriteState(t.Context(), "", state))
+
+	// A store with a different key cannot decrypt.
+	other := NewStoreWithPath(path)
+	wrong := newTestKey()
+	wrong[0] ^= 0xff
+	other.key = wrong
+
+	_, err := other.Drain(t.Context(), "", true)
+	assert.ErrorIs(t, err, crypt.ErrDecryptionFailed)
+}
+
+// TestNewWorkingStore_KeyConfigured verifies the constructor stores the
+// resolved key when the provider returns one.
+//
+//nolint:paralleltest // overrides package-level resolveKeyFunc.
+func TestNewWorkingStore_KeyConfigured(t *testing.T) {
+	origResolve := resolveKeyFunc
+	origHome := userHomeDirFunc
+
+	defer func() {
+		resolveKeyFunc = origResolve
+		userHomeDirFunc = origHome
+	}()
+
+	userHomeDirFunc = func() (string, error) { return t.TempDir(), nil }
+
+	key := newTestKey()
+	resolveKeyFunc = func() ([]byte, bool, error) { return key, false, nil }
+
+	s, err := NewWorkingStore("123456789012", "ap-northeast-1")
+	require.NoError(t, err)
+	assert.Equal(t, key, s.key)
+	assert.Empty(t, s.passphrase)
+}
+
+// TestNewWorkingStore_PlaintextFallback verifies no key is configured when the
+// provider falls back to plaintext.
+//
+//nolint:paralleltest // overrides package-level resolveKeyFunc.
+func TestNewWorkingStore_PlaintextFallback(t *testing.T) {
+	origResolve := resolveKeyFunc
+	origHome := userHomeDirFunc
+
+	defer func() {
+		resolveKeyFunc = origResolve
+		userHomeDirFunc = origHome
+	}()
+
+	userHomeDirFunc = func() (string, error) { return t.TempDir(), nil }
+
+	resolveKeyFunc = func() ([]byte, bool, error) { return nil, true, nil }
+
+	s, err := NewWorkingStore("123456789012", "ap-northeast-1")
+	require.NoError(t, err)
+	assert.Nil(t, s.key)
+}
+
+// TestNewWorkingStore_ResolveError verifies a provider error propagates.
+//
+//nolint:paralleltest // overrides package-level resolveKeyFunc.
+func TestNewWorkingStore_ResolveError(t *testing.T) {
+	origResolve := resolveKeyFunc
+	origHome := userHomeDirFunc
+
+	defer func() {
+		resolveKeyFunc = origResolve
+		userHomeDirFunc = origHome
+	}()
+
+	userHomeDirFunc = func() (string, error) { return t.TempDir(), nil }
+
+	resolveKeyFunc = func() ([]byte, bool, error) { return nil, false, errors.New("bad key") }
+
+	s, err := NewWorkingStore("123456789012", "ap-northeast-1")
+	require.Error(t, err)
+	assert.Nil(t, s)
+	assert.Contains(t, err.Error(), "failed to resolve staging encryption key")
+}


### PR DESCRIPTION
Closes #195 (Part of #189, Phase 1)

## Summary

After #194 the working staging state always lives on disk (`stage.json`). This encrypts it at rest with a data key held in the OS keychain, so **no passphrase is required on every staging operation**. The `stash` flow is unchanged (keeps its passphrase).

## Library choice
**`github.com/zalando/go-keyring`** over `99designs/keyring`: for a single-key use case its `Set/Get/Delete` API is simpler, it wraps macOS Keychain / Windows Credential Manager / Linux Secret Service, and `keyring.MockInit()` lets tests run without a real keychain (CI-safe). `99designs/keyring` offers more backends/config than needed here.

## Key resolution fallback chain (working store only)
1. **`SUVE_STAGING_KEY`** env var — base64-standard of exactly 32 bytes; an invalid value is a **hard error** (no silent fall-through). For CI/headless/explicit control.
2. **OS keychain get-or-create** — fetch the stored 256-bit key, or generate + store one (service `suve`, account `staging-data-key`).
3. **Plaintext `0600`** with a one-time stderr warning.

**Design decision (issue left the exact chain to the PR):** a passphrase prompt is intentionally **not** offered for the working store — it would prompt on *every* staging op, defeating the keychain's purpose. Headless encryption is via `SUVE_STAGING_KEY`; the *stash* keeps its passphrase. Flagged for maintainer sign-off.

## Crypt format (`internal/staging/store/file/internal/crypt`)
| Version | Layout | Key |
|---------|--------|-----|
| v1 (passphrase) | `magic(8) + ver(1)=1 + salt(32) + nonce(12) + ct` | Argon2id (unchanged) |
| v2 (raw key) | `magic(8) + ver(1)=2 + nonce(12) + ct` | 32-byte keychain key used directly (no KDF) |

- **v1 is byte-compatible** — existing stash files still decrypt.
- **P2-4 fix:** Argon2 params are now resolved from a `version → params` table keyed off the version byte, so a future param change becomes a new version and old files keep decrypting with the params they were written with. (v1 layout unchanged to preserve compatibility; the fix is that params are no longer a bare constant assumed for all versions.)
- New `EncryptWithKey`/`DecryptWithKey` (require 32-byte key). `Decrypt` rejects v2, `DecryptWithKey` rejects non-v2 — clear cross-format errors.

## Wiring
- New `internal/staging/store/file/internal/keyprovider` implements the chain (env/keychain/rand hooks overridable for tests).
- New `file.NewWorkingStore(accountID, region)` resolves the key and emits the one-time plaintext warning; all working-area (`stage.json`) construction sites repointed to it (8× in `staging/cli/command.go`, `stage/{apply,diff,reset,status}`, the working side of `stash_push`/`stash_pop`, and the GUI). Stash (`stash.json`) stays on the passphrase flow.
- File store gained a `key []byte` field; read/write prefer key (v2) → passphrase (v1) → plaintext. Legacy plaintext `stage.json` is still readable (migration). An encrypted file with no resolvable key fails **loudly** (no silent data loss).

## ⚠️ Notes
- **Key loss = data loss:** deleting the keychain entry or changing `SUVE_STAGING_KEY` makes an existing encrypted `stage.json` undecryptable. Inherent to the design.
- **CI/headless:** with no keychain and no env var, `NewWorkingStore` falls back to plaintext + warning (does not fail). The warning goes to the process stderr, not a command's `ErrWriter`, so it doesn't perturb captured-stderr test assertions.

## Out of scope
Stash stays on its passphrase flow (not moved to the keychain); no provider/`Scope` changes (#200).

## Verification
```
$ make lint     # 0 issues
$ make test     # pass (incl. new crypt + keyprovider + store_key tests)
$ CGO_ENABLED=1 go test -tags=production ./internal/gui/...   # ok
$ go test -tags e2e -run xxxNoMatch ./e2e/...                 # compiles
$ go build ./cmd/suve                                         # ok
```
Tests cover: v1 round-trip + golden v1 backward-compat blob, v2 round-trip, cross-format rejection, unknown-version rejection, key-length rejection; keyprovider env (valid/invalid/wrong-length)/keychain get-or-create (MockInit)/plaintext fallback; file-store key round-trip + legacy-plaintext read + wrong-key failure.

## Acceptance criteria
- [x] Staging state encrypted at rest via an OS-keychain data key on supported platforms
- [x] Documented fallback chain works on headless Linux/CI (`SUVE_STAGING_KEY` → keychain → warned plaintext)
- [x] Crypt header records KDF params (version→params table); old-file compatibility preserved
- [x] Stash passphrase flow unchanged
- [x] `make test` green
- [x] `make lint` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)