### PR TITLE
design(provider): provider-neutral domain model + provider interfaces

### DIFF
--- a/docs/provider-seam.md
+++ b/docs/provider-seam.md
@@ -1,0 +1,257 @@
+# Provider Seam Design
+
+Status: design (issue #199)
+Scope of this issue: the provider-neutral **seam** — the `domain` value types and
+the `provider` interfaces/registry — plus this document. No AWS adapters, no
+usecase/CLI migration, no additional cloud providers.
+
+## Motivation
+
+suve began as an AWS-only tool. To support multiple cloud backends (AWS SSM,
+AWS Secrets Manager, and later GCP/Azure) we need a **seam**: a small set of
+provider-neutral types and interfaces that the usecase and CLI layers depend
+on, with each cloud's specifics hidden behind an adapter.
+
+An earlier attempt lives on the `multicloud` branch. It got the broad shape
+right (interface segregation, a generic model, adapters) but leaked AWS
+concepts into the generic layer and hedged its type decisions. This design
+takes the lessons from that branch and commits to a single, clean shape.
+
+The rest of this document is organized around the concrete flaws that branch
+exhibited, so that each design decision here is traceable to a real problem it
+prevents.
+
+## Hard requirements (and the multicloud-branch flaw each prevents)
+
+### 1. No AWS fields in generic result types
+
+**Branch flaw.** In `internal/model/secret.go` the branch put a top-level
+`ARN string` field directly on the generic result types `SecretWriteResult`,
+`SecretDeleteResult`, and `SecretRestoreResult`. `ARN` is an Amazon Resource
+Name — a concept that only exists on AWS. Baking it into a "provider-agnostic"
+result type means every non-AWS provider must either fake an ARN or leave it
+blank, and every consumer is tempted to read `.ARN` and thereby couple itself
+to AWS.
+
+**How this design addresses it.** The generic retrieved type is
+`domain.Entry`, and it has **no `ARN` field** and no other AWS-only field. The
+provider write path returns a `domain.Version` (id/label/created) rather than
+an AWS-shaped result struct — there is no generic `WriteResult`/`DeleteResult`/
+`RestoreResult` carrying an ARN at all. `Writer.Delete` and `Restorer.Restore`
+return only `error`. If a future feature genuinely needs an ARN, it is reached
+through the provider-specific path (requirement 3), never through the generic
+seam.
+
+### 2. No AWS staging labels in generic interfaces
+
+**Branch flaw.** The branch's reader contract was
+`SecretReader.GetSecret(ctx, name, versionID, versionStage)` (see
+`internal/provider/secret.go` and the usecase/mocks that mirror it). Both
+`versionID` **and** `versionStage` are AWS concepts — `versionStage` is a
+Secrets Manager staging label such as `AWSCURRENT`/`AWSPREVIOUS`. The generic
+interface therefore hard-coded the AWS version model into its signature, so any
+non-AWS provider inherits parameters it cannot honor, and callers must know AWS
+label semantics to call a "generic" method.
+
+**How this design addresses it.** Version selection is expressed through an
+**opaque** `provider.VersionRef`, produced by the provider and consumed by the
+same provider. Generic callers never see a version id or a staging label:
+
+- `Reader.Resolve(ctx, name, spec)` takes a **provider-specific spec string**
+  (e.g. `#3~1`, `#abc123`, `:AWSCURRENT`) and returns a `VersionRef`.
+- `Reader.Get(ctx, name, ref)` consumes that `VersionRef`.
+
+`VersionRef` deliberately exposes no id/label semantics to generic callers; its
+zero value means "latest/current". AWS staging labels live **only** inside the
+AWS adapter (where `Resolve` parses `:AWSCURRENT` etc.). The generic seam knows
+nothing about them.
+
+### 3. A single typed-metadata mechanism
+
+**Branch flaw.** `internal/model/parameter.go` (and its secret twin) carried
+**two** competing mechanisms at once:
+
+- a generic `TypedParameter[M]` with a `ToBase()` method that **erased** the
+  `[M]` generic down to a base `Parameter`, and
+- a base `Parameter{ Metadata any }` bag plus `AWSMeta()` /
+  `TypedMetadata[M]()` helpers that **type-assert** the `any` back to a
+  concrete type at the consuming layer.
+
+This is the worst of both worlds: the generic parameter promises type safety,
+then `ToBase()` throws it away, and consumers recover provider metadata with
+runtime type assertions on an `any`. Two mechanisms, both lossy.
+
+**How this design addresses it.** We choose **one** mechanism, and it is
+"neither of those": the generic `domain.Entry` has **no metadata bag** (`any`)
+and **no `[M]` generic**. It carries only the handful of fields that are
+essential across every provider, each as a first-class typed field (Name,
+Value, Type, Version, Description, Tags, Modified).
+
+Provider-specific metadata (ARN, KMS key, SSM tier, allowed-pattern, Azure
+label/etag, …) is deliberately **out of the generic seam**. It is deferred to
+issue #210 (per-provider options), where it will be handled through a **typed,
+provider-specific path** — a caller that wants AWS metadata will talk to an
+AWS-typed API and receive an AWS-typed value, with no `any` erasure at any
+consuming layer. We accept that the generic layer simply cannot express
+provider-specific metadata; that is the point of a seam. This keeps the generic
+types honest (every field is meaningful for every provider) and pushes the
+irreducibly-specific data to a place where it can stay strongly typed.
+
+### 4. Base model carries cross-provider essentials
+
+**Branch flaw.** The branch's base `model.Parameter` had **no `Type` field**;
+whether a value was a `SecureString` lived only inside `AWSParameterMeta.Type`
+(reachable via `AWSMeta()`). So a fundamental, cross-provider distinction —
+"is this value secret/encrypted or plaintext?" — was only accessible through an
+AWS-specific metadata assertion. A non-AWS provider had nowhere neutral to say
+"this is a secret".
+
+**How this design addresses it.** `domain.Entry` has a first-class
+`Type domain.ValueType` field. `ValueType` is a neutral enum
+(`ValueTypePlaintext`, `ValueTypeSecret`, `ValueTypeList`) that every provider
+maps its native types onto (AWS `String`→plaintext, `SecureString`→secret,
+`StringList`→list; Secrets Manager→secret). The essential distinction is now a
+typed field on the generic type, reachable without any provider assertion.
+
+### 5. Keep interface segregation
+
+**Branch decision worth keeping.** The branch split the contract into
+`Reader` / `Writer` / `Tagger` plus optional `Restorer` / `Describer`. That
+segregation is correct: not every provider or command needs every capability,
+and small interfaces are easy to mock and to implement partially.
+
+**Branch flaw within it.** The branch also shipped **dead adapter code** around
+this shape: `WrapTypedParameterReader[M]` was unused, and the
+`typedParameterReaderAdapter.ListParameters` it produced simply
+`return nil, nil` — a stub that silently returns no data. Wiring generic ↔
+typed with an adapter whose methods are stubs defeats the segregation it claims
+to provide.
+
+**How this design addresses it.** We keep the segregation with cleaner
+contracts:
+
+- `Reader` = `Resolve` + `Get` + `History` + `List`
+- `Writer` = `Put` + `Delete`
+- `Tagger` = `Tag` + `Untag`
+- `Store` = `Reader` + `Writer` + `Tagger` (the full contract for one service)
+- optional `Restorer` (soft-delete restore, e.g. Secrets Manager) and
+  `Describer` (metadata without value)
+
+We explicitly do **not** carry forward the branch's `TypedXReader` /
+`WrapTypedXReader` adapters or any stub method that returns `(nil, nil)`. There
+is no generic↔typed bridging adapter in this design because there is no `[M]`
+generic to bridge (requirement 3).
+
+### 6. Version-spec parsing stays generic; resolution moves into adapters
+
+**Existing good code to preserve.** `internal/version` already has a generic
+`Spec[A any]` (with `paramversion` and `secretversion` supplying the
+provider-specific `AbsoluteSpec` type parameter). The *syntactic* parsing of
+`#VERSION`, `~SHIFT`, `:LABEL` is genuinely shared and should stay generic.
+
+**How this design addresses it.** Parsing stays in `internal/version`
+(`Spec[A]`), unchanged by this issue. What moves is version **resolution** —
+turning a parsed spec plus the entry's history into a concrete version. That is
+inherently provider-specific (AWS labels, AWS version ids, shift-against-history
+rules) and now lives behind `Reader.Resolve`, which returns an opaque
+`VersionRef`. Generic code calls `Resolve`; only the adapter knows how a spec
+maps onto real versions.
+
+### 7. Provider registry
+
+**Branch flaw / current-code smell.** Commands construct AWS clients directly
+via `infra.NewParamClient` / `infra.NewSecretClient` — there are ~19 such call
+sites across the CLI (and more across staging/usecase). Every one of those is a
+hard-coded dependency on AWS; adding a second provider would mean editing all
+of them.
+
+**How this design addresses it.** We define a provider **registry**: a
+`Registry` mapping a `Provider` to a `Factory`, where
+`Factory.Store(ctx, scope, kind)` builds a `provider.Store` for a given
+`Scope` + `Kind` (`param`/`secret`). Commands will ask the registry for a store
+instead of calling `infra.NewXClient`. A `Factory` returns `ErrUnsupportedKind`
+when a provider does not offer a requested kind (e.g. a provider with secrets
+but no param store), and the registry returns `ErrNoFactory` for an
+unregistered provider.
+
+Note: the **full** `Scope` (multi-field, used as a key for scope-keyed storage)
+is ported in issue #200. This issue defines only the minimal contract the
+registry needs (`Provider` + AWS `AccountID`/`Region`), enough to prove the
+seam compiles and dispatches.
+
+## Target architecture
+
+```
+                 internal/domain/         (ValueType, Version, Tag, TagChange, Entry)
+                        ▲   ▲                 provider-neutral value types; ZERO cloud SDK
+                        │   │
+        ┌───────────────┘   └───────────────┐
+        │                                     │
+ internal/provider/                    internal/provider/aws/   (issue #201)
+   Reader/Writer/Tagger,                  AWS SSM adapter  ─┐
+   Store, Restorer, Describer,            AWS SM adapter   ─┤ implement provider.Store,
+   VersionRef,                            AWS Factory      ─┘ Resolve parses AWS Spec[A]
+   Registry / Factory / Scope                                (labels), talks to paramapi/
+        ▲                                                    secretapi behind the seam
+        │ (depend on the seam, not on AWS)
+        │
+ internal/usecase/  ──────────────►  business logic against provider.Store
+        ▲                            (migration: issues #202-204)
+        │
+ internal/cli/commands/  ─────────►  ask the registry for a Store instead of
+        ▲                            infra.NewParamClient/NewSecretClient
+        │
+ internal/infra (registry wiring)    build a Registry, Register(ProviderAWS, awsFactory)
+```
+
+Dependency direction: `provider` depends on `domain`; `usecase` and `cli`
+depend on `provider` (and `domain`); the AWS adapter depends on both plus the
+existing `paramapi`/`secretapi` wrappers. Nothing generic depends on AWS.
+
+### How the AWS adapter (#201) will implement `Reader.Resolve`
+
+The AWS adapter is where all AWS version semantics live. For a call
+`Resolve(ctx, name, spec)` it will:
+
+1. **Parse** the `spec` using the existing generic parser for its service —
+   `paramversion` (`Spec[paramversion.AbsoluteSpec]`) for SSM, or
+   `secretversion` (`Spec[secretversion.AbsoluteSpec]`) for Secrets Manager.
+   This is where `:AWSCURRENT` / `:AWSPREVIOUS` labels, `#VERSION`, and
+   `~SHIFT` are understood — inside the adapter, not in the seam.
+2. **Resolve shifts against history.** If the spec includes `~N` shifts, the
+   adapter fetches the entry's version history (the same data behind
+   `Reader.History`) and walks back the requested number of versions from the
+   selected anchor (a specific version id, a staging label, or latest).
+3. **Return an opaque `VersionRef`.** The resolved concrete version id is
+   wrapped with `provider.NewVersionRef(id)` (or the zero `VersionRef` for
+   latest). `Reader.Get` then consumes that ref. Generic callers never learn
+   whether the id came from a label, a version number, or a shift.
+
+## Out of scope
+
+This issue intentionally delivers only the seam and this document. The
+following are explicitly **out of scope** here and tracked separately:
+
+- **AWS adapters** — implementing `provider.Store` for SSM and Secrets Manager,
+  including `Resolve`: issue **#201**.
+- **Usecase / CLI migration** — porting the usecase layer and CLI commands off
+  `infra.NewXClient` and onto the registry + `provider.Store`: issues
+  **#202-204**.
+- **Per-provider options / provider-specific metadata** — the typed
+  provider-specific path for ARNs, KMS keys, SSM tiers, etc.: issue **#210**.
+- **Full multi-field `Scope` and scope-keyed storage**: issue **#200**.
+- **Additional providers** — GCP (**#207**) and Azure (**#208**).
+
+No consumers are wired to the new packages in this issue; nothing in the repo
+imports `internal/domain` or `internal/provider` except the new packages' own
+tests.
+
+## Acceptance criteria
+
+- `internal/domain` and `internal/provider` contain **zero** AWS SDK imports
+  (no `aws-sdk-go`, `paramapi`, `secretapi`, `ssm`, `secretsmanager`).
+- The seam compiles and passes lint with the repo's `default: all` config.
+- The packages have real test coverage proving the interfaces are
+  implementable (a `VersionRef` test and a `Registry` test with an in-test fake
+  `Factory`), with no AWS code in the tests.
+- No existing command/usecase imports the new packages yet.

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -1,0 +1,63 @@
+// Package domain defines provider-neutral value types shared across every
+// storage backend (AWS SSM, AWS Secrets Manager, and future providers).
+//
+// It has ZERO knowledge of any cloud SDK: no ARNs, no staging labels, no
+// provider metadata bags. Types here carry only cross-provider essentials so
+// that the usecase and CLI layers can be written once against a single shape.
+package domain
+
+import "time"
+
+// ValueType classifies the nature of an entry's value in a provider-neutral
+// way. Providers map their own native types onto these values.
+type ValueType string
+
+const (
+	// ValueTypePlaintext is a plain, non-secret value (AWS String).
+	ValueTypePlaintext ValueType = "plaintext" // AWS String, plain values
+	// ValueTypeSecret is an encrypted/secret value (AWS SecureString, Secrets Manager).
+	ValueTypeSecret ValueType = "secret" // AWS SecureString, Secrets Manager
+	// ValueTypeList is a list of values (AWS StringList).
+	ValueTypeList ValueType = "list" // AWS StringList
+)
+
+// Version identifies one version of an entry. Label is optional and may be
+// empty for providers without human-facing version labels.
+type Version struct {
+	// ID is the provider-internal version identifier.
+	ID string
+	// Label is an optional human-facing label (empty when unsupported).
+	Label string
+	// Created is the version creation time, if known.
+	Created *time.Time
+}
+
+// Tag is a single key/value label attached to an entry.
+type Tag struct{ Key, Value string }
+
+// TagChange describes staged tag mutations (add/update + remove-by-key).
+type TagChange struct {
+	// Add holds tags to create or update, keyed by tag key.
+	Add map[string]string
+	// Remove holds tag keys to delete.
+	Remove []string
+}
+
+// Entry is a provider-neutral retrieved parameter/secret. It carries only
+// cross-provider essentials: no ARN, no provider metadata bag.
+type Entry struct {
+	// Name is the entry's identifier within its provider namespace.
+	Name string
+	// Value is the entry's current value.
+	Value string
+	// Type classifies the value in a provider-neutral way.
+	Type ValueType
+	// Version identifies the retrieved version.
+	Version Version
+	// Description is an optional human-readable description.
+	Description string
+	// Tags are the labels attached to the entry.
+	Tags []Tag
+	// Modified is the last-modified time, if known.
+	Modified *time.Time
+}

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -1,0 +1,62 @@
+package domain_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mpyw/suve/internal/domain"
+)
+
+func TestEntry_Fields(t *testing.T) {
+	t.Parallel()
+
+	modified := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	created := modified.Add(-time.Hour)
+
+	entry := domain.Entry{
+		Name:  "/my/param",
+		Value: "hunter2",
+		Type:  domain.ValueTypeSecret,
+		Version: domain.Version{
+			ID:      "v3",
+			Label:   "current",
+			Created: &created,
+		},
+		Description: "example",
+		Tags:        []domain.Tag{{Key: "env", Value: "prod"}},
+		Modified:    &modified,
+	}
+
+	assert.Equal(t, "/my/param", entry.Name)
+	assert.Equal(t, "hunter2", entry.Value)
+	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
+	assert.Equal(t, "v3", entry.Version.ID)
+	assert.Equal(t, "current", entry.Version.Label)
+	assert.Equal(t, &created, entry.Version.Created)
+	assert.Equal(t, "example", entry.Description)
+	assert.Len(t, entry.Tags, 1)
+	assert.Equal(t, "env", entry.Tags[0].Key)
+	assert.Equal(t, &modified, entry.Modified)
+}
+
+func TestValueType_Values(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, domain.ValueTypePlaintext, domain.ValueType("plaintext"))
+	assert.Equal(t, domain.ValueTypeSecret, domain.ValueType("secret"))
+	assert.Equal(t, domain.ValueTypeList, domain.ValueType("list"))
+}
+
+func TestTagChange_Fields(t *testing.T) {
+	t.Parallel()
+
+	change := domain.TagChange{
+		Add:    map[string]string{"env": "prod"},
+		Remove: []string{"stale"},
+	}
+
+	assert.Equal(t, "prod", change.Add["env"])
+	assert.Equal(t, []string{"stale"}, change.Remove)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,0 +1,79 @@
+// Package provider defines the provider-neutral storage seam: the interfaces
+// and opaque reference types that every backend (AWS SSM, AWS Secrets Manager,
+// and future providers) implements.
+//
+// It imports only internal/domain and the standard library; it has ZERO
+// knowledge of any cloud SDK. AWS-specific concerns (ARNs, staging labels,
+// version-id semantics) live behind these interfaces inside the AWS adapter.
+package provider
+
+import (
+	"context"
+
+	"github.com/mpyw/suve/internal/domain"
+)
+
+// VersionRef is an opaque reference to a specific version, produced by a
+// provider (Resolve/History) and consumed by the same provider. The zero
+// value denotes the latest/current version. It intentionally exposes no
+// version-id or staging-label semantics to generic callers.
+type VersionRef struct{ id string }
+
+// NewVersionRef builds a VersionRef from a provider-internal id. For adapter use.
+func NewVersionRef(id string) VersionRef { return VersionRef{id: id} }
+
+// ID returns the provider-internal identifier ("" for latest). For adapter use.
+func (r VersionRef) ID() string { return r.id }
+
+// IsLatest reports whether the ref denotes the latest/current version.
+func (r VersionRef) IsLatest() bool { return r.id == "" }
+
+// Reader provides read access to a provider's entries.
+type Reader interface {
+	// Resolve parses a provider-specific version spec string (e.g. "#3~1",
+	// "#abc123", ":AWSCURRENT" for AWS) and resolves it to an opaque VersionRef.
+	Resolve(ctx context.Context, name, spec string) (VersionRef, error)
+	// Get retrieves the entry at the given version ref.
+	Get(ctx context.Context, name string, ref VersionRef) (*domain.Entry, error)
+	// History returns the version history for an entry, newest first.
+	History(ctx context.Context, name string) ([]domain.Version, error)
+	// List returns the names of all entries in the provider's namespace.
+	List(ctx context.Context) ([]string, error)
+}
+
+// Writer provides write access to a provider's entries.
+type Writer interface {
+	// Put creates or updates an entry and returns the resulting version.
+	Put(ctx context.Context, name, value string, valueType domain.ValueType, description string) (domain.Version, error)
+	// Delete removes an entry.
+	Delete(ctx context.Context, name string) error
+}
+
+// Tagger provides tag mutation for a provider's entries.
+type Tagger interface {
+	// Tag adds or updates the given tags on an entry.
+	Tag(ctx context.Context, name string, add map[string]string) error
+	// Untag removes the tags with the given keys from an entry.
+	Untag(ctx context.Context, name string, keys []string) error
+}
+
+// Store is the full provider contract for one service (e.g. AWS SSM or
+// Secrets Manager). Providers may additionally implement the optional
+// Restorer/Describer capabilities.
+type Store interface {
+	Reader
+	Writer
+	Tagger
+}
+
+// Restorer restores a soft-deleted entry (e.g. Secrets Manager). Optional.
+type Restorer interface {
+	// Restore cancels a pending deletion for an entry.
+	Restore(ctx context.Context, name string) error
+}
+
+// Describer returns entry metadata without the value. Optional.
+type Describer interface {
+	// Describe returns an entry's metadata without fetching its value.
+	Describe(ctx context.Context, name string) (*domain.Entry, error)
+}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,0 +1,36 @@
+package provider_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mpyw/suve/internal/provider"
+)
+
+func TestVersionRef_ZeroValueIsLatest(t *testing.T) {
+	t.Parallel()
+
+	var ref provider.VersionRef
+
+	assert.True(t, ref.IsLatest())
+	assert.Empty(t, ref.ID())
+}
+
+func TestVersionRef_NewVersionRef(t *testing.T) {
+	t.Parallel()
+
+	ref := provider.NewVersionRef("abc123")
+
+	assert.False(t, ref.IsLatest())
+	assert.Equal(t, "abc123", ref.ID())
+}
+
+func TestNewVersionRef_EmptyIDIsLatest(t *testing.T) {
+	t.Parallel()
+
+	ref := provider.NewVersionRef("")
+
+	assert.True(t, ref.IsLatest())
+	assert.Empty(t, ref.ID())
+}

