### PR TITLE
feat: provider-specific parameter/secret options (typed per-provider mechanism)

### DIFF
--- a/internal/cli/commands/param/create/create.go
+++ b/internal/cli/commands/param/create/create.go
@@ -9,6 +9,7 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/cli/commands/internal"
+	"github.com/mpyw/suve/internal/cli/commands/param/paramopts"
 	"github.com/mpyw/suve/internal/cli/commands/param/paramtype"
 	"github.com/mpyw/suve/internal/cli/output"
 	awsparam "github.com/mpyw/suve/internal/provider/aws/param"
@@ -28,6 +29,9 @@ type Options struct {
 	Value       string
 	Type        string
 	Description string
+	// ParamOpts holds the raw AWS-specific option flag values (tier, data
+	// type, allowed pattern, policies). Empty fields contribute no option.
+	ParamOpts paramopts.Values
 }
 
 // Command returns the create command.
@@ -70,6 +74,22 @@ EXAMPLES:
 				Name:  "description",
 				Usage: "Parameter description",
 			},
+			&cli.StringFlag{
+				Name:  "tier",
+				Usage: "Parameter tier (Standard, Advanced, Intelligent-Tiering)",
+			},
+			&cli.StringFlag{
+				Name:  "data-type",
+				Usage: "Parameter data type (e.g. text, aws:ec2:image)",
+			},
+			&cli.StringFlag{
+				Name:  "allowed-pattern",
+				Usage: "Regular expression the value must match",
+			},
+			&cli.StringFlag{
+				Name:  "policies",
+				Usage: "Parameter policies as a JSON document",
+			},
 		},
 		Action: action,
 	}
@@ -92,6 +112,10 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		paramType = "SecureString"
 	}
 
+	if err := paramopts.ValidateTier(cmd.String("tier")); err != nil {
+		return err
+	}
+
 	client, err := internal.NewParamClient(ctx)
 	if err != nil {
 		return err
@@ -108,6 +132,12 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		Value:       cmd.Args().Get(1),
 		Type:        paramType,
 		Description: cmd.String("description"),
+		ParamOpts: paramopts.Values{
+			Tier:           cmd.String("tier"),
+			DataType:       cmd.String("data-type"),
+			AllowedPattern: cmd.String("allowed-pattern"),
+			Policies:       cmd.String("policies"),
+		},
 	})
 }
 
@@ -118,6 +148,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 		Value:       opts.Value,
 		Type:        paramtype.Parse(opts.Type),
 		Description: opts.Description,
+		Options:     paramopts.Build(opts.ParamOpts),
 	})
 	if err != nil {
 		return err

--- a/internal/cli/commands/param/create/create_test.go
+++ b/internal/cli/commands/param/create/create_test.go
@@ -10,8 +10,10 @@ import (
 
 	appcli "github.com/mpyw/suve/internal/cli/commands"
 	"github.com/mpyw/suve/internal/cli/commands/param/create"
+	"github.com/mpyw/suve/internal/cli/commands/param/paramopts"
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
+	awsparam "github.com/mpyw/suve/internal/provider/aws/param"
 	"github.com/mpyw/suve/internal/provider/providermock"
 	"github.com/mpyw/suve/internal/usecase/param"
 )
@@ -45,6 +47,79 @@ func TestCommand_Validation(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot use --secure with --type")
 	})
