### PR TITLE
refactor(cli): consolidate output + JSON + client-init plumbing

### DIFF
--- a/internal/cli/commands/internal/client.go
+++ b/internal/cli/commands/internal/client.go
@@ -1,0 +1,33 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+
+	"github.com/mpyw/suve/internal/infra"
+)
+
+// NewParamClient initializes an SSM Parameter Store client, wrapping any
+// initialization failure with a consistent, user-facing error message.
+func NewParamClient(ctx context.Context) (*ssm.Client, error) {
+	client, err := infra.NewParamClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize AWS client: %w", err)
+	}
+
+	return client, nil
+}
+
+// NewSecretClient initializes a Secrets Manager client, wrapping any
+// initialization failure with a consistent, user-facing error message.
+func NewSecretClient(ctx context.Context) (*secretsmanager.Client, error) {
+	client, err := infra.NewSecretClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize AWS client: %w", err)
+	}
+
+	return client, nil
+}

--- a/internal/cli/commands/internal/pager.go
+++ b/internal/cli/commands/internal/pager.go
@@ -1,0 +1,19 @@
+package internal
+
+import (
+	"io"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/mpyw/suve/internal/cli/pager"
+)
+
+// WithPager runs fn with the root command's stdout routed through the pager
+// (unless noPager is set) and the root command's stderr. It centralizes the
+// writer wiring shared by the paging commands so call sites only construct
+// their Runner and invoke it.
+func WithPager(cmd *cli.Command, noPager bool, fn func(stdout, stderr io.Writer) error) error {
+	return pager.WithPagerWriter(cmd.Root().Writer, noPager, func(w io.Writer) error {
+		return fn(w, cmd.Root().ErrWriter)
+	})
+}

--- a/internal/cli/commands/param/create/create.go
+++ b/internal/cli/commands/param/create/create.go
@@ -4,14 +4,13 @@ package create
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 
 	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/api/paramapi"
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/usecase/param"
 )
 
@@ -92,9 +91,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		paramType = "SecureString"
 	}
 
-	client, err := infra.NewParamClient(ctx)
+	client, err := internal.NewParamClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	r := &Runner{

--- a/internal/cli/commands/param/delete/delete.go
+++ b/internal/cli/commands/param/delete/delete.go
@@ -4,12 +4,12 @@ package delete
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/confirm"
 	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/infra"
@@ -61,9 +61,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	name := cmd.Args().First()
 	skipConfirm := cmd.Bool("yes")
 
-	client, err := infra.NewParamClient(ctx)
+	client, err := internal.NewParamClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	// Get AWS identity for confirmation display

--- a/internal/cli/commands/param/diff/diff.go
+++ b/internal/cli/commands/param/diff/diff.go
@@ -3,15 +3,13 @@ package diff
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/cli/pager"
-	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/jsonutil"
 	"github.com/mpyw/suve/internal/usecase/param"
 	"github.com/mpyw/suve/internal/version/paramversion"
@@ -94,9 +92,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	client, err := infra.NewParamClient(ctx)
+	client, err := internal.NewParamClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	opts := Options{
@@ -110,11 +108,11 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	// JSON output disables pager
 	noPager := opts.NoPager || opts.Output == output.FormatJSON
 
-	return pager.WithPagerWriter(cmd.Root().Writer, noPager, func(w io.Writer) error {
+	return internal.WithPager(cmd, noPager, func(stdout, stderr io.Writer) error {
 		r := &Runner{
 			UseCase: &param.DiffUseCase{Client: client},
-			Stdout:  w,
-			Stderr:  cmd.Root().ErrWriter,
+			Stdout:  stdout,
+			Stderr:  stderr,
 		}
 
 		return r.Run(ctx, opts)
@@ -161,10 +159,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 			)
 		}
 
-		enc := json.NewEncoder(r.Stdout)
-		enc.SetIndent("", "  ")
-
-		return enc.Encode(jsonOut)
+		return output.WriteJSON(r.Stdout, jsonOut)
 	}
 
 	if identical {

--- a/internal/cli/commands/param/list/list.go
+++ b/internal/cli/commands/param/list/list.go
@@ -3,15 +3,13 @@ package list
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/samber/lo"
 	"github.com/urfave/cli/v3"
 
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/usecase/param"
 )
 
@@ -96,9 +94,9 @@ EXAMPLES:
 }
 
 func action(ctx context.Context, cmd *cli.Command) error {
-	client, err := infra.NewParamClient(ctx)
+	client, err := internal.NewParamClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	r := &Runner{
@@ -144,10 +142,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 			items[i] = JSONOutputItem{Name: entry.Name}
 		}
 
-		enc := json.NewEncoder(r.Stdout)
-		enc.SetIndent("", "  ")
-
-		return enc.Encode(items)
+		return output.WriteJSON(r.Stdout, items)
 	}
 
 	// JSON output with values
@@ -161,10 +156,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 			}
 		}
 