--- a/internal/provider/registry.go
+++ b/internal/provider/registry.go
@@ -1,0 +1,66 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+)
+
+// Provider identifies a cloud provider backend.
+type Provider string
+
+// ProviderAWS is the Amazon Web Services provider.
+const ProviderAWS Provider = "aws"
+
+// Kind selects a store kind within a provider (some providers offer only one).
+type Kind string
+
+const (
+	// KindParam selects a parameter store (e.g. AWS SSM Parameter Store).
+	KindParam Kind = "param"
+	// KindSecret selects a secret store (e.g. AWS Secrets Manager).
+	KindSecret Kind = "secret"
+)
+
+// Scope identifies a provider-specific namespace. The full multi-field Scope
+// (and scope-keyed storage) is ported in #200; this is the minimal contract
+// the registry needs.
+type Scope struct {
+	// Provider selects which backend the scope belongs to.
+	Provider Provider
+	// AccountID is the AWS account id (AWS).
+	AccountID string // AWS
+	// Region is the AWS region (AWS).
+	Region string // AWS
+}
+
+// Factory builds a Store for a scope + kind. It returns ErrUnsupportedKind if
+// the provider does not offer that kind (e.g. GCP has no param store).
+type Factory interface {
+	// Store builds a Store for the given scope and kind.
+	Store(ctx context.Context, scope Scope, kind Kind) (Store, error)
+}
+
+// ErrUnsupportedKind is returned when a provider does not offer the requested store kind.
+var ErrUnsupportedKind = fmt.Errorf("provider: unsupported store kind")
+
+// ErrNoFactory is returned when no factory is registered for a provider.
+var ErrNoFactory = fmt.Errorf("provider: no factory registered for provider")
+
+// Registry maps a Provider to its Factory, replacing direct infra.NewXClient calls.
+type Registry struct{ factories map[Provider]Factory }
+
+// NewRegistry returns an empty Registry.
+func NewRegistry() *Registry { return &Registry{factories: map[Provider]Factory{}} }
+
+// Register associates a Factory with a Provider, overwriting any prior registration.
+func (r *Registry) Register(p Provider, f Factory) { r.factories[p] = f }
+
+// Store resolves the factory for scope.Provider and builds the requested store.
+func (r *Registry) Store(ctx context.Context, scope Scope, kind Kind) (Store, error) {
+	f, ok := r.factories[scope.Provider]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrNoFactory, scope.Provider)
+	}
+
+	return f.Store(ctx, scope, kind)
+}

