### PR TITLE
test(e2e): migrate the AWS emulator from LocalStack to floci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,13 +71,12 @@ jobs:
     name: E2E Test
     runs-on: ubuntu-latest
     services:
-      localstack:
-        image: localstack/localstack:4
+      floci:
+        # Floci is a drop-in LocalStack Community replacement; all AWS services
+        # are on by default and it keeps the /_localstack/health endpoint.
+        image: floci/floci:latest
         ports:
           - 4566:4566
-        env:
-          SERVICES: ssm,secretsmanager,events
-          DEBUG: 0
         options: >-
           --health-cmd "curl -f http://localhost:4566/_localstack/health"
           --health-interval 10s
@@ -93,7 +92,7 @@ jobs:
           install_args: "go"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Wait for localstack
+      - name: Wait for floci
         run: |
           timeout 60 bash -c 'until curl -sf http://localhost:4566/_localstack/health; do sleep 2; done'
 
@@ -102,7 +101,7 @@ jobs:
           COVERPKG=$(go list ./... | grep -v testutil | grep -v /e2e | grep -v internal/gui | grep -v /cmd/ | tr '\n' ',')
           go test -v -race -tags e2e -coverprofile=coverage-e2e.txt -covermode=atomic -coverpkg=$COVERPKG ./e2e/...
         env:
-          SUVE_LOCALSTACK_EXTERNAL_PORT: 4566
+          SUVE_FLOCI_EXTERNAL_PORT: 4566
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ suve/
 │   │
 │   └── architecture_test.go      # Arch-guard: forbids cloud SDKs outside their provider/{aws,gcp,azure} + infra
 │
-├── e2e/                          # E2E tests (requires localstack)
+├── e2e/                          # E2E tests (requires the floci AWS emulator)
 │
 ├── .github/workflows/
 │   └── test.yml                  # CI: test + lint on push/PR
@@ -187,10 +187,10 @@ make lint
 # Build CLI
 make build
 
-# E2E tests with localstack
-make up      # Start localstack
+# E2E tests with the AWS emulator (floci)
+make up      # Start floci
 make e2e     # Run E2E tests
-make down    # Stop localstack
+make down    # Stop floci
 
 # Coverage
 make coverage
@@ -204,23 +204,23 @@ make gui-bindings # Regenerate GUI bindings
 ## Testing Strategy
 
 - **Unit tests**: Each command package has `*_test.go` with provider-neutral mocking via `internal/provider/providermock`