-		enc := json.NewEncoder(r.Stdout)
-		enc.SetIndent("", "  ")
-
-		return enc.Encode(items)
+		return output.WriteJSON(r.Stdout, items)
 	}
 
 	// Text output with values

--- a/internal/cli/commands/param/log/log.go
+++ b/internal/cli/commands/param/log/log.go
@@ -6,7 +6,6 @@ package log
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"time"
@@ -14,10 +13,9 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/cli/colors"
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/cli/pager"
 	"github.com/mpyw/suve/internal/cli/terminal"
-	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/jsonutil"
 	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/usecase/param"
@@ -198,19 +196,19 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		}
 	}
 
-	client, err := infra.NewParamClient(ctx)
+	client, err := internal.NewParamClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	// JSON output disables pager
 	noPager := opts.NoPager || opts.Output == output.FormatJSON
 
-	return pager.WithPagerWriter(cmd.Root().Writer, noPager, func(w io.Writer) error {
+	return internal.WithPager(cmd, noPager, func(stdout, stderr io.Writer) error {
 		r := &Runner{
 			UseCase: &param.LogUseCase{Client: client},
-			Stdout:  w,
-			Stderr:  cmd.Root().ErrWriter,
+			Stdout:  stdout,
+			Stderr:  stderr,
 		}
 
 		return r.Run(ctx, opts)
@@ -249,10 +247,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 			}
 		}
 
-		enc := json.NewEncoder(r.Stdout)
-		enc.SetIndent("", "  ")
-
-		return enc.Encode(items)
+		return output.WriteJSON(r.Stdout, items)
 	}
 
 	for i, entry := range entries {

--- a/internal/cli/commands/param/show/show.go
+++ b/internal/cli/commands/param/show/show.go
@@ -3,7 +3,6 @@ package show
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -12,9 +11,8 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/api/paramapi"
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/cli/pager"
-	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/jsonutil"
 	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/usecase/param"
@@ -112,9 +110,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("--raw and --output=json cannot be used together")
 	}
 
-	client, err := infra.NewParamClient(ctx)
+	client, err := internal.NewParamClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	opts := Options{
@@ -128,11 +126,11 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	// Raw mode and JSON output disable pager
 	noPager := opts.NoPager || opts.Raw || opts.Output == output.FormatJSON
 
-	return pager.WithPagerWriter(cmd.Root().Writer, noPager, func(w io.Writer) error {
+	return internal.WithPager(cmd, noPager, func(stdout, stderr io.Writer) error {
 		r := &Runner{
 			UseCase: &param.ShowUseCase{Client: client},
-			Stdout:  w,
-			Stderr:  cmd.Root().ErrWriter,
+			Stdout:  stdout,
+			Stderr:  stderr,
 		}
 
 		return r.Run(ctx, opts)
@@ -194,10 +192,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 			jsonOut.Tags[tag.Key] = tag.Value
 		}
 
-		enc := json.NewEncoder(r.Stdout)
-		enc.SetIndent("", "  ")
-
-		return enc.Encode(jsonOut)
+		return output.WriteJSON(r.Stdout, jsonOut)
 	}
 
 	// Normal mode: show metadata + value

--- a/internal/cli/commands/param/tag/tag.go
+++ b/internal/cli/commands/param/tag/tag.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/usecase/param"
 )
 
@@ -57,9 +57,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	client, err := infra.NewParamClient(ctx)
+	client, err := internal.NewParamClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	r := &Runner{

--- a/internal/cli/commands/param/untag/untag.go
+++ b/internal/cli/commands/param/untag/untag.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/usecase/param"
 )
 
@@ -50,9 +50,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	name := cmd.Args().Get(0)
 	keys := cmd.Args().Slice()[1:]
 
-	client, err := infra.NewParamClient(ctx)
+	client, err := internal.NewParamClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	r := &Runner{

--- a/internal/cli/commands/param/update/update.go
+++ b/internal/cli/commands/param/update/update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/api/paramapi"
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/confirm"
 	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/infra"
@@ -100,9 +101,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	name := cmd.Args().Get(0)
 	skipConfirm := cmd.Bool("yes")
 
-	client, err := infra.NewParamClient(ctx)
+	client, err := internal.NewParamClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	uc := &param.UpdateUseCase{Client: client}

--- a/internal/cli/commands/secret/create/create.go
+++ b/internal/cli/commands/secret/create/create.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/usecase/secret"
 )
 
@@ -62,9 +62,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("usage: suve secret create <name> <value>")
 	}
 
-	client, err := infra.NewSecretClient(ctx)
+	client, err := internal.NewSecretClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	r := &Runner{

--- a/internal/cli/commands/secret/delete/delete.go
+++ b/internal/cli/commands/secret/delete/delete.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/confirm"
 	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/infra"
@@ -81,9 +82,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	name := cmd.Args().First()
 	skipConfirm := cmd.Bool("yes")
 
-	client, err := infra.NewSecretClient(ctx)
+	client, err := internal.NewSecretClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	// Get AWS identity for confirmation display

--- a/internal/cli/commands/secret/diff/diff.go
+++ b/internal/cli/commands/secret/diff/diff.go
@@ -11,15 +11,13 @@ package diff
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/cli/pager"
-	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/jsonutil"
 	"github.com/mpyw/suve/internal/usecase/secret"
 	"github.com/mpyw/suve/internal/version/secretversion"
@@ -103,9 +101,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	client, err := infra.NewSecretClient(ctx)
+	client, err := internal.NewSecretClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	opts := Options{
@@ -119,11 +117,11 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	// JSON output disables pager
 	noPager := opts.NoPager || opts.Output == output.FormatJSON
 
-	return pager.WithPagerWriter(cmd.Root().Writer, noPager, func(w io.Writer) error {
+	return internal.WithPager(cmd, noPager, func(stdout, stderr io.Writer) error {
 		r := &Runner{
 			UseCase: &secret.DiffUseCase{Client: client},
-			Stdout:  w,
-			Stderr:  cmd.Root().ErrWriter,
+			Stdout:  stdout,
+			Stderr:  stderr,
 		}
 
 		return r.Run(ctx, opts)
@@ -172,10 +170,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 			)
 		}
 
-		enc := json.NewEncoder(r.Stdout)
-		enc.SetIndent("", "  ")
-
-		return enc.Encode(jsonOut)
+		return output.WriteJSON(r.Stdout, jsonOut)
 	}
 
 	if identical {

--- a/internal/cli/commands/secret/list/list.go
+++ b/internal/cli/commands/secret/list/list.go
@@ -3,15 +3,13 @@ package list
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"io"
 
 	"github.com/samber/lo"
 	"github.com/urfave/cli/v3"
 
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/usecase/secret"
 )
 
@@ -89,9 +87,9 @@ EXAMPLES:
 }
 
 func action(ctx context.Context, cmd *cli.Command) error {
-	client, err := infra.NewSecretClient(ctx)
+	client, err := internal.NewSecretClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	r := &Runner{
@@ -137,10 +135,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 			items[i] = JSONOutputItem{Name: entry.Name}
 		}
 
-		enc := json.NewEncoder(r.Stdout)
-		enc.SetIndent("", "  ")
-
-		return enc.Encode(items)
+		return output.WriteJSON(r.Stdout, items)
 	}
 
 	// JSON output with values
@@ -154,10 +149,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 			}
 		}
 
-		enc := json.NewEncoder(r.Stdout)
-		enc.SetIndent("", "  ")
-
-		return enc.Encode(items)
+		return output.WriteJSON(r.Stdout, items)
 	}
 
 	// Text output with values

--- a/internal/cli/commands/secret/log/log.go
+++ b/internal/cli/commands/secret/log/log.go
@@ -6,7 +6,6 @@ package log
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"time"
@@ -14,9 +13,8 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/cli/colors"
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/cli/pager"
-	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/jsonutil"
 	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/usecase/secret"
@@ -186,19 +184,19 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		}
 	}
 