--- a/internal/provider/registry_test.go
+++ b/internal/provider/registry_test.go
@@ -1,0 +1,70 @@
+package provider_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider"
+)
+
+// fakeFactory is a tiny in-test Factory. It reports KindSecret as unsupported
+// to exercise the ErrUnsupportedKind path without any real (or AWS) store.
+type fakeFactory struct{}
+
+func (fakeFactory) Store(_ context.Context, _ provider.Scope, kind provider.Kind) (provider.Store, error) {
+	if kind == provider.KindSecret {
+		return nil, provider.ErrUnsupportedKind
+	}
+
+	return nil, nil //nolint:nilnil // fake: proves Register->Store dispatch without a real store
+}
+
+func TestRegistry_StoreSuccess(t *testing.T) {
+	t.Parallel()
+
+	reg := provider.NewRegistry()
+	reg.Register(provider.ProviderAWS, fakeFactory{})
+
+	store, err := reg.Store(t.Context(), provider.Scope{Provider: provider.ProviderAWS}, provider.KindParam)
+
+	require.NoError(t, err)
+	assert.Nil(t, store)
+}
+
+func TestRegistry_StoreNoFactory(t *testing.T) {
+	t.Parallel()
+
+	reg := provider.NewRegistry()
+
+	_, err := reg.Store(t.Context(), provider.Scope{Provider: provider.ProviderAWS}, provider.KindParam)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, provider.ErrNoFactory)
+}
+
+func TestRegistry_StoreUnsupportedKind(t *testing.T) {
+	t.Parallel()
+
+	reg := provider.NewRegistry()
+	reg.Register(provider.ProviderAWS, fakeFactory{})
+
+	_, err := reg.Store(t.Context(), provider.Scope{Provider: provider.ProviderAWS}, provider.KindSecret)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, provider.ErrUnsupportedKind)
+}
+
+func TestRegistry_RegisterOverwrites(t *testing.T) {
+	t.Parallel()
+
+	reg := provider.NewRegistry()
+	reg.Register(provider.ProviderAWS, fakeFactory{})
+	reg.Register(provider.ProviderAWS, fakeFactory{})
+
+	_, err := reg.Store(t.Context(), provider.Scope{Provider: provider.ProviderAWS}, provider.KindSecret)
+
+	assert.ErrorIs(t, err, provider.ErrUnsupportedKind)
+}


