### PR TITLE
feat(cli): provider-first groups with env-resolved flat aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,18 +471,76 @@ where ~SHIFT = ~ | ~N  (repeatable, cumulative)
 > [!NOTE]
 > Azure App Configuration is unversioned. Version specifiers (`#VERSION`, `~SHIFT`, `:LABEL`) are rejected, and `log` reports that history is unsupported.
 
+## Providers
+
+### Feature support
+
+| Backend | Command | Versioning | Labels / Tags | Staging | Auth |
+|---------|---------|------------|---------------|---------|------|
+| [AWS Parameter Store](docs/param.md) | `aws param` | ✅ numeric | ✅ tags | ✅ | shared config/env/role |
+| [AWS Secrets Manager](docs/secret.md) | `aws secret` | ✅ UUID + staging labels | ✅ tags | ✅ | shared config/env/role |
+| [Google Cloud Secret Manager](docs/gcloud.md) | `gcloud secret` | ✅ integer (`latest`) | ✅ labels | 🔜 [#247](https://github.com/mpyw/suve/issues/247) | Application Default Credentials |
+| [Azure Key Vault](docs/azure.md) | `azure secret` | ✅ opaque id | ✅ tags | 🔜 [#247](https://github.com/mpyw/suve/issues/247) | DefaultAzureCredential |
+| [Azure App Configuration](docs/azure.md) | `azure param` | ❌ unversioned | ❌ unsupported¹ | 🔜 [#247](https://github.com/mpyw/suve/issues/247) | DefaultAzureCredential |
+
+Read/write operations (`show`, `log`, `diff`, `list`, `create`, `update`, `delete`, `tag`, `untag`) are available on every backend, with these caveats: `restore` is AWS Secrets Manager only; on Azure App Configuration `log` reports history unsupported and `tag`/`untag` return an unsupported error; version specifiers (`#VERSION`, `~SHIFT`, `:LABEL`) are rejected on App Configuration. Only AWS Secrets Manager has staging labels (`:AWSCURRENT` etc.).
+
+¹ The `azappconfig` SDK cannot write setting tags without clearing them, so tag writes are refused.
+
+### Provider selection
+
+Every backend has an **explicit command group that is always available**, regardless of environment:
+
+```bash
+suve aws param   ...   # AWS Parameter Store
+suve aws secret  ...   # AWS Secrets Manager
+suve aws stage   ...   # AWS staging
+suve gcloud secret ... # Google Cloud Secret Manager
+suve azure secret  ... # Azure Key Vault
+suve azure param   ... # Azure App Configuration
+```
+
+For convenience, suve also exposes **bare top-level aliases** — `suve param`, `suve secret`, `suve stage` — but only when the environment makes the target unambiguous. `param` and `secret` are resolved independently; `stage` follows AWS (staging is AWS-only for now, see [#247](https://github.com/mpyw/suve/issues/247)):
+
+1. A backend is **active** when its identifying environment variable is set:
+
+   | Backend | Active when set |
+   |---------|-----------------|
+   | AWS | `AWS_ACCESS_KEY_ID`, `AWS_VAULT`, or `AWS_PROFILE` |
+   | Google Cloud | `GOOGLE_CLOUD_PROJECT` |
+   | Azure Key Vault (secret) | `AZURE_KEYVAULT_NAME` |
+   | Azure App Configuration (param) | `AZURE_APPCONFIG_NAME` |
+
+2. The bare alias for a service appears **only when exactly one backend is active** for it. Zero or two-plus active → no alias, use the explicit group. **There is no priority order** — ambiguity is never resolved silently.
+3. **AWS fallback:** if no backend is active via env at all, AWS is accepted via `~/.aws/credentials` (or `$AWS_SHARED_CREDENTIALS_FILE`). If that is also absent, there are no bare aliases.
+
+Examples (`—` = alias not exposed):
+
+| Environment | `param` → | `secret` → | `stage` |
+|-------------|-----------|------------|---------|
+| nothing set, `~/.aws/credentials` present | `aws` | `aws` | ✅ |
+| `AWS_PROFILE` | `aws` | `aws` | ✅ |
+| `GOOGLE_CLOUD_PROJECT` | — | `gcloud` | ❌ |
+| `AZURE_APPCONFIG_NAME` | `azure` | — | ❌ |
+| `AWS_PROFILE` + `GOOGLE_CLOUD_PROJECT` | `aws` | — (ambiguous) | ✅ |
+| nothing set, no credentials file | — | — | ❌ |
+
+`suve --help` lists which aliases are active in the current environment.
+
 ## Command Reference
 
 ### Services
 
-| Service | Aliases |
-|---------|---------|
-| [AWS SSM Parameter Store](docs/param.md) | `param`, `ssm`, `ps` |
-| [AWS Secrets Manager](docs/secret.md) | `secret`, `sm` |
-| [Google Cloud Secret Manager](docs/gcloud.md) | `gcloud secret` |
-| [Azure Key Vault](docs/azure.md) | `azure secret` |
-| [Azure App Configuration](docs/azure.md) | `azure param` |
-| Staging (AWS only) | `stage`, `stg` |
+Explicit command groups (always available) and their bare aliases (exposed per the [provider selection](#provider-selection) rules above):
+
+| Backend | Explicit command | Bare alias (conditional) |
+|---------|------------------|--------------------------|
+| [AWS SSM Parameter Store](docs/param.md) | `aws param` (`ssm`, `ps`) | `param` |
+| [AWS Secrets Manager](docs/secret.md) | `aws secret` (`sm`) | `secret` |
+| AWS Staging | `aws stage` (`stg`) | `stage` |
+| [Google Cloud Secret Manager](docs/gcloud.md) | `gcloud secret` | `secret` |
+| [Azure Key Vault](docs/azure.md) | `azure secret` | `secret` |
+| [Azure App Configuration](docs/azure.md) | `azure param` | `param` |
 
 ### SSM Parameter Store
 

--- a/internal/cli/commands/app.go
+++ b/internal/cli/commands/app.go
@@ -3,16 +3,21 @@ package commands
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/samber/lo"
 	"github.com/urfave/cli/v3"
 
+	awscmd "github.com/mpyw/suve/internal/cli/commands/aws"
 	"github.com/mpyw/suve/internal/cli/commands/azure"
 	"github.com/mpyw/suve/internal/cli/commands/gcloud"
 	"github.com/mpyw/suve/internal/cli/commands/param"
 	"github.com/mpyw/suve/internal/cli/commands/secret"
 	"github.com/mpyw/suve/internal/cli/commands/stage"
 	"github.com/mpyw/suve/internal/cli/output"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/detect"
 )
 
 // Version is set by goreleaser via ldflags.
@@ -20,19 +25,50 @@ import (
 //nolint:gochecknoglobals // build-time variable set by ldflags
 var Version = "dev"
 
-// MakeApp creates a new CLI application instance.
+const baseUsage = "Git-like CLI for AWS Parameter Store / Secrets Manager, " +
+	"Google Cloud Secret Manager, and Azure Key Vault / App Configuration"
+
+// MakeApp creates a new CLI application instance, resolving the flat
+// `param` / `secret` aliases from the current environment.
 func MakeApp() *cli.Command {
+	return MakeAppWithDetect(detect.Resolve(detect.OSEnvironment()))
+}
+
+// MakeAppWithDetect builds the app with an explicit provider-detection result.
+// It is the injectable seam behind MakeApp: production passes the env-resolved
+// result, while tests (and any caller needing determinism) pass a fixed one.
+func MakeAppWithDetect(det detect.Result) *cli.Command {
+	// The explicit provider groups are always present and unambiguous.
+	commands := []*cli.Command{
+		awscmd.Command(),
+		gcloud.Command(),
+		azure.Command(),
+	}
+
+	// Flat aliases are prepended only when a service resolves to exactly one
+	// active provider (see internal/provider/detect).
+	var flat []*cli.Command
+	if c := flatCommand(det.Param, provider.KindParam); c != nil {
+		flat = append(flat, c)
+	}
+
+	if c := flatCommand(det.Secret, provider.KindSecret); c != nil {
+		flat = append(flat, c)
+	}
+
+	// Staging is AWS-only, so the top-level `stage` alias appears only when AWS
+	// is active — consistent with param/secret. It is always reachable
+	// explicitly as `suve aws stage`.
+	if det.FlatStage() {
+		flat = append(flat, stage.Command())
+	}
+
 	return &cli.Command{
-		Name:    "suve",
-		Usage:   "Git-like CLI for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration",
-		Version: Version,
-		Commands: []*cli.Command{
-			param.Command(),
-			secret.Command(),
-			stage.Command(),
-			gcloud.Command(),
-			azure.Command(),
-		},
+		Name:        "suve",
+		Usage:       baseUsage,
+		Description: aliasDescription(det),
+		Version:     Version,
+		Commands:    append(flat, commands...),
 		CommandNotFound: func(_ context.Context, cmd *cli.Command, command string) {
 			_ = cli.ShowAppHelp(cmd)
 			w := lo.CoalesceOrEmpty(cmd.Root().ErrWriter, cmd.Root().Writer)
@@ -40,6 +76,81 @@ func MakeApp() *cli.Command {
 			output.Warning(w, "Command not found: %s", command)
 		},
 	}
+}
+
+// flatCommand builds the top-level alias command (named "param" or "secret") for
+// the given uniquely-active provider, or nil when there is none. It reuses each
+// provider's real implementation so the alias behaves exactly like the explicit
+// form.
+func flatCommand(p provider.Provider, kind provider.Kind) *cli.Command {
+	switch kind {
+	case provider.KindParam:
+		switch p {
+		case provider.ProviderAWS:
+			return param.Command()
+		case provider.ProviderAzure:
+			return azure.FlatParamCommand("param")
+		case provider.ProviderGoogleCloud:
+			// Google Cloud has no parameter store; never a param alias.
+			return nil
+		}
+	case provider.KindSecret:
+		switch p {
+		case provider.ProviderAWS:
+			return secret.Command()
+		case provider.ProviderGoogleCloud:
+			return gcloud.FlatSecretCommand("secret")
+		case provider.ProviderAzure:
+			return azure.FlatSecretCommand("secret")
+		}
+	}
+
+	return nil
+}
+
+// aliasDescription explains which flat aliases are active (and why), so the
+// environment-dependent top-level help is self-documenting.
+func aliasDescription(det detect.Result) string {
+	var lines []string
+	if det.FlatParam() {
+		lines = append(lines, fmt.Sprintf("  param  -> %s", groupName(det.Param)))
+	}
+
+	if det.FlatSecret() {
+		lines = append(lines, fmt.Sprintf("  secret -> %s", groupName(det.Secret)))
+	}
+
+	if det.FlatStage() {
+		lines = append(lines, fmt.Sprintf("  stage  -> %s", groupName(det.Stage)))
+	}
+
+	if len(lines) == 0 {
+		return "No provider is uniquely active in this environment, so there are no " +
+			"top-level 'param'/'secret'/'stage' aliases. Use an explicit group: " +
+			"'suve aws', 'suve gcloud', or 'suve azure'."
+	}
+
+	via := " (from environment)"
+	if det.AWSViaFallback {
+		via = " (AWS via ~/.aws/credentials)"
+	}
+
+	return "Active top-level aliases" + via + ":\n" + strings.Join(lines, "\n") +
+		"\nThe explicit groups ('suve aws', 'suve gcloud', 'suve azure') are always available."
+}
+
+// groupName maps a provider to its command-group name for user-facing messages.
+func groupName(p provider.Provider) string {
+	switch p {
+	case provider.ProviderAWS:
+		return "aws"
+	case provider.ProviderGoogleCloud:
+		return "gcloud"
+	case provider.ProviderAzure:
+		return "azure"
+	}
+
+	return string(p)
 }
 
 // App is the main CLI application.

--- a/internal/cli/commands/app_test.go
+++ b/internal/cli/commands/app_test.go
@@ -1,0 +1,84 @@
+package commands_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+
+	commands "github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/detect"
+)
+
+func topLevelNames(app *cli.Command) []string {
+	names := make([]string, 0, len(app.Commands))
+	for _, c := range app.Commands {
+		names = append(names, c.Name)
+	}
+
+	return names
+}
+
+func TestMakeAppWithDetect_flatAliases(t *testing.T) {
+	t.Parallel()
+
+	aws := provider.ProviderAWS
+	gcp := provider.ProviderGoogleCloud
+	az := provider.ProviderAzure
+
+	tests := []struct {
+		name       string
+		det        detect.Result
+		wantParam  bool // top-level flat `param` present
+		wantSecret bool // top-level flat `secret` present
+		wantStage  bool // top-level flat `stage` present (AWS-only)
+	}{
+		{name: "nothing active", det: detect.Result{}},
+		{name: "AWS all", det: detect.Result{Param: aws, Secret: aws, Stage: aws}, wantParam: true, wantSecret: true, wantStage: true},
+		{name: "GCP secret only", det: detect.Result{Secret: gcp}, wantSecret: true},
+		{name: "Azure param only", det: detect.Result{Param: az}, wantParam: true},
+		{name: "Azure both", det: detect.Result{Param: az, Secret: az}, wantParam: true, wantSecret: true},
+		{name: "GCP secret + Azure param", det: detect.Result{Param: az, Secret: gcp}, wantParam: true, wantSecret: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := commands.MakeAppWithDetect(tt.det)
+			names := topLevelNames(app)
+
+			// Explicit provider groups are always present, regardless of detection.
+			assert.Contains(t, names, "aws")
+			assert.Contains(t, names, "gcloud")
+			assert.Contains(t, names, "azure")
+
+			assert.Equal(t, tt.wantParam, contains(names, "param"), "flat param alias")
+			assert.Equal(t, tt.wantSecret, contains(names, "secret"), "flat secret alias")
+			assert.Equal(t, tt.wantStage, contains(names, "stage"), "flat stage alias")
+		})
+	}
+}
+
+func TestMakeAppWithDetect_flatCommandsAreRunnable(t *testing.T) {
+	t.Parallel()
+
+	// A flat GCP secret alias should behave like `gcloud secret`: it must carry
+	// the --project flag folded in from the group. `--help` must succeed.
+	app := commands.MakeAppWithDetect(detect.Result{Secret: provider.ProviderGoogleCloud})
+	err := app.Run(t.Context(), []string{"suve", "secret", "--help"})
+	require.NoError(t, err)
+
+	// A flat Azure param alias should carry the base --subscription flag folded
+	// in on top of --store-name.
+	app = commands.MakeAppWithDetect(detect.Result{Param: provider.ProviderAzure})
+	err = app.Run(t.Context(), []string{"suve", "param", "--help"})
+	require.NoError(t, err)
+}
+
+func contains(ss []string, s string) bool {
+	return slices.Contains(ss, s)
+}

--- a/internal/cli/commands/aws/command.go
+++ b/internal/cli/commands/aws/command.go
@@ -1,0 +1,40 @@
+// Package aws provides the "suve aws" command group: the explicit,
+// always-present home for the AWS backends (Parameter Store, Secrets Manager,
+// and the AWS-only staging workflow). It mirrors the gcloud/azure groups so
+// that AWS is a peer provider rather than a special top-level default. The
+// top-level `param` / `secret` aliases are added separately (and only when AWS
+// is the uniquely active provider); this group is what you always get with an
+// explicit `suve aws ...`.
+package aws
+
+import (
+	"github.com/urfave/cli/v3"
+
+	cliinternal "github.com/mpyw/suve/internal/cli/commands/internal"
+	"github.com/mpyw/suve/internal/cli/commands/param"
+	"github.com/mpyw/suve/internal/cli/commands/secret"
+	"github.com/mpyw/suve/internal/cli/commands/stage"
+)
+
+// Command returns the aws command group with the param (Parameter Store),
+// secret (Secrets Manager), and stage (staging) subcommands.
+func Command() *cli.Command {
+	return &cli.Command{
+		Name:  "aws",
+		Usage: "Interact with AWS Parameter Store / Secrets Manager (and staging)",
+		Description: `Interact with Amazon Web Services parameter and secret stores.
+
+  - "suve aws param"  targets Systems Manager Parameter Store.
+  - "suve aws secret" targets Secrets Manager.
+  - "suve aws stage"  stages changes to the above before applying them.
+
+Region and credentials come from the ambient AWS configuration (environment,
+shared config/credentials files, or an instance role).`,
+		Commands: []*cli.Command{
+			param.Command(),
+			secret.Command(),
+			stage.Command(),
+		},
+		CommandNotFound: cliinternal.CommandNotFound,
+	}
+}

--- a/internal/cli/commands/azure/command.go
+++ b/internal/cli/commands/azure/command.go
@@ -43,30 +43,86 @@ Set the subscription and resource group with --subscription/--resource-group or
 the AZURE_SUBSCRIPTION_ID/AZURE_RESOURCE_GROUP environment variables.
 Authentication uses the DefaultAzureCredential chain (environment, managed
 identity, Azure CLI, ...).`,
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:    "subscription",
-				Usage:   "Azure subscription id (defaults to $AZURE_SUBSCRIPTION_ID)",
-				Sources: cli.EnvVars("AZURE_SUBSCRIPTION_ID"),
-				// Persistent (default): readable by every azure subcommand.
-			},
-			&cli.StringFlag{
-				Name:    "resource-group",
-				Usage:   "Azure resource group (defaults to $AZURE_RESOURCE_GROUP)",
-				Sources: cli.EnvVars("AZURE_RESOURCE_GROUP"),
-			},
-		},
+		Flags: baseFlags(),
 		// Before resolves the shared subscription/resource-group once and stashes
 		// them in the context so the generic command presenters (which do not
 		// receive *cli.Command) can resolve a store. Resolution is deferred to
 		// store construction, so `suve azure --help` still works without them.
-		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-			return cliinternal.WithAzureBase(ctx, cmd.String("subscription"), cmd.String("resource-group")), nil
-		},
+		Before: withBase,
 		Commands: []*cli.Command{
 			secret.Command(),
 			param.Command(),
 		},
 		CommandNotFound: cliinternal.CommandNotFound,
 	}
+}
+
+// FlatSecretCommand returns the Azure Key Vault (secret) command as a standalone
+// top-level command named `name`. Because there is no parent azure group to
+// carry them, it folds in the shared --subscription / --resource-group flags and
+// base Before hook on top of the secret group's own --vault-name flag/hook. Used
+// for the flat `suve secret` alias when Azure is the uniquely active secret
+// provider.
+func FlatSecretCommand(name string) *cli.Command {
+	c := secret.Command()
+	c.Name = name
+
+	return foldBase(c)
+}
+
+// FlatParamCommand returns the Azure App Configuration (param) command as a
+// standalone top-level command named `name`, folding in the base
+// subscription/resource-group flags and hook on top of the param group's own
+// --store-name flag/hook. Used for the flat `suve param` alias when Azure is the
+// uniquely active param provider.
+func FlatParamCommand(name string) *cli.Command {
+	c := param.Command()
+	c.Name = name
+
+	return foldBase(c)
+}
+
+// baseFlags returns the shared Azure scope flags (a fresh slice per call).
+func baseFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:    "subscription",
+			Usage:   "Azure subscription id (defaults to $AZURE_SUBSCRIPTION_ID)",
+			Sources: cli.EnvVars("AZURE_SUBSCRIPTION_ID"),
+			// Persistent (default): readable by every azure subcommand.
+		},
+		&cli.StringFlag{
+			Name:    "resource-group",
+			Usage:   "Azure resource group (defaults to $AZURE_RESOURCE_GROUP)",
+			Sources: cli.EnvVars("AZURE_RESOURCE_GROUP"),
+		},
+	}
+}
+
+// withBase stashes the resolved subscription/resource-group into the context.
+func withBase(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+	return cliinternal.WithAzureBase(ctx, cmd.String("subscription"), cmd.String("resource-group")), nil
+}
+
+// foldBase prepends the base scope flags to c and wraps its Before so the base
+// subscription/resource-group are resolved before the command's own hook. It
+// turns a subgroup command (which normally relies on the azure parent) into a
+// self-contained top-level command.
+func foldBase(c *cli.Command) *cli.Command {
+	inner := c.Before
+	c.Flags = append(baseFlags(), c.Flags...)
+	c.Before = func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+		ctx, err := withBase(ctx, cmd)
+		if err != nil {
+			return ctx, err
+		}
+
+		if inner != nil {
+			return inner(ctx, cmd)
+		}
+
+		return ctx, nil
+	}
+
+	return c
 }

--- a/internal/cli/commands/gcloud/command.go
+++ b/internal/cli/commands/gcloud/command.go
@@ -27,30 +27,53 @@ func Command() *cli.Command {
 Google Cloud secrets are integer-versioned (1, 2, 3, ... or "latest") and have
 no staging labels. Set the project with --project or the GOOGLE_CLOUD_PROJECT
 environment variable. Authentication uses Application Default Credentials.`,
-		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:  "project",
-				Usage: "Google Cloud project id (defaults to $GOOGLE_CLOUD_PROJECT)",
-				// Persistent (default): readable by every gcloud subcommand.
-			},
-		},
+		Flags: projectFlags(),
 		// Before resolves the project once and stashes it in the context so the
 		// generic command presenters (which do not receive *cli.Command) can
 		// resolve a store. Resolution is deferred to store construction, so
 		// `suve gcloud secret --help` still works without a project.
-		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-			project := cmd.String("project")
-			if project == "" {
-				project = os.Getenv("GOOGLE_CLOUD_PROJECT")
-			}
-
-			return cliinternal.WithGCPProject(ctx, project), nil
-		},
+		Before: resolveProject,
 		Commands: []*cli.Command{
 			SecretCommand(),
 		},
 		CommandNotFound: cliinternal.CommandNotFound,
 	}
+}
+
+// FlatSecretCommand returns the Google Cloud secret command as a standalone
+// top-level command named `name` (e.g. "secret"). Because there is no parent
+// gcloud group to carry them, it folds in the --project flag and the
+// project-resolving Before hook. Used for the flat `suve secret` alias when
+// Google Cloud is the uniquely active secret provider.
+func FlatSecretCommand(name string) *cli.Command {
+	c := SecretCommand()
+	c.Name = name
+	c.Flags = projectFlags()
+	c.Before = resolveProject
+
+	return c
+}
+
+// projectFlags returns the shared --project flag (a fresh slice per call so
+// each command owns its flag instance).
+func projectFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:  "project",
+			Usage: "Google Cloud project id (defaults to $GOOGLE_CLOUD_PROJECT)",
+		},
+	}
+}
+
+// resolveProject stashes the resolved project id (from --project or
+// GOOGLE_CLOUD_PROJECT) into the context for the subcommands.
+func resolveProject(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+	project := cmd.String("project")
+	if project == "" {
+		project = os.Getenv("GOOGLE_CLOUD_PROJECT")
+	}
+
+	return cliinternal.WithGCPProject(ctx, project), nil
 }
 
 // SecretCommand returns the "gcloud secret" subcommand group.