-	client, err := infra.NewSecretClient(ctx)
+	client, err := internal.NewSecretClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	// JSON output disables pager
 	noPager := opts.NoPager || opts.Output == output.FormatJSON
 
-	return pager.WithPagerWriter(cmd.Root().Writer, noPager, func(w io.Writer) error {
+	return internal.WithPager(cmd, noPager, func(stdout, stderr io.Writer) error {
 		r := &Runner{
 			UseCase: &secret.LogUseCase{Client: client},
-			Stdout:  w,
-			Stderr:  cmd.Root().ErrWriter,
+			Stdout:  stdout,
+			Stderr:  stderr,
 		}
 
 		return r.Run(ctx, opts)
@@ -249,10 +247,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 			items = append(items, item)
 		}
 
-		enc := json.NewEncoder(r.Stdout)
-		enc.SetIndent("", "  ")
-
-		return enc.Encode(items)
+		return output.WriteJSON(r.Stdout, items)
 	}
 
 	// Build secret values map for patch mode

--- a/internal/cli/commands/secret/restore/restore.go
+++ b/internal/cli/commands/secret/restore/restore.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/usecase/secret"
 )
 
@@ -48,9 +48,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("usage: suve secret restore <name>")
 	}
 
-	client, err := infra.NewSecretClient(ctx)
+	client, err := internal.NewSecretClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	r := &Runner{

--- a/internal/cli/commands/secret/show/show.go
+++ b/internal/cli/commands/secret/show/show.go
@@ -3,15 +3,13 @@ package show
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/cli/pager"
-	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/jsonutil"
 	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/usecase/secret"
@@ -110,9 +108,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return fmt.Errorf("--raw and --output=json cannot be used together")
 	}
 
