### PR TITLE
refactor(staging/cli): decompose command.go (847 LOC)

### DIFF
--- a/internal/staging/cli/apply.go
+++ b/internal/staging/cli/apply.go
@@ -10,14 +10,29 @@ import (
 
 	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/maputil"
+	"github.com/mpyw/suve/internal/staging"
+	"github.com/mpyw/suve/internal/staging/store"
 	stagingusecase "github.com/mpyw/suve/internal/usecase/staging"
 )
 
-// ApplyRunner executes apply operations using a usecase.
+// confirmer prompts the user to confirm an action. *confirm.Prompter satisfies
+// this interface; it is kept small so the apply flow stays testable.
+type confirmer interface {
+	Confirm(message string, skip bool) (bool, error)
+}
+
+// ApplyRunner applies staged changes via the ApplyUseCase and reports the
+// results. RunInteractive wraps Run with the presentation-layer orchestration
+// (empty-check, name validation, and interactive confirmation) that the
+// `stage <service> apply` command performs before applying.
 type ApplyRunner struct {
-	UseCase *stagingusecase.ApplyUseCase
-	Stdout  io.Writer
-	Stderr  io.Writer
+	UseCase     *stagingusecase.ApplyUseCase
+	Store       store.ReadWriteOperator
+	Parser      staging.Parser
+	Confirmer   confirmer
+	SkipConfirm bool
+	Stdout      io.Writer
+	Stderr      io.Writer
 }
 
 // ApplyOptions holds options for the apply command.
@@ -26,7 +41,54 @@ type ApplyOptions struct {
 	IgnoreConflicts bool   // Skip conflict detection and force apply
 }
 