+
+	t.Run("invalid tier value", func(t *testing.T) {
+		t.Parallel()
+
+		app := appcli.MakeApp()
+		err := app.Run(t.Context(), []string{"suve", "param", "create", "--tier", "Bogus", "/app/param", "value"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid --tier")
+	})
+}
+
+func TestRun_WriteOptions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("set flags produce options", func(t *testing.T) {
+		t.Parallel()
+
+		var gotOpts []provider.WriteOption
+
+		store := &providermock.Store{
+			CreateFunc: func(
+				_ context.Context, _, _ string, _ domain.ValueType, _ string, opts ...provider.WriteOption,
+			) (domain.Version, error) {
+				gotOpts = opts
+
+				return domain.Version{ID: "1"}, nil
+			},
+		}
+
+		var buf, errBuf bytes.Buffer
+
+		r := &create.Runner{UseCase: &param.CreateUseCase{Writer: store}, Stdout: &buf, Stderr: &errBuf}
+		err := r.Run(t.Context(), create.Options{
+			Name:  "/app/param",
+			Value: "v",
+			Type:  "String",
+			ParamOpts: paramopts.Values{
+				Tier:           "Advanced",
+				DataType:       "text",
+				AllowedPattern: "^a",
+				Policies:       "[]",
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, gotOpts, 4)
+		assert.Contains(t, gotOpts, awsparam.Tier{Value: "Advanced"})
+		assert.Contains(t, gotOpts, awsparam.DataType{Value: "text"})
+		assert.Contains(t, gotOpts, awsparam.AllowedPattern{Value: "^a"})
+		assert.Contains(t, gotOpts, awsparam.Policies{JSON: "[]"})
+	})
+
+	t.Run("unset flags produce no options", func(t *testing.T) {
+		t.Parallel()
+
+		var gotOpts []provider.WriteOption
+
+		store := &providermock.Store{
+			CreateFunc: func(
+				_ context.Context, _, _ string, _ domain.ValueType, _ string, opts ...provider.WriteOption,
+			) (domain.Version, error) {
+				gotOpts = opts
+
+				return domain.Version{ID: "1"}, nil
+			},
+		}
+
+		var buf, errBuf bytes.Buffer
+
+		r := &create.Runner{UseCase: &param.CreateUseCase{Writer: store}, Stdout: &buf, Stderr: &errBuf}
+		err := r.Run(t.Context(), create.Options{Name: "/app/param", Value: "v", Type: "String"})
+		require.NoError(t, err)
+		assert.Empty(t, gotOpts)
+	})
 }
 
 func TestRun(t *testing.T) {
@@ -65,7 +140,7 @@ func TestRun(t *testing.T) {
 				Type:  "SecureString",
 			},
 			store: &providermock.Store{
-				CreateFunc: func(_ context.Context, name, value string, vt domain.ValueType, _ string) (domain.Version, error) {
+				CreateFunc: func(_ context.Context, name, value string, vt domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
 					assert.Equal(t, "/app/param", name)
 					assert.Equal(t, "test-value", value)
 					assert.Equal(t, domain.ValueTypeSecret, vt)
@@ -89,7 +164,7 @@ func TestRun(t *testing.T) {
 				Description: "Test description",
 			},
 			store: &providermock.Store{
-				CreateFunc: func(_ context.Context, _, _ string, _ domain.ValueType, description string) (domain.Version, error) {
+				CreateFunc: func(_ context.Context, _, _ string, _ domain.ValueType, description string, _ ...provider.WriteOption) (domain.Version, error) {
 					assert.Equal(t, "Test description", description)
 
 					return domain.Version{ID: "1"}, nil
@@ -103,7 +178,7 @@ func TestRun(t *testing.T) {
 			opts:    create.Options{Name: "/app/param", Value: "test-value", Type: "String"},
 			wantErr: "failed to create parameter",
 			store: &providermock.Store{
-				CreateFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string) (domain.Version, error) {
+				CreateFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
 					return domain.Version{}, provider.ErrAlreadyExists
 				},
 			},
@@ -113,7 +188,7 @@ func TestRun(t *testing.T) {
 			opts:    create.Options{Name: "/app/param", Value: "test-value", Type: "String"},
 			wantErr: "failed to create parameter",
 			store: &providermock.Store{
-				CreateFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string) (domain.Version, error) {
+				CreateFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
 					return domain.Version{}, assert.AnError
 				},
 			},

--- a/internal/cli/commands/param/delete/delete_test.go
+++ b/internal/cli/commands/param/delete/delete_test.go
@@ -10,6 +10,7 @@ import (
 
 	appcli "github.com/mpyw/suve/internal/cli/commands"
 	"github.com/mpyw/suve/internal/cli/commands/param/delete"
+	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/providermock"
 	"github.com/mpyw/suve/internal/usecase/param"
 )
@@ -40,7 +41,7 @@ func TestRun(t *testing.T) {
 			name: "delete parameter",
 			opts: delete.Options{Name: "/app/param"},
 			store: &providermock.Store{
-				DeleteFunc: func(_ context.Context, _ string) error {
+				DeleteFunc: func(_ context.Context, _ string, _ ...provider.DeleteOption) error {
 					return nil
 				},
 			},
@@ -54,7 +55,7 @@ func TestRun(t *testing.T) {
 			name: "error from AWS",
 			opts: delete.Options{Name: "/app/param"},
 			store: &providermock.Store{
-				DeleteFunc: func(_ context.Context, _ string) error {
+				DeleteFunc: func(_ context.Context, _ string, _ ...provider.DeleteOption) error {
 					return assert.AnError
 				},
 			},

--- a/internal/cli/commands/param/paramopts/paramopts.go
+++ b/internal/cli/commands/param/paramopts/paramopts.go
@@ -1,0 +1,63 @@
+// Package paramopts builds AWS Parameter Store provider write options from CLI
+// flag values, keeping the flag-to-option mapping in one place shared by the
+// param create and update commands. It also validates the --tier value.
+package paramopts
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/mpyw/suve/internal/provider"
+	awsparam "github.com/mpyw/suve/internal/provider/aws/param"
+)
+
+// SSM parameter tier names accepted by the --tier flag.
+const (
+	TierStandard           = "Standard"
+	TierAdvanced           = "Advanced"
+	TierIntelligentTiering = "Intelligent-Tiering"
+)
+
+// ValidateTier reports an error if tier is a non-empty, unrecognized value. An
+// empty tier is valid (it means "leave the tier unset").
+func ValidateTier(tier string) error {
+	validTiers := []string{TierStandard, TierAdvanced, TierIntelligentTiering}
+	if tier == "" || slices.Contains(validTiers, tier) {
+		return nil
+	}
+
+	return fmt.Errorf("invalid --tier %q (want one of %s, %s, %s)", tier, TierStandard, TierAdvanced, TierIntelligentTiering)
+}
+
+// Values holds the raw flag values for the provider-specific param options.
+type Values struct {
+	Tier           string
+	DataType       string
+	AllowedPattern string
+	Policies       string
+}
+
+// Build converts the set (non-empty) flag values into provider.WriteOptions.
+// Empty values contribute no option, so passing an all-empty Values yields nil
+// and preserves the exact behavior of the command when no flags are set.
+func Build(v Values) []provider.WriteOption {
+	var opts []provider.WriteOption
+
+	if v.Tier != "" {
+		opts = append(opts, awsparam.Tier{Value: v.Tier})
+	}
+
+	if v.DataType != "" {
+		opts = append(opts, awsparam.DataType{Value: v.DataType})
+	}
+
+	if v.AllowedPattern != "" {
+		opts = append(opts, awsparam.AllowedPattern{Value: v.AllowedPattern})
+	}
+
+	if v.Policies != "" {
+		opts = append(opts, awsparam.Policies{JSON: v.Policies})
+	}
+
+	return opts
+}

--- a/internal/cli/commands/param/paramopts/paramopts_test.go
+++ b/internal/cli/commands/param/paramopts/paramopts_test.go
@@ -1,0 +1,50 @@
+package paramopts_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/cli/commands/param/paramopts"
+	awsparam "github.com/mpyw/suve/internal/provider/aws/param"
+)
+
+func TestValidateTier(t *testing.T) {
+	t.Parallel()
+
+	for _, tier := range []string{"", "Standard", "Advanced", "Intelligent-Tiering"} {
+		require.NoError(t, paramopts.ValidateTier(tier))
+	}
+
+	err := paramopts.ValidateTier("Bogus")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid --tier")
+}
+
+func TestBuild(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty values yield no options", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Empty(t, paramopts.Build(paramopts.Values{}))
+	})
+
+	t.Run("set values map to typed options", func(t *testing.T) {
+		t.Parallel()
+
+		opts := paramopts.Build(paramopts.Values{
+			Tier:           "Advanced",
+			DataType:       "text",
+			AllowedPattern: "^a",
+			Policies:       "[]",
+		})
+
+		require.Len(t, opts, 4)
+		assert.Contains(t, opts, awsparam.Tier{Value: "Advanced"})
+		assert.Contains(t, opts, awsparam.DataType{Value: "text"})
+		assert.Contains(t, opts, awsparam.AllowedPattern{Value: "^a"})
+		assert.Contains(t, opts, awsparam.Policies{JSON: "[]"})
+	})
+}

--- a/internal/cli/commands/param/update/update.go
+++ b/internal/cli/commands/param/update/update.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mpyw/suve/internal/api/paramapi"
 	"github.com/mpyw/suve/internal/cli/commands/internal"
+	"github.com/mpyw/suve/internal/cli/commands/param/paramopts"
 	"github.com/mpyw/suve/internal/cli/commands/param/paramtype"
 	"github.com/mpyw/suve/internal/cli/confirm"
 	"github.com/mpyw/suve/internal/cli/output"
@@ -33,6 +34,9 @@ type Options struct {
 	Value       string
 	Type        string
 	Description string
+	// ParamOpts holds the raw AWS-specific option flag values (tier, data
+	// type, allowed pattern, policies). Empty fields contribute no option.
+	ParamOpts paramopts.Values
 }
 
 // Command returns the update command.
@@ -74,6 +78,22 @@ EXAMPLES:
 				Name:  "description",
 				Usage: "Parameter description",
 			},
+			&cli.StringFlag{
+				Name:  "tier",
+				Usage: "Parameter tier (Standard, Advanced, Intelligent-Tiering)",
+			},
+			&cli.StringFlag{
+				Name:  "data-type",
+				Usage: "Parameter data type (e.g. text, aws:ec2:image)",
+			},
+			&cli.StringFlag{
+				Name:  "allowed-pattern",
+				Usage: "Regular expression the value must match",
+			},
+			&cli.StringFlag{
+				Name:  "policies",
+				Usage: "Parameter policies as a JSON document",
+			},
 			&cli.BoolFlag{
 				Name:  "yes",
 				Usage: "Skip confirmation prompt",
@@ -98,6 +118,10 @@ func action(ctx context.Context, cmd *cli.Command) error {
 
 	if secure {
 		paramType = "SecureString"
+	}
+
+	if err := paramopts.ValidateTier(cmd.String("tier")); err != nil {
+		return err
 	}
 
 	name := cmd.Args().Get(0)
@@ -154,6 +178,12 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		Value:       newValue,
 		Type:        paramType,
 		Description: cmd.String("description"),
+		ParamOpts: paramopts.Values{
+			Tier:           cmd.String("tier"),
+			DataType:       cmd.String("data-type"),
+			AllowedPattern: cmd.String("allowed-pattern"),
+			Policies:       cmd.String("policies"),
+		},
 	})
 }
 
@@ -164,6 +194,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 		Value:       opts.Value,
 		Type:        paramtype.Parse(opts.Type),
 		Description: opts.Description,
+		Options:     paramopts.Build(opts.ParamOpts),
 	})
 	if err != nil {
 		return err

--- a/internal/cli/commands/param/update/update_test.go
+++ b/internal/cli/commands/param/update/update_test.go
@@ -9,9 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	appcli "github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/cli/commands/param/paramopts"
 	"github.com/mpyw/suve/internal/cli/commands/param/update"
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
+	awsparam "github.com/mpyw/suve/internal/provider/aws/param"
 	"github.com/mpyw/suve/internal/provider/providermock"
 	"github.com/mpyw/suve/internal/usecase/param"
 )
@@ -45,6 +47,81 @@ func TestCommand_Validation(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot use --secure with --type")
 	})
+
+	t.Run("invalid tier value", func(t *testing.T) {
+		t.Parallel()
+
+		app := appcli.MakeApp()
+		err := app.Run(t.Context(), []string{"suve", "param", "update", "--yes", "--tier", "Bogus", "/app/param", "value"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid --tier")
+	})
+}
+
+func TestRun_WriteOptions(t *testing.T) {
+	t.Parallel()
+
+	existsGet := func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+		return &domain.Entry{Name: name, Value: "old-value"}, nil
+	}
+
+	t.Run("set flags produce options", func(t *testing.T) {
+		t.Parallel()
+
+		var gotOpts []provider.WriteOption
+
+		store := &providermock.Store{
+			GetFunc: existsGet,
+			PutFunc: func(
+				_ context.Context, _, _ string, _ domain.ValueType, _ string, opts ...provider.WriteOption,
+			) (domain.Version, error) {
+				gotOpts = opts
+
+				return domain.Version{ID: "2"}, nil
+			},
+		}
+
+		var buf, errBuf bytes.Buffer
+
+		r := &update.Runner{UseCase: &param.UpdateUseCase{Store: store}, Stdout: &buf, Stderr: &errBuf}
+		err := r.Run(t.Context(), update.Options{
+			Name:  "/app/param",
+			Value: "v",
+			Type:  "String",
+			ParamOpts: paramopts.Values{
+				Tier:     "Intelligent-Tiering",
+				DataType: "text",
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, gotOpts, 2)
+		assert.Contains(t, gotOpts, awsparam.Tier{Value: "Intelligent-Tiering"})
+		assert.Contains(t, gotOpts, awsparam.DataType{Value: "text"})
+	})
+
+	t.Run("unset flags produce no options", func(t *testing.T) {
+		t.Parallel()
+
+		var gotOpts []provider.WriteOption
+
+		store := &providermock.Store{
+			GetFunc: existsGet,
+			PutFunc: func(
+				_ context.Context, _, _ string, _ domain.ValueType, _ string, opts ...provider.WriteOption,
+			) (domain.Version, error) {
+				gotOpts = opts
+
+				return domain.Version{ID: "2"}, nil
+			},
+		}
+
+		var buf, errBuf bytes.Buffer
+
+		r := &update.Runner{UseCase: &param.UpdateUseCase{Store: store}, Stdout: &buf, Stderr: &errBuf}
+		err := r.Run(t.Context(), update.Options{Name: "/app/param", Value: "v", Type: "String"})
+		require.NoError(t, err)
+		assert.Empty(t, gotOpts)
+	})
 }
 
 func TestRun(t *testing.T) {
@@ -71,7 +148,7 @@ func TestRun(t *testing.T) {
 			},
 			store: &providermock.Store{
 				GetFunc: existsGet,
-				PutFunc: func(_ context.Context, name, value string, vt domain.ValueType, _ string) (domain.Version, error) {
+				PutFunc: func(_ context.Context, name, value string, vt domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
 					assert.Equal(t, "/app/param", name)
 					assert.Equal(t, "test-value", value)
 					assert.Equal(t, domain.ValueTypeSecret, vt)
@@ -96,7 +173,7 @@ func TestRun(t *testing.T) {
 			},
 			store: &providermock.Store{
 				GetFunc: existsGet,
-				PutFunc: func(_ context.Context, _, _ string, _ domain.ValueType, description string) (domain.Version, error) {
+				PutFunc: func(_ context.Context, _, _ string, _ domain.ValueType, description string, _ ...provider.WriteOption) (domain.Version, error) {
 					assert.Equal(t, "Test description", description)
 
 					return domain.Version{ID: "2"}, nil
@@ -119,7 +196,7 @@ func TestRun(t *testing.T) {
 			wantErr: "failed to update parameter",
 			store: &providermock.Store{
 				GetFunc: existsGet,
-				PutFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string) (domain.Version, error) {
+				PutFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
 					return domain.Version{}, assert.AnError
 				},
 			},

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -35,6 +35,19 @@ type Version struct {
 // Tag is a single key/value label attached to an entry.
 type Tag struct{ Key, Value string }
 
+// Field is a neutral, display-only piece of provider metadata surfaced on a
+// read Entry (e.g. an AWS Secrets Manager ARN). It carries a human-facing Label
+// and a pre-formatted string Value only: it is deliberately provider-neutral in
+// SHAPE (no AWS types, no any) so the usecase/CLI layers can render it without
+// knowing which provider produced it. Providers populate Entry.Extra; consumers
+// display it verbatim and never interpret it.
+type Field struct {
+	// Label is the human-facing field name (e.g. "ARN").
+	Label string
+	// Value is the pre-formatted display value.
+	Value string
+}
+
 // TagChange describes staged tag mutations (add/update + remove-by-key).
 type TagChange struct {
 	// Add holds tags to create or update, keyed by tag key.
@@ -60,4 +73,9 @@ type Entry struct {
 	Tags []Tag
 	// Modified is the last-modified time, if known.
 	Modified *time.Time
+	// Extra holds provider-populated, display-only metadata (e.g. an AWS
+	// Secrets Manager ARN). Its SHAPE is provider-neutral: a list of neutral
+	// Field values, never AWS types or an untyped any. Providers may leave it
+	// empty when they have no extra metadata to surface.
+	Extra []Field
 }

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/mpyw/suve/internal/domain"
 )
@@ -39,6 +40,30 @@ func TestEntry_Fields(t *testing.T) {
 	assert.Len(t, entry.Tags, 1)
 	assert.Equal(t, "env", entry.Tags[0].Key)
 	assert.Equal(t, &modified, entry.Modified)
+}
+
+func TestEntry_Extra(t *testing.T) {
+	t.Parallel()
+
+	entry := domain.Entry{
+		Name: "my-secret",
+		Extra: []domain.Field{
+			{Label: "ARN", Value: "arn:aws:secretsmanager:us-east-1:123:secret:my-secret"},
+		},
+	}
+
+	require.Len(t, entry.Extra, 1)
+	assert.Equal(t, "ARN", entry.Extra[0].Label)
+	assert.Equal(t, "arn:aws:secretsmanager:us-east-1:123:secret:my-secret", entry.Extra[0].Value)
+}
+
+func TestField_Construction(t *testing.T) {
+	t.Parallel()
+
+	f := domain.Field{Label: "Tier", Value: "Advanced"}
+
+	assert.Equal(t, "Tier", f.Label)
+	assert.Equal(t, "Advanced", f.Value)
 }
 
 func TestValueType_Values(t *testing.T) {

--- a/internal/provider/aws/param/options.go
+++ b/internal/provider/aws/param/options.go
@@ -1,0 +1,75 @@
+package param
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+
+	"github.com/mpyw/suve/internal/provider"
+)
+
+// Tier sets the SSM parameter tier (Standard, Advanced, or
+// Intelligent-Tiering). It implements provider.WriteOption.
+type Tier struct {
+	provider.WriteOptionMarker
+
+	Value string
+}
+
+// DataType sets the SSM parameter data type (e.g. "text" or "aws:ec2:image").
+// It implements provider.WriteOption.
+type DataType struct {
+	provider.WriteOptionMarker
+
+	Value string
+}
+
+// AllowedPattern sets a regular expression the parameter value must match. It
+// implements provider.WriteOption.
+type AllowedPattern struct {
+	provider.WriteOptionMarker
+
+	Value string
+}
+
+// Policies sets the parameter policies as a JSON document (expiration,
+// no-change notification, etc.). It implements provider.WriteOption.
+type Policies struct {
+	provider.WriteOptionMarker
+
+	JSON string
+}
+
+// Compile-time assertions that the param write options satisfy the marker.
+var (
+	_ provider.WriteOption = Tier{}
+	_ provider.WriteOption = DataType{}
+	_ provider.WriteOption = AllowedPattern{}
+	_ provider.WriteOption = Policies{}
+)
+
+// applyWriteOptions folds the recognized WriteOptions onto a PutParameterInput.
+// Unknown options are ignored, per the provider.WriteOption pass-through
+// contract. Empty option values are treated as unset.
+func applyWriteOptions(input *ssm.PutParameterInput, opts []provider.WriteOption) {
+	for _, opt := range opts {
+		switch o := opt.(type) {
+		case Tier:
+			if o.Value != "" {
+				input.Tier = types.ParameterTier(o.Value)
+			}
+		case DataType:
+			if o.Value != "" {
+				input.DataType = aws.String(o.Value)
+			}
+		case AllowedPattern:
+			if o.Value != "" {
+				input.AllowedPattern = aws.String(o.Value)
+			}
+		case Policies:
+			if o.JSON != "" {
+				input.Policies = aws.String(o.JSON)
+			}
+		}
+	}
+}

--- a/internal/provider/aws/param/param.go
+++ b/internal/provider/aws/param/param.go
@@ -213,7 +213,7 @@ func (s *Store) List(ctx context.Context) ([]string, error) {
 // version. It returns a wrapped provider.ErrAlreadyExists if the parameter
 // already exists.
 func (s *Store) Create(
-	ctx context.Context, name, value string, valueType domain.ValueType, description string,
+	ctx context.Context, name, value string, valueType domain.ValueType, description string, opts ...provider.WriteOption,
 ) (domain.Version, error) {
 	input := &ssm.PutParameterInput{
 		Name:      aws.String(name),
@@ -224,6 +224,8 @@ func (s *Store) Create(
 	if description != "" {
 		input.Description = aws.String(description)
 	}
+
+	applyWriteOptions(input, opts)
 
 	out, err := s.client.PutParameter(ctx, input)
 	if err != nil {
@@ -240,7 +242,7 @@ func (s *Store) Create(
 
 // Put creates or updates a parameter (Overwrite=true) and returns the resulting version.
 func (s *Store) Put(
-	ctx context.Context, name, value string, valueType domain.ValueType, description string,
+	ctx context.Context, name, value string, valueType domain.ValueType, description string, opts ...provider.WriteOption,
 ) (domain.Version, error) {
 	input := &ssm.PutParameterInput{
 		Name:      aws.String(name),
@@ -252,6 +254,8 @@ func (s *Store) Put(
 		input.Description = aws.String(description)
 	}
 
+	applyWriteOptions(input, opts)
+
 	out, err := s.client.PutParameter(ctx, input)
 	if err != nil {
 		return domain.Version{}, fmt.Errorf("failed to put parameter: %w", err)
@@ -260,8 +264,9 @@ func (s *Store) Put(
 	return domain.Version{ID: strconv.FormatInt(out.Version, 10)}, nil
 }
 
-// Delete removes a parameter.
-func (s *Store) Delete(ctx context.Context, name string) error {
+// Delete removes a parameter. Parameter Store exposes no delete options, so any
+// provided DeleteOptions are ignored.
+func (s *Store) Delete(ctx context.Context, name string, _ ...provider.DeleteOption) error {
 	_, err := s.client.DeleteParameter(ctx, &ssm.DeleteParameterInput{
 		Name: aws.String(name),
 	})

--- a/internal/provider/aws/param/param_test.go
+++ b/internal/provider/aws/param/param_test.go
@@ -278,6 +278,64 @@ func TestPut_MapsTypeAndReturnsVersion(t *testing.T) {
 	assert.Equal(t, "desc", aws.ToString(got.Description))
 }
 
+func TestCreate_AppliesWriteOptions(t *testing.T) {
+	t.Parallel()
+
+	var got *ssm.PutParameterInput
+
+	store := param.New(&mockClient{
+		putParameter: func(in *ssm.PutParameterInput) (*ssm.PutParameterOutput, error) {
+			got = in
+
+			return &ssm.PutParameterOutput{Version: 1}, nil
+		},
+	})
+
+	_, err := store.Create(t.Context(), "/my/param", "v", domain.ValueTypePlaintext, "",
+		param.Tier{Value: "Advanced"},
+		param.DataType{Value: "aws:ec2:image"},
+		param.AllowedPattern{Value: "^ami-"},
+		param.Policies{JSON: `[{"Type":"Expiration"}]`},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, types.ParameterTierAdvanced, got.Tier)
+	assert.Equal(t, "aws:ec2:image", aws.ToString(got.DataType))
+	assert.Equal(t, "^ami-", aws.ToString(got.AllowedPattern))
+	assert.JSONEq(t, `[{"Type":"Expiration"}]`, aws.ToString(got.Policies))
+}
+
+func TestPut_AppliesWriteOptionsAndIgnoresUnknown(t *testing.T) {
+	t.Parallel()
+
+	var got *ssm.PutParameterInput
+
+	store := param.New(&mockClient{
+		putParameter: func(in *ssm.PutParameterInput) (*ssm.PutParameterOutput, error) {
+			got = in
+
+			return &ssm.PutParameterOutput{Version: 2}, nil
+		},
+	})
+
+	// unknownOption is not one this adapter understands; it must be ignored.
+	_, err := store.Put(t.Context(), "/my/param", "v", domain.ValueTypePlaintext, "",
+		param.Tier{Value: "Intelligent-Tiering"},
+		unknownOption{},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, types.ParameterTierIntelligentTiering, got.Tier)
+	// Options that were not provided stay unset.
+	assert.Nil(t, got.DataType)
+	assert.Nil(t, got.AllowedPattern)
+	assert.Nil(t, got.Policies)
+}
+
+// unknownOption is a WriteOption the param adapter does not recognize; it
+// exercises the "ignore unknown options" branch of the pass-through contract.
+type unknownOption struct{ provider.WriteOptionMarker }
+
 func TestDelete(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/aws/secret/options.go
+++ b/internal/provider/aws/secret/options.go
@@ -1,0 +1,103 @@
+package secret
+
+import (
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+
+	"github.com/mpyw/suve/internal/provider"
+)
+
+// KMSKeyID sets the KMS key (ID or ARN) used to encrypt the secret value. It
+// implements provider.WriteOption.
+type KMSKeyID struct {
+	provider.WriteOptionMarker
+
+	Value string
+}
+
+// RotationRules configures automatic rotation for the secret. It is modeled
+// minimally (rotation interval in days); it implements provider.WriteOption.
+type RotationRules struct {
+	provider.WriteOptionMarker
+
+	// AutomaticallyAfterDays is the number of days between automatic rotations.
+	// A zero value leaves rotation unconfigured.
+	AutomaticallyAfterDays int64
+}
+
+// ForceDelete deletes the secret immediately, without a recovery window
+// (ForceDeleteWithoutRecovery). It implements provider.DeleteOption.
+type ForceDelete struct {
+	provider.DeleteOptionMarker
+}
+
+// RecoveryWindow sets the number of days AWS retains the secret before
+// permanent deletion. It implements provider.DeleteOption.
+type RecoveryWindow struct {
+	provider.DeleteOptionMarker
+
+	Days int64
+}
+
+// Compile-time assertions that the secret options satisfy the markers.
+var (
+	_ provider.WriteOption  = KMSKeyID{}
+	_ provider.WriteOption  = RotationRules{}
+	_ provider.DeleteOption = ForceDelete{}
+	_ provider.DeleteOption = RecoveryWindow{}
+)
+
+// applyCreateOptions folds recognized WriteOptions onto a CreateSecretInput.
+func applyCreateOptions(input *secretsmanager.CreateSecretInput, opts []provider.WriteOption) {
+	for _, opt := range opts {
+		if k, ok := opt.(KMSKeyID); ok && k.Value != "" {
+			input.KmsKeyId = aws.String(k.Value)
+		}
+	}
+}
+
+// applyUpdateOptions folds recognized WriteOptions onto an UpdateSecretInput.
+func applyUpdateOptions(input *secretsmanager.UpdateSecretInput, opts []provider.WriteOption) {
+	for _, opt := range opts {
+		if k, ok := opt.(KMSKeyID); ok && k.Value != "" {
+			input.KmsKeyId = aws.String(k.Value)
+		}
+	}
+}
+
+// rotationOption returns the RotationRules option if one with a non-zero
+// interval was provided, so callers can issue a RotateSecret request.
+func rotationOption(opts []provider.WriteOption) (RotationRules, bool) {
+	for _, opt := range opts {
+		if r, ok := opt.(RotationRules); ok && r.AutomaticallyAfterDays > 0 {
+			return r, true
+		}
+	}
+
+	return RotationRules{}, false
+}
+
+// applyDeleteOptions folds recognized DeleteOptions onto a DeleteSecretInput.
+func applyDeleteOptions(input *secretsmanager.DeleteSecretInput, opts []provider.DeleteOption) {
+	for _, opt := range opts {
+		switch o := opt.(type) {
+		case ForceDelete:
+			input.ForceDeleteWithoutRecovery = aws.Bool(true)
+		case RecoveryWindow:
+			if o.Days > 0 {
+				input.RecoveryWindowInDays = aws.Int64(o.Days)
+			}
+		}
+	}
+}
+
+// rotationInput builds a RotateSecretInput for the given secret and rules.
+func rotationInput(name string, rules RotationRules) *secretsmanager.RotateSecretInput {
+	return &secretsmanager.RotateSecretInput{
+		SecretId: aws.String(name),
+		RotationRules: &types.RotationRulesType{
+			AutomaticallyAfterDays: aws.Int64(rules.AutomaticallyAfterDays),
+		},
+	}
+}

--- a/internal/provider/aws/secret/secret.go
+++ b/internal/provider/aws/secret/secret.go
@@ -24,6 +24,8 @@ import (
 
 // Client is the narrow Secrets Manager surface this adapter needs. The concrete
 // *secretsmanager.Client satisfies it; tests provide their own mock.
+//
+//nolint:interfacebloat // mirrors the Secrets Manager operations this adapter uses; splitting adds no value
 type Client interface {
 	GetSecretValue(
 		ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options),
@@ -37,9 +39,12 @@ type Client interface {
 	CreateSecret(
 		ctx context.Context, params *secretsmanager.CreateSecretInput, optFns ...func(*secretsmanager.Options),
 	) (*secretsmanager.CreateSecretOutput, error)
-	PutSecretValue(
-		ctx context.Context, params *secretsmanager.PutSecretValueInput, optFns ...func(*secretsmanager.Options),
-	) (*secretsmanager.PutSecretValueOutput, error)
+	UpdateSecret(
+		ctx context.Context, params *secretsmanager.UpdateSecretInput, optFns ...func(*secretsmanager.Options),
+	) (*secretsmanager.UpdateSecretOutput, error)
+	RotateSecret(
+		ctx context.Context, params *secretsmanager.RotateSecretInput, optFns ...func(*secretsmanager.Options),
+	) (*secretsmanager.RotateSecretOutput, error)
 	DeleteSecret(
 		ctx context.Context, params *secretsmanager.DeleteSecretInput, optFns ...func(*secretsmanager.Options),
 	) (*secretsmanager.DeleteSecretOutput, error)
@@ -197,6 +202,7 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 			Created: out.CreatedDate,
 		},
 		Modified: out.CreatedDate,
+		Extra:    []domain.Field{{Label: "ARN", Value: aws.ToString(out.ARN)}},
 	}
 
 	// Description and tags are best-effort via DescribeSecret.
@@ -266,7 +272,7 @@ func (s *Store) List(ctx context.Context) ([]string, error) {
 // writes a new version of an existing secret). The valueType is ignored
 // (Secrets Manager values are always secret).
 func (s *Store) Create(
-	ctx context.Context, name, value string, _ domain.ValueType, description string,
+	ctx context.Context, name, value string, _ domain.ValueType, description string, opts ...provider.WriteOption,
 ) (domain.Version, error) {
 	input := &secretsmanager.CreateSecretInput{
 		Name:         aws.String(name),
@@ -275,6 +281,8 @@ func (s *Store) Create(
 	if description != "" {
 		input.Description = aws.String(description)
 	}
+
+	applyCreateOptions(input, opts)
 
 	created, err := s.client.CreateSecret(ctx, input)
 	if err != nil {
@@ -286,14 +294,19 @@ func (s *Store) Create(
 		return domain.Version{}, fmt.Errorf("failed to create secret: %w", err)
 	}
 
+	if err := s.applyRotation(ctx, name, opts); err != nil {
+		return domain.Version{}, err
+	}
+
 	return domain.Version{ID: aws.ToString(created.VersionId)}, nil
 }
 
-// Put creates the secret, or writes a new version if it already exists. The
-// valueType is ignored (Secrets Manager values are always secret). A
-// description is applied only on creation.
+// Put creates the secret, or updates it (new version + metadata) if it already
+// exists. The valueType is ignored (Secrets Manager values are always secret).
+// On an existing secret the description is updated as well (via UpdateSecret),
+// unlike Create which is create-only.
 func (s *Store) Put(
-	ctx context.Context, name, value string, _ domain.ValueType, description string,
+	ctx context.Context, name, value string, _ domain.ValueType, description string, opts ...provider.WriteOption,
 ) (domain.Version, error) {
 	createInput := &secretsmanager.CreateSecretInput{
 		Name:         aws.String(name),
@@ -303,33 +316,71 @@ func (s *Store) Put(
 		createInput.Description = aws.String(description)
 	}
 
+	applyCreateOptions(createInput, opts)
+
 	created, err := s.client.CreateSecret(ctx, createInput)
 	if err == nil {
+		if err := s.applyRotation(ctx, name, opts); err != nil {
+			return domain.Version{}, err
+		}
+
 		return domain.Version{ID: aws.ToString(created.VersionId)}, nil
 	}
 
-	// Already exists: write a new version instead.
+	// Already exists: update the value (new version) and metadata in one call.
 	var exists *types.ResourceExistsException
 	if !errors.As(err, &exists) {
 		return domain.Version{}, fmt.Errorf("failed to create secret: %w", err)
 	}
 
-	put, err := s.client.PutSecretValue(ctx, &secretsmanager.PutSecretValueInput{
+	updateInput := &secretsmanager.UpdateSecretInput{
 		SecretId:     aws.String(name),
 		SecretString: aws.String(value),
-	})
-	if err != nil {
-		return domain.Version{}, fmt.Errorf("failed to put secret value: %w", err)
+	}
+	if description != "" {
+		updateInput.Description = aws.String(description)
 	}
 
-	return domain.Version{ID: aws.ToString(put.VersionId)}, nil
+	applyUpdateOptions(updateInput, opts)
+
+	updated, err := s.client.UpdateSecret(ctx, updateInput)
+	if err != nil {
+		return domain.Version{}, fmt.Errorf("failed to update secret: %w", err)
+	}
+
+	if err := s.applyRotation(ctx, name, opts); err != nil {
+		return domain.Version{}, err
+	}
+
+	return domain.Version{ID: aws.ToString(updated.VersionId)}, nil
 }
 
-// Delete schedules a secret for deletion (default recovery window).
-func (s *Store) Delete(ctx context.Context, name string) error {
-	_, err := s.client.DeleteSecret(ctx, &secretsmanager.DeleteSecretInput{
+// applyRotation issues a RotateSecret request when a RotationRules option with a
+// non-zero interval was provided; otherwise it is a no-op.
+func (s *Store) applyRotation(ctx context.Context, name string, opts []provider.WriteOption) error {
+	rules, ok := rotationOption(opts)
+	if !ok {
+		return nil
+	}
+
+	if _, err := s.client.RotateSecret(ctx, rotationInput(name, rules)); err != nil {
+		return fmt.Errorf("failed to configure secret rotation: %w", err)
+	}
+
+	return nil
+}
+
+// Delete schedules a secret for deletion. DeleteOptions select immediate
+// deletion (ForceDelete) or a custom recovery window (RecoveryWindow); with no
+// options the AWS default recovery window applies.
+func (s *Store) Delete(ctx context.Context, name string, opts ...provider.DeleteOption) error {
+	input := &secretsmanager.DeleteSecretInput{
 		SecretId: aws.String(name),
-	})
+	}
+
+	applyDeleteOptions(input, opts)
+
+	_, err := s.client.DeleteSecret(ctx, input)
 	if err != nil {
 		return fmt.Errorf("failed to delete secret: %w", err)
 	}
@@ -370,6 +421,7 @@ func (s *Store) Describe(ctx context.Context, name string) (*domain.Entry, error
 		Description: aws.ToString(desc.Description),
 		Tags:        mapTags(desc.Tags),
 		Modified:    desc.LastChangedDate,
+		Extra:       []domain.Field{{Label: "ARN", Value: aws.ToString(desc.ARN)}},
 	}
 
 	// Best-effort: surface the current (AWSCURRENT) version if present.

--- a/internal/provider/aws/secret/secret_test.go
+++ b/internal/provider/aws/secret/secret_test.go
@@ -22,7 +22,8 @@ type mockClient struct {
 	listVersion func(*secretsmanager.ListSecretVersionIdsInput) (*secretsmanager.ListSecretVersionIdsOutput, error)
 	describe    func(*secretsmanager.DescribeSecretInput) (*secretsmanager.DescribeSecretOutput, error)
 	create      func(*secretsmanager.CreateSecretInput) (*secretsmanager.CreateSecretOutput, error)
-	putValue    func(*secretsmanager.PutSecretValueInput) (*secretsmanager.PutSecretValueOutput, error)
+	updateSec   func(*secretsmanager.UpdateSecretInput) (*secretsmanager.UpdateSecretOutput, error)
+	rotate      func(*secretsmanager.RotateSecretInput) (*secretsmanager.RotateSecretOutput, error)
 	deleteSec   func(*secretsmanager.DeleteSecretInput) (*secretsmanager.DeleteSecretOutput, error)
 	restore     func(*secretsmanager.RestoreSecretInput) (*secretsmanager.RestoreSecretOutput, error)
 	tag         func(*secretsmanager.TagResourceInput) (*secretsmanager.TagResourceOutput, error)
@@ -55,10 +56,16 @@ func (m *mockClient) CreateSecret(
 	return m.create(in)
 }
 
-func (m *mockClient) PutSecretValue(
-	_ context.Context, in *secretsmanager.PutSecretValueInput, _ ...func(*secretsmanager.Options),
-) (*secretsmanager.PutSecretValueOutput, error) {
-	return m.putValue(in)
+func (m *mockClient) UpdateSecret(
+	_ context.Context, in *secretsmanager.UpdateSecretInput, _ ...func(*secretsmanager.Options),
+) (*secretsmanager.UpdateSecretOutput, error) {
+	return m.updateSec(in)
+}
+
+func (m *mockClient) RotateSecret(
+	_ context.Context, in *secretsmanager.RotateSecretInput, _ ...func(*secretsmanager.Options),
+) (*secretsmanager.RotateSecretOutput, error) {
+	return m.rotate(in)
 }
 
 func (m *mockClient) DeleteSecret(
@@ -282,26 +289,29 @@ func TestPut_CreateWhenNew(t *testing.T) {
 	assert.Equal(t, "desc", aws.ToString(createIn.Description))
 }
 
-func TestPut_PutsNewVersionWhenExists(t *testing.T) {
+func TestPut_UpdatesWhenExists(t *testing.T) {
 	t.Parallel()
 
-	var putCalled bool
+	var updateIn *secretsmanager.UpdateSecretInput
 
 	store := secret.New(&mockClient{
 		create: func(_ *secretsmanager.CreateSecretInput) (*secretsmanager.CreateSecretOutput, error) {
 			return nil, &types.ResourceExistsException{Message: aws.String("exists")}
 		},
-		putValue: func(_ *secretsmanager.PutSecretValueInput) (*secretsmanager.PutSecretValueOutput, error) {
-			putCalled = true
+		updateSec: func(in *secretsmanager.UpdateSecretInput) (*secretsmanager.UpdateSecretOutput, error) {
+			updateIn = in
 
-			return &secretsmanager.PutSecretValueOutput{VersionId: aws.String("ver-2")}, nil
+			return &secretsmanager.UpdateSecretOutput{VersionId: aws.String("ver-2")}, nil
 		},
 	})
 
-	v, err := store.Put(t.Context(), "my-secret", "val", domain.ValueTypeSecret, "")
+	// Put on an existing secret updates both value and description in one call.
+	v, err := store.Put(t.Context(), "my-secret", "val", domain.ValueTypeSecret, "new desc")
 	require.NoError(t, err)
-	assert.True(t, putCalled)
 	assert.Equal(t, "ver-2", v.ID)
+	require.NotNil(t, updateIn)
+	assert.Equal(t, "val", aws.ToString(updateIn.SecretString))
+	assert.Equal(t, "new desc", aws.ToString(updateIn.Description))
 }
 
 func TestDelete(t *testing.T) {
@@ -319,6 +329,101 @@ func TestDelete(t *testing.T) {
 
 	require.NoError(t, store.Delete(t.Context(), "my-secret"))
 	assert.Equal(t, "my-secret", gotID)
+}
+
+func TestDelete_ForceDelete(t *testing.T) {
+	t.Parallel()
+
+	var in *secretsmanager.DeleteSecretInput
+
+	store := secret.New(&mockClient{
+		deleteSec: func(got *secretsmanager.DeleteSecretInput) (*secretsmanager.DeleteSecretOutput, error) {
+			in = got
+
+			return &secretsmanager.DeleteSecretOutput{}, nil
+		},
+	})
+
+	require.NoError(t, store.Delete(t.Context(), "my-secret", secret.ForceDelete{}))
+	require.NotNil(t, in)
+	assert.True(t, aws.ToBool(in.ForceDeleteWithoutRecovery))
+	assert.Nil(t, in.RecoveryWindowInDays)
+}
+
+func TestDelete_RecoveryWindow(t *testing.T) {
+	t.Parallel()
+
+	var in *secretsmanager.DeleteSecretInput
+
+	store := secret.New(&mockClient{
+		deleteSec: func(got *secretsmanager.DeleteSecretInput) (*secretsmanager.DeleteSecretOutput, error) {
+			in = got
+
+			return &secretsmanager.DeleteSecretOutput{}, nil
+		},
+	})
+
+	require.NoError(t, store.Delete(t.Context(), "my-secret", secret.RecoveryWindow{Days: 14}))
+	require.NotNil(t, in)
+	assert.Equal(t, int64(14), aws.ToInt64(in.RecoveryWindowInDays))
+	assert.Nil(t, in.ForceDeleteWithoutRecovery)
+}
+
+func TestGet_PopulatesExtraARN(t *testing.T) {
+	t.Parallel()
+
+	store := secret.New(&mockClient{
+		getValue: func(*secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+			return &secretsmanager.GetSecretValueOutput{
+				Name:         aws.String("my-secret"),
+				ARN:          aws.String("arn:aws:secretsmanager:us-east-1:123:secret:my-secret-AbCdEf"),
+				SecretString: aws.String("val"),
+				VersionId:    aws.String("id-3"),
+			}, nil
+		},
+		describe: func(*secretsmanager.DescribeSecretInput) (*secretsmanager.DescribeSecretOutput, error) {
+			return &secretsmanager.DescribeSecretOutput{}, nil
+		},
+	})
+
+	entry, err := store.Get(t.Context(), "my-secret", provider.VersionRef{})
+	require.NoError(t, err)
+	require.Len(t, entry.Extra, 1)
+	assert.Equal(t, "ARN", entry.Extra[0].Label)
+	assert.Equal(t, "arn:aws:secretsmanager:us-east-1:123:secret:my-secret-AbCdEf", entry.Extra[0].Value)
+}
+
+func TestCreate_AppliesKMSKeyAndRotation(t *testing.T) {
+	t.Parallel()
+
+	var (
+		createIn *secretsmanager.CreateSecretInput
+		rotateIn *secretsmanager.RotateSecretInput
+	)
+
+	store := secret.New(&mockClient{
+		create: func(in *secretsmanager.CreateSecretInput) (*secretsmanager.CreateSecretOutput, error) {
+			createIn = in
+
+			return &secretsmanager.CreateSecretOutput{VersionId: aws.String("new-id")}, nil
+		},
+		rotate: func(in *secretsmanager.RotateSecretInput) (*secretsmanager.RotateSecretOutput, error) {
+			rotateIn = in
+
+			return &secretsmanager.RotateSecretOutput{}, nil
+		},
+	})
+
+	_, err := store.Create(t.Context(), "my-secret", "val", domain.ValueTypeSecret, "",
+		secret.KMSKeyID{Value: "alias/my-key"},
+		secret.RotationRules{AutomaticallyAfterDays: 30},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, createIn)
+	assert.Equal(t, "alias/my-key", aws.ToString(createIn.KmsKeyId))
+	require.NotNil(t, rotateIn)
+	require.NotNil(t, rotateIn.RotationRules)
+	assert.Equal(t, int64(30), aws.ToInt64(rotateIn.RotationRules.AutomaticallyAfterDays))
 }
 
 func TestRestore(t *testing.T) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -28,6 +28,41 @@ func (r VersionRef) ID() string { return r.id }
 // IsLatest reports whether the ref denotes the latest/current version.
 func (r VersionRef) IsLatest() bool { return r.id == "" }
 
+// WriteOption is a provider-interpreted functional option for create/update
+// operations. Providers define concrete option types (e.g. AWS param Tier or
+// DataType) that satisfy this marker by embedding WriteOptionMarker.
+//
+// Consumers (usecases, CLI) build and pass these options through WITHOUT
+// type-asserting them; the provider adapter type-switches over the options it
+// understands and silently ignores the rest. This keeps provider-specific
+// options out of the neutral domain model while remaining strongly typed.
+//
+// The marker method is unexported, so the WriteOption set stays closed to types
+// that embed WriteOptionMarker; arbitrary external types cannot masquerade as
+// options.
+type WriteOption interface{ writeOption() }
+
+// WriteOptionMarker is embedded by provider-specific option types to satisfy
+// WriteOption. Embedding it (rather than defining the unexported method in
+// each provider package, which Go forbids across packages) is what lets the
+// AWS adapters declare their own option types against this sealed interface.
+type WriteOptionMarker struct{}
+
+func (WriteOptionMarker) writeOption() {}
+
+// DeleteOption is a provider-interpreted functional option for delete
+// operations (e.g. AWS Secrets Manager ForceDelete / RecoveryWindow). It
+// follows the same pass-through contract as WriteOption: consumers pass options
+// through untyped and the adapter interprets the ones it recognizes. Concrete
+// options satisfy it by embedding DeleteOptionMarker.
+type DeleteOption interface{ deleteOption() }
+
+// DeleteOptionMarker is embedded by provider-specific delete-option types to
+// satisfy DeleteOption. See WriteOptionMarker for the rationale.
+type DeleteOptionMarker struct{}
+
+func (DeleteOptionMarker) deleteOption() {}
+
 // Reader provides read access to a provider's entries.
 type Reader interface {
 	// Resolve parses a provider-specific version spec string (e.g. "#3~1",
@@ -46,13 +81,20 @@ type Reader interface {
 type Writer interface {
 	// Create creates a new entry and returns the resulting version. It returns
 	// a wrapped ErrAlreadyExists if an entry with the same name already exists
-	// (it never overwrites).
-	Create(ctx context.Context, name, value string, valueType domain.ValueType, description string) (domain.Version, error)
+	// (it never overwrites). Provider-specific WriteOptions are interpreted by
+	// the adapter and ignored when unrecognized.
+	Create(
+		ctx context.Context, name, value string, valueType domain.ValueType, description string, opts ...WriteOption,
+	) (domain.Version, error)
 	// Put creates or updates an entry (upsert) and returns the resulting
-	// version. Unlike Create it overwrites an existing entry.
-	Put(ctx context.Context, name, value string, valueType domain.ValueType, description string) (domain.Version, error)
-	// Delete removes an entry.
-	Delete(ctx context.Context, name string) error
+	// version. Unlike Create it overwrites an existing entry. Provider-specific
+	// WriteOptions are interpreted by the adapter and ignored when unrecognized.
+	Put(
+		ctx context.Context, name, value string, valueType domain.ValueType, description string, opts ...WriteOption,
+	) (domain.Version, error)
+	// Delete removes an entry. Provider-specific DeleteOptions are interpreted
+	// by the adapter and ignored when unrecognized.
+	Delete(ctx context.Context, name string, opts ...DeleteOption) error
 }
 
 // Tagger provides tag mutation for a provider's entries.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -34,3 +34,21 @@ func TestNewVersionRef_EmptyIDIsLatest(t *testing.T) {
 	assert.True(t, ref.IsLatest())
 	assert.Empty(t, ref.ID())
 }
+
+// sampleWriteOption / sampleDeleteOption prove the marker interfaces are
+// satisfiable from outside the provider package by embedding the markers.
+type sampleWriteOption struct{ provider.WriteOptionMarker }
+
+type sampleDeleteOption struct{ provider.DeleteOptionMarker }
+
+func TestOptionMarkers_SatisfyInterfaces(t *testing.T) {
+	t.Parallel()
+
+	var (
+		w provider.WriteOption  = sampleWriteOption{}
+		d provider.DeleteOption = sampleDeleteOption{}
+	)
+
+	assert.NotNil(t, w)
+	assert.NotNil(t, d)
+}

--- a/internal/provider/providermock/mock.go
+++ b/internal/provider/providermock/mock.go
@@ -23,11 +23,15 @@ type Store struct {
 	GetFunc     func(ctx context.Context, name string, ref provider.VersionRef) (*domain.Entry, error)
 	HistoryFunc func(ctx context.Context, name string) ([]domain.Version, error)
 	ListFunc    func(ctx context.Context) ([]string, error)
-	CreateFunc  func(ctx context.Context, name, value string, valueType domain.ValueType, description string) (domain.Version, error)
-	PutFunc     func(ctx context.Context, name, value string, valueType domain.ValueType, description string) (domain.Version, error)
-	DeleteFunc  func(ctx context.Context, name string) error
-	TagFunc     func(ctx context.Context, name string, add map[string]string) error
-	UntagFunc   func(ctx context.Context, name string, keys []string) error
+	CreateFunc  func(
+		ctx context.Context, name, value string, valueType domain.ValueType, description string, opts ...provider.WriteOption,
+	) (domain.Version, error)
+	PutFunc func(
+		ctx context.Context, name, value string, valueType domain.ValueType, description string, opts ...provider.WriteOption,
+	) (domain.Version, error)
+	DeleteFunc func(ctx context.Context, name string, opts ...provider.DeleteOption) error
+	TagFunc    func(ctx context.Context, name string, add map[string]string) error
+	UntagFunc  func(ctx context.Context, name string, keys []string) error
 }
 
 // Compile-time assertion that *Store implements the full provider contract.
@@ -71,33 +75,33 @@ func (s *Store) List(ctx context.Context) ([]string, error) {
 
 // Create delegates to CreateFunc.
 func (s *Store) Create(
-	ctx context.Context, name, value string, valueType domain.ValueType, description string,
+	ctx context.Context, name, value string, valueType domain.ValueType, description string, opts ...provider.WriteOption,
 ) (domain.Version, error) {
 	if s.CreateFunc == nil {
 		return domain.Version{}, ErrNotConfigured
 	}
 
-	return s.CreateFunc(ctx, name, value, valueType, description)
+	return s.CreateFunc(ctx, name, value, valueType, description, opts...)
 }
 
 // Put delegates to PutFunc.
 func (s *Store) Put(
-	ctx context.Context, name, value string, valueType domain.ValueType, description string,
+	ctx context.Context, name, value string, valueType domain.ValueType, description string, opts ...provider.WriteOption,
 ) (domain.Version, error) {
 	if s.PutFunc == nil {
 		return domain.Version{}, ErrNotConfigured
 	}
 
-	return s.PutFunc(ctx, name, value, valueType, description)
+	return s.PutFunc(ctx, name, value, valueType, description, opts...)
 }
 
 // Delete delegates to DeleteFunc.
-func (s *Store) Delete(ctx context.Context, name string) error {
+func (s *Store) Delete(ctx context.Context, name string, opts ...provider.DeleteOption) error {
 	if s.DeleteFunc == nil {
 		return ErrNotConfigured
 	}
 
-	return s.DeleteFunc(ctx, name)
+	return s.DeleteFunc(ctx, name, opts...)
 }
 
 // Tag delegates to TagFunc.

--- a/internal/usecase/param/create.go
+++ b/internal/usecase/param/create.go
@@ -14,6 +14,9 @@ type CreateInput struct {
 	Value       string
 	Type        domain.ValueType
 	Description string
+	// Options carries provider-specific write options (e.g. AWS param Tier,
+	// DataType). They are passed through to the provider unchanged.
+	Options []provider.WriteOption
 }
 
 // CreateOutput holds the result of the create use case.
@@ -31,7 +34,7 @@ type CreateUseCase struct {
 // provider; if the parameter already exists the provider returns a wrapped
 // provider.ErrAlreadyExists and no overwrite occurs.
 func (u *CreateUseCase) Execute(ctx context.Context, input CreateInput) (*CreateOutput, error) {
-	version, err := u.Writer.Create(ctx, input.Name, input.Value, input.Type, input.Description)
+	version, err := u.Writer.Create(ctx, input.Name, input.Value, input.Type, input.Description, input.Options...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create parameter: %w", err)
 	}

--- a/internal/usecase/param/create_test.go
+++ b/internal/usecase/param/create_test.go
@@ -17,7 +17,7 @@ func TestCreateUseCase_Execute(t *testing.T) {
 	t.Parallel()
 
 	store := &providermock.Store{
-		CreateFunc: func(_ context.Context, name, value string, vt domain.ValueType, _ string) (domain.Version, error) {
+		CreateFunc: func(_ context.Context, name, value string, vt domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
 			assert.Equal(t, "/app/new", name)
 			assert.Equal(t, "new-value", value)
 			assert.Equal(t, domain.ValueTypePlaintext, vt)
@@ -42,7 +42,7 @@ func TestCreateUseCase_Execute_WithDescription(t *testing.T) {
 	t.Parallel()
 
 	store := &providermock.Store{
-		CreateFunc: func(_ context.Context, _, _ string, _ domain.ValueType, description string) (domain.Version, error) {
+		CreateFunc: func(_ context.Context, _, _ string, _ domain.ValueType, description string, _ ...provider.WriteOption) (domain.Version, error) {
 			assert.Equal(t, "my description", description)
 
 			return domain.Version{ID: "1"}, nil
@@ -69,7 +69,7 @@ func TestCreateUseCase_Execute_AlreadyExists(t *testing.T) {
 	t.Parallel()
 
 	store := &providermock.Store{
-		CreateFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string) (domain.Version, error) {
+		CreateFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
 			return domain.Version{}, provider.ErrAlreadyExists
 		},
 	}
@@ -90,7 +90,7 @@ func TestCreateUseCase_Execute_CreateError(t *testing.T) {
 	t.Parallel()
 
 	store := &providermock.Store{
-		CreateFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string) (domain.Version, error) {
+		CreateFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
 			return domain.Version{}, errPutFailed
 		},
 	}

--- a/internal/usecase/param/delete_test.go
+++ b/internal/usecase/param/delete_test.go
@@ -68,7 +68,7 @@ func TestDeleteUseCase_Execute(t *testing.T) {
 	t.Parallel()
 
 	store := &providermock.Store{
-		DeleteFunc: func(_ context.Context, name string) error {
+		DeleteFunc: func(_ context.Context, name string, _ ...provider.DeleteOption) error {
 			assert.Equal(t, "/app/to-delete", name)
 
 			return nil
@@ -86,7 +86,7 @@ func TestDeleteUseCase_Execute_Error(t *testing.T) {
 	t.Parallel()
 
 	store := &providermock.Store{
-		DeleteFunc: func(_ context.Context, _ string) error {
+		DeleteFunc: func(_ context.Context, _ string, _ ...provider.DeleteOption) error {
 			return errDeleteFailed
 		},
 	}

--- a/internal/usecase/param/update.go
+++ b/internal/usecase/param/update.go
@@ -15,6 +15,9 @@ type UpdateInput struct {
 	Value       string
 	Type        domain.ValueType
 	Description string
+	// Options carries provider-specific write options (e.g. AWS param Tier,
+	// DataType). They are passed through to the provider unchanged.
+	Options []provider.WriteOption
 }
 
 // UpdateOutput holds the result of the update use case.
@@ -41,7 +44,7 @@ func (u *UpdateUseCase) Execute(ctx context.Context, input UpdateInput) (*Update
 		return nil, err
 	}
 
-	version, err := u.Store.Put(ctx, input.Name, input.Value, input.Type, input.Description)
+	version, err := u.Store.Put(ctx, input.Name, input.Value, input.Type, input.Description, input.Options...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update parameter: %w", err)
 	}

--- a/internal/usecase/param/update_test.go
+++ b/internal/usecase/param/update_test.go
@@ -20,7 +20,7 @@ func TestUpdateUseCase_Execute(t *testing.T) {
 		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
 			return &domain.Entry{Name: name}, nil
 		},
-		PutFunc: func(_ context.Context, name, value string, vt domain.ValueType, description string) (domain.Version, error) {
+		PutFunc: func(_ context.Context, name, value string, vt domain.ValueType, description string, _ ...provider.WriteOption) (domain.Version, error) {
 			assert.Equal(t, "/app/config", name)
 			assert.Equal(t, "updated-value", value)
 			assert.Equal(t, domain.ValueTypePlaintext, vt)
@@ -95,7 +95,7 @@ func TestUpdateUseCase_Execute_PutError(t *testing.T) {
 		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
 			return &domain.Entry{Name: name}, nil
 		},
-		PutFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string) (domain.Version, error) {
+		PutFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
 			return domain.Version{}, errPutFailed
 		},
 	}


### PR DESCRIPTION
Closes #210 (Part of #189, Phase 2)

## Summary

Establishes the **per-provider typed metadata/options mechanism** that #199 deferred and the `multicloud` branch (#141) botched, using the maintainer-approved design (**Option 1**: neutral display-field list + provider-interpreted functional options). This **unblocks the secret migration redo (#203)** to preserve ARN display + delete options without leaking AWS shape into the neutral model. `+908 / −69`.

## Mechanism (`internal/domain`, `internal/provider`)
- `domain.Field{Label,Value string}` + `domain.Entry.Extra []Field` — provider-populated display metadata; **provider-neutral shape, no AWS types, no `any`**. A generic (`#204`) `show` renders `Extra` uniformly.
- `provider.WriteOption` / `provider.DeleteOption` — **sealed** marker interfaces (unexported method), implemented by provider option types via embedding `WriteOptionMarker`/`DeleteOptionMarker`. `Writer.Create`/`Put` take `...WriteOption`; `Delete` takes `...DeleteOption` (variadic → existing callers unchanged; the provider adapter type-switches over the options it understands, consumers never assert).

## AWS adapters (SDK stays confined to `internal/provider/aws/**`)
- **param**: `Tier` / `DataType` / `AllowedPattern` / `Policies` write options → `PutParameterInput`.
- **secret**: `KMSKeyID` / `RotationRules` write options; `ForceDelete` / `RecoveryWindow` delete options; `Get`/`Describe` populate `Extra` with the **ARN**; `Put` now **updates the description** on existing secrets (via `UpdateSecret`); `Create` stays create-only (`ErrAlreadyExists`).

## Wiring
New `--tier` / `--data-type` / `--allowed-pattern` / `--policies` flags on the (already-migrated, #202) `param create`/`update` commands — proving options are settable end-to-end. Output/behavior unchanged when the flags are unset.

## Deferred to #203-redo (intentional)
Secret **command** wiring (surfacing `Extra` ARN in `secret show`, and `--force`/`--recovery-window` via `DeleteOption`) is not done here because the secret usecases aren't migrated yet. The secret **adapter** support is built and unit-tested, ready for #203 to consume — that's exactly what makes the #203 redo behavior-preserving.

## Verification
```
$ make test    # green; existing expected-output unchanged; new option/flag tests added
$ make lint     # 0 issues
$ CGO_ENABLED=1 go test -tags=production ./internal/gui/...   # ok
$ go test -tags e2e -run xxxNoMatch ./e2e/...                 # compiles
$ go build ./cmd/suve                                         # ok
# AWS SDK confined to internal/provider/aws (+ pre-existing api/infra/cli-internal)
```

## Acceptance criteria
- [x] Provider-specific options settable via typed per-provider mechanism, no leakage into the neutral model
- [x] `make test` green
- [x] `make lint` green

## Note
A stray local `gui/go.mod` dbus bump (a `go mod tidy` artifact from #195, unrelated to #210) was excluded from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)