-	client, err := infra.NewSecretClient(ctx)
+	client, err := internal.NewSecretClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	opts := Options{
@@ -126,11 +124,11 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	// Raw mode and JSON output disable pager
 	noPager := opts.NoPager || opts.Raw || opts.Output == output.FormatJSON
 
-	return pager.WithPagerWriter(cmd.Root().Writer, noPager, func(w io.Writer) error {
+	return internal.WithPager(cmd, noPager, func(stdout, stderr io.Writer) error {
 		r := &Runner{
 			UseCase: &secret.ShowUseCase{Client: client},
-			Stdout:  w,
-			Stderr:  cmd.Root().ErrWriter,
+			Stdout:  stdout,
+			Stderr:  stderr,
 		}
 
 		return r.Run(ctx, opts)
@@ -184,10 +182,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 			jsonOut.Tags[tag.Key] = tag.Value
 		}
 
-		enc := json.NewEncoder(r.Stdout)
-		enc.SetIndent("", "  ")
-
-		return enc.Encode(jsonOut)
+		return output.WriteJSON(r.Stdout, jsonOut)
 	}
 
 	// Normal mode: show metadata + value

--- a/internal/cli/commands/secret/tag/tag.go
+++ b/internal/cli/commands/secret/tag/tag.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/usecase/secret"
 )
 
@@ -57,9 +57,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	client, err := infra.NewSecretClient(ctx)
+	client, err := internal.NewSecretClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	r := &Runner{

--- a/internal/cli/commands/secret/untag/untag.go
+++ b/internal/cli/commands/secret/untag/untag.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/usecase/secret"
 )
 
@@ -50,9 +50,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	name := cmd.Args().Get(0)
 	keys := cmd.Args().Slice()[1:]
 
-	client, err := infra.NewSecretClient(ctx)
+	client, err := internal.NewSecretClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	r := &Runner{

--- a/internal/cli/commands/secret/update/update.go
+++ b/internal/cli/commands/secret/update/update.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/urfave/cli/v3"
 
+	"github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/confirm"
 	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/infra"
@@ -69,9 +70,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	name := cmd.Args().Get(0)
 	skipConfirm := cmd.Bool("yes")
 
-	client, err := infra.NewSecretClient(ctx)
+	client, err := internal.NewSecretClient(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to initialize AWS client: %w", err)
+		return err
 	}
 
 	uc := &secret.UpdateUseCase{Client: client}

--- a/internal/cli/output/output.go
+++ b/internal/cli/output/output.go
@@ -10,6 +10,7 @@
 package output
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -67,14 +68,46 @@ func (o *Writer) Value(value string) {
 	}
 }
 
+// The functions below form the CLI's set of user-feedback primitives. Each
+// emits a single colored line to w and serves a distinct role, so they are not
+// interchangeable — pick the one whose prefix, color, and tone match the intent:
+//
+//   - Warning — "Warning: X" (yellow): a non-critical issue that does not stop the command.
+//   - Warn    — "! X" (yellow): a per-item caveat within a larger operation.
+//   - Info    — "X" (cyan): neutral status or progress, no prefix.
+//   - Hint    — "Hint: X" (cyan): an actionable suggestion, usually after a Warning.
+//   - Error   — "Error: X" (red): a user-facing error that is not a Go error value.
+//   - Success — "✓ X": a completed action.
+//   - Failed  — "Failed NAME: ERR" (red "Failed"): a per-item failure carrying its error.
+//
+// Warning, Warn, Info, Hint, and Error share two internal shapes (labeled and
+// prefixed) so the exact byte layout of each family stays consistent.
+
+// labeled formats a message and prints it as a single line, coloring the whole
+// "label+message" string with colorize. A label of "" colors the message alone.
+//
+//nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
+func labeled(w io.Writer, colorize func(...any) string, label, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	_, _ = fmt.Fprintln(w, colorize(label+msg))
+}
+
+// prefixed formats a message and prints it as "prefix message" on a single
+// line, where only prefix carries color and the message stays uncolored.
+//
+//nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
+func prefixed(w io.Writer, prefix, format string, args ...any) {
+	msg := fmt.Sprintf(format, args...)
+	_, _ = fmt.Fprintf(w, "%s %s\n", prefix, msg)
+}
+
 // Warning prints a warning message in yellow.
 // Used to alert users about non-critical issues that don't prevent command execution.
 // Example: "Warning: comparing identical versions".
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
 func Warning(w io.Writer, format string, args ...any) {
-	msg := fmt.Sprintf(format, args...)
-	_, _ = fmt.Fprintln(w, colors.Warning("Warning: "+msg))
+	labeled(w, colors.Warning, "Warning: ", format, args...)
 }
 
 // Hint prints a hint message in cyan.
@@ -83,8 +116,7 @@ func Warning(w io.Writer, format string, args ...any) {
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
 func Hint(w io.Writer, format string, args ...any) {
-	msg := fmt.Sprintf(format, args...)
-	_, _ = fmt.Fprintln(w, colors.Info("Hint: "+msg))
+	labeled(w, colors.Info, "Hint: ", format, args...)
 }
 
 // Error prints an error message in red.
@@ -93,42 +125,51 @@ func Hint(w io.Writer, format string, args ...any) {
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
 func Error(w io.Writer, format string, args ...any) {
-	msg := fmt.Sprintf(format, args...)
-	_, _ = fmt.Fprintln(w, colors.Error("Error: "+msg))
+	labeled(w, colors.Error, "Error: ", format, args...)
 }
 
-// Success prints a success message with green checkmark.
-// Example: "✓ Created parameter /app/config".
-//
-//nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
-func Success(w io.Writer, format string, args ...any) {
-	msg := fmt.Sprintf(format, args...)
-	_, _ = fmt.Fprintf(w, "%s %s\n", colors.Success("✓"), msg)
-}
-
-// Failed prints a failure message in red.
-// Example: "Failed /app/config: error message".
-func Failed(w io.Writer, name string, err error) {
-	_, _ = fmt.Fprintf(w, "%s %s: %v\n", colors.Failed("Failed"), name, err)
-}
-
-// Info prints an informational message in cyan.
+// Info prints an informational message in cyan with no prefix.
 // Used for status updates, progress messages, and neutral information.
 // Example: "No changes staged.", "Agent started".
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
 func Info(w io.Writer, format string, args ...any) {
-	msg := fmt.Sprintf(format, args...)
-	_, _ = fmt.Fprintln(w, colors.Info(msg))
+	labeled(w, colors.Info, "", format, args...)
 }
 
-// Warn prints a warning message with yellow "!" prefix.
+// Warn prints a warning message with a yellow "!" prefix.
+// Used for per-item caveats within a larger operation.
 // Example: "! Skipped /app/config (same as AWS)".
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
 func Warn(w io.Writer, format string, args ...any) {
-	msg := fmt.Sprintf(format, args...)
-	_, _ = fmt.Fprintf(w, "%s %s\n", colors.Warning("!"), msg)
+	prefixed(w, colors.Warning("!"), format, args...)
+}
+
+// Success prints a success message with a green checkmark prefix.
+// Used to confirm a completed action.
+// Example: "✓ Created parameter /app/config".
+//
+//nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
+func Success(w io.Writer, format string, args ...any) {
+	prefixed(w, colors.Success("✓"), format, args...)
+}
+
+// Failed prints a per-item failure message with a red "Failed" prefix,
+// appending the error that caused it.
+// Example: "Failed /app/config: error message".
+func Failed(w io.Writer, name string, err error) {
+	_, _ = fmt.Fprintf(w, "%s %s: %v\n", colors.Failed("Failed"), name, err)
+}
+
+// WriteJSON encodes v as indented JSON (two-space indent) followed by a
+// trailing newline, writing the result to w. It is the shared implementation
+// for the CLI's --output=json modes.
+func WriteJSON(w io.Writer, v any) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+
+	return enc.Encode(v)
 }
 
 // Diff generates a unified diff between two strings with ANSI colors.


### PR DESCRIPTION
Closes #196 (Part of #189, Phase 1)

## Summary

Pure refactor of three CLI plumbing duplication sources (P1-4/5/6). **No behavior change** — every existing golden-output test passes with zero edits to expectations (confirmed: no `*_test.go` expectation file was modified). Net `+204 / −155` across 22 files.

### (b) `output.WriteJSON`
Added `func WriteJSON(w io.Writer, v any) error` (`json.NewEncoder` + `SetIndent("", "  ")` + `Encode`) and replaced **10 inline JSON blocks** across `param/{show,log,diff,list}` and `secret/{show,log,diff,list}`. Byte-identical (two-space indent + trailing newline). Removed the now-unused `encoding/json` imports.

### (c) client-init + pager helpers
- New `internal/cli/commands/internal/client.go`: `NewParamClient`/`NewSecretClient` wrap `infra.New*Client` and return the error wrapped exactly as `"failed to initialize AWS client: %w"`. Migrated the **19 identical** call sites. Differently-worded sites (e.g. `stage/diff`'s "…SSM Parameter Store client") were left untouched to avoid changing output.
- New `internal/cli/commands/internal/pager.go`: `WithPager(cmd, noPager, func(stdout, stderr io.Writer) error)` factors the `cmd.Root().Writer`/`ErrWriter` plumbing out of the **6 uniform** Runner+pager wrappers. `stage/diff` was intentionally left as-is (its Runner is pre-constructed and only sets `Stdout` in the closure — forcing it through the helper would contort it).

### (a) output primitives — API/impl consolidation only, zero output-byte change
`Warning`/`Warn`/`Info`/`Hint`/`Error` each emit **different bytes**, so they cannot be merged without changing output (which the acceptance criteria forbid). Instead:
- Routed their implementations through two small private helpers (`labeled` for `"Label: msg"` fully-colored lines, `prefixed` for a colored prefix + uncolored message).
- Added a group doc comment describing the set as one coherent family with each member's role.
- No prefix/color/spacing/newline changed; no function removed (all 7 still used repo-wide). Verified byte-for-byte equivalence with the originals.

> Note on interpretation: the issue asks to "consolidate to one coherent set (resolve Warning/Warn, Info/Hint, Error)" while also mandating no output change. Since those primitives emit distinct bytes, "consolidate" is realized as implementation dedup + a coherent documented set rather than merging functions (which would change emitted output). Flagging for sign-off.

## Out of scope
Collapsing param/secret command trees into generic commands (#204); any provider/`Scope` abstraction.

## Verification
```
$ make test    # all packages ok; NO test expectation edited (git shows 0 *_test.go changes)
$ make lint     # 0 issues
$ CGO_ENABLED=1 go test -tags=production ./internal/gui/...   # ok
$ go test -tags e2e -run xxxNoMatch ./e2e/...                 # compiles
$ go build ./cmd/suve                                         # ok
```

## Acceptance criteria
- [x] No behavior change; golden-output tests pass without edits
- [x] Single JSON helper (`WriteJSON`); single client-init helper pair; single pager helper; coherent output-primitive set
- [x] `make test` green
- [x] `make lint` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)