### PR TITLE
feat(provider): AWS adapters implementing the new interfaces

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -85,6 +85,7 @@ linters:
           files:
             - "!**/internal/api/**"
             - "!**/internal/infra/**"
+            - "!**/internal/provider/aws/**"
           deny:
             - pkg: "github.com/aws/aws-sdk-go-v2/service/ssm"
               desc: "Use github.com/mpyw/suve/internal/api/paramapi instead"

--- a/internal/provider/aws/aws.go
+++ b/internal/provider/aws/aws.go
@@ -1,0 +1,62 @@
+// Package aws wires the AWS parameter and secret adapters into a
+// provider.Factory / provider.Registry. It builds SSM and Secrets Manager
+// clients from the AWS config (honoring the scope's region) and hands them to
+// the per-service adapters in the param and secret subpackages.
+//
+// This package is additive: it makes the AWS provider available behind the
+// #199 interfaces without rewiring existing commands (that migration is #204).
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+
+	"github.com/mpyw/suve/internal/infra"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/aws/param"
+	"github.com/mpyw/suve/internal/provider/aws/secret"
+)
+
+// Factory builds AWS-backed provider.Store values for a scope + kind.
+type Factory struct{}
+
+// Compile-time assertion that Factory implements provider.Factory.
+var _ provider.Factory = Factory{}
+
+// Store builds a Store for the given scope and kind. It returns
+// provider.ErrUnsupportedKind for kinds AWS does not offer.
+func (Factory) Store(ctx context.Context, scope provider.Scope, kind provider.Kind) (provider.Store, error) {
+	cfg, err := infra.LoadConfig(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	if scope.Region != "" {
+		cfg.Region = scope.Region
+	}
+
+	switch kind {
+	case provider.KindParam:
+		return param.New(ssm.NewFromConfig(cfg)), nil
+	case provider.KindSecret:
+		return secret.New(secretsmanager.NewFromConfig(cfg)), nil
+	default:
+		return nil, fmt.Errorf("%w: %s", provider.ErrUnsupportedKind, kind)
+	}
+}
+
+// Register associates the AWS Factory with provider.ProviderAWS in reg.
+func Register(reg *provider.Registry) {
+	reg.Register(provider.ProviderAWS, Factory{})
+}
+
+// NewRegistry returns a provider.Registry with the AWS provider registered.
+func NewRegistry() *provider.Registry {
+	reg := provider.NewRegistry()
+	Register(reg)
+
+	return reg
+}

--- a/internal/provider/aws/aws_test.go
+++ b/internal/provider/aws/aws_test.go
@@ -1,0 +1,56 @@
+package aws_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider"
+	awsprovider "github.com/mpyw/suve/internal/provider/aws"
+)
+
+func TestFactory_Param(t *testing.T) {
+	t.Parallel()
+
+	store, err := awsprovider.Factory{}.Store(t.Context(), provider.AWSScope("123456789012", "us-east-1"), provider.KindParam)
+	require.NoError(t, err)
+	require.NotNil(t, store)
+}
+
+func TestFactory_Secret(t *testing.T) {
+	t.Parallel()
+
+	store, err := awsprovider.Factory{}.Store(t.Context(), provider.AWSScope("123456789012", "us-east-1"), provider.KindSecret)
+	require.NoError(t, err)
+	require.NotNil(t, store)
+}
+
+func TestFactory_UnsupportedKind(t *testing.T) {
+	t.Parallel()
+
+	_, err := awsprovider.Factory{}.Store(t.Context(), provider.AWSScope("123456789012", "us-east-1"), provider.Kind("bogus"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, provider.ErrUnsupportedKind)
+}
+
+func TestNewRegistry_ResolvesAWS(t *testing.T) {
+	t.Parallel()
+
+	reg := awsprovider.NewRegistry()
+
+	store, err := reg.Store(t.Context(), provider.AWSScope("123456789012", "eu-west-1"), provider.KindParam)
+	require.NoError(t, err)
+	require.NotNil(t, store)
+}
+
+func TestRegister_AddsFactory(t *testing.T) {
+	t.Parallel()
+
+	reg := provider.NewRegistry()
+	awsprovider.Register(reg)
+
+	store, err := reg.Store(t.Context(), provider.AWSScope("123456789012", "ap-northeast-1"), provider.KindSecret)
+	require.NoError(t, err)
+	require.NotNil(t, store)
+}

--- a/internal/provider/aws/param/param.go
+++ b/internal/provider/aws/param/param.go
@@ -1,0 +1,306 @@
+// Package param implements the provider.Store contract for AWS Systems Manager
+// Parameter Store. It confines all SSM SDK types to this package: version
+// resolution (absolute #version and ~shift against history) lives here, while
+// spec PARSING stays generic via paramversion.Parse.
+package param
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/samber/lo"
+
+	"github.com/mpyw/suve/internal/domain"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/version/paramversion"
+)
+
+// Client is the narrow SSM Parameter Store surface this adapter needs. The
+// concrete *ssm.Client satisfies it; tests provide their own mock.
+type Client interface {
+	GetParameter(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
+	GetParameterHistory(
+		ctx context.Context, params *ssm.GetParameterHistoryInput, optFns ...func(*ssm.Options),
+	) (*ssm.GetParameterHistoryOutput, error)
+	PutParameter(ctx context.Context, params *ssm.PutParameterInput, optFns ...func(*ssm.Options)) (*ssm.PutParameterOutput, error)
+	DeleteParameter(ctx context.Context, params *ssm.DeleteParameterInput, optFns ...func(*ssm.Options)) (*ssm.DeleteParameterOutput, error)
+	DescribeParameters(
+		ctx context.Context, params *ssm.DescribeParametersInput, optFns ...func(*ssm.Options),
+	) (*ssm.DescribeParametersOutput, error)
+	AddTagsToResource(ctx context.Context, params *ssm.AddTagsToResourceInput, optFns ...func(*ssm.Options)) (*ssm.AddTagsToResourceOutput, error)
+	RemoveTagsFromResource(
+		ctx context.Context, params *ssm.RemoveTagsFromResourceInput, optFns ...func(*ssm.Options),
+	) (*ssm.RemoveTagsFromResourceOutput, error)
+	ListTagsForResource(
+		ctx context.Context, params *ssm.ListTagsForResourceInput, optFns ...func(*ssm.Options),
+	) (*ssm.ListTagsForResourceOutput, error)
+}
+
+// Store is the SSM Parameter Store implementation of provider.Store.
+type Store struct {
+	client Client
+}
+
+// Compile-time assertion that Store implements the provider contract.
+var _ provider.Store = (*Store)(nil)
+
+// New builds a Store backed by the given SSM client.
+func New(client Client) *Store {
+	return &Store{client: client}
+}
+
+// Resolve parses the version spec (generic) and resolves it (SSM-specific) to
+// an opaque VersionRef holding the concrete version number. An empty/latest
+// spec resolves to the latest ref (empty id).
+func (s *Store) Resolve(ctx context.Context, name, spec string) (provider.VersionRef, error) {
+	parsed, err := paramversion.Parse(name + spec)
+	if err != nil {
+		return provider.VersionRef{}, err
+	}
+
+	// No shift: the ref is the explicit version (if any), otherwise latest.
+	if !parsed.HasShift() {
+		if parsed.Absolute.Version != nil {
+			return provider.NewVersionRef(strconv.FormatInt(*parsed.Absolute.Version, 10)), nil
+		}
+
+		return provider.NewVersionRef(""), nil
+	}
+
+	// Shift present: walk the history newest-first from the base version.
+	history, err := s.client.GetParameterHistory(ctx, &ssm.GetParameterHistoryInput{
+		Name:           aws.String(name),
+		WithDecryption: aws.Bool(true),
+	})
+	if err != nil {
+		return provider.VersionRef{}, fmt.Errorf("failed to get parameter history: %w", err)
+	}
+
+	params := history.Parameters
+	if len(params) == 0 {
+		return provider.VersionRef{}, fmt.Errorf("parameter not found: %s", name)
+	}
+
+	slices.Reverse(params) // AWS returns oldest-first; make it newest-first.
+
+	baseIdx := 0
+
+	if parsed.Absolute.Version != nil {
+		var found bool
+
+		_, baseIdx, found = lo.FindIndexOf(params, func(p types.ParameterHistory) bool {
+			return p.Version == *parsed.Absolute.Version
+		})
+		if !found {
+			return provider.VersionRef{}, fmt.Errorf("version %d not found", *parsed.Absolute.Version)
+		}
+	}
+
+	targetIdx := baseIdx + parsed.Shift
+	if targetIdx >= len(params) {
+		return provider.VersionRef{}, fmt.Errorf("version shift out of range: ~%d", parsed.Shift)
+	}
+
+	return provider.NewVersionRef(strconv.FormatInt(params[targetIdx].Version, 10)), nil
+}
+
+// Get retrieves the parameter at the given ref (latest when ref is latest),
+// decrypting SecureString values, and maps it to a domain.Entry with tags.
+func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (*domain.Entry, error) {
+	target := name
+	if !ref.IsLatest() {
+		target = fmt.Sprintf("%s:%s", name, ref.ID())
+	}
+
+	result, err := s.client.GetParameter(ctx, &ssm.GetParameterInput{
+		Name:           aws.String(target),
+		WithDecryption: aws.Bool(true),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get parameter: %w", err)
+	}
+
+	p := result.Parameter
+
+	entry := &domain.Entry{
+		Name:  aws.ToString(p.Name),
+		Value: aws.ToString(p.Value),
+		Type:  mapTypeToDomain(p.Type),
+		Version: domain.Version{
+			ID:      strconv.FormatInt(p.Version, 10),
+			Created: p.LastModifiedDate,
+		},
+		Modified: p.LastModifiedDate,
+	}
+
+	// Tags are best-effort: a tagging failure must not fail the read.
+	tagsOutput, err := s.client.ListTagsForResource(ctx, &ssm.ListTagsForResourceInput{
+		ResourceType: types.ResourceTypeForTaggingParameter,
+		ResourceId:   p.Name,
+	})
+	if err == nil && tagsOutput != nil {
+		entry.Tags = lo.Map(tagsOutput.TagList, func(t types.Tag, _ int) domain.Tag {
+			return domain.Tag{Key: aws.ToString(t.Key), Value: aws.ToString(t.Value)}
+		})
+	}
+
+	return entry, nil
+}
+
+// History returns the parameter's version history, newest first.
+func (s *Store) History(ctx context.Context, name string) ([]domain.Version, error) {
+	history, err := s.client.GetParameterHistory(ctx, &ssm.GetParameterHistoryInput{
+		Name:           aws.String(name),
+		WithDecryption: aws.Bool(true),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get parameter history: %w", err)
+	}
+
+	versions := lo.Map(history.Parameters, func(p types.ParameterHistory, _ int) domain.Version {
+		return domain.Version{
+			ID:      strconv.FormatInt(p.Version, 10),
+			Created: p.LastModifiedDate,
+		}
+	})
+
+	slices.Reverse(versions) // newest first
+
+	return versions, nil
+}
+
+// List returns the names of all parameters, paging through DescribeParameters.
+func (s *Store) List(ctx context.Context) ([]string, error) {
+	var (
+		names []string
+		token *string
+	)
+
+	for {
+		out, err := s.client.DescribeParameters(ctx, &ssm.DescribeParametersInput{
+			NextToken: token,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to describe parameters: %w", err)
+		}
+
+		for _, p := range out.Parameters {
+			names = append(names, aws.ToString(p.Name))
+		}
+
+		if aws.ToString(out.NextToken) == "" {
+			break
+		}
+
+		token = out.NextToken
+	}
+
+	return names, nil
+}
+
+// Put creates or updates a parameter and returns the resulting version.
+func (s *Store) Put(
+	ctx context.Context, name, value string, valueType domain.ValueType, description string,
+) (domain.Version, error) {
+	input := &ssm.PutParameterInput{
+		Name:      aws.String(name),
+		Value:     aws.String(value),
+		Type:      mapDomainToType(valueType),
+		Overwrite: aws.Bool(true),
+	}
+	if description != "" {
+		input.Description = aws.String(description)
+	}
+
+	out, err := s.client.PutParameter(ctx, input)
+	if err != nil {
+		return domain.Version{}, fmt.Errorf("failed to put parameter: %w", err)
+	}
+
+	return domain.Version{ID: strconv.FormatInt(out.Version, 10)}, nil
+}
+
+// Delete removes a parameter.
+func (s *Store) Delete(ctx context.Context, name string) error {
+	_, err := s.client.DeleteParameter(ctx, &ssm.DeleteParameterInput{
+		Name: aws.String(name),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete parameter: %w", err)
+	}
+
+	return nil
+}
+
+// Tag adds or updates tags on a parameter.
+func (s *Store) Tag(ctx context.Context, name string, add map[string]string) error {
+	if len(add) == 0 {
+		return nil
+	}
+
+	tags := lo.MapToSlice(add, func(k, v string) types.Tag {
+		return types.Tag{Key: aws.String(k), Value: aws.String(v)}
+	})
+
+	_, err := s.client.AddTagsToResource(ctx, &ssm.AddTagsToResourceInput{
+		ResourceId:   aws.String(name),
+		ResourceType: types.ResourceTypeForTaggingParameter,
+		Tags:         tags,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to add tags: %w", err)
+	}
+
+	return nil
+}
+
+// Untag removes tags (by key) from a parameter.
+func (s *Store) Untag(ctx context.Context, name string, keys []string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+
+	_, err := s.client.RemoveTagsFromResource(ctx, &ssm.RemoveTagsFromResourceInput{
+		ResourceId:   aws.String(name),
+		ResourceType: types.ResourceTypeForTaggingParameter,
+		TagKeys:      keys,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to remove tags: %w", err)
+	}
+
+	return nil
+}
+
+// mapTypeToDomain maps an SSM parameter type to the provider-neutral ValueType.
+func mapTypeToDomain(t types.ParameterType) domain.ValueType {
+	switch t {
+	case types.ParameterTypeSecureString:
+		return domain.ValueTypeSecret
+	case types.ParameterTypeStringList:
+		return domain.ValueTypeList
+	case types.ParameterTypeString:
+		return domain.ValueTypePlaintext
+	default:
+		return domain.ValueTypePlaintext
+	}
+}
+
+// mapDomainToType maps a provider-neutral ValueType to an SSM parameter type.
+func mapDomainToType(t domain.ValueType) types.ParameterType {
+	switch t {
+	case domain.ValueTypeSecret:
+		return types.ParameterTypeSecureString
+	case domain.ValueTypeList:
+		return types.ParameterTypeStringList
+	case domain.ValueTypePlaintext:
+		return types.ParameterTypeString
+	default:
+		return types.ParameterTypeString
+	}
+}

--- a/internal/provider/aws/param/param_test.go
+++ b/internal/provider/aws/param/param_test.go
@@ -1,0 +1,327 @@
+package param_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/domain"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/aws/param"
+)
+
+// mockClient is a configurable mock of the narrow SSM client interface.
+type mockClient struct {
+	getParameter    func(*ssm.GetParameterInput) (*ssm.GetParameterOutput, error)
+	getHistory      func(*ssm.GetParameterHistoryInput) (*ssm.GetParameterHistoryOutput, error)
+	putParameter    func(*ssm.PutParameterInput) (*ssm.PutParameterOutput, error)
+	deleteParameter func(*ssm.DeleteParameterInput) (*ssm.DeleteParameterOutput, error)
+	describe        func(*ssm.DescribeParametersInput) (*ssm.DescribeParametersOutput, error)
+	addTags         func(*ssm.AddTagsToResourceInput) (*ssm.AddTagsToResourceOutput, error)
+	removeTags      func(*ssm.RemoveTagsFromResourceInput) (*ssm.RemoveTagsFromResourceOutput, error)
+	listTags        func(*ssm.ListTagsForResourceInput) (*ssm.ListTagsForResourceOutput, error)
+}
+
+func (m *mockClient) GetParameter(_ context.Context, in *ssm.GetParameterInput, _ ...func(*ssm.Options)) (*ssm.GetParameterOutput, error) {
+	return m.getParameter(in)
+}
+
+func (m *mockClient) GetParameterHistory(
+	_ context.Context, in *ssm.GetParameterHistoryInput, _ ...func(*ssm.Options),
+) (*ssm.GetParameterHistoryOutput, error) {
+	return m.getHistory(in)
+}
+
+func (m *mockClient) PutParameter(_ context.Context, in *ssm.PutParameterInput, _ ...func(*ssm.Options)) (*ssm.PutParameterOutput, error) {
+	return m.putParameter(in)
+}
+
+func (m *mockClient) DeleteParameter(
+	_ context.Context, in *ssm.DeleteParameterInput, _ ...func(*ssm.Options),
+) (*ssm.DeleteParameterOutput, error) {
+	return m.deleteParameter(in)
+}
+
+func (m *mockClient) DescribeParameters(
+	_ context.Context, in *ssm.DescribeParametersInput, _ ...func(*ssm.Options),
+) (*ssm.DescribeParametersOutput, error) {
+	return m.describe(in)
+}
+
+func (m *mockClient) AddTagsToResource(
+	_ context.Context, in *ssm.AddTagsToResourceInput, _ ...func(*ssm.Options),
+) (*ssm.AddTagsToResourceOutput, error) {
+	return m.addTags(in)
+}
+
+func (m *mockClient) RemoveTagsFromResource(
+	_ context.Context, in *ssm.RemoveTagsFromResourceInput, _ ...func(*ssm.Options),
+) (*ssm.RemoveTagsFromResourceOutput, error) {
+	return m.removeTags(in)
+}
+
+func (m *mockClient) ListTagsForResource(
+	_ context.Context, in *ssm.ListTagsForResourceInput, _ ...func(*ssm.Options),
+) (*ssm.ListTagsForResourceOutput, error) {
+	return m.listTags(in)
+}
+
+// historyOldestFirst returns 3 versions (oldest first, as AWS returns them).
+func historyOldestFirst() []types.ParameterHistory {
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	return []types.ParameterHistory{
+		{Name: aws.String("/my/param"), Value: aws.String("v1"), Version: 1, Type: types.ParameterTypeString, LastModifiedDate: aws.Time(base)},
+		{
+			Name: aws.String("/my/param"), Value: aws.String("v2"), Version: 2,
+			Type: types.ParameterTypeString, LastModifiedDate: aws.Time(base.Add(time.Hour)),
+		},
+		{
+			Name: aws.String("/my/param"), Value: aws.String("v3"), Version: 3,
+			Type: types.ParameterTypeString, LastModifiedDate: aws.Time(base.Add(2 * time.Hour)),
+		},
+	}
+}
+
+func TestResolve_Latest(t *testing.T) {
+	t.Parallel()
+
+	store := param.New(&mockClient{})
+
+	ref, err := store.Resolve(t.Context(), "/my/param", "")
+	require.NoError(t, err)
+	assert.True(t, ref.IsLatest())
+	assert.Empty(t, ref.ID())
+}
+
+func TestResolve_AbsoluteVersion(t *testing.T) {
+	t.Parallel()
+
+	// No shift => no history call needed.
+	store := param.New(&mockClient{})
+
+	ref, err := store.Resolve(t.Context(), "/my/param", "#3")
+	require.NoError(t, err)
+	assert.False(t, ref.IsLatest())
+	assert.Equal(t, "3", ref.ID())
+}
+
+func TestResolve_Shift(t *testing.T) {
+	t.Parallel()
+
+	store := param.New(&mockClient{
+		getHistory: func(_ *ssm.GetParameterHistoryInput) (*ssm.GetParameterHistoryOutput, error) {
+			return &ssm.GetParameterHistoryOutput{Parameters: historyOldestFirst()}, nil
+		},
+	})
+
+	// ~1 from latest (v3) => v2.
+	ref, err := store.Resolve(t.Context(), "/my/param", "~1")
+	require.NoError(t, err)
+	assert.Equal(t, "2", ref.ID())
+}
+
+func TestResolve_VersionThenShift(t *testing.T) {
+	t.Parallel()
+
+	store := param.New(&mockClient{
+		getHistory: func(_ *ssm.GetParameterHistoryInput) (*ssm.GetParameterHistoryOutput, error) {
+			return &ssm.GetParameterHistoryOutput{Parameters: historyOldestFirst()}, nil
+		},
+	})
+
+	// #3~2 => v3 then 2 back => v1.
+	ref, err := store.Resolve(t.Context(), "/my/param", "#3~2")
+	require.NoError(t, err)
+	assert.Equal(t, "1", ref.ID())
+}
+
+func TestResolve_ShiftOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	store := param.New(&mockClient{
+		getHistory: func(_ *ssm.GetParameterHistoryInput) (*ssm.GetParameterHistoryOutput, error) {
+			return &ssm.GetParameterHistoryOutput{Parameters: historyOldestFirst()}, nil
+		},
+	})
+
+	_, err := store.Resolve(t.Context(), "/my/param", "~5")
+	require.Error(t, err)
+}
+
+func TestGet_LatestWithTypeMappingAndTags(t *testing.T) {
+	t.Parallel()
+
+	var gotName string
+
+	store := param.New(&mockClient{
+		getParameter: func(in *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+			gotName = aws.ToString(in.Name)
+
+			return &ssm.GetParameterOutput{Parameter: &types.Parameter{
+				Name:             aws.String("/my/param"),
+				Value:            aws.String("hunter2"),
+				Version:          3,
+				Type:             types.ParameterTypeSecureString,
+				LastModifiedDate: aws.Time(time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)),
+			}}, nil
+		},
+		listTags: func(_ *ssm.ListTagsForResourceInput) (*ssm.ListTagsForResourceOutput, error) {
+			return &ssm.ListTagsForResourceOutput{TagList: []types.Tag{
+				{Key: aws.String("env"), Value: aws.String("prod")},
+			}}, nil
+		},
+	})
+
+	entry, err := store.Get(t.Context(), "/my/param", provider.NewVersionRef(""))
+	require.NoError(t, err)
+	assert.Equal(t, "/my/param", gotName) // latest => no ":version" suffix
+	assert.Equal(t, "hunter2", entry.Value)
+	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
+	assert.Equal(t, "3", entry.Version.ID)
+	require.Len(t, entry.Tags, 1)
+	assert.Equal(t, "env", entry.Tags[0].Key)
+	assert.Equal(t, "prod", entry.Tags[0].Value)
+}
+
+func TestGet_SpecificVersionSuffix(t *testing.T) {
+	t.Parallel()
+
+	var gotName string
+
+	store := param.New(&mockClient{
+		getParameter: func(in *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+			gotName = aws.ToString(in.Name)
+
+			return &ssm.GetParameterOutput{Parameter: &types.Parameter{
+				Name: aws.String("/my/param"), Value: aws.String("v2"), Version: 2, Type: types.ParameterTypeStringList,
+			}}, nil
+		},
+		listTags: func(_ *ssm.ListTagsForResourceInput) (*ssm.ListTagsForResourceOutput, error) {
+			return &ssm.ListTagsForResourceOutput{}, nil
+		},
+	})
+
+	entry, err := store.Get(t.Context(), "/my/param", provider.NewVersionRef("2"))
+	require.NoError(t, err)
+	assert.Equal(t, "/my/param:2", gotName)
+	assert.Equal(t, domain.ValueTypeList, entry.Type)
+}
+
+func TestHistory_NewestFirst(t *testing.T) {
+	t.Parallel()
+
+	store := param.New(&mockClient{
+		getHistory: func(_ *ssm.GetParameterHistoryInput) (*ssm.GetParameterHistoryOutput, error) {
+			return &ssm.GetParameterHistoryOutput{Parameters: historyOldestFirst()}, nil
+		},
+	})
+
+	versions, err := store.History(t.Context(), "/my/param")
+	require.NoError(t, err)
+	require.Len(t, versions, 3)
+	assert.Equal(t, "3", versions[0].ID)
+	assert.Equal(t, "1", versions[2].ID)
+}
+
+func TestList_Paginated(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	store := param.New(&mockClient{
+		describe: func(in *ssm.DescribeParametersInput) (*ssm.DescribeParametersOutput, error) {
+			calls++
+
+			if aws.ToString(in.NextToken) == "" {
+				return &ssm.DescribeParametersOutput{
+					Parameters: []types.ParameterMetadata{{Name: aws.String("/a")}},
+					NextToken:  aws.String("tok"),
+				}, nil
+			}
+
+			return &ssm.DescribeParametersOutput{
+				Parameters: []types.ParameterMetadata{{Name: aws.String("/b")}},
+			}, nil
+		},
+	})
+
+	names, err := store.List(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"/a", "/b"}, names)
+	assert.Equal(t, 2, calls)
+}
+
+func TestPut_MapsTypeAndReturnsVersion(t *testing.T) {
+	t.Parallel()
+
+	var got *ssm.PutParameterInput
+
+	store := param.New(&mockClient{
+		putParameter: func(in *ssm.PutParameterInput) (*ssm.PutParameterOutput, error) {
+			got = in
+
+			return &ssm.PutParameterOutput{Version: 7}, nil
+		},
+	})
+
+	v, err := store.Put(t.Context(), "/my/param", "val", domain.ValueTypeSecret, "desc")
+	require.NoError(t, err)
+	assert.Equal(t, "7", v.ID)
+	assert.Equal(t, types.ParameterTypeSecureString, got.Type)
+	assert.True(t, aws.ToBool(got.Overwrite))
+	assert.Equal(t, "desc", aws.ToString(got.Description))
+}
+
+func TestDelete(t *testing.T) {
+	t.Parallel()
+
+	var gotName string
+
+	store := param.New(&mockClient{
+		deleteParameter: func(in *ssm.DeleteParameterInput) (*ssm.DeleteParameterOutput, error) {
+			gotName = aws.ToString(in.Name)
+
+			return &ssm.DeleteParameterOutput{}, nil
+		},
+	})
+
+	require.NoError(t, store.Delete(t.Context(), "/my/param"))
+	assert.Equal(t, "/my/param", gotName)
+}
+
+func TestTagAndUntag(t *testing.T) {
+	t.Parallel()
+
+	var (
+		addIn    *ssm.AddTagsToResourceInput
+		removeIn *ssm.RemoveTagsFromResourceInput
+	)
+
+	store := param.New(&mockClient{
+		addTags: func(in *ssm.AddTagsToResourceInput) (*ssm.AddTagsToResourceOutput, error) {
+			addIn = in
+
+			return &ssm.AddTagsToResourceOutput{}, nil
+		},
+		removeTags: func(in *ssm.RemoveTagsFromResourceInput) (*ssm.RemoveTagsFromResourceOutput, error) {
+			removeIn = in
+
+			return &ssm.RemoveTagsFromResourceOutput{}, nil
+		},
+	})
+
+	require.NoError(t, store.Tag(t.Context(), "/my/param", map[string]string{"env": "prod"}))
+	require.NotNil(t, addIn)
+	assert.Equal(t, types.ResourceTypeForTaggingParameter, addIn.ResourceType)
+	require.Len(t, addIn.Tags, 1)
+
+	require.NoError(t, store.Untag(t.Context(), "/my/param", []string{"env"}))
+	require.NotNil(t, removeIn)
+	assert.Equal(t, []string{"env"}, removeIn.TagKeys)
+}

--- a/internal/provider/aws/secret/secret.go
+++ b/internal/provider/aws/secret/secret.go
@@ -1,0 +1,410 @@
+// Package secret implements the provider.Store, provider.Restorer and
+// provider.Describer contracts for AWS Secrets Manager. It confines all
+// Secrets Manager SDK types to this package: version/label/shift resolution
+// lives here, so AWS staging labels (AWSCURRENT etc.) never leak past this
+// boundary. Spec PARSING stays generic via secretversion.Parse.
+package secret
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"sort"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/samber/lo"
+
+	"github.com/mpyw/suve/internal/domain"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/version/secretversion"
+)
+
+// Client is the narrow Secrets Manager surface this adapter needs. The concrete
+// *secretsmanager.Client satisfies it; tests provide their own mock.
+type Client interface {
+	GetSecretValue(
+		ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options),
+	) (*secretsmanager.GetSecretValueOutput, error)
+	ListSecretVersionIds(
+		ctx context.Context, params *secretsmanager.ListSecretVersionIdsInput, optFns ...func(*secretsmanager.Options),
+	) (*secretsmanager.ListSecretVersionIdsOutput, error)
+	DescribeSecret(
+		ctx context.Context, params *secretsmanager.DescribeSecretInput, optFns ...func(*secretsmanager.Options),
+	) (*secretsmanager.DescribeSecretOutput, error)
+	CreateSecret(
+		ctx context.Context, params *secretsmanager.CreateSecretInput, optFns ...func(*secretsmanager.Options),
+	) (*secretsmanager.CreateSecretOutput, error)
+	PutSecretValue(
+		ctx context.Context, params *secretsmanager.PutSecretValueInput, optFns ...func(*secretsmanager.Options),
+	) (*secretsmanager.PutSecretValueOutput, error)
+	DeleteSecret(
+		ctx context.Context, params *secretsmanager.DeleteSecretInput, optFns ...func(*secretsmanager.Options),
+	) (*secretsmanager.DeleteSecretOutput, error)
+	RestoreSecret(
+		ctx context.Context, params *secretsmanager.RestoreSecretInput, optFns ...func(*secretsmanager.Options),
+	) (*secretsmanager.RestoreSecretOutput, error)
+	TagResource(
+		ctx context.Context, params *secretsmanager.TagResourceInput, optFns ...func(*secretsmanager.Options),
+	) (*secretsmanager.TagResourceOutput, error)
+	UntagResource(
+		ctx context.Context, params *secretsmanager.UntagResourceInput, optFns ...func(*secretsmanager.Options),
+	) (*secretsmanager.UntagResourceOutput, error)
+	ListSecrets(
+		ctx context.Context, params *secretsmanager.ListSecretsInput, optFns ...func(*secretsmanager.Options),
+	) (*secretsmanager.ListSecretsOutput, error)
+}
+
+// Store is the Secrets Manager implementation of provider.Store (+ Restorer, Describer).
+type Store struct {
+	client Client
+}
+
+// Compile-time assertions that Store implements the provider contracts.
+var (
+	_ provider.Store     = (*Store)(nil)
+	_ provider.Restorer  = (*Store)(nil)
+	_ provider.Describer = (*Store)(nil)
+)
+
+// New builds a Store backed by the given Secrets Manager client.
+func New(client Client) *Store {
+	return &Store{client: client}
+}
+
+// Resolve parses the version spec (generic) and resolves it (AWS-specific) to
+// an opaque VersionRef holding a concrete version ID. Staging labels
+// (:AWSCURRENT etc.) and ~shift are resolved here against ListSecretVersionIds,
+// so no AWS label escapes this package. An empty/latest spec resolves to the
+// latest ref (empty id).
+func (s *Store) Resolve(ctx context.Context, name, spec string) (provider.VersionRef, error) {
+	parsed, err := secretversion.Parse(name + spec)
+	if err != nil {
+		return provider.VersionRef{}, err
+	}
+
+	// Fast paths that need no listing.
+	if !parsed.HasShift() {
+		switch {
+		case parsed.Absolute.ID != nil:
+			return provider.NewVersionRef(*parsed.Absolute.ID), nil
+		case parsed.Absolute.Label == nil:
+			// No absolute spec at all: latest/current.
+			return provider.NewVersionRef(""), nil
+		}
+	}
+
+	// Label resolution and/or shift require the full version list.
+	versions, err := s.client.ListSecretVersionIds(ctx, &secretsmanager.ListSecretVersionIdsInput{
+		SecretId: aws.String(name),
+	})
+	if err != nil {
+		return provider.VersionRef{}, fmt.Errorf("failed to list versions: %w", err)
+	}
+
+	list := versions.Versions
+	if len(list) == 0 {
+		return provider.VersionRef{}, fmt.Errorf("secret not found or has no versions: %s", name)
+	}
+
+	sortNewestFirst(list)
+
+	baseIdx, err := baseIndex(list, parsed.Absolute)
+	if err != nil {
+		return provider.VersionRef{}, err
+	}
+
+	targetIdx := baseIdx + parsed.Shift
+	if targetIdx >= len(list) {
+		return provider.VersionRef{}, fmt.Errorf("version shift out of range: ~%d", parsed.Shift)
+	}
+
+	return provider.NewVersionRef(aws.ToString(list[targetIdx].VersionId)), nil
+}
+
+// baseIndex finds the starting index in a newest-first version list for the
+// given absolute spec (version ID or staging label). No absolute spec anchors
+// at the newest version (index 0).
+func baseIndex(list []types.SecretVersionsListEntry, abs secretversion.AbsoluteSpec) (int, error) {
+	switch {
+	case abs.ID != nil:
+		_, idx, found := lo.FindIndexOf(list, func(v types.SecretVersionsListEntry) bool {
+			return aws.ToString(v.VersionId) == *abs.ID
+		})
+		if !found {
+			return 0, fmt.Errorf("version ID not found: %s", *abs.ID)
+		}
+
+		return idx, nil
+	case abs.Label != nil:
+		_, idx, found := lo.FindIndexOf(list, func(v types.SecretVersionsListEntry) bool {
+			return slices.Contains(v.VersionStages, *abs.Label)
+		})
+		if !found {
+			return 0, fmt.Errorf("version label not found: %s", *abs.Label)
+		}
+
+		return idx, nil
+	default:
+		return 0, nil
+	}
+}
+
+// sortNewestFirst sorts version entries by creation date, newest first.
+func sortNewestFirst(list []types.SecretVersionsListEntry) {
+	sort.Slice(list, func(i, j int) bool {
+		if list[i].CreatedDate == nil {
+			return false
+		}
+
+		if list[j].CreatedDate == nil {
+			return true
+		}
+
+		return list[i].CreatedDate.After(*list[j].CreatedDate)
+	})
+}
+
+// Get retrieves the secret at the given ref (current when ref is latest) and
+// maps it to a domain.Entry with description and tags. Type is always secret.
+func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (*domain.Entry, error) {
+	input := &secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(name),
+	}
+	if !ref.IsLatest() {
+		input.VersionId = aws.String(ref.ID())
+	}
+
+	out, err := s.client.GetSecretValue(ctx, input)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret value: %w", err)
+	}
+
+	entry := &domain.Entry{
+		Name:  aws.ToString(out.Name),
+		Value: aws.ToString(out.SecretString),
+		Type:  domain.ValueTypeSecret,
+		Version: domain.Version{
+			ID:      aws.ToString(out.VersionId),
+			Label:   firstStage(out.VersionStages),
+			Created: out.CreatedDate,
+		},
+		Modified: out.CreatedDate,
+	}
+
+	// Description and tags are best-effort via DescribeSecret.
+	desc, err := s.client.DescribeSecret(ctx, &secretsmanager.DescribeSecretInput{
+		SecretId: aws.String(name),
+	})
+	if err == nil && desc != nil {
+		entry.Description = aws.ToString(desc.Description)
+		entry.Tags = mapTags(desc.Tags)
+	}
+
+	return entry, nil
+}
+
+// History returns the secret's version history, newest first.
+func (s *Store) History(ctx context.Context, name string) ([]domain.Version, error) {
+	out, err := s.client.ListSecretVersionIds(ctx, &secretsmanager.ListSecretVersionIdsInput{
+		SecretId: aws.String(name),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list secret versions: %w", err)
+	}
+
+	list := out.Versions
+	sortNewestFirst(list)
+
+	return lo.Map(list, func(v types.SecretVersionsListEntry, _ int) domain.Version {
+		return domain.Version{
+			ID:      aws.ToString(v.VersionId),
+			Label:   firstStage(v.VersionStages),
+			Created: v.CreatedDate,
+		}
+	}), nil
+}
+
+// List returns the names of all secrets, paging through ListSecrets.
+func (s *Store) List(ctx context.Context) ([]string, error) {
+	var (
+		names []string
+		token *string
+	)
+
+	for {
+		out, err := s.client.ListSecrets(ctx, &secretsmanager.ListSecretsInput{
+			NextToken: token,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("failed to list secrets: %w", err)
+		}
+
+		for _, sec := range out.SecretList {
+			names = append(names, aws.ToString(sec.Name))
+		}
+
+		if aws.ToString(out.NextToken) == "" {
+			break
+		}
+
+		token = out.NextToken
+	}
+
+	return names, nil
+}
+
+// Put creates the secret, or writes a new version if it already exists. The
+// valueType is ignored (Secrets Manager values are always secret). A
+// description is applied only on creation.
+func (s *Store) Put(
+	ctx context.Context, name, value string, _ domain.ValueType, description string,
+) (domain.Version, error) {
+	createInput := &secretsmanager.CreateSecretInput{
+		Name:         aws.String(name),
+		SecretString: aws.String(value),
+	}
+	if description != "" {
+		createInput.Description = aws.String(description)
+	}
+
+	created, err := s.client.CreateSecret(ctx, createInput)
+	if err == nil {
+		return domain.Version{ID: aws.ToString(created.VersionId)}, nil
+	}
+
+	// Already exists: write a new version instead.
+	var exists *types.ResourceExistsException
+	if !errors.As(err, &exists) {
+		return domain.Version{}, fmt.Errorf("failed to create secret: %w", err)
+	}
+
+	put, err := s.client.PutSecretValue(ctx, &secretsmanager.PutSecretValueInput{
+		SecretId:     aws.String(name),
+		SecretString: aws.String(value),
+	})
+	if err != nil {
+		return domain.Version{}, fmt.Errorf("failed to put secret value: %w", err)
+	}
+
+	return domain.Version{ID: aws.ToString(put.VersionId)}, nil
+}
+
+// Delete schedules a secret for deletion (default recovery window).
+func (s *Store) Delete(ctx context.Context, name string) error {
+	_, err := s.client.DeleteSecret(ctx, &secretsmanager.DeleteSecretInput{
+		SecretId: aws.String(name),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete secret: %w", err)
+	}
+
+	return nil
+}
+
+// Restore cancels a pending deletion for a secret.
+func (s *Store) Restore(ctx context.Context, name string) error {
+	_, err := s.client.RestoreSecret(ctx, &secretsmanager.RestoreSecretInput{
+		SecretId: aws.String(name),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to restore secret: %w", err)
+	}
+
+	return nil
+}
+
+// Describe returns the secret's metadata (description, tags, current version)
+// without fetching its value. Type is always secret.
+func (s *Store) Describe(ctx context.Context, name string) (*domain.Entry, error) {
+	desc, err := s.client.DescribeSecret(ctx, &secretsmanager.DescribeSecretInput{
+		SecretId: aws.String(name),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to describe secret: %w", err)
+	}
+
+	entry := &domain.Entry{
+		Name:        aws.ToString(desc.Name),
+		Type:        domain.ValueTypeSecret,
+		Description: aws.ToString(desc.Description),
+		Tags:        mapTags(desc.Tags),
+		Modified:    desc.LastChangedDate,
+	}
+
+	// Best-effort: surface the current (AWSCURRENT) version if present.
+	for versionID, stages := range desc.VersionIdsToStages {
+		if slices.Contains(stages, "AWSCURRENT") {
+			entry.Version = domain.Version{
+				ID:      versionID,
+				Label:   firstStage(stages),
+				Created: desc.CreatedDate,
+			}
+
+			break
+		}
+	}
+
+	return entry, nil
+}
+
+// Tag adds or updates tags on a secret.
+func (s *Store) Tag(ctx context.Context, name string, add map[string]string) error {
+	if len(add) == 0 {
+		return nil
+	}
+
+	tags := lo.MapToSlice(add, func(k, v string) types.Tag {
+		return types.Tag{Key: aws.String(k), Value: aws.String(v)}
+	})
+
+	_, err := s.client.TagResource(ctx, &secretsmanager.TagResourceInput{
+		SecretId: aws.String(name),
+		Tags:     tags,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to add tags: %w", err)
+	}
+
+	return nil
+}
+
+// Untag removes tags (by key) from a secret.
+func (s *Store) Untag(ctx context.Context, name string, keys []string) error {
+	if len(keys) == 0 {
+		return nil
+	}
+
+	_, err := s.client.UntagResource(ctx, &secretsmanager.UntagResourceInput{
+		SecretId: aws.String(name),
+		TagKeys:  keys,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to remove tags: %w", err)
+	}
+
+	return nil
+}
+
+// firstStage returns the first staging label, or "" when there are none. It
+// keeps the AWS label confined to a provider-neutral, informational Label.
+func firstStage(stages []string) string {
+	if len(stages) == 0 {
+		return ""
+	}
+
+	return stages[0]
+}
+
+// mapTags maps Secrets Manager tags to provider-neutral domain tags.
+func mapTags(tags []types.Tag) []domain.Tag {
+	if len(tags) == 0 {
+		return nil
+	}
+
+	return lo.Map(tags, func(t types.Tag, _ int) domain.Tag {
+		return domain.Tag{Key: aws.ToString(t.Key), Value: aws.ToString(t.Value)}
+	})
+}

--- a/internal/provider/aws/secret/secret_test.go
+++ b/internal/provider/aws/secret/secret_test.go
@@ -1,0 +1,395 @@
+package secret_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/domain"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/aws/secret"
+)
+
+// mockClient is a configurable mock of the narrow Secrets Manager interface.
+type mockClient struct {
+	getValue    func(*secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error)
+	listVersion func(*secretsmanager.ListSecretVersionIdsInput) (*secretsmanager.ListSecretVersionIdsOutput, error)
+	describe    func(*secretsmanager.DescribeSecretInput) (*secretsmanager.DescribeSecretOutput, error)
+	create      func(*secretsmanager.CreateSecretInput) (*secretsmanager.CreateSecretOutput, error)
+	putValue    func(*secretsmanager.PutSecretValueInput) (*secretsmanager.PutSecretValueOutput, error)
+	deleteSec   func(*secretsmanager.DeleteSecretInput) (*secretsmanager.DeleteSecretOutput, error)
+	restore     func(*secretsmanager.RestoreSecretInput) (*secretsmanager.RestoreSecretOutput, error)
+	tag         func(*secretsmanager.TagResourceInput) (*secretsmanager.TagResourceOutput, error)
+	untag       func(*secretsmanager.UntagResourceInput) (*secretsmanager.UntagResourceOutput, error)
+	listSecrets func(*secretsmanager.ListSecretsInput) (*secretsmanager.ListSecretsOutput, error)
+}
+
+func (m *mockClient) GetSecretValue(
+	_ context.Context, in *secretsmanager.GetSecretValueInput, _ ...func(*secretsmanager.Options),
+) (*secretsmanager.GetSecretValueOutput, error) {
+	return m.getValue(in)
+}
+
+//nolint:revive // Method name matches AWS SDK interface naming convention
+func (m *mockClient) ListSecretVersionIds(
+	_ context.Context, in *secretsmanager.ListSecretVersionIdsInput, _ ...func(*secretsmanager.Options),
+) (*secretsmanager.ListSecretVersionIdsOutput, error) {
+	return m.listVersion(in)
+}
+
+func (m *mockClient) DescribeSecret(
+	_ context.Context, in *secretsmanager.DescribeSecretInput, _ ...func(*secretsmanager.Options),
+) (*secretsmanager.DescribeSecretOutput, error) {
+	return m.describe(in)
+}
+
+func (m *mockClient) CreateSecret(
+	_ context.Context, in *secretsmanager.CreateSecretInput, _ ...func(*secretsmanager.Options),
+) (*secretsmanager.CreateSecretOutput, error) {
+	return m.create(in)
+}
+
+func (m *mockClient) PutSecretValue(
+	_ context.Context, in *secretsmanager.PutSecretValueInput, _ ...func(*secretsmanager.Options),
+) (*secretsmanager.PutSecretValueOutput, error) {
+	return m.putValue(in)
+}
+
+func (m *mockClient) DeleteSecret(
+	_ context.Context, in *secretsmanager.DeleteSecretInput, _ ...func(*secretsmanager.Options),
+) (*secretsmanager.DeleteSecretOutput, error) {
+	return m.deleteSec(in)
+}
+
+func (m *mockClient) RestoreSecret(
+	_ context.Context, in *secretsmanager.RestoreSecretInput, _ ...func(*secretsmanager.Options),
+) (*secretsmanager.RestoreSecretOutput, error) {
+	return m.restore(in)
+}
+
+func (m *mockClient) TagResource(
+	_ context.Context, in *secretsmanager.TagResourceInput, _ ...func(*secretsmanager.Options),
+) (*secretsmanager.TagResourceOutput, error) {
+	return m.tag(in)
+}
+
+func (m *mockClient) UntagResource(
+	_ context.Context, in *secretsmanager.UntagResourceInput, _ ...func(*secretsmanager.Options),
+) (*secretsmanager.UntagResourceOutput, error) {
+	return m.untag(in)
+}
+
+func (m *mockClient) ListSecrets(
+	_ context.Context, in *secretsmanager.ListSecretsInput, _ ...func(*secretsmanager.Options),
+) (*secretsmanager.ListSecretsOutput, error) {
+	return m.listSecrets(in)
+}
+
+// versionsNewestFirst returns three versions; v3 is AWSCURRENT, v2 AWSPREVIOUS.
+func versionsList() []types.SecretVersionsListEntry {
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	return []types.SecretVersionsListEntry{
+		{VersionId: aws.String("id-1"), CreatedDate: aws.Time(base), VersionStages: []string{}},
+		{VersionId: aws.String("id-2"), CreatedDate: aws.Time(base.Add(time.Hour)), VersionStages: []string{"AWSPREVIOUS"}},
+		{VersionId: aws.String("id-3"), CreatedDate: aws.Time(base.Add(2 * time.Hour)), VersionStages: []string{"AWSCURRENT"}},
+	}
+}
+
+func TestResolve_Latest(t *testing.T) {
+	t.Parallel()
+
+	store := secret.New(&mockClient{})
+
+	ref, err := store.Resolve(t.Context(), "my-secret", "")
+	require.NoError(t, err)
+	assert.True(t, ref.IsLatest())
+}
+
+func TestResolve_VersionID(t *testing.T) {
+	t.Parallel()
+
+	// Explicit id, no shift => no listing needed.
+	store := secret.New(&mockClient{})
+
+	ref, err := store.Resolve(t.Context(), "my-secret", "#abc123")
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", ref.ID())
+}
+
+func TestResolve_Label(t *testing.T) {
+	t.Parallel()
+
+	store := secret.New(&mockClient{
+		listVersion: func(_ *secretsmanager.ListSecretVersionIdsInput) (*secretsmanager.ListSecretVersionIdsOutput, error) {
+			return &secretsmanager.ListSecretVersionIdsOutput{Versions: versionsList()}, nil
+		},
+	})
+
+	// :AWSCURRENT resolves to the concrete version id (label confined here).
+	ref, err := store.Resolve(t.Context(), "my-secret", ":AWSCURRENT")
+	require.NoError(t, err)
+	assert.Equal(t, "id-3", ref.ID())
+}
+
+func TestResolve_LabelThenShift(t *testing.T) {
+	t.Parallel()
+
+	store := secret.New(&mockClient{
+		listVersion: func(_ *secretsmanager.ListSecretVersionIdsInput) (*secretsmanager.ListSecretVersionIdsOutput, error) {
+			return &secretsmanager.ListSecretVersionIdsOutput{Versions: versionsList()}, nil
+		},
+	})
+
+	// :AWSCURRENT~1 => one before current (id-3) => id-2.
+	ref, err := store.Resolve(t.Context(), "my-secret", ":AWSCURRENT~1")
+	require.NoError(t, err)
+	assert.Equal(t, "id-2", ref.ID())
+}
+
+func TestResolve_ShiftOutOfRange(t *testing.T) {
+	t.Parallel()
+
+	store := secret.New(&mockClient{
+		listVersion: func(_ *secretsmanager.ListSecretVersionIdsInput) (*secretsmanager.ListSecretVersionIdsOutput, error) {
+			return &secretsmanager.ListSecretVersionIdsOutput{Versions: versionsList()}, nil
+		},
+	})
+
+	_, err := store.Resolve(t.Context(), "my-secret", "~9")
+	require.Error(t, err)
+}
+
+func TestGet_MapsEntryWithDescriptionAndTags(t *testing.T) {
+	t.Parallel()
+
+	var gotVersionID string
+
+	store := secret.New(&mockClient{
+		getValue: func(in *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+			gotVersionID = aws.ToString(in.VersionId)
+
+			return &secretsmanager.GetSecretValueOutput{
+				Name:          aws.String("my-secret"),
+				SecretString:  aws.String("s3cr3t"),
+				VersionId:     aws.String("id-3"),
+				VersionStages: []string{"AWSCURRENT"},
+				CreatedDate:   aws.Time(time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)),
+			}, nil
+		},
+		describe: func(_ *secretsmanager.DescribeSecretInput) (*secretsmanager.DescribeSecretOutput, error) {
+			return &secretsmanager.DescribeSecretOutput{
+				Description: aws.String("my desc"),
+				Tags:        []types.Tag{{Key: aws.String("env"), Value: aws.String("prod")}},
+			}, nil
+		},
+	})
+
+	entry, err := store.Get(t.Context(), "my-secret", provider.NewVersionRef("id-3"))
+	require.NoError(t, err)
+	assert.Equal(t, "id-3", gotVersionID)
+	assert.Equal(t, "s3cr3t", entry.Value)
+	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
+	assert.Equal(t, "id-3", entry.Version.ID)
+	assert.Equal(t, "AWSCURRENT", entry.Version.Label)
+	assert.Equal(t, "my desc", entry.Description)
+	require.Len(t, entry.Tags, 1)
+	assert.Equal(t, "env", entry.Tags[0].Key)
+}
+
+func TestGet_LatestOmitsVersionID(t *testing.T) {
+	t.Parallel()
+
+	var hadVersionID bool
+
+	store := secret.New(&mockClient{
+		getValue: func(in *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+			hadVersionID = in.VersionId != nil
+
+			return &secretsmanager.GetSecretValueOutput{Name: aws.String("my-secret"), SecretString: aws.String("v")}, nil
+		},
+		describe: func(_ *secretsmanager.DescribeSecretInput) (*secretsmanager.DescribeSecretOutput, error) {
+			return &secretsmanager.DescribeSecretOutput{}, nil
+		},
+	})
+
+	_, err := store.Get(t.Context(), "my-secret", provider.NewVersionRef(""))
+	require.NoError(t, err)
+	assert.False(t, hadVersionID)
+}
+
+func TestHistory_NewestFirst(t *testing.T) {
+	t.Parallel()
+
+	store := secret.New(&mockClient{
+		listVersion: func(_ *secretsmanager.ListSecretVersionIdsInput) (*secretsmanager.ListSecretVersionIdsOutput, error) {
+			return &secretsmanager.ListSecretVersionIdsOutput{Versions: versionsList()}, nil
+		},
+	})
+
+	versions, err := store.History(t.Context(), "my-secret")
+	require.NoError(t, err)
+	require.Len(t, versions, 3)
+	assert.Equal(t, "id-3", versions[0].ID)
+	assert.Equal(t, "AWSCURRENT", versions[0].Label)
+	assert.Equal(t, "id-1", versions[2].ID)
+}
+
+func TestList_Paginated(t *testing.T) {
+	t.Parallel()
+
+	store := secret.New(&mockClient{
+		listSecrets: func(in *secretsmanager.ListSecretsInput) (*secretsmanager.ListSecretsOutput, error) {
+			if aws.ToString(in.NextToken) == "" {
+				return &secretsmanager.ListSecretsOutput{
+					SecretList: []types.SecretListEntry{{Name: aws.String("a")}},
+					NextToken:  aws.String("tok"),
+				}, nil
+			}
+
+			return &secretsmanager.ListSecretsOutput{SecretList: []types.SecretListEntry{{Name: aws.String("b")}}}, nil
+		},
+	})
+
+	names, err := store.List(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, names)
+}
+
+func TestPut_CreateWhenNew(t *testing.T) {
+	t.Parallel()
+
+	var createIn *secretsmanager.CreateSecretInput
+
+	store := secret.New(&mockClient{
+		create: func(in *secretsmanager.CreateSecretInput) (*secretsmanager.CreateSecretOutput, error) {
+			createIn = in
+
+			return &secretsmanager.CreateSecretOutput{VersionId: aws.String("new-id")}, nil
+		},
+	})
+
+	v, err := store.Put(t.Context(), "my-secret", "val", domain.ValueTypeSecret, "desc")
+	require.NoError(t, err)
+	assert.Equal(t, "new-id", v.ID)
+	require.NotNil(t, createIn)
+	assert.Equal(t, "desc", aws.ToString(createIn.Description))
+}
+
+func TestPut_PutsNewVersionWhenExists(t *testing.T) {
+	t.Parallel()
+
+	var putCalled bool
+
+	store := secret.New(&mockClient{
+		create: func(_ *secretsmanager.CreateSecretInput) (*secretsmanager.CreateSecretOutput, error) {
+			return nil, &types.ResourceExistsException{Message: aws.String("exists")}
+		},
+		putValue: func(_ *secretsmanager.PutSecretValueInput) (*secretsmanager.PutSecretValueOutput, error) {
+			putCalled = true
+
+			return &secretsmanager.PutSecretValueOutput{VersionId: aws.String("ver-2")}, nil
+		},
+	})
+
+	v, err := store.Put(t.Context(), "my-secret", "val", domain.ValueTypeSecret, "")
+	require.NoError(t, err)
+	assert.True(t, putCalled)
+	assert.Equal(t, "ver-2", v.ID)
+}
+
+func TestDelete(t *testing.T) {
+	t.Parallel()
+
+	var gotID string
+
+	store := secret.New(&mockClient{
+		deleteSec: func(in *secretsmanager.DeleteSecretInput) (*secretsmanager.DeleteSecretOutput, error) {
+			gotID = aws.ToString(in.SecretId)
+
+			return &secretsmanager.DeleteSecretOutput{}, nil
+		},
+	})
+
+	require.NoError(t, store.Delete(t.Context(), "my-secret"))
+	assert.Equal(t, "my-secret", gotID)
+}
+
+func TestRestore(t *testing.T) {
+	t.Parallel()
+
+	var gotID string
+
+	store := secret.New(&mockClient{
+		restore: func(in *secretsmanager.RestoreSecretInput) (*secretsmanager.RestoreSecretOutput, error) {
+			gotID = aws.ToString(in.SecretId)
+
+			return &secretsmanager.RestoreSecretOutput{}, nil
+		},
+	})
+
+	require.NoError(t, store.Restore(t.Context(), "my-secret"))
+	assert.Equal(t, "my-secret", gotID)
+}
+
+func TestDescribe(t *testing.T) {
+	t.Parallel()
+
+	store := secret.New(&mockClient{
+		describe: func(_ *secretsmanager.DescribeSecretInput) (*secretsmanager.DescribeSecretOutput, error) {
+			return &secretsmanager.DescribeSecretOutput{
+				Name:               aws.String("my-secret"),
+				Description:        aws.String("the desc"),
+				Tags:               []types.Tag{{Key: aws.String("team"), Value: aws.String("sec")}},
+				LastChangedDate:    aws.Time(time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)),
+				VersionIdsToStages: map[string][]string{"id-3": {"AWSCURRENT"}},
+			}, nil
+		},
+	})
+
+	entry, err := store.Describe(t.Context(), "my-secret")
+	require.NoError(t, err)
+	assert.Equal(t, "my-secret", entry.Name)
+	assert.Empty(t, entry.Value) // Describe never fetches the value
+	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
+	assert.Equal(t, "the desc", entry.Description)
+	assert.Equal(t, "id-3", entry.Version.ID)
+	require.Len(t, entry.Tags, 1)
+	assert.Equal(t, "team", entry.Tags[0].Key)
+}
+
+func TestTagAndUntag(t *testing.T) {
+	t.Parallel()
+
+	var (
+		tagIn   *secretsmanager.TagResourceInput
+		untagIn *secretsmanager.UntagResourceInput
+	)
+
+	store := secret.New(&mockClient{
+		tag: func(in *secretsmanager.TagResourceInput) (*secretsmanager.TagResourceOutput, error) {
+			tagIn = in
+
+			return &secretsmanager.TagResourceOutput{}, nil
+		},
+		untag: func(in *secretsmanager.UntagResourceInput) (*secretsmanager.UntagResourceOutput, error) {
+			untagIn = in
+
+			return &secretsmanager.UntagResourceOutput{}, nil
+		},
+	})
+
+	require.NoError(t, store.Tag(t.Context(), "my-secret", map[string]string{"env": "prod"}))
+	require.NotNil(t, tagIn)
+	require.Len(t, tagIn.Tags, 1)
+
+	require.NoError(t, store.Untag(t.Context(), "my-secret", []string{"env"}))
+	require.NotNil(t, untagIn)
+	assert.Equal(t, []string{"env"}, untagIn.TagKeys)
+}


### PR DESCRIPTION
Closes #201 (Part of #189, Phase 2)

## Summary

Implements the #199 provider interfaces for AWS, **confining the SSM / Secrets Manager SDK to `internal/provider/aws/**`**. This is the first real implementation of the #199 seam (and validates it). **Additive** — provides the adapters + a registry factory + adapter tests; **no consumers are migrated** (that is #202/#203/#204). `+1,557` across 7 new files.

## Adapters
- **`internal/provider/aws/param`** — SSM Parameter Store `provider.Store`. Narrow in-package SSM client interface (mockable). Type mapping `String`/`SecureString`/`StringList` ↔ `ValueTypePlaintext`/`Secret`/`List`. `Put` uses `Overwrite=true`.
- **`internal/provider/aws/secret`** — Secrets Manager `provider.Store` + `Restorer` + `Describer`. Always `ValueTypeSecret`. `Put` → `CreateSecret`, falling back to `PutSecretValue` on `ResourceExistsException`.
- Compile-time interface assertions on both.

## Version resolution moved behind the adapters
Spec **parsing** stays generic (`paramversion.Parse` / `secretversion.Parse`); **resolution** (absolute version, `~shift` via history, and — for secrets — AWS staging labels like `AWSCURRENT`) happens **inside the adapter** and returns an opaque `provider.VersionRef`. AWS labels never leave `provider/aws/secret`.

## Registry factory (additive)
`aws.Factory` implements `provider.Factory` (`Store(ctx, scope, kind)` → param/secret adapter, `ErrUnsupportedKind` otherwise), building clients from `infra.LoadConfig` honoring `scope.Region`. `aws.NewRegistry()` returns a `provider.Registry` with AWS registered. **Commands are not rewired** (that's #204).

## depguard
`.golangci.yaml`: one-line allowlist extension (`"!**/internal/provider/aws/**"`) so the adapters may import the AWS SDK. The rule is otherwise intact (SDK still denied everywhere else).

## ⚠️ Deferred acceptance items (issue-internal scope conflict — flagged for your call)
The issue lists "delete `internal/api/paramapi`/`secretapi` re-exports" and "make `infra` the provider registry", but **28 non-test files** (usecases, CLI, staging, tagging, GUI) still use `paramapi.`/`secretapi.` and `infra.NewXClient`, and migrating them is **explicitly out of scope** here (#202/#203/#204). Deleting the aliases or gutting `infra` now would break the build. So:
- **Deferred:** paramapi/secretapi deletion, and `infra`-as-registry / removing `infra.NewXClient` — these complete during the consumer migration (#202–#204).
- **Delivered:** the adapters (the issue's titular deliverable), the registry factory, and AWS-SDK confinement for the new code.

I closed #201 on the adapters since that's the core deliverable, but if you'd prefer to track the deferred deletions on #201 itself, reopen and I'll adjust. (SDK confinement is complete for new code; the only remaining external SDK importers are the pre-existing `internal/{api,infra}` and `cli/commands/internal/client.go`, all slated for #202–#204.)

Minor note: `secret.Put` sets `description` only on create (update path uses `PutSecretValue`; `UpdateSecret` wasn't in the method set) — trivial to extend when #203 needs it.

## Verification
```
$ make test    # provider/aws/{param,secret,} tests pass
$ make lint     # 0 issues (incl. updated depguard)
$ CGO_ENABLED=1 go test -tags=production ./internal/gui/...   # ok
$ go test -tags e2e -run xxxNoMatch ./e2e/...                 # compiles
$ go build ./cmd/suve                                         # ok
# AWS SDK service imports only in internal/{api,infra,provider/aws} + pre-existing cli/commands/internal
```

## Acceptance criteria
- [x] AWS adapters implement the #199 interfaces; no AWS SDK type escapes `internal/provider/aws/**` (for the new code)
- [ ] `internal/api/*` re-export aliases gone — **deferred to #202–204** (consumers still use them)
- [ ] `infra` is the provider registry — **deferred to #204** (registry provided additively under provider/aws; `infra.NewXClient` still used)
- [x] `make test` green
- [x] `make lint` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)