--- a/internal/cli/commands/generic/diff/diff_test.go
+++ b/internal/cli/commands/generic/diff/diff_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	appcli "github.com/mpyw/suve/internal/cli/commands"
 	genericdiff "github.com/mpyw/suve/internal/cli/commands/generic/diff"
+	"github.com/mpyw/suve/internal/cli/commands/internal/apptest"
 	cmdparam "github.com/mpyw/suve/internal/cli/commands/param"
 	cmdsecret "github.com/mpyw/suve/internal/cli/commands/secret"
 	"github.com/mpyw/suve/internal/cli/diffargs"
@@ -48,7 +48,7 @@ func TestCommand_Validation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			app := appcli.MakeApp()
+			app := apptest.AWSApp()
 			err := app.Run(t.Context(), tc.args)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.wantSub)

--- a/internal/cli/commands/generic/list/list_test.go
+++ b/internal/cli/commands/generic/list/list_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	appcli "github.com/mpyw/suve/internal/cli/commands"
 	genericlist "github.com/mpyw/suve/internal/cli/commands/generic/list"
+	"github.com/mpyw/suve/internal/cli/commands/internal/apptest"
 	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
@@ -25,7 +25,7 @@ func TestCommand_Help(t *testing.T) {
 	t.Run("param", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 
 		var buf bytes.Buffer
 
@@ -41,7 +41,7 @@ func TestCommand_Help(t *testing.T) {
 	t.Run("secret", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 
 		var buf bytes.Buffer
 

--- a/internal/cli/commands/generic/log/log_test.go
+++ b/internal/cli/commands/generic/log/log_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	appcli "github.com/mpyw/suve/internal/cli/commands"
 	genericlog "github.com/mpyw/suve/internal/cli/commands/generic/log"
+	"github.com/mpyw/suve/internal/cli/commands/internal/apptest"
 	cmdparam "github.com/mpyw/suve/internal/cli/commands/param"
 	cmdsecret "github.com/mpyw/suve/internal/cli/commands/secret"
 	"github.com/mpyw/suve/internal/cli/output"
@@ -46,7 +46,7 @@ func TestCommand_Validation(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				t.Parallel()
 
-				app := appcli.MakeApp()
+				app := apptest.AWSApp()
 				err := app.Run(t.Context(), tc.args)
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantSub)
@@ -78,7 +78,7 @@ func TestCommand_Validation(t *testing.T) {
 
 				var errBuf bytes.Buffer
 
-				app := appcli.MakeApp()
+				app := apptest.AWSApp()
 				app.ErrWriter = &errBuf
 				_ = app.Run(t.Context(), tc.args)
 				assert.Contains(t, errBuf.String(), tc.wantSub)
@@ -89,7 +89,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("help", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 
 		var buf bytes.Buffer
 

--- a/internal/cli/commands/generic/show/show_test.go
+++ b/internal/cli/commands/generic/show/show_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	appcli "github.com/mpyw/suve/internal/cli/commands"
 	genericshow "github.com/mpyw/suve/internal/cli/commands/generic/show"
+	"github.com/mpyw/suve/internal/cli/commands/internal/apptest"
 	cmdparam "github.com/mpyw/suve/internal/cli/commands/param"
 	cmdsecret "github.com/mpyw/suve/internal/cli/commands/secret"
 	"github.com/mpyw/suve/internal/cli/output"
@@ -40,7 +40,7 @@ func TestCommand_Validation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			app := appcli.MakeApp()
+			app := apptest.AWSApp()
 			err := app.Run(t.Context(), tc.args)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.wantSub)

--- a/internal/cli/commands/generic/tag/tag_test.go
+++ b/internal/cli/commands/generic/tag/tag_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	appcli "github.com/mpyw/suve/internal/cli/commands"
 	generictag "github.com/mpyw/suve/internal/cli/commands/generic/tag"
+	"github.com/mpyw/suve/internal/cli/commands/internal/apptest"
 	"github.com/mpyw/suve/internal/provider/providermock"
 )
 
@@ -42,7 +42,7 @@ func TestCommand_Validation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			app := appcli.MakeApp()
+			app := apptest.AWSApp()
 			err := app.Run(t.Context(), tc.args)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.wantSub)

--- a/internal/cli/commands/internal/apptest/apptest.go
+++ b/internal/cli/commands/internal/apptest/apptest.go
@@ -1,0 +1,24 @@
+// Package apptest provides helpers for constructing the CLI app with a
+// deterministic provider-detection result, so command tests do not depend on
+// the ambient environment (which decides the top-level param/secret aliases).
+package apptest
+
+import (
+	"github.com/urfave/cli/v3"
+
+	commands "github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/detect"
+)
+
+// AWSApp builds the app as if AWS were the uniquely active provider for both
+// services, so the top-level `param` / `secret` aliases resolve to AWS
+// regardless of the test environment. Use it in tests that exercise the AWS
+// commands via `suve param ...` / `suve secret ...`.
+func AWSApp() *cli.Command {
+	return commands.MakeAppWithDetect(detect.Result{
+		Param:  provider.ProviderAWS,
+		Secret: provider.ProviderAWS,
+		Stage:  provider.ProviderAWS,
+	})
+}

--- a/internal/cli/commands/param/create/create_test.go
+++ b/internal/cli/commands/param/create/create_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	appcli "github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/cli/commands/internal/apptest"
 	"github.com/mpyw/suve/internal/cli/commands/param/create"
 	"github.com/mpyw/suve/internal/cli/commands/param/paramopts"
 	"github.com/mpyw/suve/internal/domain"
@@ -24,7 +24,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("missing arguments", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 		err := app.Run(t.Context(), []string{"suve", "param", "create"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "usage:")
@@ -33,7 +33,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("missing value argument", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 		err := app.Run(t.Context(), []string{"suve", "param", "create", "/app/param"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "usage:")
@@ -42,7 +42,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("conflicting secure and type flags", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 		err := app.Run(t.Context(), []string{"suve", "param", "create", "--secure", "--type", "String", "/app/param", "value"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot use --secure with --type")
@@ -51,7 +51,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("invalid tier value", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 		err := app.Run(t.Context(), []string{"suve", "param", "create", "--tier", "Bogus", "/app/param", "value"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid --tier")

--- a/internal/cli/commands/param/delete/delete_test.go
+++ b/internal/cli/commands/param/delete/delete_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	appcli "github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/cli/commands/internal/apptest"
 	"github.com/mpyw/suve/internal/cli/commands/param/delete"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/providermock"
@@ -21,7 +21,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("missing parameter name", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 		err := app.Run(t.Context(), []string{"suve", "param", "delete"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "usage: suve param delete")

--- a/internal/cli/commands/param/update/update_test.go
+++ b/internal/cli/commands/param/update/update_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	appcli "github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/cli/commands/internal/apptest"
 	"github.com/mpyw/suve/internal/cli/commands/param/paramopts"
 	"github.com/mpyw/suve/internal/cli/commands/param/update"
 	"github.com/mpyw/suve/internal/domain"
@@ -24,7 +24,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("missing arguments", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 		err := app.Run(t.Context(), []string{"suve", "param", "update"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "usage:")
@@ -33,7 +33,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("missing value argument", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 		err := app.Run(t.Context(), []string{"suve", "param", "update", "/app/param"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "usage:")
@@ -42,7 +42,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("conflicting secure and type flags", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 		err := app.Run(t.Context(), []string{"suve", "param", "update", "--secure", "--type", "String", "/app/param", "value"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot use --secure with --type")
@@ -51,7 +51,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("invalid tier value", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 		err := app.Run(t.Context(), []string{"suve", "param", "update", "--yes", "--tier", "Bogus", "/app/param", "value"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "invalid --tier")

--- a/internal/cli/commands/secret/create/create_test.go
+++ b/internal/cli/commands/secret/create/create_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	appcli "github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/cli/commands/internal/apptest"
 	"github.com/mpyw/suve/internal/cli/commands/secret/create"
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
@@ -23,7 +23,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("missing arguments", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 		err := app.Run(t.Context(), []string{"suve", "secret", "create"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "usage:")
@@ -32,7 +32,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("missing value argument", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 		err := app.Run(t.Context(), []string{"suve", "secret", "create", "my-secret"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "usage:")

--- a/internal/cli/commands/secret/delete/delete_test.go
+++ b/internal/cli/commands/secret/delete/delete_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	appcli "github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/cli/commands/internal/apptest"
 	"github.com/mpyw/suve/internal/cli/commands/secret/delete"
 	"github.com/mpyw/suve/internal/provider"
 	awssecret "github.com/mpyw/suve/internal/provider/aws/secret"
@@ -23,7 +23,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("missing secret name", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 		err := app.Run(t.Context(), []string{"suve", "secret", "delete"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "usage:")

--- a/internal/cli/commands/secret/restore/restore_test.go
+++ b/internal/cli/commands/secret/restore/restore_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	appcli "github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/cli/commands/internal/apptest"
 	"github.com/mpyw/suve/internal/cli/commands/secret/restore"
 	"github.com/mpyw/suve/internal/provider/providermock"
 	"github.com/mpyw/suve/internal/usecase/secret"
@@ -21,7 +21,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("missing secret name", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 		err := app.Run(t.Context(), []string{"suve", "secret", "restore"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "usage:")

--- a/internal/cli/commands/secret/update/update_test.go
+++ b/internal/cli/commands/secret/update/update_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	appcli "github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/cli/commands/internal/apptest"
 	"github.com/mpyw/suve/internal/cli/commands/secret/update"
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
@@ -23,7 +23,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("missing arguments", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 		err := app.Run(t.Context(), []string{"suve", "secret", "update"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "usage:")
@@ -32,7 +32,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("missing value argument", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 		err := app.Run(t.Context(), []string{"suve", "secret", "update", "my-secret"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "usage:")

--- a/internal/cli/commands/stage/apply/apply_test.go
+++ b/internal/cli/commands/stage/apply/apply_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	appcli "github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/cli/commands/internal/apptest"
 	"github.com/mpyw/suve/internal/cli/commands/stage/apply"
 	"github.com/mpyw/suve/internal/maputil"
 	"github.com/mpyw/suve/internal/staging"
@@ -79,7 +79,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("help", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 
 		var buf bytes.Buffer
 

--- a/internal/cli/commands/stage/diff/diff_test.go
+++ b/internal/cli/commands/stage/diff/diff_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	appcli "github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/cli/commands/internal/apptest"
 	stagediff "github.com/mpyw/suve/internal/cli/commands/stage/diff"
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/maputil"
@@ -58,7 +58,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("help", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 
 		var buf bytes.Buffer
 
@@ -71,7 +71,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("no arguments allowed", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 		err := app.Run(t.Context(), []string{"suve", "stage", "diff", "extra-arg"})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "usage:")

--- a/internal/cli/commands/stage/reset/reset_test.go
+++ b/internal/cli/commands/stage/reset/reset_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	appcli "github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/cli/commands/internal/apptest"
 	"github.com/mpyw/suve/internal/cli/commands/stage/reset"
 	"github.com/mpyw/suve/internal/maputil"
 	"github.com/mpyw/suve/internal/staging"
@@ -23,7 +23,7 @@ func TestCommand_Validation(t *testing.T) {
 	t.Run("help", func(t *testing.T) {
 		t.Parallel()
 
-		app := appcli.MakeApp()
+		app := apptest.AWSApp()
 
 		var buf bytes.Buffer
 

--- a/internal/cli/commands/stage/status/status_test.go
+++ b/internal/cli/commands/stage/status/status_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	appcli "github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/cli/commands/internal/apptest"
 	"github.com/mpyw/suve/internal/cli/commands/stage/status"
 	"github.com/mpyw/suve/internal/maputil"
 	"github.com/mpyw/suve/internal/staging"
@@ -224,7 +224,7 @@ func TestCommand_VerboseTruncatesLongValue(t *testing.T) {
 func TestCommand_Validation(t *testing.T) {
 	t.Parallel()
 
-	app := appcli.MakeApp()
+	app := apptest.AWSApp()
 
 	var buf bytes.Buffer
 

--- a/internal/provider/detect/detect.go
+++ b/internal/provider/detect/detect.go
@@ -1,0 +1,163 @@
+// Package detect resolves which cloud provider should back the flat `param` /
+// `secret` command aliases (and, later, the GUI's initial provider selection),
+// based purely on environment variables. It performs no network calls and no
+// credential-chain resolution, so it is safe to run on every process start.
+//
+// The rules (per service, param and secret decided independently):
+//
+//   - A provider is "active via env" when its address/identity env var is set:
+//     AWS     — AWS_ACCESS_KEY_ID | AWS_VAULT | AWS_PROFILE (both services)
+//     GCP     — GOOGLE_CLOUD_PROJECT (secret only)
+//     Azure   — AZURE_KEYVAULT_NAME (secret) / AZURE_APPCONFIG_NAME (param)
+//   - A flat alias is exposed for a service only when exactly ONE provider is
+//     active for it. Zero or two-plus active means no alias — the user must use
+//     the explicit group (e.g. `suve aws secret`). There is no priority order.
+//   - AWS-only final fallback: when NO provider is active via env for any
+//     service, AWS is accepted via ~/.aws/credentials so the common "plain AWS"
+//     setup keeps working. If that file is absent too, nothing is aliased.
+package detect
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/mpyw/suve/internal/provider"
+)
+
+// Environment abstracts the inputs the resolver reads, so it can be tested
+// without mutating the real process environment or filesystem.
+type Environment struct {
+	// Getenv reads an environment variable (os.Getenv in production).
+	Getenv func(string) string
+	// AWSCredentialsExist reports whether the AWS shared credentials file is
+	// present. It is only consulted for the final fallback, never eagerly.
+	AWSCredentialsExist func() bool
+}
+
+// OSEnvironment returns an Environment backed by the real OS.
+func OSEnvironment() Environment {
+	return Environment{
+		Getenv:              os.Getenv,
+		AWSCredentialsExist: awsCredentialsExist,
+	}
+}
+
+// Result holds the resolved flat-alias target for each service plus the full
+// active sets (useful for help text and the GUI).
+type Result struct {
+	// Param and Secret name the single active provider for that service, or an
+	// empty Provider ("") when the service is not uniquely resolvable (0 or 2+
+	// active) — meaning no flat alias should be exposed for it.
+	Param  provider.Provider
+	Secret provider.Provider
+	// Stage names the active provider for the staging workflow. Staging is
+	// AWS-only, so it is ProviderAWS when AWS is active (via env or the
+	// credentials fallback) and empty otherwise.
+	Stage provider.Provider
+
+	// ParamActive and SecretActive list every provider active for that service,
+	// in stable order (AWS, GCP, Azure).
+	ParamActive  []provider.Provider
+	SecretActive []provider.Provider
+
+	// AWSViaFallback is true when AWS became active only through the
+	// ~/.aws/credentials fallback (no provider was active via env).
+	AWSViaFallback bool
+}
+
+// FlatParam reports whether a top-level `param` alias should be exposed.
+func (r Result) FlatParam() bool { return r.Param != "" }
+
+// FlatSecret reports whether a top-level `secret` alias should be exposed.
+func (r Result) FlatSecret() bool { return r.Secret != "" }
+
+// FlatStage reports whether a top-level `stage` alias should be exposed.
+func (r Result) FlatStage() bool { return r.Stage != "" }
+
+// Resolve computes the alias targets from the given environment.
+func Resolve(env Environment) Result {
+	getenv := env.Getenv
+	if getenv == nil {
+		getenv = func(string) string { return "" }
+	}
+
+	awsEnv := getenv("AWS_ACCESS_KEY_ID") != "" ||
+		getenv("AWS_VAULT") != "" ||
+		getenv("AWS_PROFILE") != ""
+	gcpSecret := getenv("GOOGLE_CLOUD_PROJECT") != ""
+	azureSecret := getenv("AZURE_KEYVAULT_NAME") != ""
+	azureParam := getenv("AZURE_APPCONFIG_NAME") != ""
+
+	anyEnv := awsEnv || gcpSecret || azureSecret || azureParam
+
+	var res Result
+
+	awsActive := awsEnv
+	if !anyEnv && env.AWSCredentialsExist != nil && env.AWSCredentialsExist() {
+		awsActive = true
+		res.AWSViaFallback = true
+	}
+
+	// Secret candidates in stable order: AWS, GCP, Azure (Key Vault).
+	if awsActive {
+		res.SecretActive = append(res.SecretActive, provider.ProviderAWS)
+	}
+
+	if gcpSecret {
+		res.SecretActive = append(res.SecretActive, provider.ProviderGoogleCloud)
+	}
+
+	if azureSecret {
+		res.SecretActive = append(res.SecretActive, provider.ProviderAzure)
+	}
+
+	// Param candidates in stable order: AWS, Azure (App Configuration). GCP has
+	// no parameter store.
+	if awsActive {
+		res.ParamActive = append(res.ParamActive, provider.ProviderAWS)
+	}
+
+	if azureParam {
+		res.ParamActive = append(res.ParamActive, provider.ProviderAzure)
+	}
+
+	res.Secret = unique(res.SecretActive)
+	res.Param = unique(res.ParamActive)
+
+	// Staging is AWS-only, so it is active exactly when AWS is.
+	if awsActive {
+		res.Stage = provider.ProviderAWS
+	}
+
+	return res
+}
+
+// unique returns the sole element of ps, or "" when ps has zero or 2+ elements.
+func unique(ps []provider.Provider) provider.Provider {
+	if len(ps) == 1 {
+		return ps[0]
+	}
+
+	return ""
+}
+
+// awsCredentialsExist reports whether the AWS shared credentials file is
+// present, honoring AWS_SHARED_CREDENTIALS_FILE and falling back to
+// ~/.aws/credentials. Existence only — the file is not parsed.
+func awsCredentialsExist() bool {
+	path := os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
+	if path == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return false
+		}
+
+		path = filepath.Join(home, ".aws", "credentials")
+	}
+
+	// Path is the user's own AWS credentials location (AWS_SHARED_CREDENTIALS_FILE
+	// or ~/.aws/credentials); an existence check on it is intentional.
+	info, err := os.Stat(path) //nolint:gosec // user-controlled AWS credentials path by design
+
+	return err == nil && !info.IsDir()
+}

--- a/internal/provider/detect/detect_test.go
+++ b/internal/provider/detect/detect_test.go
@@ -1,0 +1,171 @@
+package detect_test
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/detect"
+)
+
+func env(vars map[string]string, credsExist bool) detect.Environment {
+	return detect.Environment{
+		Getenv:              func(k string) string { return vars[k] },
+		AWSCredentialsExist: func() bool { return credsExist },
+	}
+}
+
+func TestResolve(t *testing.T) {
+	t.Parallel()
+
+	aws := provider.ProviderAWS
+	gcp := provider.ProviderGoogleCloud
+	az := provider.ProviderAzure
+
+	tests := []struct {
+		name           string
+		vars           map[string]string
+		credsExist     bool
+		wantParam      provider.Provider
+		wantSecret     provider.Provider
+		wantParamSet   []provider.Provider
+		wantSecretSet  []provider.Provider
+		wantAWSViaFall bool
+	}{
+		{
+			name:       "nothing set, no credentials file",
+			vars:       nil,
+			credsExist: false,
+			// no aliases at all
+		},
+		{
+			name:           "nothing set, credentials file present -> AWS fallback for both",
+			vars:           nil,
+			credsExist:     true,
+			wantParam:      aws,
+			wantSecret:     aws,
+			wantParamSet:   []provider.Provider{aws},
+			wantSecretSet:  []provider.Provider{aws},
+			wantAWSViaFall: true,
+		},
+		{
+			name:          "AWS_ACCESS_KEY_ID set -> AWS both, no fallback",
+			vars:          map[string]string{"AWS_ACCESS_KEY_ID": "AKIA..."},
+			credsExist:    true, // must be ignored: env is active
+			wantParam:     aws,
+			wantSecret:    aws,
+			wantParamSet:  []provider.Provider{aws},
+			wantSecretSet: []provider.Provider{aws},
+		},
+		{
+			name:          "AWS_VAULT set -> AWS both",
+			vars:          map[string]string{"AWS_VAULT": "myprofile"},
+			wantParam:     aws,
+			wantSecret:    aws,
+			wantParamSet:  []provider.Provider{aws},
+			wantSecretSet: []provider.Provider{aws},
+		},
+		{
+			name:          "AWS_PROFILE set -> AWS both",
+			vars:          map[string]string{"AWS_PROFILE": "dev"},
+			wantParam:     aws,
+			wantSecret:    aws,
+			wantParamSet:  []provider.Provider{aws},
+			wantSecretSet: []provider.Provider{aws},
+		},
+		{
+			name:          "GCP only -> secret=GCP, no param",
+			vars:          map[string]string{"GOOGLE_CLOUD_PROJECT": "my-proj"},
+			wantSecret:    gcp,
+			wantSecretSet: []provider.Provider{gcp},
+			// param stays empty: GCP has no parameter store
+		},
+		{
+			name:          "Azure Key Vault only -> secret=Azure, no param",
+			vars:          map[string]string{"AZURE_KEYVAULT_NAME": "kv"},
+			wantSecret:    az,
+			wantSecretSet: []provider.Provider{az},
+		},
+		{
+			name:         "Azure App Config only -> param=Azure, no secret",
+			vars:         map[string]string{"AZURE_APPCONFIG_NAME": "ac"},
+			wantParam:    az,
+			wantParamSet: []provider.Provider{az},
+		},
+		{
+			name:          "Azure both services -> param=Azure, secret=Azure",
+			vars:          map[string]string{"AZURE_KEYVAULT_NAME": "kv", "AZURE_APPCONFIG_NAME": "ac"},
+			wantParam:     az,
+			wantSecret:    az,
+			wantParamSet:  []provider.Provider{az},
+			wantSecretSet: []provider.Provider{az},
+		},
+		{
+			name:          "AWS + GCP -> secret ambiguous (none), param=AWS",
+			vars:          map[string]string{"AWS_PROFILE": "dev", "GOOGLE_CLOUD_PROJECT": "p"},
+			wantParam:     aws,
+			wantSecret:    "",
+			wantParamSet:  []provider.Provider{aws},
+			wantSecretSet: []provider.Provider{aws, gcp},
+		},
+		{
+			name:          "AWS + Azure Key Vault -> secret ambiguous, param=AWS",
+			vars:          map[string]string{"AWS_PROFILE": "dev", "AZURE_KEYVAULT_NAME": "kv"},
+			wantParam:     aws,
+			wantSecret:    "",
+			wantParamSet:  []provider.Provider{aws},
+			wantSecretSet: []provider.Provider{aws, az},
+		},
+		{
+			name:          "GCP + Azure App Config -> secret=GCP, param=Azure (each unique)",
+			vars:          map[string]string{"GOOGLE_CLOUD_PROJECT": "p", "AZURE_APPCONFIG_NAME": "ac"},
+			wantParam:     az,
+			wantSecret:    gcp,
+			wantParamSet:  []provider.Provider{az},
+			wantSecretSet: []provider.Provider{gcp},
+		},
+		{
+			name:          "AWS + Azure App Config -> param ambiguous, secret=AWS",
+			vars:          map[string]string{"AWS_PROFILE": "dev", "AZURE_APPCONFIG_NAME": "ac"},
+			wantParam:     "",
+			wantSecret:    aws,
+			wantParamSet:  []provider.Provider{aws, az},
+			wantSecretSet: []provider.Provider{aws},
+		},
+		{
+			name:       "GCP set with creds file present -> no AWS fallback (env is active)",
+			vars:       map[string]string{"GOOGLE_CLOUD_PROJECT": "p"},
+			credsExist: true,
+			wantSecret: gcp, wantSecretSet: []provider.Provider{gcp},
+			// AWS must NOT appear: fallback only when nothing is active via env
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := detect.Resolve(env(tt.vars, tt.credsExist))
+
+			assert.Equal(t, tt.wantParam, got.Param, "Param")
+			assert.Equal(t, tt.wantSecret, got.Secret, "Secret")
+			assert.Equal(t, tt.wantParamSet, got.ParamActive, "ParamActive")
+			assert.Equal(t, tt.wantSecretSet, got.SecretActive, "SecretActive")
+			assert.Equal(t, tt.wantAWSViaFall, got.AWSViaFallback, "AWSViaFallback")
+			assert.Equal(t, tt.wantParam != "", got.FlatParam(), "FlatParam")
+			assert.Equal(t, tt.wantSecret != "", got.FlatSecret(), "FlatSecret")
+
+			// Staging is AWS-only: Stage is AWS exactly when AWS is active,
+			// i.e. when AWS appears in the (secret) active set.
+			wantStage := provider.Provider("")
+			if slices.Contains(tt.wantSecretSet, provider.ProviderAWS) {
+				wantStage = provider.ProviderAWS
+			}
+
+			assert.Equal(t, wantStage, got.Stage, "Stage")
+			assert.Equal(t, wantStage != "", got.FlatStage(), "FlatStage")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Restructures the top-level CLI so every cloud backend is an explicit, always-present group, and the bare `param` / `secret` / `stage` commands become **environment-resolved aliases** instead of hard-wired AWS. AWS becomes a peer provider rather than the implicit default.

Design agreed in discussion; staging stays AWS-only for now (full multi-provider staging tracked in #247).

## Behavior

**Always available (explicit):**
```
suve aws param|secret|stage
suve gcloud secret
suve azure secret|param
```

**Bare aliases (`param`/`secret`/`stage`)** appear only when the environment resolves the target unambiguously:

1. A backend is *active* when its identifying env var is set — AWS: `AWS_ACCESS_KEY_ID`/`AWS_VAULT`/`AWS_PROFILE`; GCP: `GOOGLE_CLOUD_PROJECT`; Azure secret: `AZURE_KEYVAULT_NAME`; Azure param: `AZURE_APPCONFIG_NAME`.
2. A bare alias is exposed only when **exactly one** backend is active for that service. Zero or 2+ → no alias (use the explicit group). **No priority ordering.**
3. **AWS fallback:** when nothing is active via env, AWS is accepted via `~/.aws/credentials` (`$AWS_SHARED_CREDENTIALS_FILE`).
4. `stage` follows AWS activeness (staging is AWS-only for now).

`suve --help` reports which aliases are active in the current environment.

### ⚠️ Breaking change
`suve param` / `suve secret` are no longer unconditionally AWS. With no AWS env and no `~/.aws/credentials`, they are not exposed — use `suve aws param` / `suve aws secret` (always available). With another provider uniquely active, the bare alias points there.

## Implementation
- New `internal/provider/detect` — env-only resolver (no network calls), fully unit-tested (all provider combinations + fallback).
- New `internal/cli/commands/aws` group (reuses the existing AWS param/secret/stage commands).
- `gcloud`/`azure` gain `Flat*Command` factories that fold group-level scope flags/Before hooks onto a standalone alias command.
- `app.go` builds the tree from a `detect.Result`; `MakeApp()` uses the OS env, `MakeAppWithDetect()` is the injectable seam. Command tests use a new `apptest.AWSApp()` helper so they are environment-independent.
- README: provider feature-support matrix + alias-resolution spec.

## Test
- `internal/provider/detect`: table tests for every env combination, ambiguity, and the credentials fallback.
- `internal/cli/commands`: `MakeAppWithDetect` composition tests (which aliases appear per detection; folded-in flags on flat GCP/Azure commands are runnable).
- Existing per-command tests migrated to `apptest.AWSApp()` (deterministic; assertions unchanged).
- `make test` green; `golangci-lint run` 0 issues.

Refs #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155B8urnRZNHqfLrEnpxUE9