### PR DESCRIPTION
Closes #199 (Part of #189, Phase 2 — the provider-seam linchpin)

## Summary

Design doc + **compiling skeleton** (interfaces + model types, **no consumers, no migration**) for the Phase 2 provider seam. This is the direct, corrected response to the ~40% "wrong-direction / leaky" abstraction graded on the `multicloud` branch (PR #141).

- **`docs/provider-seam.md`** — design doc. Contains the 7 hard requirements, each mapped to the concrete `origin/multicloud` flaw it prevents, plus the target architecture and how the AWS adapter (#201) will implement `Reader.Resolve`.
- **`internal/domain/`** — provider-neutral model: `Entry`, `Version{ID,Label,Created}`, `Tag`, `TagChange`, `ValueType{plaintext,secret,list}`. **Zero AWS imports.**
- **`internal/provider/`** — segregated `Reader`/`Writer`/`Tagger` + optional `Restorer`/`Describer` + composed `Store`; opaque `VersionRef`; `Scope → Factory` `Registry`. **Zero AWS imports.**

## How each hard requirement is met
| # | Requirement (branch flaw) | This design |
|---|---------------------------|-------------|
| 1 | No AWS fields in generic results (branch put `ARN` on `Secret*Result`) | `domain.Entry` has no `ARN`; write returns `domain.Version`, delete/restore return only `error` — no `*Result` structs |
| 2 | No AWS staging labels in interfaces (branch's `GetSecret(...,versionStage)`) | opaque `provider.VersionRef` produced by `Reader.Resolve`; AWS labels live only in the AWS adapter |
| 3 | One typed-metadata mechanism (branch had `TypedParameter[M]` **and** `Metadata any` + `ToBase()` erasure + `AWSMeta()`) | generic `Entry` has **no** metadata bag and **no** `[M]`; only first-class typed fields; provider-specific metadata deferred to #210 — no `any` erasure |
| 4 | Base carries cross-provider essentials (branch had no `Type`; SecureString only in `AWSMeta`) | first-class `Type domain.ValueType` |
| 5 | Keep interface segregation, drop dead adapters (branch's `(nil,nil)` stub, unused `WrapTyped*`) | Reader/Writer/Tagger + optional Restorer/Describer; no typed-reader adapters carried forward |
| 6 | Generic parse, adapter resolve | `internal/version` `Spec[A]` untouched; resolution behind `Reader.Resolve` |
| 7 | Provider registry (branch had no Scope→provider mapping) | `Registry`/`Factory`/`Scope`/`Kind` replacing the 19 direct `infra.NewXClient` sites; minimal `Scope` (full port in #200) |

## Out of scope
AWS adapters (#201), usecase/CLI migration (#202–204), GCP/Azure (#207/208). The skeleton has **no consumers** — nothing else in the repo imports it yet.

## ⚠️ For maintainer review
This is the **foundational design** that #200–#206 build on. The key decisions above (especially #3 — no generic metadata bag; provider-specific metadata deferred to #210) and the opaque `VersionRef` + `Reader.Resolve` shape are the ones worth a close look before Phase 2 continues. The skeleton is deliberately small and consumer-free, so it's cheap to revise if you'd steer the contracts differently.

## Verification
```
$ make test    # domain + provider ok
$ make lint     # 0 issues
$ CGO_ENABLED=1 go test -tags=production ./internal/gui/...   # ok
$ go test -tags e2e -run xxxNoMatch ./e2e/...                 # compiles
$ go build ./cmd/suve                                         # ok
$ grep -rE "aws-sdk-go|paramapi|secretapi|/ssm|/secretsmanager" internal/domain internal/provider   # (nothing)
```

## Acceptance criteria
- [x] Design doc; every hard requirement addressed with rationale
- [x] Skeleton interfaces/models compile
- [x] No AWS SDK types leak into the generic model/interfaces
- [x] `make test` green
- [x] `make lint` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)