-- **E2E tests**: `e2e/e2e_test.go` runs against localstack (SSM only, SM requires Pro)
+- **E2E tests**: `e2e/e2e_test.go` runs against floci (a LocalStack Community replacement), covering SSM Parameter Store and Secrets Manager
 - **GUI tests**: `internal/gui/frontend/tests/` uses Playwright for component/integration testing
 - **Test dependencies**: Uses `github.com/samber/lo` for pointer helpers and `github.com/stretchr/testify` for assertions
 
 ### Running E2E Tests
 
 ```bash
-# Start localstack (SSM service)
+# Start floci (AWS emulator)
 make up
 
 # Run E2E tests
 make e2e
 
 # Or with custom port
-SUVE_LOCALSTACK_EXTERNAL_PORT=4599 make e2e
+SUVE_FLOCI_EXTERNAL_PORT=4599 make e2e
 
-# Stop localstack
+# Stop floci
 make down
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ else
     MISE_RUN :=
 endif
 
-SUVE_LOCALSTACK_EXTERNAL_PORT ?= 4566
+SUVE_FLOCI_EXTERNAL_PORT ?= 4566
 COVERPKG = $(shell go list ./... | grep -v testutil | grep -v /e2e | grep -v internal/gui | grep -v /cmd/ | tr '\n' ',')
 
 help: ## Show this help
@@ -44,17 +44,17 @@ test: ## Run unit tests
 lint: ## Run linter (host OS only, with all build tags)
 	GOOS=$(HOST_GOOS) golangci-lint run --build-tags=e2e,production ./...
 
-up: ## Start localstack container
-	SUVE_LOCALSTACK_EXTERNAL_PORT=$(SUVE_LOCALSTACK_EXTERNAL_PORT) docker compose up -d
-	@echo "Waiting for localstack to be ready on port $(SUVE_LOCALSTACK_EXTERNAL_PORT)..."
-	@until curl -sf http://127.0.0.1:$(SUVE_LOCALSTACK_EXTERNAL_PORT)/_localstack/health > /dev/null 2>&1; do sleep 1; done
-	@echo "localstack is ready"
+up: ## Start floci (AWS emulator) container
+	SUVE_FLOCI_EXTERNAL_PORT=$(SUVE_FLOCI_EXTERNAL_PORT) docker compose up -d floci
+	@echo "Waiting for floci to be ready on port $(SUVE_FLOCI_EXTERNAL_PORT)..."
+	@until curl -sf http://127.0.0.1:$(SUVE_FLOCI_EXTERNAL_PORT)/_localstack/health > /dev/null 2>&1; do sleep 1; done
+	@echo "floci is ready"
 
-down: ## Stop localstack container
+down: ## Stop floci (AWS emulator) container
 	docker compose down
 
-e2e: up ## Run E2E tests (starts localstack)
-	SUVE_LOCALSTACK_EXTERNAL_PORT=$(SUVE_LOCALSTACK_EXTERNAL_PORT) go test -tags=e2e -v ./e2e/...
+e2e: up ## Run E2E tests (starts floci)
+	SUVE_FLOCI_EXTERNAL_PORT=$(SUVE_FLOCI_EXTERNAL_PORT) go test -tags=e2e -v ./e2e/...
 
 clean: ## Clean build artifacts and stop containers
 	rm -rf bin/ *.out
@@ -65,14 +65,14 @@ coverage: ## Run unit tests with coverage
 	go tool cover -func=coverage.out | grep total
 
 coverage-e2e: up ## Run E2E tests with coverage
-	SUVE_LOCALSTACK_EXTERNAL_PORT=$(SUVE_LOCALSTACK_EXTERNAL_PORT) go test -tags=e2e -coverprofile=coverage-e2e.out -coverpkg=$(COVERPKG) ./e2e/...
+	SUVE_FLOCI_EXTERNAL_PORT=$(SUVE_FLOCI_EXTERNAL_PORT) go test -tags=e2e -coverprofile=coverage-e2e.out -coverpkg=$(COVERPKG) ./e2e/...
 	go tool cover -func=coverage-e2e.out | grep total
 
 coverage-all: up ## Run all tests with combined coverage
 	@echo "Running unit tests with coverage..."
 	go test -coverprofile=coverage-unit.out -covermode=atomic -coverpkg=$(COVERPKG) $(shell go list ./... | grep -v internal/gui | grep -v /cmd/)
 	@echo "Running E2E tests with coverage..."
-	SUVE_LOCALSTACK_EXTERNAL_PORT=$(SUVE_LOCALSTACK_EXTERNAL_PORT) go test -tags=e2e -coverprofile=coverage-e2e.out -covermode=atomic -coverpkg=$(COVERPKG) ./e2e/...
+	SUVE_FLOCI_EXTERNAL_PORT=$(SUVE_FLOCI_EXTERNAL_PORT) go test -tags=e2e -coverprofile=coverage-e2e.out -covermode=atomic -coverpkg=$(COVERPKG) ./e2e/...
 	@echo "Merging coverage profiles..."
 	@go run github.com/wadey/gocovmerge@latest coverage-unit.out coverage-e2e.out > coverage-all.out
 	go tool cover -func=coverage-all.out | grep total

--- a/README.md
+++ b/README.md
@@ -766,29 +766,29 @@ make e2e
 make coverage-all
 ```
 
-### Local Development with Localstack
+### Local Development with an AWS Emulator
 
