### PR TITLE
refactor(gui): frontend debt

### DIFF
--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -158,47 +158,42 @@ func (a *App) serviceStrategy(service string) (staging.FullStrategy, error) {
 	}
 }
 
-func (a *App) getEditStrategy(service string) (staging.EditStrategy, error) {
+// strategyAs resolves the service strategy and narrows it to the requested
+// staging strategy interface T. The concrete *ParamStrategy / *SecretStrategy
+// satisfy every staging strategy interface, so this succeeds for the Edit,
+// Apply and Diff interfaces (which FullStrategy embeds) as well as for
+// DeleteStrategy (which it does not embed but the concrete types implement).
+// It is a free function because Go methods cannot declare type parameters.
+func strategyAs[T any](a *App, service string) (T, error) {
+	var zero T
+
 	strategy, err := a.serviceStrategy(service)
 	if err != nil {
-		return nil, err
+		return zero, err
 	}
 
-	return strategy, nil
+	narrowed, ok := any(strategy).(T)
+	if !ok {
+		return zero, errInvalidService
+	}
+
+	return narrowed, nil
+}
+
+func (a *App) getEditStrategy(service string) (staging.EditStrategy, error) {
+	return strategyAs[staging.EditStrategy](a, service)
 }
 
 func (a *App) getDeleteStrategy(service string) (staging.DeleteStrategy, error) {
-	strategy, err := a.serviceStrategy(service)
-	if err != nil {
-		return nil, err
-	}
-
-	// FullStrategy does not embed DeleteStrategy, but the concrete
-	// *ParamStrategy / *SecretStrategy both implement it.
-	deleter, ok := strategy.(staging.DeleteStrategy)
-	if !ok {
-		return nil, errInvalidService
-	}
-
-	return deleter, nil
+	return strategyAs[staging.DeleteStrategy](a, service)
 }
 
 func (a *App) getApplyStrategy(service string) (staging.ApplyStrategy, error) {
-	strategy, err := a.serviceStrategy(service)
-	if err != nil {
-		return nil, err
-	}
-
-	return strategy, nil
+	return strategyAs[staging.ApplyStrategy](a, service)
 }
 
 func (a *App) getDiffStrategy(service string) (staging.DiffStrategy, error) {
-	strategy, err := a.serviceStrategy(service)
-	if err != nil {
-		return nil, err
-	}
-
-	return strategy, nil
+	return strategyAs[staging.DiffStrategy](a, service)
 }
 
 // =============================================================================

--- a/internal/gui/dto_contract_internal_test.go
+++ b/internal/gui/dto_contract_internal_test.go
@@ -1,0 +1,164 @@
+//go:build production || dev
+
+package gui
+
+import (
+	"os"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// modelsPath is the Wails-generated (hand-maintained) TypeScript mirror of the
+// Go binding DTOs that the frontend consumes.
+const modelsPath = "frontend/wailsjs/go/models.ts"
+
+// dtoContract lists every exported binding DTO whose JSON shape the frontend
+// depends on. Adding a new binding DTO (or a field to one) requires updating
+// both the Go struct and models.ts; this test fails loudly when the two drift.
+//
+//nolint:exhaustruct // zero values are fine: the test only inspects field tags
+func dtoContract() []any {
+	return []any{
+		// app.go
+		AWSIdentityResult{},
+		// param.go
+		ParamListResult{}, ParamListEntry{}, ParamShowTag{}, ParamShowResult{},
+		ParamLogResult{}, ParamLogEntry{}, ParamDiffResult{}, ParamSetResult{},
+		ParamDeleteResult{},
+		// secret.go
+		SecretListResult{}, SecretListEntry{}, SecretShowTag{}, SecretShowResult{},
+		SecretLogResult{}, SecretLogEntry{}, SecretCreateResult{}, SecretUpdateResult{},
+		SecretDeleteResult{}, SecretDiffResult{}, SecretRestoreResult{},
+		// staging.go
+		StagingStatusResult{}, StagingEntry{}, StagingTagEntry{},
+		StagingApplyEntryResult{}, StagingApplyTagResult{}, StagingApplyResult{},
+		StagingResetResult{}, StagingAddResult{}, StagingEditResult{},
+		StagingDeleteResult{}, StagingUnstageResult{}, StagingAddTagResult{},
+		StagingRemoveTagResult{}, StagingCancelAddTagResult{}, StagingCancelRemoveTagResult{},
+		StagingDiffResult{}, StagingDiffEntry{}, StagingDiffTagEntry{},
+		StagingCheckStatusResult{}, StagingDrainResult{}, StagingPersistResult{},
+		StagingFileStatusResult{}, StagingDropResult{},
+	}
+}
+
+// jsonFieldNames returns the JSON object keys a struct type marshals to,
+// honoring `json:"name"` tags (including ",omitempty"), skipping `json:"-"`,
+// and defaulting to the Go field name when no tag is present.
+func jsonFieldNames(t reflect.Type) []string {
+	var names []string
+
+	for i := range t.NumField() {
+		field := t.Field(i)
+		if field.PkgPath != "" {
+			continue // unexported
+		}
+
+		tag := field.Tag.Get("json")
+		name, _, _ := strings.Cut(tag, ",")
+
+		switch name {
+		case "-":
+			continue
+		case "":
+			name = field.Name
+		}
+
+		names = append(names, name)
+	}
+
+	sort.Strings(names)
+
+	return names
+}
+
+// tsClassFields parses models.ts and returns, for each exported class, the set
+// of JSON keys its constructor reads via source["key"].
+func tsClassFields(t *testing.T) map[string][]string {
+	t.Helper()
+
+	data, err := os.ReadFile(modelsPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", modelsPath, err)
+	}
+
+	classRe := regexp.MustCompile(`export class (\w+) \{`)
+	sourceKeyRe := regexp.MustCompile(`source\["([^"]+)"\]`)
+
+	result := make(map[string][]string)
+
+	src := string(data)
+	locs := classRe.FindAllStringSubmatchIndex(src, -1)
+
+	for i, loc := range locs {
+		name := src[loc[2]:loc[3]]
+		start := loc[1]
+
+		end := len(src)
+		if i+1 < len(locs) {
+			end = locs[i+1][0]
+		}
+
+		body := src[start:end]
+
+		seen := make(map[string]struct{})
+
+		var keys []string
+
+		for _, m := range sourceKeyRe.FindAllStringSubmatch(body, -1) {
+			key := m[1]
+			if _, ok := seen[key]; ok {
+				continue
+			}
+
+			seen[key] = struct{}{}
+
+			keys = append(keys, key)
+		}
+
+		sort.Strings(keys)
+		result[name] = keys
+	}
+
+	return result
+}
+
+// TestDTOContract guards against Go-binding ↔ frontend DTO drift: every Go DTO
+// must have a matching TypeScript class in models.ts with the exact same set of
+// JSON field names, and vice versa.
+func TestDTOContract(t *testing.T) {
+	t.Parallel()
+
+	tsFields := tsClassFields(t)
+
+	goFields := make(map[string][]string)
+
+	for _, dto := range dtoContract() {
+		typ := reflect.TypeOf(dto)
+		goFields[typ.Name()] = jsonFieldNames(typ)
+	}
+
+	// Every Go DTO has a TS class with identical JSON field names.
+	for name, want := range goFields {
+		got, ok := tsFields[name]
+		if !ok {
+			t.Errorf("Go DTO %q has no matching class in %s", name, modelsPath)
+
+			continue
+		}
+
+		if !reflect.DeepEqual(want, got) {
+			t.Errorf("DTO %q field mismatch:\n  Go: %v\n  TS: %v", name, want, got)
+		}
+	}
+
+	// Every TS class in the gui namespace maps back to a listed Go DTO, so a
+	// removed/renamed Go DTO (or an untracked TS class) is caught too.
+	for name := range tsFields {
+		if _, ok := goFields[name]; !ok {
+			t.Errorf("models.ts class %q has no matching Go DTO in dtoContract()", name)
+		}
+	}
+}

--- a/internal/gui/frontend/src/lib/ParamView.svelte
+++ b/internal/gui/frontend/src/lib/ParamView.svelte
@@ -8,6 +8,8 @@
   import EyeOffIcon from './icons/EyeOffIcon.svelte';
   import Modal from './Modal.svelte';
   import { withRetry } from './retry';
+  import StagingBanner from './StagingBanner.svelte';
+  import TagList from './TagList.svelte';
   import { createDiffMode } from './useDiffMode.svelte';
   import { createDebouncer, formatDate, maskValue, parseError } from './viewUtils';
   import './common.css';
@@ -185,19 +187,6 @@
     paramLog = [];
     showValue = false;
     stagingStatus = null;
-  }
-
-  function getStagingMessage(): string | null {
-    if (!stagingStatus || (!stagingStatus.hasEntry && !stagingStatus.hasTags)) {
-      return null;
-    }
-    if (stagingStatus.hasEntry && stagingStatus.hasTags) {
-      return 'This item has staged value and tag changes';
-    }
-    if (stagingStatus.hasEntry) {
-      return 'This item has staged value changes';
-    }
-    return 'This item has staged tag changes';
   }
 
   function toggleShowValue() {
@@ -459,14 +448,7 @@
           </div>
         </div>
 
-        {#if getStagingMessage()}
-          <!-- Using div instead of button to avoid conflicts with Playwright button selectors -->
-          <div class="staging-banner" role="link" tabindex="0" onclick={onnavigatetostaging} onkeydown={(e) => e.key === 'Enter' && onnavigatetostaging?.()}>
-            <span class="staging-icon">⚠</span>
-            <span class="staging-text">{getStagingMessage()}</span>
-            <span class="staging-link">View in Staging →</span>
-          </div>
-        {/if}
+        <StagingBanner {stagingStatus} onnavigate={onnavigatetostaging} />
 
         {#if detailLoading}
           <div class="loading">Loading...</div>
@@ -517,26 +499,7 @@
               </div>
             {/if}
 
-            <div class="detail-section">
-              <div class="section-header">
-                <h4>Tags</h4>
-                <button class="btn-action-sm" onclick={openTagModal}>+ Add</button>
-              </div>
-              {#if paramDetail.tags && paramDetail.tags.length > 0}
-                <div class="tags-list">
-                  {#each paramDetail.tags as tag}
-                    <div class="tag-item">
-                      <span class="tag-key param">{tag.key}</span>
-                      <span class="tag-separator">=</span>
-                      <span class="tag-value">{tag.value}</span>
-                      <button class="btn-tag-remove" onclick={() => openRemoveTagModal(tag.key)} title="Remove tag">×</button>
-                    </div>
-                  {/each}
-                </div>
-              {:else}
-                <p class="no-tags">No tags</p>
-              {/if}
-            </div>
+            <TagList tags={paramDetail.tags} serviceClass="param" onadd={openTagModal} onremove={openRemoveTagModal} />
 
             {#if paramLog.length > 0}
               <div class="detail-section">
@@ -759,44 +722,5 @@
 
   .value-display.masked {
     font-style: italic;
-  }
-
-  .staging-banner {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    width: 100%;
-    padding: 10px 12px;
-    margin: 8px 0 0 0;
-    background: rgba(255, 193, 7, 0.15);
-    border: 1px solid rgba(255, 193, 7, 0.4);
-    border-radius: 6px;
-    cursor: pointer;
-    transition: background-color 0.2s, border-color 0.2s;
-    text-align: left;
-  }
-
-  .staging-banner:hover {
-    background: rgba(255, 193, 7, 0.25);
-    border-color: rgba(255, 193, 7, 0.6);
-  }
-
-  .staging-icon {
-    color: #ffc107;
-    font-size: 14px;
-    flex-shrink: 0;
-  }
-
-  .staging-text {
-    color: #e0e0e0;
-    font-size: 13px;
-    flex: 1;
-  }
-
-  .staging-link {
-    color: #ffc107;
-    font-size: 12px;
-    font-weight: 500;
-    flex-shrink: 0;
   }
 </style>

--- a/internal/gui/frontend/src/lib/SecretView.svelte
+++ b/internal/gui/frontend/src/lib/SecretView.svelte
@@ -8,6 +8,8 @@
   import EyeOffIcon from './icons/EyeOffIcon.svelte';
   import Modal from './Modal.svelte';
   import { withRetry } from './retry';
+  import StagingBanner from './StagingBanner.svelte';
+  import TagList from './TagList.svelte';
   import { createDiffMode } from './useDiffMode.svelte';
   import { createDebouncer, formatDate, formatJsonValue, maskValue, parseError } from './viewUtils';
   import './common.css';
@@ -186,19 +188,6 @@
     secretLog = [];
     showValue = false;
     stagingStatus = null;
-  }
-
-  function getStagingMessage(): string | null {
-    if (!stagingStatus || (!stagingStatus.hasEntry && !stagingStatus.hasTags)) {
-      return null;
-    }
-    if (stagingStatus.hasEntry && stagingStatus.hasTags) {
-      return 'This item has staged value and tag changes';
-    }
-    if (stagingStatus.hasEntry) {
-      return 'This item has staged value changes';
-    }
-    return 'This item has staged tag changes';
   }
 
   function toggleShowValue() {
@@ -496,14 +485,7 @@
           </div>
         </div>
 
-        {#if getStagingMessage()}
-          <!-- Using div instead of button to avoid conflicts with Playwright button selectors -->
-          <div class="staging-banner" role="link" tabindex="0" onclick={onnavigatetostaging} onkeydown={(e) => e.key === 'Enter' && onnavigatetostaging?.()}>
-            <span class="staging-icon">⚠</span>
-            <span class="staging-text">{getStagingMessage()}</span>
-            <span class="staging-link">View in Staging →</span>
-          </div>
-        {/if}
+        <StagingBanner {stagingStatus} onnavigate={onnavigatetostaging} />
 
         {#if detailLoading}
           <div class="loading">Loading...</div>
@@ -561,26 +543,7 @@
               <code class="arn-display">{secretDetail.arn}</code>
             </div>
 
-            <div class="detail-section">
-              <div class="section-header">
-                <h4>Tags</h4>
-                <button class="btn-action-sm" onclick={openTagModal}>+ Add</button>
-              </div>
-              {#if secretDetail.tags && secretDetail.tags.length > 0}
-                <div class="tags-list">
-                  {#each secretDetail.tags as tag}
-                    <div class="tag-item">
-                      <span class="tag-key secret">{tag.key}</span>
-                      <span class="tag-separator">=</span>
-                      <span class="tag-value">{tag.value}</span>
-                      <button class="btn-tag-remove" onclick={() => openRemoveTagModal(tag.key)} title="Remove tag">×</button>
-                    </div>
-                  {/each}
-                </div>
-              {:else}
-                <p class="no-tags">No tags</p>
-              {/if}
-            </div>
+            <TagList tags={secretDetail.tags} serviceClass="secret" onadd={openTagModal} onremove={openRemoveTagModal} />
 
             {#if secretLog.length > 0}
               <div class="detail-section">
@@ -887,44 +850,5 @@
 
   .btn-restore-confirm:hover {
     background: #43a047;
-  }
-
-  .staging-banner {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    width: 100%;
-    padding: 10px 12px;
-    margin: 8px 0 0 0;
-    background: rgba(255, 193, 7, 0.15);
-    border: 1px solid rgba(255, 193, 7, 0.4);
-    border-radius: 6px;
-    cursor: pointer;
-    transition: background-color 0.2s, border-color 0.2s;
-    text-align: left;
-  }
-
-  .staging-banner:hover {
-    background: rgba(255, 193, 7, 0.25);
-    border-color: rgba(255, 193, 7, 0.6);
-  }
-
-  .staging-icon {
-    color: #ffc107;
-    font-size: 14px;
-    flex-shrink: 0;
-  }
-
-  .staging-text {
-    color: #e0e0e0;
-    font-size: 13px;
-    flex: 1;
-  }
-
-  .staging-link {
-    color: #ffc107;
-    font-size: 12px;
-    font-weight: 500;
-    flex-shrink: 0;
   }
 </style>

--- a/internal/gui/frontend/src/lib/StagingBanner.svelte
+++ b/internal/gui/frontend/src/lib/StagingBanner.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  interface Props {
+    stagingStatus: { hasEntry: boolean; hasTags: boolean } | null;
+    onnavigate?: () => void;
+  }
+
+  let { stagingStatus, onnavigate }: Props = $props();
+
+  function getStagingMessage(): string | null {
+    if (!stagingStatus || (!stagingStatus.hasEntry && !stagingStatus.hasTags)) {
+      return null;
+    }
+    if (stagingStatus.hasEntry && stagingStatus.hasTags) {
+      return 'This item has staged value and tag changes';
+    }
+    if (stagingStatus.hasEntry) {
+      return 'This item has staged value changes';
+    }
+    return 'This item has staged tag changes';
+  }
+</script>
+
+{#if getStagingMessage()}
+  <!-- Using div instead of button to avoid conflicts with Playwright button selectors -->
+  <div class="staging-banner" role="link" tabindex="0" onclick={onnavigate} onkeydown={(e) => e.key === 'Enter' && onnavigate?.()}>
+    <span class="staging-icon">⚠</span>
+    <span class="staging-text">{getStagingMessage()}</span>
+    <span class="staging-link">View in Staging →</span>
+  </div>
+{/if}
+
+<style>
+  .staging-banner {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 10px 12px;
+    margin: 8px 0 0 0;
+    background: rgba(255, 193, 7, 0.15);
+    border: 1px solid rgba(255, 193, 7, 0.4);
+    border-radius: 6px;
+    cursor: pointer;
+    transition: background-color 0.2s, border-color 0.2s;
+    text-align: left;
+  }
+
+  .staging-banner:hover {
+    background: rgba(255, 193, 7, 0.25);
+    border-color: rgba(255, 193, 7, 0.6);
+  }
+
+  .staging-icon {
+    color: #ffc107;
+    font-size: 14px;
+    flex-shrink: 0;
+  }
+
+  .staging-text {
+    color: #e0e0e0;
+    font-size: 13px;
+    flex: 1;
+  }
+
+  .staging-link {
+    color: #ffc107;
+    font-size: 12px;
+    font-weight: 500;
+    flex-shrink: 0;
+  }
+</style>

--- a/internal/gui/frontend/src/lib/StagingSection.svelte
+++ b/internal/gui/frontend/src/lib/StagingSection.svelte
@@ -1,0 +1,420 @@
+<script lang="ts">
+  import type { gui } from '../../wailsjs/go/models';
+  import DiffDisplay from './DiffDisplay.svelte';
+  import './common.css';
+
+  interface Props {
+    icon: string;
+    title: string;
+    emptyText: string;
+    entries: gui.StagingDiffEntry[];
+    tagEntries: gui.StagingDiffTagEntry[];
+    viewMode: 'diff' | 'value';
+    onapply: () => void;
+    onreset: () => void;
+    onedit: (entry: gui.StagingDiffEntry) => void;
+    onunstage: (name: string) => void;
+    onaddtag: (entryName: string) => void;
+    onedittag: (entryName: string, key: string, value: string) => void;
+    onremovetag: (entryName: string, key: string) => void;
+    oncanceluntag: (entryName: string, key: string) => void;
+  }
+
+  let {
+    icon,
+    title,
+    emptyText,
+    entries,
+    tagEntries,
+    viewMode,
+    onapply,
+    onreset,
+    onedit,
+    onunstage,
+    onaddtag,
+    onedittag,
+    onremovetag,
+    oncanceluntag,
+  }: Props = $props();
+
+  function getOperationColor(op: string): string {
+    switch (op?.toLowerCase()) {
+      case 'set':
+      case 'create':
+        return '#4caf50';
+      case 'update':
+        return '#ff9800';
+      case 'delete':
+        return '#f44336';
+      default:
+        return '#888';
+    }
+  }
+
+  function hasValueChange(entry: gui.StagingDiffEntry): boolean {
+    return entry.stagedValue !== undefined && entry.stagedValue !== '';
+  }
+
+  function showEditButton(entry: gui.StagingDiffEntry): boolean {
+    return entry.operation !== 'delete' && hasValueChange(entry);
+  }
+
+  function findTagEntry(name: string): gui.StagingDiffTagEntry | undefined {
+    return tagEntries.find(t => t.name === name);
+  }
+</script>
+
+<div class="section">
+  <div class="section-header">
+    <h3 class="section-title">
+      <span class="section-icon">{icon}</span>
+      {title}
+    </h3>
+    <span class="count-badge">{entries.length}</span>
+    <div class="section-actions">
+      {#if entries.length > 0}
+        <button class="btn-section btn-apply-sm" onclick={onapply}>Apply</button>
+        <button class="btn-section btn-reset-sm" onclick={onreset}>Reset</button>
+      {/if}
+    </div>
+  </div>
+
+  {#if entries.length === 0}
+    <div class="empty-state">{emptyText}</div>
+  {:else}
+    <ul class="entry-list">
+      {#each entries as entry}
+        {@const tagEntry = findTagEntry(entry.name)}
+        <li class="entry-item">
+          <div class="entry-header">
+            <span class="operation-badge" style="background: {getOperationColor(entry.operation || '')}">
+              {entry.operation}
+            </span>
+            <span class="entry-name">{entry.name}</span>
+            <div class="entry-actions">
+              {#if showEditButton(entry)}
+                <button class="btn-entry" onclick={() => onedit(entry)}>Edit</button>
+              {/if}
+              <button class="btn-entry btn-unstage" onclick={() => onunstage(entry.name)}>Unstage</button>
+            </div>
+          </div>
+          <div class="entry-tags">
+            {#if tagEntry?.addTags && Object.keys(tagEntry.addTags).length > 0}
+              <div class="tag-changes tag-add">
+                <span class="tag-label">+ Tags:</span>
+                {#each Object.entries(tagEntry.addTags) as [key, value]}
+                  <button class="tag-item tag-item-editable" type="button" onclick={() => onedittag(entry.name, key, value)}>
+                    {key}={value}
+                    <span class="tag-delete-btn" role="button" tabindex="0" onclick={(e: MouseEvent) => { e.stopPropagation(); onremovetag(entry.name, key); }} onkeydown={(e: KeyboardEvent) => { e.stopPropagation(); if (e.key === 'Enter') onremovetag(entry.name, key); }}>×</span>
+                  </button>
+                {/each}
+              </div>
+            {/if}
+            {#if tagEntry?.removeTags && Object.keys(tagEntry.removeTags).length > 0}
+              <div class="tag-changes tag-remove">
+                <span class="tag-label">- Tags:</span>
+                {#each Object.entries(tagEntry.removeTags) as [key, value]}
+                  <span class="tag-item">
+                    {value ? `${key}=${value}` : key}
+                    <button class="tag-cancel-btn" onclick={() => oncanceluntag(entry.name, key)} title="Cancel untag">↩</button>
+                  </span>
+                {/each}
+              </div>
+            {/if}
+            {#if entry.operation !== 'delete'}
+              <button class="btn-add-tag" onclick={() => onaddtag(entry.name)}>+ Add Tag</button>
+            {/if}
+          </div>
+          {#if entry.operation === 'delete'}
+            {#if viewMode === 'diff'}
+              <div class="entry-diff">
+                <DiffDisplay
+                  oldValue={entry.awsValue || ''}
+                  newValue="(deleted)"
+                  oldLabel="AWS"
+                  newLabel="Staged"
+                  oldSubLabel={entry.awsIdentifier || ''}
+                />
+              </div>
+            {:else}
+              <pre class="entry-value entry-value-delete">(will be deleted)</pre>
+            {/if}
+          {:else if entry.stagedValue !== undefined && entry.stagedValue !== ''}
+            {#if viewMode === 'diff' && entry.operation !== 'create'}
+              <div class="entry-diff">
+                <DiffDisplay
+                  oldValue={entry.awsValue || ''}
+                  newValue={entry.stagedValue}
+                  oldLabel="AWS"
+                  newLabel="Staged"
+                  oldSubLabel={entry.awsIdentifier || ''}
+                />
+              </div>
+            {:else}
+              <pre class="entry-value">{entry.stagedValue}</pre>
+            {/if}
+          {/if}
+        </li>
+      {/each}
+    </ul>
+  {/if}
+</div>
+
+<style>
+  .section {
+    background: #1a1a2e;
+    border-radius: 8px;
+    overflow: hidden;
+  }
+
+  .section-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px;
+    border-bottom: 1px solid #2d2d44;
+  }
+
+  .section-title {
+    margin: 0;
+    font-size: 14px;
+    color: #fff;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .section-icon {
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 4px;
+    font-weight: bold;
+    font-size: 12px;
+  }
+
+  .count-badge {
+    font-size: 12px;
+    padding: 2px 8px;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 10px;
+    color: #888;
+  }
+
+  .section-actions {
+    margin-left: auto;
+    display: flex;
+    gap: 8px;
+  }
+
+  .btn-section {
+    padding: 4px 10px;
+    border: none;
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+  }
+
+  .btn-apply-sm {
+    background: #4caf50;
+    color: #fff;
+  }
+
+  .btn-apply-sm:hover {
+    background: #43a047;
+  }
+
+  .btn-reset-sm {
+    background: #f44336;
+    color: #fff;
+  }
+
+  .btn-reset-sm:hover {
+    background: #e53935;
+  }
+
+  .entry-actions {
+    display: flex;
+    gap: 6px;
+    margin-left: auto;
+  }
+
+  .btn-entry {
+    padding: 2px 8px;
+    font-size: 11px;
+    border: none;
+    border-radius: 3px;
+    cursor: pointer;
+    background: #2d2d44;
+    color: #fff;
+  }
+
+  .btn-entry:hover {
+    background: #3d3d54;
+  }
+
+  .btn-unstage {
+    background: #666;
+  }
+
+  .btn-unstage:hover {
+    background: #888;
+  }
+
+  .entry-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .entry-item {
+    padding: 12px 16px;
+    border-bottom: 1px solid #2d2d44;
+  }
+
+  .entry-item:last-child {
+    border-bottom: none;
+  }
+
+  .entry-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .operation-badge {
+    font-size: 10px;
+    padding: 2px 8px;
+    border-radius: 3px;
+    color: #fff;
+    text-transform: uppercase;
+    font-weight: bold;
+  }
+
+  .entry-name {
+    flex: 1;
+    font-family: monospace;
+    font-size: 13px;
+    color: #4fc3f7;
+  }
+
+  .entry-diff {
+    margin-top: 12px;
+  }
+
+  .entry-value {
+    margin: 8px 0 0 0;
+    padding: 8px;
+    background: #0f0f1a;
+    border-radius: 4px;
+    font-family: monospace;
+    font-size: 12px;
+    color: #a5d6a7;
+    white-space: pre-wrap;
+    word-break: break-all;
+  }
+
+  .entry-value-delete {
+    color: #ef9a9a;
+  }
+
+  /* Tag display styles */
+  .entry-tags {
+    margin-top: 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .tag-changes {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    font-size: 12px;
+    padding: 4px 8px;
+    border-radius: 4px;
+  }
+
+  .tag-add {
+    background: rgba(76, 175, 80, 0.1);
+    border: 1px solid rgba(76, 175, 80, 0.3);
+  }
+
+  .tag-remove {
+    background: rgba(244, 67, 54, 0.1);
+    border: 1px solid rgba(244, 67, 54, 0.3);
+  }
+
+  .tag-label {
+    font-weight: bold;
+  }
+
+  .tag-add .tag-label {
+    color: #4caf50;
+  }
+
+  .tag-remove .tag-label {
+    color: #f44336;
+  }
+
+  .tag-item {
+    font-family: monospace;
+    padding: 2px 6px;
+    border-radius: 3px;
+    background: rgba(255, 255, 255, 0.1);
+    color: #ddd;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .tag-item-editable {
+    cursor: pointer;
+    transition: background 0.2s;
+  }
+
+  .tag-item-editable:hover {
+    background: rgba(255, 255, 255, 0.2);
+  }
+
+  .tag-delete-btn,
+  .tag-cancel-btn {
+    background: none;
+    border: none;
+    color: #888;
+    cursor: pointer;
+    font-size: 14px;
+    line-height: 1;
+    padding: 0 2px;
+    margin-left: 2px;
+  }
+
+  .tag-delete-btn:hover {
+    color: #f44336;
+  }
+
+  .tag-cancel-btn:hover {
+    color: #4caf50;
+  }
+
+  .btn-add-tag {
+    padding: 2px 8px;
+    font-size: 11px;
+    border: 1px dashed #4caf50;
+    border-radius: 3px;
+    background: transparent;
+    color: #4caf50;
+    cursor: pointer;
+    margin-top: 4px;
+    transition: all 0.2s;
+  }
+
+  .btn-add-tag:hover {
+    background: rgba(76, 175, 80, 0.1);
+    border-style: solid;
+  }
+</style>

--- a/internal/gui/frontend/src/lib/StagingView.svelte
+++ b/internal/gui/frontend/src/lib/StagingView.svelte
@@ -2,11 +2,11 @@
   import { onMount } from 'svelte';
   import { StagingAddTag, StagingApply, StagingCancelAddTag, StagingCancelRemoveTag, StagingDiff, StagingDrain, StagingDrop, StagingEdit, StagingFileStatus, StagingPersist, StagingReset, StagingUnstage } from '../../wailsjs/go/gui/App';
   import type { gui } from '../../wailsjs/go/models';
-  import DiffDisplay from './DiffDisplay.svelte';
   import Modal from './Modal.svelte';
   import PassphraseModal from './PassphraseModal.svelte';
   import { withRetry } from './retry';
-  import { formatDate, parseError } from './viewUtils';
+  import StagingSection from './StagingSection.svelte';
+  import { parseError } from './viewUtils';
   import './common.css';
 
   interface Props {
@@ -106,20 +106,6 @@
       oncountchange?.(0);
     } finally {
       loading = false;
-    }
-  }
-
-  function getOperationColor(op: string): string {
-    switch (op?.toLowerCase()) {
-      case 'set':
-      case 'create':
-        return '#4caf50';
-      case 'update':
-        return '#ff9800';
-      case 'delete':
-        return '#f44336';
-      default:
-        return '#888';
     }
   }
 
@@ -428,21 +414,6 @@
     showDropModal = false;
   }
 
-  // Computed helpers for entry display logic
-  function hasValueChange(entry: gui.StagingDiffEntry): boolean {
-    return entry.stagedValue !== undefined && entry.stagedValue !== '';
-  }
-
-  function showEditButton(entry: gui.StagingDiffEntry): boolean {
-    return entry.operation !== 'delete' && hasValueChange(entry);
-  }
-
-  // Find tag entry for a given name
-  function findTagEntry(service: string, name: string): gui.StagingDiffTagEntry | undefined {
-    const tagEntries = service === 'param' ? paramTagEntries : secretTagEntries;
-    return tagEntries.find(t => t.name === name);
-  }
-
   onMount(() => {
     loadStatus();
   });
@@ -479,197 +450,39 @@
   {/if}
 
   <div class="staging-content">
-    <div class="section">
-      <div class="section-header">
-        <h3 class="section-title">
-          <span class="section-icon">P</span>
-          Parameters
-        </h3>
-        <span class="count-badge">{paramEntries.length}</span>
-        <div class="section-actions">
-          {#if paramEntries.length > 0}
-            <button class="btn-section btn-apply-sm" onclick={() => openApplyModal('param')}>Apply</button>
-            <button class="btn-section btn-reset-sm" onclick={() => openResetModal('param')}>Reset</button>
-          {/if}
-        </div>
-      </div>
+    <StagingSection
+      icon="P"
+      title="Parameters"
+      emptyText="No staged parameter changes"
+      entries={paramEntries}
+      tagEntries={paramTagEntries}
+      {viewMode}
+      onapply={() => openApplyModal('param')}
+      onreset={() => openResetModal('param')}
+      onedit={(entry) => openEditModal('param', entry)}
+      onunstage={(name) => handleUnstage('param', name)}
+      onaddtag={(entryName) => openAddTagModal('param', entryName)}
+      onedittag={(entryName, key, value) => openEditTagModal('param', entryName, key, value)}
+      onremovetag={(entryName, key) => handleRemoveTag('param', entryName, key)}
+      oncanceluntag={(entryName, key) => handleCancelUntag('param', entryName, key)}
+    />
 
-      {#if paramEntries.length === 0}
-        <div class="empty-state">No staged parameter changes</div>
-      {:else}
-        <ul class="entry-list">
-          {#each paramEntries as entry}
-            {@const tagEntry = findTagEntry('param', entry.name)}
-            <li class="entry-item">
-              <div class="entry-header">
-                <span class="operation-badge" style="background: {getOperationColor(entry.operation || '')}">
-                  {entry.operation}
-                </span>
-                <span class="entry-name">{entry.name}</span>
-                <div class="entry-actions">
-                  {#if showEditButton(entry)}
-                    <button class="btn-entry" onclick={() => openEditModal('param', entry)}>Edit</button>
-                  {/if}
-                  <button class="btn-entry btn-unstage" onclick={() => handleUnstage('param', entry.name)}>Unstage</button>
-                </div>
-              </div>
-              <div class="entry-tags">
-                {#if tagEntry?.addTags && Object.keys(tagEntry.addTags).length > 0}
-                  <div class="tag-changes tag-add">
-                    <span class="tag-label">+ Tags:</span>
-                    {#each Object.entries(tagEntry.addTags) as [key, value]}
-                      <button class="tag-item tag-item-editable" type="button" onclick={() => openEditTagModal('param', entry.name, key, value)}>
-                        {key}={value}
-                        <span class="tag-delete-btn" role="button" tabindex="0" onclick={(e: MouseEvent) => { e.stopPropagation(); handleRemoveTag('param', entry.name, key); }} onkeydown={(e: KeyboardEvent) => { e.stopPropagation(); if (e.key === 'Enter') handleRemoveTag('param', entry.name, key); }}>×</span>
-                      </button>
-                    {/each}
-                  </div>
-                {/if}
-                {#if tagEntry?.removeTags && Object.keys(tagEntry.removeTags).length > 0}
-                  <div class="tag-changes tag-remove">
-                    <span class="tag-label">- Tags:</span>
-                    {#each Object.entries(tagEntry.removeTags) as [key, value]}
-                      <span class="tag-item">
-                        {value ? `${key}=${value}` : key}
-                        <button class="tag-cancel-btn" onclick={() => handleCancelUntag('param', entry.name, key)} title="Cancel untag">↩</button>
-                      </span>
-                    {/each}
-                  </div>
-                {/if}
-                {#if entry.operation !== 'delete'}
-                  <button class="btn-add-tag" onclick={() => openAddTagModal('param', entry.name)}>+ Add Tag</button>
-                {/if}
-              </div>
-              {#if entry.operation === 'delete'}
-                {#if viewMode === 'diff'}
-                  <div class="entry-diff">
-                    <DiffDisplay
-                      oldValue={entry.awsValue || ''}
-                      newValue="(deleted)"
-                      oldLabel="AWS"
-                      newLabel="Staged"
-                      oldSubLabel={entry.awsIdentifier || ''}
-                    />
-                  </div>
-                {:else}
-                  <pre class="entry-value entry-value-delete">(will be deleted)</pre>
-                {/if}
-              {:else if entry.stagedValue !== undefined && entry.stagedValue !== ''}
-                {#if viewMode === 'diff' && entry.operation !== 'create'}
-                  <div class="entry-diff">
-                    <DiffDisplay
-                      oldValue={entry.awsValue || ''}
-                      newValue={entry.stagedValue}
-                      oldLabel="AWS"
-                      newLabel="Staged"
-                      oldSubLabel={entry.awsIdentifier || ''}
-                    />
-                  </div>
-                {:else}
-                  <pre class="entry-value">{entry.stagedValue}</pre>
-                {/if}
-              {/if}
-            </li>
-          {/each}
-        </ul>
-      {/if}
-    </div>
-
-    <div class="section">
-      <div class="section-header">
-        <h3 class="section-title">
-          <span class="section-icon">S</span>
-          Secrets
-        </h3>
-        <span class="count-badge">{secretEntries.length}</span>
-        <div class="section-actions">
-          {#if secretEntries.length > 0}
-            <button class="btn-section btn-apply-sm" onclick={() => openApplyModal('secret')}>Apply</button>
-            <button class="btn-section btn-reset-sm" onclick={() => openResetModal('secret')}>Reset</button>
-          {/if}
-        </div>
-      </div>
-
-      {#if secretEntries.length === 0}
-        <div class="empty-state">No staged secret changes</div>
-      {:else}
-        <ul class="entry-list">
-          {#each secretEntries as entry}
-            {@const tagEntry = findTagEntry('secret', entry.name)}
-            <li class="entry-item">
-              <div class="entry-header">
-                <span class="operation-badge" style="background: {getOperationColor(entry.operation || '')}">
-                  {entry.operation}
-                </span>
-                <span class="entry-name">{entry.name}</span>
-                <div class="entry-actions">
-                  {#if showEditButton(entry)}
-                    <button class="btn-entry" onclick={() => openEditModal('secret', entry)}>Edit</button>
-                  {/if}
-                  <button class="btn-entry btn-unstage" onclick={() => handleUnstage('secret', entry.name)}>Unstage</button>
-                </div>
-              </div>
-              <div class="entry-tags">
-                {#if tagEntry?.addTags && Object.keys(tagEntry.addTags).length > 0}
-                  <div class="tag-changes tag-add">
-                    <span class="tag-label">+ Tags:</span>
-                    {#each Object.entries(tagEntry.addTags) as [key, value]}
-                      <button class="tag-item tag-item-editable" type="button" onclick={() => openEditTagModal('secret', entry.name, key, value)}>
-                        {key}={value}
-                        <span class="tag-delete-btn" role="button" tabindex="0" onclick={(e: MouseEvent) => { e.stopPropagation(); handleRemoveTag('secret', entry.name, key); }} onkeydown={(e: KeyboardEvent) => { e.stopPropagation(); if (e.key === 'Enter') handleRemoveTag('secret', entry.name, key); }}>×</span>
-                      </button>
-                    {/each}
-                  </div>
-                {/if}
-                {#if tagEntry?.removeTags && Object.keys(tagEntry.removeTags).length > 0}
-                  <div class="tag-changes tag-remove">
-                    <span class="tag-label">- Tags:</span>
-                    {#each Object.entries(tagEntry.removeTags) as [key, value]}
-                      <span class="tag-item">
-                        {value ? `${key}=${value}` : key}
-                        <button class="tag-cancel-btn" onclick={() => handleCancelUntag('secret', entry.name, key)} title="Cancel untag">↩</button>
-                      </span>
-                    {/each}
-                  </div>
-                {/if}
-                {#if entry.operation !== 'delete'}
-                  <button class="btn-add-tag" onclick={() => openAddTagModal('secret', entry.name)}>+ Add Tag</button>
-                {/if}
-              </div>
-              {#if entry.operation === 'delete'}
-                {#if viewMode === 'diff'}
-                  <div class="entry-diff">
-                    <DiffDisplay
-                      oldValue={entry.awsValue || ''}
-                      newValue="(deleted)"
-                      oldLabel="AWS"
-                      newLabel="Staged"
-                      oldSubLabel={entry.awsIdentifier || ''}
-                    />
-                  </div>
-                {:else}
-                  <pre class="entry-value entry-value-delete">(will be deleted)</pre>
-                {/if}
-              {:else if entry.stagedValue !== undefined && entry.stagedValue !== ''}
-                {#if viewMode === 'diff' && entry.operation !== 'create'}
-                  <div class="entry-diff">
-                    <DiffDisplay
-                      oldValue={entry.awsValue || ''}
-                      newValue={entry.stagedValue}
-                      oldLabel="AWS"
-                      newLabel="Staged"
-                      oldSubLabel={entry.awsIdentifier || ''}
-                    />
-                  </div>
-                {:else}
-                  <pre class="entry-value">{entry.stagedValue}</pre>
-                {/if}
-              {/if}
-            </li>
-          {/each}
-        </ul>
-      {/if}
-    </div>
+    <StagingSection
+      icon="S"
+      title="Secrets"
+      emptyText="No staged secret changes"
+      entries={secretEntries}
+      tagEntries={secretTagEntries}
+      {viewMode}
+      onapply={() => openApplyModal('secret')}
+      onreset={() => openResetModal('secret')}
+      onedit={(entry) => openEditModal('secret', entry)}
+      onunstage={(name) => handleUnstage('secret', name)}
+      onaddtag={(entryName) => openAddTagModal('secret', entryName)}
+      onedittag={(entryName, key, value) => openEditTagModal('secret', entryName, key, value)}
+      onremovetag={(entryName, key) => handleRemoveTag('secret', entryName, key)}
+      oncanceluntag={(entryName, key) => handleCancelUntag('secret', entryName, key)}
+    />
   </div>
 
   <div class="actions">
@@ -1124,166 +937,6 @@
     gap: 24px;
   }
 
-  .section {
-    background: #1a1a2e;
-    border-radius: 8px;
-    overflow: hidden;
-  }
-
-  .section-header {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 16px;
-    border-bottom: 1px solid #2d2d44;
-  }
-
-  .section-title {
-    margin: 0;
-    font-size: 14px;
-    color: #fff;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .section-icon {
-    width: 24px;
-    height: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 4px;
-    font-weight: bold;
-    font-size: 12px;
-  }
-
-  .count-badge {
-    font-size: 12px;
-    padding: 2px 8px;
-    background: rgba(255, 255, 255, 0.1);
-    border-radius: 10px;
-    color: #888;
-  }
-
-  .section-actions {
-    margin-left: auto;
-    display: flex;
-    gap: 8px;
-  }
-
-  .btn-section {
-    padding: 4px 10px;
-    border: none;
-    border-radius: 4px;
-    font-size: 12px;
-    cursor: pointer;
-  }
-
-  .btn-apply-sm {
-    background: #4caf50;
-    color: #fff;
-  }
-
-  .btn-apply-sm:hover {
-    background: #43a047;
-  }
-
-  .btn-reset-sm {
-    background: #f44336;
-    color: #fff;
-  }
-
-  .btn-reset-sm:hover {
-    background: #e53935;
-  }
-
-  .entry-actions {
-    display: flex;
-    gap: 6px;
-    margin-left: auto;
-  }
-
-  .btn-entry {
-    padding: 2px 8px;
-    font-size: 11px;
-    border: none;
-    border-radius: 3px;
-    cursor: pointer;
-    background: #2d2d44;
-    color: #fff;
-  }
-
-  .btn-entry:hover {
-    background: #3d3d54;
-  }
-
-  .btn-unstage {
-    background: #666;
-  }
-
-  .btn-unstage:hover {
-    background: #888;
-  }
-
-  .entry-list {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-  }
-
-  .entry-item {
-    padding: 12px 16px;
-    border-bottom: 1px solid #2d2d44;
-  }
-
-  .entry-item:last-child {
-    border-bottom: none;
-  }
-
-  .entry-header {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
-  .operation-badge {
-    font-size: 10px;
-    padding: 2px 8px;
-    border-radius: 3px;
-    color: #fff;
-    text-transform: uppercase;
-    font-weight: bold;
-  }
-
-  .entry-name {
-    flex: 1;
-    font-family: monospace;
-    font-size: 13px;
-    color: #4fc3f7;
-  }
-
-  .entry-diff {
-    margin-top: 12px;
-  }
-
-  .entry-value {
-    margin: 8px 0 0 0;
-    padding: 8px;
-    background: #0f0f1a;
-    border-radius: 4px;
-    font-family: monospace;
-    font-size: 12px;
-    color: #a5d6a7;
-    white-space: pre-wrap;
-    word-break: break-all;
-  }
-
-  .entry-value-delete {
-    color: #ef9a9a;
-  }
-
   .actions {
     position: relative;
     display: flex;
@@ -1720,103 +1373,6 @@
 
   .checkbox-label input {
     cursor: pointer;
-  }
-
-  /* Tag display styles */
-  .entry-tags {
-    margin-top: 8px;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-  }
-
-  .tag-changes {
-    display: flex;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 6px;
-    font-size: 12px;
-    padding: 4px 8px;
-    border-radius: 4px;
-  }
-
-  .tag-add {
-    background: rgba(76, 175, 80, 0.1);
-    border: 1px solid rgba(76, 175, 80, 0.3);
-  }
-
-  .tag-remove {
-    background: rgba(244, 67, 54, 0.1);
-    border: 1px solid rgba(244, 67, 54, 0.3);
-  }
-
-  .tag-label {
-    font-weight: bold;
-  }
-
-  .tag-add .tag-label {
-    color: #4caf50;
-  }
-
-  .tag-remove .tag-label {
-    color: #f44336;
-  }
-
-  .tag-item {
-    font-family: monospace;
-    padding: 2px 6px;
-    border-radius: 3px;
-    background: rgba(255, 255, 255, 0.1);
-    color: #ddd;
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-  }
-
-  .tag-item-editable {
-    cursor: pointer;
-    transition: background 0.2s;
-  }
-
-  .tag-item-editable:hover {
-    background: rgba(255, 255, 255, 0.2);
-  }
-
-  .tag-delete-btn,
-  .tag-cancel-btn {
-    background: none;
-    border: none;
-    color: #888;
-    cursor: pointer;
-    font-size: 14px;
-    line-height: 1;
-    padding: 0 2px;
-    margin-left: 2px;
-  }
-
-  .tag-delete-btn:hover {
-    color: #f44336;
-  }
-
-  .tag-cancel-btn:hover {
-    color: #4caf50;
-  }
-
-  .btn-add-tag {
-    padding: 2px 8px;
-    font-size: 11px;
-    border: 1px dashed #4caf50;
-    border-radius: 3px;
-    background: transparent;
-    color: #4caf50;
-    cursor: pointer;
-    margin-top: 4px;
-    transition: all 0.2s;
-  }
-
-  .btn-add-tag:hover {
-    background: rgba(76, 175, 80, 0.1);
-    border-style: solid;
   }
 
   /* Modal action buttons */

--- a/internal/gui/frontend/src/lib/TagList.svelte
+++ b/internal/gui/frontend/src/lib/TagList.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import './common.css';
+
+  interface Props {
+    tags: Array<{ key: string; value: string }> | undefined;
+    serviceClass: 'param' | 'secret';
+    onadd: () => void;
+    onremove: (key: string) => void;
+  }
+
+  let { tags, serviceClass, onadd, onremove }: Props = $props();
+</script>
+
+<div class="detail-section">
+  <div class="section-header">
+    <h4>Tags</h4>
+    <button class="btn-action-sm" onclick={onadd}>+ Add</button>
+  </div>
+  {#if tags && tags.length > 0}
+    <div class="tags-list">
+      {#each tags as tag}
+        <div class="tag-item">
+          <span class="tag-key {serviceClass}">{tag.key}</span>
+          <span class="tag-separator">=</span>
+          <span class="tag-value">{tag.value}</span>
+          <button class="btn-tag-remove" onclick={() => onremove(tag.key)} title="Remove tag">×</button>
+        </div>
+      {/each}
+    </div>
+  {:else}
+    <p class="no-tags">No tags</p>
+  {/if}
+</div>

--- a/internal/gui/frontend/tests/param.spec.ts
+++ b/internal/gui/frontend/tests/param.spec.ts
@@ -5,6 +5,7 @@ import {
   createParam,
   createMultiTagState,
   createNoTagsState,
+  createStagedValue,
   waitForItemList,
   clickItemByName,
   openCreateModal,
@@ -345,6 +346,8 @@ test.describe('Parameter Edge Cases', () => {
       await waitForItemList(page);
       await clickItemByName(page, '/app/config');
       await expect(page.locator('.tag-item')).toHaveCount(0);
+      // The TagList empty branch renders an explicit "No tags" message.
+      await expect(page.locator('.no-tags')).toHaveText('No tags');
     });
 
     test('should show add tag button even when no tags exist', async ({ page }) => {
@@ -353,6 +356,43 @@ test.describe('Parameter Edge Cases', () => {
       await waitForItemList(page);
       await clickItemByName(page, '/app/config');
       await expect(page.getByRole('button', { name: '+ Add' })).toBeVisible();
+    });
+  });
+
+  test.describe('Staging Banner', () => {
+    test('should not show staging banner for an item with no staged changes', async ({ page }) => {
+      await setupWailsMocks(page);
+      await page.goto('/');
+      await waitForItemList(page);
+      await clickItemByName(page, '/app/config');
+      await expect(page.locator('.staging-banner')).toHaveCount(0);
+    });
+
+    test('should show staging banner when the selected item has a staged value change', async ({ page }) => {
+      const staged: Partial<MockState> = {
+        stagedParam: [createStagedValue('/app/config', 'update', 'staged-value')],
+      };
+      await setupWailsMocks(page, staged);
+      await page.goto('/');
+      await waitForItemList(page);
+      await clickItemByName(page, '/app/config');
+      const banner = page.locator('.staging-banner');
+      await expect(banner).toBeVisible();
+      await expect(banner).toContainText('This item has staged value changes');
+      await expect(banner).toContainText('View in Staging');
+    });
+
+    test('should navigate to the staging view when the banner is clicked', async ({ page }) => {
+      const staged: Partial<MockState> = {
+        stagedParam: [createStagedValue('/app/config', 'update', 'staged-value')],
+      };
+      await setupWailsMocks(page, staged);
+      await page.goto('/');
+      await waitForItemList(page);
+      await clickItemByName(page, '/app/config');
+      await page.locator('.staging-banner').click();
+      // Clicking the banner switches the active view to the Staging area.
+      await expect(page.getByText('Staging Area')).toBeVisible();
     });
   });
 

--- a/internal/gui/frontend/tests/staging.spec.ts
+++ b/internal/gui/frontend/tests/staging.spec.ts
@@ -191,7 +191,10 @@ test.describe('Staging State Combinations', () => {
       await page.goto('/');
       await navigateTo(page, 'Staging');
       await page.waitForFunction(() => document.querySelector('.entry-item') !== null);
-      await expect(page.locator('.entry-item')).toBeVisible();
+      await expect(page.locator('.entry-item')).toHaveCount(1);
+      // Verify the staged entry renders its real name and create badge.
+      await expect(page.locator('.entry-name')).toHaveText('/test/param');
+      await expect(page.locator('.operation-badge')).toHaveText(/create/i);
     });
 
     test('should show empty state in Secret section when only Param has changes', async ({ page }) => {
@@ -217,7 +220,9 @@ test.describe('Staging State Combinations', () => {
       await page.goto('/');
       await navigateTo(page, 'Staging');
       await page.waitForFunction(() => document.querySelector('.entry-item') !== null);
-      await expect(page.locator('.entry-item')).toBeVisible();
+      await expect(page.locator('.entry-item')).toHaveCount(1);
+      // Verify the staged secret entry renders its real name.
+      await expect(page.locator('.entry-name')).toHaveText('new-secret');
     });
 
     test('should show empty state in Param section when only Secret has changes', async ({ page }) => {
@@ -366,6 +371,9 @@ test.describe('Tag Staging Display', () => {
     await page.goto('/');
     await navigateTo(page, 'Staging');
     await page.waitForFunction(() => document.querySelector('.entry-item') !== null);
+    // The entry renders both its name and the staged add-tag chip (key=value).
+    await expect(page.locator('.entry-name')).toHaveText('/app/config');
+    await expect(page.locator('.tag-add')).toContainText('version=2');
   });
 });
 

--- a/internal/gui/param.go
+++ b/internal/gui/param.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mpyw/suve/internal/cli/commands/param/paramtype"
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/usecase/param"
 	"github.com/mpyw/suve/internal/version/paramversion"
 )
@@ -153,7 +154,7 @@ func (a *App) ParamShow(specStr string) (*ParamShowResult, error) {
 		Tags:        make([]ParamShowTag, 0, len(result.Tags)),
 	}
 	if result.LastModified != nil {
-		r.LastModified = result.LastModified.Format("2006-01-02T15:04:05Z07:00")
+		r.LastModified = timeutil.FormatRFC3339(*result.LastModified)
 	}
 
 	for _, tag := range result.Tags {
@@ -193,7 +194,7 @@ func (a *App) ParamLog(name string, maxResults int32) (*ParamLogResult, error) {
 			IsCurrent: e.IsCurrent,
 		}
 		if e.LastModified != nil {
-			entry.LastModified = e.LastModified.Format("2006-01-02T15:04:05Z07:00")
+			entry.LastModified = timeutil.FormatRFC3339(*e.LastModified)
 		}
 
 		entries[i] = entry

--- a/internal/gui/secret.go
+++ b/internal/gui/secret.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mpyw/suve/internal/provider"
 	awssecret "github.com/mpyw/suve/internal/provider/aws/secret"
+	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/usecase/secret"
 	"github.com/mpyw/suve/internal/version/secretversion"
 )
@@ -163,7 +164,7 @@ func (a *App) SecretShow(specStr string) (*SecretShowResult, error) {
 		Tags:         make([]SecretShowTag, 0, len(result.Tags)),
 	}
 	if result.CreatedDate != nil {
-		r.CreatedDate = result.CreatedDate.Format("2006-01-02T15:04:05Z07:00")
+		r.CreatedDate = timeutil.FormatRFC3339(*result.CreatedDate)
 	}
 
 	for _, tag := range result.Tags {
@@ -202,7 +203,7 @@ func (a *App) SecretLog(name string, maxResults int32) (*SecretLogResult, error)
 			IsCurrent: e.IsCurrent,
 		}
 		if e.CreatedDate != nil {
-			entry.Created = e.CreatedDate.Format("2006-01-02T15:04:05Z07:00")
+			entry.Created = timeutil.FormatRFC3339(*e.CreatedDate)
 		}
 
 		entries[i] = entry
@@ -287,7 +288,7 @@ func (a *App) SecretDelete(name string, force bool) (*SecretDeleteResult, error)
 	if !force {
 		const defaultRecoveryWindowDays = 30
 
-		r.DeletionDate = time.Now().AddDate(0, 0, defaultRecoveryWindowDays).Format("2006-01-02T15:04:05Z07:00")
+		r.DeletionDate = timeutil.FormatRFC3339(time.Now().AddDate(0, 0, defaultRecoveryWindowDays))
 	}
 
 	return r, nil

--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store/file"
+	"github.com/mpyw/suve/internal/timeutil"
 	stagingusecase "github.com/mpyw/suve/internal/usecase/staging"
 )
 
@@ -142,6 +143,35 @@ type StagingDiffTagEntry struct {
 	RemoveTags map[string]string `json:"removeTags,omitempty"` // key=current value from AWS
 }
 
+// Enum → frontend-string lookup tables. Kept as immutable package-level maps so
+// the conversion sites stay a single lookup instead of a repeated switch.
+//
+//nolint:gochecknoglobals // immutable enum→string lookup tables
+var (
+	applyStatusNames = map[stagingusecase.ApplyResultStatus]string{
+		stagingusecase.ApplyResultCreated: "created",
+		stagingusecase.ApplyResultUpdated: "updated",
+		stagingusecase.ApplyResultDeleted: "deleted",
+		stagingusecase.ApplyResultFailed:  "failed",
+	}
+
+	resetTypeNames = map[stagingusecase.ResetResultType]string{
+		stagingusecase.ResetResultUnstaged:      "unstaged",
+		stagingusecase.ResetResultUnstagedAll:   "unstagedAll",
+		stagingusecase.ResetResultRestored:      "restored",
+		stagingusecase.ResetResultNotStaged:     "notStaged",
+		stagingusecase.ResetResultNothingStaged: "nothingStaged",
+		stagingusecase.ResetResultSkipped:       "skipped",
+	}
+
+	diffEntryTypeNames = map[stagingusecase.DiffEntryType]string{
+		stagingusecase.DiffEntryNormal:       "normal",
+		stagingusecase.DiffEntryCreate:       "create",
+		stagingusecase.DiffEntryAutoUnstaged: "autoUnstaged",
+		stagingusecase.DiffEntryWarning:      "warning",
+	}
+)
+
 // =============================================================================
 // Staging Methods
 // =============================================================================
@@ -178,50 +208,44 @@ func (a *App) StagingStatus() (*StagingStatusResult, error) {
 		return nil, err
 	}
 
-	result := &StagingStatusResult{
-		Param:      make([]StagingEntry, len(paramResult.Entries)),
-		Secret:     make([]StagingEntry, len(secretResult.Entries)),
-		ParamTags:  make([]StagingTagEntry, len(paramResult.TagEntries)),
-		SecretTags: make([]StagingTagEntry, len(secretResult.TagEntries)),
-	}
+	return &StagingStatusResult{
+		Param:      toStagingEntries(paramResult.Entries),
+		Secret:     toStagingEntries(secretResult.Entries),
+		ParamTags:  toStagingTagEntries(paramResult.TagEntries),
+		SecretTags: toStagingTagEntries(secretResult.TagEntries),
+	}, nil
+}
 
-	for i, e := range paramResult.Entries {
-		result.Param[i] = StagingEntry{
+// toStagingEntries converts use-case status entries into the frontend DTO,
+// formatting timestamps as RFC3339.
+func toStagingEntries(entries []stagingusecase.StatusEntry) []StagingEntry {
+	out := make([]StagingEntry, len(entries))
+	for i, e := range entries {
+		out[i] = StagingEntry{
 			Name:      e.Name,
 			Operation: string(e.Operation),
 			Value:     e.Value,
-			StagedAt:  e.StagedAt.Format("2006-01-02T15:04:05Z07:00"),
+			StagedAt:  timeutil.FormatRFC3339(e.StagedAt),
 		}
 	}
 
-	for i, e := range secretResult.Entries {
-		result.Secret[i] = StagingEntry{
-			Name:      e.Name,
-			Operation: string(e.Operation),
-			Value:     e.Value,
-			StagedAt:  e.StagedAt.Format("2006-01-02T15:04:05Z07:00"),
-		}
-	}
+	return out
+}
 
-	for i, t := range paramResult.TagEntries {
-		result.ParamTags[i] = StagingTagEntry{
+// toStagingTagEntries converts use-case status tag entries into the frontend
+// DTO, formatting timestamps as RFC3339.
+func toStagingTagEntries(tags []stagingusecase.StatusTagEntry) []StagingTagEntry {
+	out := make([]StagingTagEntry, len(tags))
+	for i, t := range tags {
+		out[i] = StagingTagEntry{
 			Name:       t.Name,
 			AddTags:    t.Add,
 			RemoveTags: t.Remove.Values(),
-			StagedAt:   t.StagedAt.Format("2006-01-02T15:04:05Z07:00"),
+			StagedAt:   timeutil.FormatRFC3339(t.StagedAt),
 		}
 	}
 
-	for i, t := range secretResult.TagEntries {
-		result.SecretTags[i] = StagingTagEntry{
-			Name:       t.Name,
-			AddTags:    t.Add,
-			RemoveTags: t.Remove.Values(),
-			StagedAt:   t.StagedAt.Format("2006-01-02T15:04:05Z07:00"),
-		}
-	}
-
-	return result, nil
+	return out
 }
 
 // StagingApply applies staged changes for a service.
@@ -259,20 +283,11 @@ func (a *App) StagingApply(service string, ignoreConflicts bool) (*StagingApplyR
 
 	for _, r := range result.EntryResults {
 		entry := StagingApplyEntryResult{
-			Name: r.Name,
+			Name:   r.Name,
+			Status: applyStatusNames[r.Status],
 		}
-		switch r.Status {
-		case stagingusecase.ApplyResultCreated:
-			entry.Status = "created"
-		case stagingusecase.ApplyResultUpdated:
-			entry.Status = "updated"
-		case stagingusecase.ApplyResultDeleted:
-			entry.Status = "deleted"
-		case stagingusecase.ApplyResultFailed:
-			entry.Status = "failed"
-			if r.Error != nil {
-				entry.Error = r.Error.Error()
-			}
+		if r.Status == stagingusecase.ApplyResultFailed && r.Error != nil {
+			entry.Error = r.Error.Error()
 		}
 
 		output.EntryResults = append(output.EntryResults, entry)
@@ -316,28 +331,12 @@ func (a *App) StagingReset(service string) (*StagingResetResult, error) {
 		return nil, err
 	}
 
-	output := &StagingResetResult{
+	return &StagingResetResult{
 		ServiceName: result.ServiceName,
 		Name:        result.Name,
 		Count:       result.Count,
-	}
-
-	switch result.Type {
-	case stagingusecase.ResetResultUnstaged:
-		output.Type = "unstaged"
-	case stagingusecase.ResetResultUnstagedAll:
-		output.Type = "unstagedAll"
-	case stagingusecase.ResetResultRestored:
-		output.Type = "restored"
-	case stagingusecase.ResetResultNotStaged:
-		output.Type = "notStaged"
-	case stagingusecase.ResetResultNothingStaged:
-		output.Type = "nothingStaged"
-	case stagingusecase.ResetResultSkipped:
-		output.Type = "skipped"
-	}
-
-	return output, nil
+		Type:        resetTypeNames[result.Type],
+	}, nil
 }
 
 // StagingAdd stages a create operation for a new item.
@@ -633,8 +632,9 @@ func (a *App) StagingDiff(service string, name string) (*StagingDiffResult, erro
 
 	entries := make([]StagingDiffEntry, len(result.Entries))
 	for i, e := range result.Entries {
-		entry := StagingDiffEntry{
+		entries[i] = StagingDiffEntry{
 			Name:          e.Name,
+			Type:          diffEntryTypeNames[e.Type],
 			Operation:     string(e.Operation),
 			AWSValue:      e.AWSValue,
 			AWSIdentifier: e.AWSIdentifier,
@@ -642,18 +642,6 @@ func (a *App) StagingDiff(service string, name string) (*StagingDiffResult, erro
 			Description:   e.Description,
 			Warning:       e.Warning,
 		}
-		switch e.Type {
-		case stagingusecase.DiffEntryNormal:
-			entry.Type = "normal"
-		case stagingusecase.DiffEntryCreate:
-			entry.Type = "create"
-		case stagingusecase.DiffEntryAutoUnstaged:
-			entry.Type = "autoUnstaged"
-		case stagingusecase.DiffEntryWarning:
-			entry.Type = "warning"
-		}
-
-		entries[i] = entry
 	}
 
 	tagEntries := make([]StagingDiffTagEntry, len(result.TagEntries))
@@ -732,31 +720,45 @@ func (a *App) StagingFileStatus() (*StagingFileStatusResult, error) {
 	return result, nil
 }
 
+// stashStores builds the stash (stash.json) and working (stage.json) file
+// stores for the current AWS identity and resolves the optional service
+// selector. It is the shared prelude of StagingDrain and StagingPersist. An
+// empty service yields the zero staging.Service (all services).
+func (a *App) stashStores(service, passphrase string) (stash, working *file.Store, svc staging.Service, err error) {
+	identity, err := infra.GetAWSIdentity(a.ctx)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	scope := provider.AWSScope(identity.AccountID, identity.Region)
+
+	stash, err = file.NewStashStoreWithPassphrase(scope, passphrase)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	working, err = file.NewWorkingStore(scope)
+	if err != nil {
+		return nil, nil, "", err
+	}
+
+	if service != "" {
+		svc, err = a.getService(service)
+		if err != nil {
+			return nil, nil, "", err
+		}
+	}
+
+	return stash, working, svc, nil
+}
+
 // StagingDrain loads staged changes from the stash file into the working staging area.
 // If the file is encrypted, passphrase must be provided.
 // mode: "overwrite" or "merge" (default)
 func (a *App) StagingDrain(service string, passphrase string, keep bool, mode string) (*StagingDrainResult, error) {
-	identity, err := infra.GetAWSIdentity(a.ctx)
+	stashStore, working, svc, err := a.stashStores(service, passphrase)
 	if err != nil {
 		return nil, err
-	}
-
-	stashStore, err := file.NewStashStoreWithPassphrase(provider.AWSScope(identity.AccountID, identity.Region), passphrase)
-	if err != nil {
-		return nil, err
-	}
-
-	working, err := file.NewWorkingStore(provider.AWSScope(identity.AccountID, identity.Region))
-	if err != nil {
-		return nil, err
-	}
-
-	var svc staging.Service
-	if service != "" {
-		svc, err = a.getService(service)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	drainMode := stagingusecase.StashModeMerge
@@ -789,27 +791,9 @@ func (a *App) StagingDrain(service string, passphrase string, keep bool, mode st
 // If passphrase is provided, the file will be encrypted.
 // mode: "overwrite" or "merge"
 func (a *App) StagingPersist(service string, passphrase string, keep bool, mode string) (*StagingPersistResult, error) {
-	identity, err := infra.GetAWSIdentity(a.ctx)
+	stashStore, working, svc, err := a.stashStores(service, passphrase)
 	if err != nil {
 		return nil, err
-	}
-
-	stashStore, err := file.NewStashStoreWithPassphrase(provider.AWSScope(identity.AccountID, identity.Region), passphrase)
-	if err != nil {
-		return nil, err
-	}
-
-	working, err := file.NewWorkingStore(provider.AWSScope(identity.AccountID, identity.Region))
-	if err != nil {
-		return nil, err
-	}
-
-	var svc staging.Service
-	if service != "" {
-		svc, err = a.getService(service)
-		if err != nil {
-			return nil, err
-		}
 	}
 
 	persistMode := stagingusecase.StashModeOverwrite


### PR DESCRIPTION
Closes #211 (Part of #189, Backlog)

## Summary

Reduces the GUI frontend + Go-binding debt from the GUI audit. **Behavior-preserving** — Playwright green (chromium 458→461, +3 new tests). `+899 / −778` across 13 files.

## Go bindings (`internal/gui`)
- **RFC3339 helper**: ~10 `"2006-01-02T15:04:05Z07:00"` literals → `timeutil.FormatRFC3339` (matches the rest of the codebase).
- **`get*Strategy` collapse**: the 4 near-identical param/secret switches → one generic `strategyAs[T]` helper (preserving `getDeleteStrategy`'s `DeleteStrategy` assertion).
- **Conversion loops / enum switches**: `StagingStatus`'s 4 loops → `toStagingEntries`/`toStagingTagEntries`; the apply-status/reset-type/diff-entry-type switches → immutable lookup tables.
- **`StagingDrain`/`StagingPersist`**: share a `stashStores(...)` prelude; the two public methods are thin wrappers with identical observable behavior.

## Frontend (Svelte)
- **StagingView 1959 → 1515**: extracted `StagingSection.svelte` (the per-service staged-changes section, previously duplicated for Parameters and Secrets).
- **ParamView 802 → 726 / SecretView 930 → 854**: extracted shared `StagingBanner.svelte` + `TagList.svelte`. **#206 provider-driven param types (`ParamTypeOptions`) and secret ARN/Version-ID/Stages differences are preserved.** Bundle shrank (JS 118.6→114.0 kB), confirming real dedup.

## Tests
- **Go↔JS contract test** (`dto_contract_internal_test.go`): reflects all 44 exported binding DTOs' JSON field sets and diffs them against `wailsjs/go/models.ts` — catches Go/JS DTO drift in either direction. Runs in the `-tags=production` GUI lane.
- **Playwright**: strengthened weak `toBeVisible` assertions around the refactored areas (entry content, add-tag chips, TagList "No tags") and added a `Staging Banner` describe (+3, previously uncovered). Chromium **461 passed** locally; CI validates firefox/webkit.

## GUI-as-own-module (evaluation)
The top-level `gui/` is just the Wails entry; DTOs live in `internal/gui` behind `production||dev` tags (so the contract test runs only in the GUI lane, not default `make test`). **Recommendation**: extracting the DTO structs into a build-tag-free `contract` package would be worth it *if* the team wants the contract test in `make test` and/or to codegen `models.ts` — non-trivial (DTOs are `App` method return types), so a follow-up, not folded in here.

## ⚠️ Deferred (documented follow-up)
Extracting the stash/persist/drain/drop modal cluster from StagingView into a `StashControls` child — it owns heavy shared async state and is the most Playwright-covered area (`staging-stash.spec.ts`, 2229 LOC); lifting it cleanly risked regressions disproportionate to the gain. StagingView still dropped ~450 LOC via the section split.

## Verification
```
$ make test    # green (incl. Go↔JS contract test in the GUI lane)
$ make lint     # 0 issues
$ CGO_ENABLED=1 go test -tags=production ./internal/gui/...   # ok
$ go test -tags e2e -run xxxNoMatch ./e2e/...                 # compiles
$ go build ./cmd/suve
$ cd internal/gui/frontend && npm run build && npm run ci     # clean (2 pre-existing a11y warnings, untouched files)
# Playwright chromium 461 passed; CI runs firefox/webkit
```

## Acceptance criteria
- [x] StagingView decomposed; ParamView/SecretView duplication reduced; Go binding duplication reduced
- [x] A Go↔JS contract test exists
- [x] `make test` green · `make lint` green · `make gui-test` green (chromium local; CI cross-browser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)