### PR TITLE
docs: fix issues found in self-review of the multi-cloud cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ suve/
 ├── .github/workflows/
 │   └── test.yml                  # CI: test + lint on push/PR
 │
-└── Makefile                      # build, test, lint, e2e, gui, up, down
+└── Makefile                      # build, test, lint, e2e, gui-dev/gui-build/gui-bindings, up, down
 ```
 
 ### Key Design Patterns

--- a/README.md
+++ b/README.md
@@ -548,7 +548,7 @@ Uses integer version numbers (with the `latest` alias) and has no staging labels
 | Command | Options | Description |
 |---------|---------|-------------|
 | `suve gcloud secret show` | `--raw`<br>`--parse-json` (`-j`)<br>`--no-pager`<br>`--output=<FORMAT>` | Display secret with metadata |
-| `suve gcloud secret log` | `--number=<N>` (`-n`)<br>`--patch` (`-p`)<br>`--parse-json` (`-j`)<br>`--oneline`<br>`--reverse`<br>`--no-pager`<br>`--output=<FORMAT>` | Show version history |
+| `suve gcloud secret log` | `--number=<N>` (`-n`)<br>`--patch` (`-p`)<br>`--parse-json` (`-j`)<br>`--oneline`<br>`--reverse`<br>`--since=<DATE>`<br>`--until=<DATE>`<br>`--no-pager`<br>`--output=<FORMAT>` | Show version history |
 | `suve gcloud secret diff` | `--parse-json` (`-j`)<br>`--no-pager`<br>`--output=<FORMAT>` | Compare versions |
 | `suve gcloud secret list` | `--filter=<REGEX>`<br>`--show`<br>`--output=<FORMAT>` | List secrets |
 | `suve gcloud secret create` | | Create new secret |
@@ -567,7 +567,7 @@ Secrets are versioned by opaque IDs and have no staging labels. Select the vault
 | Command | Options | Description |
 |---------|---------|-------------|
 | `suve azure secret show` | `--raw`<br>`--parse-json` (`-j`)<br>`--no-pager`<br>`--output=<FORMAT>` | Display secret with metadata |
-| `suve azure secret log` | `--number=<N>` (`-n`)<br>`--patch` (`-p`)<br>`--parse-json` (`-j`)<br>`--oneline`<br>`--reverse`<br>`--no-pager`<br>`--output=<FORMAT>` | Show version history |
+| `suve azure secret log` | `--number=<N>` (`-n`)<br>`--patch` (`-p`)<br>`--parse-json` (`-j`)<br>`--oneline`<br>`--reverse`<br>`--since=<DATE>`<br>`--until=<DATE>`<br>`--no-pager`<br>`--output=<FORMAT>` | Show version history |
 | `suve azure secret diff` | `--parse-json` (`-j`)<br>`--no-pager`<br>`--output=<FORMAT>` | Compare versions |
 | `suve azure secret list` | `--filter=<REGEX>`<br>`--show`<br>`--output=<FORMAT>` | List secrets |
 | `suve azure secret create` | | Create new secret |

--- a/docs/provider-seam.md
+++ b/docs/provider-seam.md
@@ -1,6 +1,13 @@
 # Provider Seam Design
 
-Status: design (issue #199)
+Status: design (issue #199) — **historical**. This is the original design note
+for the seam. It has since shipped and evolved: the AWS/GCP/Azure adapters, the
+usecase/CLI migration, and multi-cloud support all landed. Notably, the
+`internal/api/paramapi` / `internal/api/secretapi` wrappers referenced below
+were **removed** — the AWS adapter now imports the AWS SDK directly (confined to
+`internal/provider/aws/**`). See `docs/provider-selection.md` for the current
+architecture.
+
 Scope of this issue: the provider-neutral **seam** — the `domain` value types and
 the `provider` interfaces/registry — plus this document. No AWS adapters, no
 usecase/CLI migration, no additional cloud providers.

--- a/docs/provider-selection.md
+++ b/docs/provider-selection.md
@@ -3,70 +3,81 @@
 suve is built around a provider seam: the CLI and staging layers talk to a
 provider-neutral `provider.Store` (Reader / Writer / Tagger) instead of a cloud
 SDK. A `provider.Registry` maps a `provider.Scope` to the concrete backend that
-serves it. This document describes how a provider is selected today and how new
-clouds will plug in.
+serves it. This document describes how a provider is selected.
 
-## Today: AWS is the default (and only) provider
+## Selection is by top-level command group
 
-The top-level commands are unchanged and always target AWS:
+There is **no `--provider` flag**. The provider is chosen by which top-level
+command group you invoke; each group builds a provider-specific `provider.Scope`
+and reuses the *same* generic commands and the *same* registry:
 
 ```
-suve param  ...   # AWS Systems Manager Parameter Store
-suve secret ...   # AWS Secrets Manager
-suve stage  ...   # staging for the above
+suve param  ...          # AWS Systems Manager Parameter Store  (provider.AWSScope)
+suve secret ...          # AWS Secrets Manager                  (provider.AWSScope)
+suve stage  ...          # staging for the AWS services above
+suve gcloud secret ...   # Google Cloud Secret Manager          (provider.GoogleCloudScope)
+suve azure  secret ...   # Azure Key Vault                      (provider.AzureKeyVaultScope)
+suve azure  param  ...   # Azure App Configuration              (provider.AzureAppConfigScope)
 ```
 
-There is **no `--provider` flag** — AWS is the only registered backend, so
-adding a selection flag now would have nothing to select. Provider resolution
-still goes through the registry:
+The registry is built once with all backends registered
+(`internal/cli/commands/internal/client.go`):
 
-1. The registry is built once with AWS registered
-   (`internal/provider/aws.NewRegistry()`), reachable from the command layer
-   via `internal/cli/commands/internal`.
-2. Each command builds an AWS `provider.Scope` from the current AWS identity
-   (`infra.GetAWSIdentity` → `provider.AWSScope(accountID, region)`).
-3. It asks the registry for the store it needs:
+```go
+reg := aws.NewRegistry()
+gcp.Register(reg)
+azure.Register(reg)
+```
+
+Each command group resolves its store through this shared registry:
+
+1. It builds the provider-specific `provider.Scope`:
+   - **AWS** — from the current AWS identity (`infra.GetAWSIdentity` →
+     `provider.AWSScope(accountID, region)`). Read/write commands only need
+     `provider.Scope{Provider: provider.ProviderAWS}` (the region comes from the
+     ambient AWS config), so they do not pay for an STS call; the account/region
+     identity is resolved separately, only where staging state must be keyed.
+   - **Google Cloud** — the project id from `--project` or `GOOGLE_CLOUD_PROJECT`
+     (`provider.GoogleCloudScope(project)`).
+   - **Azure** — subscription / resource group (`--subscription` /
+     `--resource-group` or `AZURE_*` env) plus the Key Vault name
+     (`--vault-name`) or App Configuration store name (`--store-name`)
+     (`provider.AzureKeyVaultScope(...)` / `provider.AzureAppConfigScope(...)`).
+2. It asks the registry for the store it needs:
    `registry.Store(ctx, scope, provider.KindParam)` (or `KindSecret`).
 
 The returned `provider.Store` is handed to the generic show / diff / list / log
-/ tag / untag commands, the create / update / delete / restore commands, and the
-staging strategies (`staging.NewParamStrategy` / `NewSecretStrategy`). No command
-or usecase constructs an AWS SDK client or adapter directly anymore.
+/ tag / untag commands and the create / update / delete / restore commands. No
+command or usecase constructs a cloud SDK client or adapter directly.
 
-The same AWS scope keys on-disk staging state (see `provider.Scope.Key`), so
-staged changes are partitioned per account/region.
+Staging is AWS-only. The AWS scope keys on-disk staging state (see
+`provider.Scope.Key`), so staged changes are partitioned per account/region
+under `~/.suve/staging/aws/<account>/<region>/`.
 
 ## Enforced boundary
 
 An architecture test (`internal/architecture_test.go`) fails the build if any
-non-test package under `internal/cli`, `internal/usecase`, or `internal/staging`
-imports the AWS service SDK (`aws-sdk-go-v2/service/ssm`,
-`.../secretsmanager`) or the `internal/api/paramapi` / `internal/api/secretapi`
-aliases. The AWS SDK is confined to `internal/provider/aws/**`
-(`internal/api` and `internal/infra` are low-level allowed importers).
+non-test package under `internal/cli`, `internal/usecase`, `internal/staging`,
+or `internal/gui` imports a cloud service SDK directly. Each SDK is confined to
+its own adapter:
 
-> Note: `internal/gui/**` is intentionally excluded from this guard for now; its
-> migration onto the provider registry is tracked by issue #206. Until then the
-> GUI keeps constructing AWS clients directly.
+| SDK (banned outside its adapter)                       | Allowed only in            |
+| ----------------------------------------------------- | -------------------------- |
+| `aws-sdk-go-v2/service/ssm`, `.../secretsmanager`     | `internal/provider/aws/**` |
+| `cloud.google.com/go/secretmanager`                   | `internal/provider/gcp/**` |
+| `github.com/Azure/azure-sdk-for-go`                   | `internal/provider/azure/**` |
 
-## Future: additional clouds as top-level command groups
+`internal/infra` is a low-level allowed importer for AWS client bootstrapping
+and is not under the guarded roots. The `internal/gui` tree is guarded too: it
+constructs stores through the provider registry rather than talking to a cloud
+SDK. depguard (`.golangci.yaml`) enforces the same confinement at lint time.
 
-New providers will be added as their own top-level command groups that build a
-provider-specific `provider.Scope` and reuse the *same* generic commands and the
-*same* registry. Sketch:
+## Adding another cloud
 
-```
-suve gcloud secret ...   # Google Cloud Secret Manager  (provider.GoogleCloudScope)
-suve azure  secret ...   # Azure Key Vault              (provider.AzureKeyVaultScope)
-suve azure  param  ...   # Azure App Configuration      (provider.AzureAppConfigScope)
-```
-
-Each group differs only in how it builds its `provider.Scope` (project id,
-subscription/resource-group/vault, …) and in registering its factory
-(`registry.Register(provider.ProviderGoogleCloud, …)`). Everything downstream —
-version-spec parsing, the generic command presenters, and the staging
-strategies — is provider-neutral and is reused unchanged.
-
-`suve param` / `suve secret` remain AWS-only shortcuts and keep their current
-behavior. Implementing the GCP and Azure backends is out of scope here (tracked
-by #207 and #208); this wiring only makes the selection pluggable.
+A new provider is another top-level command group plus a registered factory:
+implement the `provider.Reader` / `Writer` / `Tagger` interfaces in a new
+`internal/provider/<cloud>/**` adapter, register it
+(`registry.Register(provider.Provider<Cloud>, ...)`), add its version-spec
+parser under `internal/version/`, and wire a command group that builds the
+provider's `provider.Scope`. Everything downstream — the generic command
+presenters and version resolution — is provider-neutral and reused unchanged.

--- a/mise.toml
+++ b/mise.toml
@@ -7,7 +7,10 @@
 #   - the wails CLI is pinned to the same release as the wailsapp/wails/v2
 #     library in gui/go.mod so `wails dev` / `wails build` match the bindings.
 [tools]
-go = "1.25"
+# Pinned to the exact go.mod directive so CI's carve-out jobs (which read the
+# version from go.mod via setup-go) and the mise jobs compile with the same
+# Go patch release.
+go = "1.25.0"
 node = "20"
 golangci-lint = "2.11.4"
 goreleaser = "2"


### PR DESCRIPTION
## Summary

A strict self-review of the prior multi-cloud docs/tooling work (PRs #242–244) surfaced one real miss and a few small inaccuracies. This PR fixes them.

## Findings addressed

- **`docs/provider-selection.md` (was materially stale — the real miss):** it still described AWS as the only provider and GCP/Azure as unimplemented "future" work. Both are shipped and selected via the `gcloud`/`azure` command groups. Rewritten to describe the current selection model. Also corrected removed-architecture references: `internal/api` listed as an "allowed importer" (deleted), the `#206` GUI-guard exclusion (GUI is now guarded and on the registry), and the incomplete arch-guard SDK list (it now also bans the GCP and Azure SDKs).
- **`docs/provider-seam.md`:** marked as a historical design note; added a line that the `paramapi`/`secretapi` wrappers it references were later removed (AWS adapter imports the SDK directly).
- **`README.md`:** the `gcloud secret log` and `azure secret log` option rows omitted `--since`/`--until`, which both commands accept (the AWS rows and the dedicated docs already listed them).
- **`CLAUDE.md`:** the architecture tree's Makefile one-line comment still said `gui`; corrected to `gui-dev/gui-build/gui-bindings`.
- **`mise.toml`:** pinned `go` to exact `1.25.0` (matching the go.mod directive), so the Ubuntu-22.04 carve-out jobs (which read Go from go.mod via setup-go) and the mise jobs use the same Go patch — closes a reproducibility drift flagged in review.

## Not changed (deliberate)
- `docs/staging-state-transitions.md` uses AWS-centric wording ("in AWS") but matches the Go source comments' own convention and is otherwise accurate; left as-is to avoid churn.

## Test
- Docs + one-line mise pin only. `mise.toml` parses and `go 1.25.0` resolves. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155B8urnRZNHqfLrEnpxUE9