-// Run executes the apply command.
+// RunInteractive performs the command-level apply flow: it lists staged
+// entries, short-circuits when nothing is staged, validates an optional target
+// name, asks for confirmation, and then delegates to Run. Interactive
+// confirmation lives here (presentation layer) rather than in the usecase.
+func (r *ApplyRunner) RunInteractive(ctx context.Context, opts ApplyOptions) error {
+	service := r.Parser.Service()
+
+	// Get entries to show what will be applied
+	entries, err := r.Store.ListEntries(ctx, service)
+	if err != nil {
+		return err
+	}
+
+	serviceEntries := entries[service]
+	if len(serviceEntries) == 0 {
+		output.Info(r.Stdout, "No %s changes staged.", r.Parser.ServiceName())
+
+		return nil
+	}
+
+	// Validate the target name if specified
+	if opts.Name != "" {
+		if _, ok := serviceEntries[opts.Name]; !ok {
+			return fmt.Errorf("%s is not staged", opts.Name)
+		}
+	}
+
+	// Confirm apply
+	var message string
+	if opts.Name != "" {
+		message = fmt.Sprintf("Apply staged changes for %s to AWS?", opts.Name)
+	} else {
+		message = fmt.Sprintf("Apply %d staged %s change(s) to AWS?", len(serviceEntries), r.Parser.ServiceName())
+	}
+
+	confirmed, err := r.Confirmer.Confirm(message, r.SkipConfirm)
+	if err != nil {
+		return err
+	}
+
+	if !confirmed {
+		return nil
+	}
+
+	return r.Run(ctx, opts)
+}
+
+// Run applies the staged changes via the usecase and reports the results.
 func (r *ApplyRunner) Run(ctx context.Context, opts ApplyOptions) error {
 	result, err := r.UseCase.Execute(ctx, stagingusecase.ApplyInput{
 		Name:            opts.Name,

--- a/internal/staging/cli/command.go
+++ b/internal/staging/cli/command.go
@@ -10,7 +10,6 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/cli/confirm"
-	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/cli/pager"
 	"github.com/mpyw/suve/internal/infra"
 	"github.com/mpyw/suve/internal/staging"
@@ -36,24 +35,10 @@ type CommandConfig struct {
 // NewStatusCommand creates a status command with the given config.
 func NewStatusCommand(cfg CommandConfig) *cli.Command {
 	return &cli.Command{
-		Name:      "status",
-		Usage:     fmt.Sprintf("Show staged %s changes", cfg.ItemName),
-		ArgsUsage: "[name]",
-		Description: fmt.Sprintf(`Display staged changes for %s.
-
-Without arguments, shows all staged %s changes.
-With a %s name, shows the staged change for that specific %s.
-
-Use --verbose to show detailed information including the staged value.
-
-EXAMPLES:
-   suve stage %s status              Show all staged %s changes
-   suve stage %s status <name>       Show staged change for specific %s
-   suve stage %s status --verbose    Show detailed information`,
-			cfg.CommandName, cfg.ItemName, cfg.ItemName, cfg.ItemName,
-			cfg.CommandName, cfg.ItemName,
-			cfg.CommandName, cfg.ItemName,
-			cfg.CommandName),
+		Name:        "status",
+		Usage:       fmt.Sprintf("Show staged %s changes", cfg.ItemName),
+		ArgsUsage:   "[name]",
+		Description: statusDescription(cfg),
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "verbose",
@@ -96,22 +81,10 @@ EXAMPLES:
 // NewDiffCommand creates a diff command with the given config.
 func NewDiffCommand(cfg CommandConfig) *cli.Command {
 	return &cli.Command{
-		Name:      "diff",
-		Usage:     "Show diff between staged and AWS values",
-		ArgsUsage: "[name]",
-		Description: fmt.Sprintf(`Compare staged values against AWS current values.
-
-If a %s name is specified, shows diff for that %s only.
-Otherwise, shows diff for all staged %ss.
-
-EXAMPLES:
-   suve stage %s diff                   Show diff for all staged %ss
-   suve stage %s diff <name>            Show diff for specific %s
-   suve stage %s diff --parse-json      Show diff with JSON formatting`,
-			cfg.ItemName, cfg.ItemName, cfg.ItemName,
-			cfg.CommandName, cfg.ItemName,
-			cfg.CommandName, cfg.ItemName,
-			cfg.CommandName),
+		Name:        "diff",
+		Usage:       "Show diff between staged and AWS values",
+		ArgsUsage:   "[name]",
+		Description: diffDescription(cfg),
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:    "parse-json",
@@ -181,30 +154,10 @@ EXAMPLES:
 // NewAddCommand creates an add command with the given config.
 func NewAddCommand(cfg CommandConfig) *cli.Command {
 	return &cli.Command{
-		Name:      "add",
-		Usage:     fmt.Sprintf("Create new %s and stage it", cfg.ItemName),
-		ArgsUsage: "<name> [value]",
-		Description: fmt.Sprintf(`Create a new %s value and stage the change.
-
-If value is provided as an argument, uses that value directly.
-Otherwise, opens an editor to create the value.
-
-If the %s is already staged for creation, edits the staged value.
-The new %s will be created in AWS when you run 'suve stage %s apply'.
-
-Use 'suve stage %s edit' to modify an existing %s.
-Use 'suve stage %s status' to view staged changes.
-
-EXAMPLES:
-   suve stage %s add <name>              Open editor to create new %s
-   suve stage %s add <name> <value>      Create new %s with given value`,
-			cfg.ItemName,
-			cfg.ItemName,
-			cfg.ItemName, cfg.CommandName,
-			cfg.CommandName, cfg.ItemName,
-			cfg.CommandName,
-			cfg.CommandName, cfg.ItemName,
-			cfg.CommandName, cfg.ItemName),
+		Name:        "add",
+		Usage:       fmt.Sprintf("Create new %s and stage it", cfg.ItemName),
+		ArgsUsage:   "<name> [value]",
+		Description: addDescription(cfg),
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "description",
@@ -259,32 +212,10 @@ EXAMPLES:
 // NewEditCommand creates an edit command with the given config.
 func NewEditCommand(cfg CommandConfig) *cli.Command {
 	return &cli.Command{
-		Name:      "edit",
-		Usage:     fmt.Sprintf("Edit %s value and stage changes", cfg.ItemName),
-		ArgsUsage: "<name> [value]",
-		Description: fmt.Sprintf(`Modify a %s value and stage the change.
-
-If value is provided as an argument, uses that value directly.
-Otherwise, opens an editor to modify the value.
-
-If the %s is already staged, edits the staged value.
-Otherwise, fetches the current value from AWS and opens it for editing.
-Saves the edited value to the staging area (does not immediately apply to AWS).
-
-Use 'suve stage %s delete' to stage a %s for deletion.
-Use 'suve stage %s apply' to apply staged changes to AWS.
-Use 'suve stage %s status' to view staged changes.
-
-EXAMPLES:
-   suve stage %s edit <name>              Open editor to modify %s
-   suve stage %s edit <name> <value>      Set %s to given value`,
-			cfg.ItemName,
-			cfg.ItemName,
-			cfg.CommandName, cfg.ItemName,
-			cfg.CommandName,
-			cfg.CommandName,
-			cfg.CommandName, cfg.ItemName,
-			cfg.CommandName, cfg.ItemName),
+		Name:        "edit",
+		Usage:       fmt.Sprintf("Edit %s value and stage changes", cfg.ItemName),
+		ArgsUsage:   "<name> [value]",
+		Description: editDescription(cfg),
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "description",
@@ -339,38 +270,11 @@ EXAMPLES:
 // NewApplyCommand creates an apply command with the given config.
 func NewApplyCommand(cfg CommandConfig) *cli.Command {
 	return &cli.Command{
-		Name:      "apply",
-		Aliases:   []string{"push"},
-		Usage:     fmt.Sprintf("Apply staged %s changes to AWS", cfg.ItemName),
-		ArgsUsage: "[name]",
-		Description: fmt.Sprintf(`Apply all staged %s changes to AWS.
-
-If a %s name is specified, only that %s's staged changes are applied.
-Otherwise, all staged %s changes are applied.
-
-After successful apply, the staged changes are cleared.
-
-Use 'suve stage %s status' to view staged changes before applying.
-
-CONFLICT DETECTION:
-   Before applying, suve checks for conflicts to prevent lost updates:
-   - For new resources: checks if someone else created it after staging
-   - For existing resources: checks if it was modified after staging
-   Use --ignore-conflicts to force apply despite conflicts.
-
-EXAMPLES:
-   suve stage %s apply                      Apply all staged %s changes (with confirmation)
-   suve stage %s apply <name>               Apply only the specified %s
-   suve stage %s apply --yes                Apply without confirmation
-   suve stage %s apply --ignore-conflicts   Apply even if AWS was modified after staging`,
-			cfg.ItemName,
-			cfg.ItemName, cfg.ItemName,
-			cfg.ItemName,
-			cfg.CommandName,
-			cfg.CommandName, cfg.ItemName,
-			cfg.CommandName, cfg.ItemName,
-			cfg.CommandName,
-			cfg.CommandName),
+		Name:        "apply",
+		Aliases:     []string{"push"},
+		Usage:       fmt.Sprintf("Apply staged %s changes to AWS", cfg.ItemName),
+		ArgsUsage:   "[name]",
+		Description: applyDescription(cfg),
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "yes",
@@ -392,56 +296,11 @@ EXAMPLES:
 				return fmt.Errorf("failed to create staging store: %w", err)
 			}
 
-			parser := cfg.ParserFactory()
-
-			// Get entries to show what will be applied
-			service := parser.Service()
-
-			entries, err := store.ListEntries(ctx, service)
-			if err != nil {
-				return err
-			}
-
-			serviceEntries := entries[service]
-			if len(serviceEntries) == 0 {
-				output.Info(cmd.Root().Writer, "No %s changes staged.", parser.ServiceName())
-
-				return nil
-			}
-
-			// Filter by name if specified
 			opts := ApplyOptions{
 				IgnoreConflicts: cmd.Bool("ignore-conflicts"),
 			}
 			if cmd.Args().Len() > 0 {
 				opts.Name = cmd.Args().First()
-				if _, ok := serviceEntries[opts.Name]; !ok {
-					return fmt.Errorf("%s is not staged", opts.Name)
-				}
-			}
-
-			// Confirm apply
-			skipConfirm := cmd.Bool("yes")
-			prompter := &confirm.Prompter{
-				Stdin:  os.Stdin,
-				Stdout: cmd.Root().Writer,
-				Stderr: cmd.Root().ErrWriter,
-			}
-
-			var message string
-			if opts.Name != "" {
-				message = fmt.Sprintf("Apply staged changes for %s to AWS?", opts.Name)
-			} else {
-				message = fmt.Sprintf("Apply %d staged %s change(s) to AWS?", len(serviceEntries), parser.ServiceName())
-			}
-
-			confirmed, err := prompter.Confirm(message, skipConfirm)
-			if err != nil {
-				return err
-			}
-
-			if !confirmed {
-				return nil
 			}
 
 			strategy, err := cfg.Factory(ctx)
@@ -449,16 +308,26 @@ EXAMPLES:
 				return err
 			}
 
+			prompter := &confirm.Prompter{
+				Stdin:  os.Stdin,
+				Stdout: cmd.Root().Writer,
+				Stderr: cmd.Root().ErrWriter,
+			}
+
 			r := &ApplyRunner{
 				UseCase: &stagingusecase.ApplyUseCase{
 					Strategy: strategy,
 					Store:    store,
 				},
-				Stdout: cmd.Root().Writer,
-				Stderr: cmd.Root().ErrWriter,
+				Store:       store,
+				Parser:      cfg.ParserFactory(),
+				Confirmer:   prompter,
+				SkipConfirm: cmd.Bool("yes"),
+				Stdout:      cmd.Root().Writer,
+				Stderr:      cmd.Root().ErrWriter,
 			}
 
-			return r.Run(ctx, opts)
+			return r.RunInteractive(ctx, opts)
 		},
 	}
 }
@@ -466,34 +335,10 @@ EXAMPLES:
 // NewResetCommand creates a reset command with the given config.
 func NewResetCommand(cfg CommandConfig) *cli.Command {
 	return &cli.Command{
-		Name:      "reset",
-		Usage:     fmt.Sprintf("Unstage %s or restore to specific version", cfg.ItemName),
-		ArgsUsage: "[spec]",
-		Description: fmt.Sprintf(`Remove a %s from staging area or restore to a specific version.
-
-Without a version specifier, the %s is simply removed from staging.
-With a version specifier, the value at that version is fetched and staged.
-
-Use 'suve stage %s reset --all' to unstage all %ss at once.
-
-VERSION SPECIFIERS:
-   <name>          Unstage %s (remove from staging)
-   <name>#<ver>    Restore to specific version
-   <name>~1        Restore to 1 version ago
-
-EXAMPLES:
-   suve stage %s reset <name>              Unstage (remove from staging)
-   suve stage %s reset <name>#<ver>        Stage value from specific version
-   suve stage %s reset <name>~1            Stage value from previous version
-   suve stage %s reset --all               Unstage all %ss`,
-			cfg.ItemName,
-			cfg.ItemName,
-			cfg.CommandName, cfg.ItemName,
-			cfg.ItemName,
-			cfg.CommandName,
-			cfg.CommandName,
-			cfg.CommandName,
-			cfg.CommandName, cfg.ItemName),
+		Name:        "reset",
+		Usage:       fmt.Sprintf("Unstage %s or restore to specific version", cfg.ItemName),
+		ArgsUsage:   "[spec]",
+		Description: resetDescription(cfg),
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "all",
@@ -573,8 +418,6 @@ func NewDeleteCommand(cfg CommandConfig) *cli.Command {
 
 	var flags []cli.Flag
 
-	var description string
-
 	if hasDeleteOptions {
 		// Secrets Manager has delete options
 		flags = []cli.Flag{
@@ -588,56 +431,13 @@ func NewDeleteCommand(cfg CommandConfig) *cli.Command {
 				Value: 30, //nolint:mnd // AWS Secrets Manager default recovery window
 			},
 		}
-		description = fmt.Sprintf(`Stage a %s for deletion.
-
-The %s will be deleted from AWS when you run 'suve stage %s apply'.
-Use 'suve stage %s status' to view staged changes.
-Use 'suve stage %s reset <name>' to unstage.
-
-RECOVERY WINDOW:
-   By default, %ss are scheduled for deletion after a 30-day recovery window.
-   During this period, you can restore the %s using 'suve %s restore'.
-   Use --force for immediate permanent deletion without recovery.
-
-   Minimum: 7 days
-   Maximum: 30 days
-   Default: 30 days
-
-EXAMPLES:
-   suve stage %s delete <name>                      Stage with 30-day recovery
-   suve stage %s delete --recovery-window 7 <name>  Stage with 7-day recovery
-   suve stage %s delete --force <name>              Stage for immediate deletion`,
-			cfg.ItemName,
-			cfg.ItemName, cfg.CommandName,
-			cfg.CommandName,
-			cfg.CommandName,
-			cfg.ItemName,
-			cfg.ItemName, cfg.CommandName,
-			cfg.CommandName,
-			cfg.CommandName,
-			cfg.CommandName)
-	} else {
-		// SSM Parameter Store doesn't have delete options
-		description = fmt.Sprintf(`Stage a %s for deletion.
-
-The %s will be deleted from AWS when you run 'suve stage %s apply'.
-Use 'suve stage %s status' to view staged changes.
-Use 'suve stage %s reset <name>' to unstage.
-
-EXAMPLES:
-   suve stage %s delete <name>  Stage %s for deletion`,
-			cfg.ItemName,
-			cfg.ItemName, cfg.CommandName,
-			cfg.CommandName,
-			cfg.CommandName,
-			cfg.CommandName, cfg.ItemName)
 	}
 
 	return &cli.Command{
 		Name:        "delete",
 		Usage:       fmt.Sprintf("Stage a %s for deletion", cfg.ItemName),
 		ArgsUsage:   "<name>",
-		Description: description,
+		Description: deleteDescription(cfg, hasDeleteOptions),
 		Flags:       flags,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.Args().Len() < 1 {
@@ -743,28 +543,11 @@ func NewTagCommand(cfg CommandConfig) *cli.Command {
 	}
 
 	return &cli.Command{
-		Name:      "tag",
-		Usage:     fmt.Sprintf("Stage tags for a %s", cfg.ItemName),
-		ArgsUsage: "<name> <key>=<value>...",
-		Description: fmt.Sprintf(`Stage tags to add or update for a %s.
-
-Tags are staged locally and applied when you run 'suve stage %s apply'.
-If the %s is not already staged, a tag-only change is created.
-
-Use 'suve stage %s untag' to stage tag removals.
-Use 'suve stage %s status' to view staged changes.
-
-EXAMPLES:
-   suve stage %s tag <name> env=prod              Stage single tag
-   suve stage %s tag <name> env=prod team=api     Stage multiple tags`,
-			cfg.ItemName,
-			cfg.CommandName,
-			cfg.ItemName,
-			cfg.CommandName,
-			cfg.CommandName,
-			cfg.CommandName,
-			cfg.CommandName),
-		Action: tagAction(cfg, "tag <name> <key>=<value>", runner),
+		Name:        "tag",
+		Usage:       fmt.Sprintf("Stage tags for a %s", cfg.ItemName),
+		ArgsUsage:   "<name> <key>=<value>...",
+		Description: tagDescription(cfg),
+		Action:      tagAction(cfg, "tag <name> <key>=<value>", runner),
 	}
 }
 
@@ -787,27 +570,10 @@ func NewUntagCommand(cfg CommandConfig) *cli.Command {
 	}
 
 	return &cli.Command{
-		Name:      "untag",
-		Usage:     fmt.Sprintf("Stage tag removal for a %s", cfg.ItemName),
-		ArgsUsage: "<name> <key>...",
-		Description: fmt.Sprintf(`Stage tags to remove from a %s.
-
-Tag removals are staged locally and applied when you run 'suve stage %s apply'.
-If the %s is not already staged, a tag-only change is created.
-
-Use 'suve stage %s tag' to stage tag additions.
-Use 'suve stage %s status' to view staged changes.
-
-EXAMPLES:
-   suve stage %s untag <name> env              Stage single tag removal
-   suve stage %s untag <name> env team         Stage multiple tag removals`,
-			cfg.ItemName,
-			cfg.CommandName,
-			cfg.ItemName,
-			cfg.CommandName,
-			cfg.CommandName,
-			cfg.CommandName,
-			cfg.CommandName),
-		Action: tagAction(cfg, "untag <name> <key>", runner),
+		Name:        "untag",
+		Usage:       fmt.Sprintf("Stage tag removal for a %s", cfg.ItemName),
+		ArgsUsage:   "<name> <key>...",
+		Description: untagDescription(cfg),
+		Action:      tagAction(cfg, "untag <name> <key>", runner),
 	}
 }

--- a/internal/staging/cli/help.go
+++ b/internal/staging/cli/help.go
@@ -1,0 +1,252 @@
+package cli
+
+import "fmt"
+
+// This file centralizes the multi-line Usage/Description help text for the
+// stage subcommands. Each helper renders the exact same string that was
+// previously built inline in command.go, so command output is unchanged.
+
+// statusDescription returns the Description text for the status command.
+func statusDescription(cfg CommandConfig) string {
+	return fmt.Sprintf(`Display staged changes for %s.
+
+Without arguments, shows all staged %s changes.
+With a %s name, shows the staged change for that specific %s.
+
+Use --verbose to show detailed information including the staged value.
+
+EXAMPLES:
+   suve stage %s status              Show all staged %s changes
+   suve stage %s status <name>       Show staged change for specific %s
+   suve stage %s status --verbose    Show detailed information`,
+		cfg.CommandName, cfg.ItemName, cfg.ItemName, cfg.ItemName,
+		cfg.CommandName, cfg.ItemName,
+		cfg.CommandName, cfg.ItemName,
+		cfg.CommandName)
+}
+
+// diffDescription returns the Description text for the diff command.
+func diffDescription(cfg CommandConfig) string {
+	return fmt.Sprintf(`Compare staged values against AWS current values.
+
+If a %s name is specified, shows diff for that %s only.
+Otherwise, shows diff for all staged %ss.
+
+EXAMPLES:
+   suve stage %s diff                   Show diff for all staged %ss
+   suve stage %s diff <name>            Show diff for specific %s
+   suve stage %s diff --parse-json      Show diff with JSON formatting`,
+		cfg.ItemName, cfg.ItemName, cfg.ItemName,
+		cfg.CommandName, cfg.ItemName,
+		cfg.CommandName, cfg.ItemName,
+		cfg.CommandName)
+}
+
+// addDescription returns the Description text for the add command.
+func addDescription(cfg CommandConfig) string {
+	return fmt.Sprintf(`Create a new %s value and stage the change.
+
+If value is provided as an argument, uses that value directly.
+Otherwise, opens an editor to create the value.
+
+If the %s is already staged for creation, edits the staged value.
+The new %s will be created in AWS when you run 'suve stage %s apply'.
+
+Use 'suve stage %s edit' to modify an existing %s.
+Use 'suve stage %s status' to view staged changes.
+
+EXAMPLES:
+   suve stage %s add <name>              Open editor to create new %s
+   suve stage %s add <name> <value>      Create new %s with given value`,
+		cfg.ItemName,
+		cfg.ItemName,
+		cfg.ItemName, cfg.CommandName,
+		cfg.CommandName, cfg.ItemName,
+		cfg.CommandName,
+		cfg.CommandName, cfg.ItemName,
+		cfg.CommandName, cfg.ItemName)
+}
+
+// editDescription returns the Description text for the edit command.
+func editDescription(cfg CommandConfig) string {
+	return fmt.Sprintf(`Modify a %s value and stage the change.
+
+If value is provided as an argument, uses that value directly.
+Otherwise, opens an editor to modify the value.
+
+If the %s is already staged, edits the staged value.
+Otherwise, fetches the current value from AWS and opens it for editing.
+Saves the edited value to the staging area (does not immediately apply to AWS).
+
+Use 'suve stage %s delete' to stage a %s for deletion.
+Use 'suve stage %s apply' to apply staged changes to AWS.
+Use 'suve stage %s status' to view staged changes.
+
+EXAMPLES:
+   suve stage %s edit <name>              Open editor to modify %s
+   suve stage %s edit <name> <value>      Set %s to given value`,
+		cfg.ItemName,
+		cfg.ItemName,
+		cfg.CommandName, cfg.ItemName,
+		cfg.CommandName,
+		cfg.CommandName,
+		cfg.CommandName, cfg.ItemName,
+		cfg.CommandName, cfg.ItemName)
+}
+
+// applyDescription returns the Description text for the apply command.
+func applyDescription(cfg CommandConfig) string {
+	return fmt.Sprintf(`Apply all staged %s changes to AWS.
+
+If a %s name is specified, only that %s's staged changes are applied.
+Otherwise, all staged %s changes are applied.
+
+After successful apply, the staged changes are cleared.
+
+Use 'suve stage %s status' to view staged changes before applying.
+
+CONFLICT DETECTION:
+   Before applying, suve checks for conflicts to prevent lost updates:
+   - For new resources: checks if someone else created it after staging
+   - For existing resources: checks if it was modified after staging
+   Use --ignore-conflicts to force apply despite conflicts.
+
+EXAMPLES:
+   suve stage %s apply                      Apply all staged %s changes (with confirmation)
+   suve stage %s apply <name>               Apply only the specified %s
+   suve stage %s apply --yes                Apply without confirmation
+   suve stage %s apply --ignore-conflicts   Apply even if AWS was modified after staging`,
+		cfg.ItemName,
+		cfg.ItemName, cfg.ItemName,
+		cfg.ItemName,
+		cfg.CommandName,
+		cfg.CommandName, cfg.ItemName,
+		cfg.CommandName, cfg.ItemName,
+		cfg.CommandName,
+		cfg.CommandName)
+}
+
+// resetDescription returns the Description text for the reset command.
+func resetDescription(cfg CommandConfig) string {
+	return fmt.Sprintf(`Remove a %s from staging area or restore to a specific version.
+
+Without a version specifier, the %s is simply removed from staging.
+With a version specifier, the value at that version is fetched and staged.
+
+Use 'suve stage %s reset --all' to unstage all %ss at once.
+
+VERSION SPECIFIERS:
+   <name>          Unstage %s (remove from staging)
+   <name>#<ver>    Restore to specific version
+   <name>~1        Restore to 1 version ago
+
+EXAMPLES:
+   suve stage %s reset <name>              Unstage (remove from staging)
+   suve stage %s reset <name>#<ver>        Stage value from specific version
+   suve stage %s reset <name>~1            Stage value from previous version
+   suve stage %s reset --all               Unstage all %ss`,
+		cfg.ItemName,
+		cfg.ItemName,
+		cfg.CommandName, cfg.ItemName,
+		cfg.ItemName,
+		cfg.CommandName,
+		cfg.CommandName,
+		cfg.CommandName,
+		cfg.CommandName, cfg.ItemName)
+}
+
+// deleteDescription returns the Description text for the delete command.
+// Secrets Manager (hasDeleteOptions) exposes recovery-window details that
+// SSM Parameter Store does not.
+func deleteDescription(cfg CommandConfig, hasDeleteOptions bool) string {
+	if hasDeleteOptions {
+		// Secrets Manager has delete options
+		return fmt.Sprintf(`Stage a %s for deletion.
+
+The %s will be deleted from AWS when you run 'suve stage %s apply'.
+Use 'suve stage %s status' to view staged changes.
+Use 'suve stage %s reset <name>' to unstage.
+
+RECOVERY WINDOW:
+   By default, %ss are scheduled for deletion after a 30-day recovery window.
+   During this period, you can restore the %s using 'suve %s restore'.
+   Use --force for immediate permanent deletion without recovery.
+
+   Minimum: 7 days
+   Maximum: 30 days
+   Default: 30 days
+
+EXAMPLES:
+   suve stage %s delete <name>                      Stage with 30-day recovery
+   suve stage %s delete --recovery-window 7 <name>  Stage with 7-day recovery
+   suve stage %s delete --force <name>              Stage for immediate deletion`,
+			cfg.ItemName,
+			cfg.ItemName, cfg.CommandName,
+			cfg.CommandName,
+			cfg.CommandName,
+			cfg.ItemName,
+			cfg.ItemName, cfg.CommandName,
+			cfg.CommandName,
+			cfg.CommandName,
+			cfg.CommandName)
+	}
+
+	// SSM Parameter Store doesn't have delete options
+	return fmt.Sprintf(`Stage a %s for deletion.
+
+The %s will be deleted from AWS when you run 'suve stage %s apply'.
+Use 'suve stage %s status' to view staged changes.
+Use 'suve stage %s reset <name>' to unstage.
+
+EXAMPLES:
+   suve stage %s delete <name>  Stage %s for deletion`,
+		cfg.ItemName,
+		cfg.ItemName, cfg.CommandName,
+		cfg.CommandName,
+		cfg.CommandName,
+		cfg.CommandName, cfg.ItemName)
+}
+
+// tagDescription returns the Description text for the tag command.
+func tagDescription(cfg CommandConfig) string {
+	return fmt.Sprintf(`Stage tags to add or update for a %s.
+
+Tags are staged locally and applied when you run 'suve stage %s apply'.
+If the %s is not already staged, a tag-only change is created.
+
+Use 'suve stage %s untag' to stage tag removals.
+Use 'suve stage %s status' to view staged changes.
+
+EXAMPLES:
+   suve stage %s tag <name> env=prod              Stage single tag
+   suve stage %s tag <name> env=prod team=api     Stage multiple tags`,
+		cfg.ItemName,
+		cfg.CommandName,
+		cfg.ItemName,
+		cfg.CommandName,
+		cfg.CommandName,
+		cfg.CommandName,
+		cfg.CommandName)
+}
+
+// untagDescription returns the Description text for the untag command.
+func untagDescription(cfg CommandConfig) string {
+	return fmt.Sprintf(`Stage tags to remove from a %s.
+
+Tag removals are staged locally and applied when you run 'suve stage %s apply'.
+If the %s is not already staged, a tag-only change is created.
+
+Use 'suve stage %s tag' to stage tag additions.
+Use 'suve stage %s status' to view staged changes.
+
+EXAMPLES:
+   suve stage %s untag <name> env              Stage single tag removal
+   suve stage %s untag <name> env team         Stage multiple tag removals`,
+		cfg.ItemName,
+		cfg.CommandName,
+		cfg.ItemName,
+		cfg.CommandName,
+		cfg.CommandName,
+		cfg.CommandName,
+		cfg.CommandName)
+}


### PR DESCRIPTION
Closes #197 (Part of #189, Phase 1)

## Summary

Decomposes the staging-CLI god-file `internal/staging/cli/command.go`. **Pure refactor — no behavior change; all existing tests pass with zero edits** (`git diff` shows `cli_test.go` byte-for-byte unchanged). `command.go`: **813 → 579 LOC** (−234).

### 1. Help text → `help.go`
Every command's multi-line `Usage`/`Description` (built with `fmt.Sprintf(cfg.ItemName, ...)`) moved into a new `internal/staging/cli/help.go` as `fooDescription(cfg)` helpers. Strings are byte-identical — same placeholders and arg order, just relocated. Command constructors now read `Description: applyDescription(cfg)` etc.

### 2. Apply orchestration out of the inline closure
`NewApplyCommand`'s `Action` no longer inlines business orchestration. It moved into the existing CLI-layer runner in `apply.go`:
- `ApplyRunner.Run` stays the **execute path** (`UseCase.Execute` + result output) — unchanged, so the existing runner unit tests are untouched.
- New `ApplyRunner.RunInteractive` holds the flow: list → empty-check → name-validate → confirm → `Run`. A small `confirmer` interface (satisfied by `*confirm.Prompter`) is injected, keeping interactive prompting in the presentation layer.
- The `Action` closure now just wires flags + store + strategy + prompter and calls `RunInteractive`.

**Layering note (design decision):** the issue's scope says "move orchestration into the usecase layer", but interactive confirmation reads `os.Stdin` and must not live in an I/O-agnostic usecase — and the pure business logic (name-filter, empty, conflict detection) *already* lives in `stagingusecase.ApplyUseCase.Execute`. So the remaining (interactive) orchestration was moved into the CLI runner rather than the usecase. This satisfies the acceptance criterion ("command.go no longer contains inlined business orchestration") with correct layering. Flagged for sign-off.

### Flag wiring
Stays in `command.go`.

## ⚠️ Preserved latent quirk (not fixed here — pure refactor)
The apply empty-check is intentionally kept **entries-only**: `stage apply` when *only tags* are staged (zero value entries) still prints `"No … changes staged."` and applies nothing — exactly the old behavior. (The `ApplyUseCase` *can* apply tag-only, and applies tags alongside entries when entries exist; only the pure tag-only-via-command case is short-circuited.) This looks like a latent bug but changing it is out of scope for a decompose refactor — **suggest a follow-up issue** if the maintainer wants tag-only `stage apply` to apply tags.

## Out of scope
No behavior change; no provider/`Scope` (#200); no `transition/` collapse (#212). The global `stage apply` command (`commands/stage/apply`) has its own `Runner` and was left untouched.

## Verification
```
$ make test    # green; cli_test.go unchanged (no expectation edited)
$ make lint     # 0 issues
$ CGO_ENABLED=1 go test -tags=production ./internal/gui/...   # ok
$ go test -tags e2e -run xxxNoMatch ./e2e/...                 # compiles
$ go build ./cmd/suve                                         # ok
```

## Acceptance criteria
- [x] `command.go` free of inlined business orchestration; help text in templates/helpers
- [x] No behavior change to any `stage` command
- [x] `make test` green
- [x] `make lint` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)