-To test against [localstack](https://localstack.cloud/) instead of real AWS:
+To test against [floci](https://floci.io/) (a drop-in LocalStack Community replacement) instead of real AWS:
 
 ```bash
-# Start localstack
-SUVE_LOCALSTACK_EXTERNAL_PORT=4566 docker compose up -d
+# Start floci
+SUVE_FLOCI_EXTERNAL_PORT=4566 docker compose up -d floci
 
-# Run commands with localstack
+# Run commands against the emulator
 AWS_ENDPOINT_URL=http://127.0.0.1:4566 \
 AWS_ACCESS_KEY_ID=dummy \
 AWS_SECRET_ACCESS_KEY=dummy \
 AWS_DEFAULT_REGION=us-east-1 \
-suve param ls
+suve aws param ls
 
-# GUI with localstack
+# GUI against the emulator
 AWS_ENDPOINT_URL=http://127.0.0.1:4566 \
 AWS_ACCESS_KEY_ID=dummy \
 AWS_SECRET_ACCESS_KEY=dummy \
 AWS_DEFAULT_REGION=us-east-1 \
 suve --gui
 
-# Stop localstack
+# Stop floci
 docker compose down
 ```
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,11 +1,11 @@
 services:
-  localstack:
-    image: localstack/localstack:4
+  floci:
+    # Floci is a drop-in LocalStack Community replacement (MIT, no auth token).
+    # It serves all AWS services on :4566 and keeps the /_localstack/health
+    # endpoint for parity, so the AWS SDK's AWS_ENDPOINT_URL flow is unchanged.
+    image: floci/floci:latest
     ports:
-      - "127.0.0.1:${SUVE_LOCALSTACK_EXTERNAL_PORT:-4566}:4566/tcp"
-    environment:
-      - SERVICES=ssm,secretsmanager,events
-      - DEBUG=0
+      - "127.0.0.1:${SUVE_FLOCI_EXTERNAL_PORT:-4566}:4566/tcp"
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:4566/_localstack/health"]
       interval: 5s

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -2,13 +2,15 @@
 
 // Package e2e contains end-to-end tests for the suve CLI.
 //
-// These tests run against a real AWS-compatible service (localstack) and verify
-// the complete workflow of each command using the actual CLI commands.
+// These tests run against a real AWS-compatible service (floci, a LocalStack
+// Community replacement) and verify the complete workflow of each command using
+// the actual CLI commands.
 //
 // Run with: make e2e
 //
 // Environment variables:
-//   - SUVE_LOCALSTACK_EXTERNAL_PORT: Custom localstack port (default: 4566)
+//   - SUVE_FLOCI_EXTERNAL_PORT: Custom floci port (default: 4566)
+//     (SUVE_LOCALSTACK_EXTERNAL_PORT is still honored as a fallback)
 package e2e_test
 
 import (
@@ -57,17 +59,21 @@ func TestMain(m *testing.M) {
 func getEndpoint() string {
 	return fmt.Sprintf(
 		"http://127.0.0.1:%s",
-		lo.CoalesceOrEmpty(os.Getenv("SUVE_LOCALSTACK_EXTERNAL_PORT"), "4566"),
+		lo.CoalesceOrEmpty(
+			os.Getenv("SUVE_FLOCI_EXTERNAL_PORT"),
+			os.Getenv("SUVE_LOCALSTACK_EXTERNAL_PORT"), // backward-compatible fallback
+			"4566",
+		),
 	)
 }
 
-// setupEnv sets up environment variables for localstack and returns a cleanup function.
+// setupEnv sets up environment variables for the AWS emulator (floci).
 func setupEnv(t *testing.T) {
 	t.Helper()
 
 	endpoint := getEndpoint()
 
-	// Set AWS environment variables for localstack
+	// Set AWS environment variables for the emulator (floci)
 	t.Setenv("AWS_ENDPOINT_URL", endpoint)
 	t.Setenv("AWS_ACCESS_KEY_ID", "test")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
@@ -81,7 +87,7 @@ func setupTempHome(t *testing.T) {
 }
 
 // newStore creates a new staging store for E2E tests.
-// localstack uses account ID "000000000000" and region "us-east-1".
+// The AWS emulator uses account ID "000000000000" and region "us-east-1".
 func newStore() *file.Store {
 	s, err := file.NewStore(provider.AWSScope("000000000000", "us-east-1"))
 	if err != nil {

--- a/e2e/param_test.go
+++ b/e2e/param_test.go
@@ -134,11 +134,11 @@ func TestParam_FullWorkflow(t *testing.T) {
 		assert.Contains(t, stdout, "+updated-value")
 	})
 
-	// 10. List (note: localstack may not support path filtering perfectly)
+	// 10. List (note: the AWS emulator may not support path filtering perfectly)
 	t.Run("list", func(t *testing.T) {
 		stdout, _, err := runCommand(t, cmdparam.ListCommand(), "/suve-e2e-test/basic/")
 		require.NoError(t, err)
-		// Localstack might return empty for path-filtered list, skip assertion if empty
+		// The AWS emulator might return empty for path-filtered list, skip assertion if empty
 		if stdout != "" {
 			assert.Contains(t, stdout, paramName)
 		}

--- a/e2e/secret_test.go
+++ b/e2e/secret_test.go
@@ -108,12 +108,12 @@ func TestSecret_FullWorkflow(t *testing.T) {
 	})
 
 	// 9. Diff with ~SHIFT
-	// Note: Secrets Manager shift (~) may not work correctly in localstack due to version history limitations
+	// Note: Secrets Manager shift (~) may not work correctly in the AWS emulator due to version history limitations
 	t.Run("diff-shift", func(t *testing.T) {
 		stdout, stderr, err := runCommand(t, cmdsecret.DiffCommand(), secretName+"~1")
 		t.Logf("diff-shift stdout: %s", stdout)
 		t.Logf("diff-shift stderr: %s", stderr)
-		// Skip strict assertion - localstack may not support shift properly
+		// Skip strict assertion - the AWS emulator may not support shift properly
 		if err == nil && stdout != "" {
 			// If it works, check for the values
 			assert.True(t, strings.Contains(stdout, "initial-secret") || strings.Contains(stdout, "updated-secret"))
@@ -191,11 +191,11 @@ func TestSecret_VersionSpecifiers(t *testing.T) {
 	})
 
 	// Test ~SHIFT
-	// Note: Secrets Manager shift (~) may not work correctly in localstack due to version history limitations
+	// Note: Secrets Manager shift (~) may not work correctly in the AWS emulator due to version history limitations
 	t.Run("shift", func(t *testing.T) {
 		// ~1 = 1 version ago
 		stdout, _, err := runCommand(t, cmdsecret.ShowCommand(), "--raw", secretName+"~1")
-		// Localstack may not support shift properly, skip strict assertion
+		// The AWS emulator may not support shift properly, skip strict assertion
 		t.Logf("shift ~1 stdout: %s, err: %v", stdout, err)
 
 		if err == nil {
@@ -206,12 +206,12 @@ func TestSecret_VersionSpecifiers(t *testing.T) {
 	})
 
 	// Test :LABEL~SHIFT combination
-	// Note: May not work in localstack due to version history limitations
+	// Note: May not work in the AWS emulator due to version history limitations
 	t.Run("label-and-shift", func(t *testing.T) {
 		// :AWSCURRENT~1 = 1 version before current
 		stdout, _, err := runCommand(t, cmdsecret.ShowCommand(), "--raw", secretName+":AWSCURRENT~1")
 		t.Logf("label-and-shift stdout: %s, err: %v", stdout, err)
-		// Skip strict assertion - localstack may error with "version shift out of range"
+		// Skip strict assertion - the AWS emulator may error with "version shift out of range"
 		if err == nil {
 			assert.True(t, stdout == "v1" || stdout == "v2",
 				"expected v1 or v2, got %s", stdout)
@@ -351,8 +351,8 @@ func TestSecret_ErrorCases(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	// Note: localstack may not error on delete of non-existent secret
-	// So we skip this test for localstack compatibility
+	// Note: the AWS emulator may not error on delete of non-existent secret
+	// So we skip this test for the AWS emulator compatibility
 
 	// Invalid label
 	t.Run("invalid-label", func(t *testing.T) {
@@ -745,7 +745,7 @@ func TestSecret_DeleteNonExistent(t *testing.T) {
 	// Try to delete (should fail since it doesn't exist)
 	// Note: AWS Secrets Manager returns ResourceNotFoundException for non-existent secrets
 	_, _, err := runCommand(t, secretdelete.Command(), "--yes", "--force", secretName)
-	// Localstack may return success for non-existent secrets, so we just log the result
+	// The AWS emulator may return success for non-existent secrets, so we just log the result
 	if err != nil {
 		t.Logf("Delete non-existent returned error as expected: %v", err)
 	}


### PR DESCRIPTION
## Summary

LocalStack's Community edition now requires an auth token (freezing the free path). [**floci**](https://floci.io/) is a drop-in, MIT-licensed replacement: it serves all AWS services on `:4566` and keeps the `/_localstack/health` endpoint, so the AWS SDK's `AWS_ENDPOINT_URL` flow is unchanged. This migrates the AWS e2e emulator over.

## Changes (test infra only — no production code)
- **compose.yaml**: `localstack` service → `floci` (`floci/floci:latest`); dropped the LocalStack-only `SERVICES`/`DEBUG` env (floci enables all services by default).
- **.github/workflows/test.yml**: the e2e job's service container → floci.
- **Makefile**: renamed the port override `SUVE_LOCALSTACK_EXTERNAL_PORT` → `SUVE_FLOCI_EXTERNAL_PORT`; `make up` now starts only the `floci` service.
- **e2e/**: read `SUVE_FLOCI_EXTERNAL_PORT` (old var kept as a backward-compatible fallback); reworded LocalStack-specific comments to "the AWS emulator".
- **README / CLAUDE.md**: document floci instead of LocalStack.

## Validation
- `golangci-lint` (e2e tags) 0 issues; e2e package compiles; `actionlint` clean; compose YAML valid.
- ⚠️ I can't run floci locally, so **this PR's own e2e CI job is the real validation** of the migration. floci claims LocalStack parity for SSM + Secrets Manager; the existing permissive skips in `secret_test.go`/`param_test.go` (originally for LocalStack quirks) should absorb any minor behavioral differences. If the e2e job surfaces a real gap, I'll follow up.

Part of a broader move to per-provider e2e emulators (GCP via the Secret Manager emulator, Azure Key Vault via the keyvault-emulator) — those come as separate PRs since they need small env-gated test seams in the provider adapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155B8urnRZNHqfLrEnpxUE9