### PR TITLE
test(e2e): Google Cloud Secret Manager e2e against a local emulator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,33 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
 
+  e2e-gcp:
+    name: E2E Test (Google Cloud)
+    runs-on: ubuntu-latest
+    services:
+      # Google Cloud Secret Manager emulator (gRPC :9090), no auth, offline.
+      gcp-secretmanager:
+        image: ghcr.io/blackwell-systems/gcp-secret-manager-emulator-dual:latest
+        ports:
+          - 9090:9090
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up toolchain (mise)
+        uses: jdx/mise-action@v4
+        with:
+          install_args: "go"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for the Secret Manager emulator
+        run: timeout 60 bash -c 'until (echo > /dev/tcp/localhost/9090) 2>/dev/null; do sleep 1; done'
+
+      - name: Run Google Cloud e2e tests
+        run: go test -v -tags e2e -run TestGCP ./e2e/...
+        env:
+          SUVE_GCP_SECRETMANAGER_ENDPOINT: localhost:9090
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint e2e up down clean coverage coverage-e2e coverage-all gui-dev gui-build gui-bindings ubuntu-22 ubuntu-24 x11-setup help
+.PHONY: build test lint e2e e2e-gcp up down clean coverage coverage-e2e coverage-all gui-dev gui-build gui-bindings ubuntu-22 ubuntu-24 x11-setup help
 
 .DEFAULT_GOAL := help
 
@@ -24,6 +24,7 @@ else
 endif
 
 SUVE_LOCALSTACK_EXTERNAL_PORT ?= 4566
+SUVE_GCP_EMULATOR_PORT ?= 9090
 COVERPKG = $(shell go list ./... | grep -v testutil | grep -v /e2e | grep -v internal/gui | grep -v /cmd/ | tr '\n' ',')
 
 help: ## Show this help
@@ -55,6 +56,13 @@ down: ## Stop localstack container
 
 e2e: up ## Run E2E tests (starts localstack)
 	SUVE_LOCALSTACK_EXTERNAL_PORT=$(SUVE_LOCALSTACK_EXTERNAL_PORT) go test -tags=e2e -v ./e2e/...
+
+e2e-gcp: ## Run Google Cloud Secret Manager E2E tests (starts the emulator)
+	SUVE_GCP_EMULATOR_PORT=$(SUVE_GCP_EMULATOR_PORT) docker compose --profile gcp up -d gcp-secretmanager
+	@echo "Waiting for the GCP Secret Manager emulator on port $(SUVE_GCP_EMULATOR_PORT)..."
+	@until bash -c 'echo > /dev/tcp/127.0.0.1/$(SUVE_GCP_EMULATOR_PORT)' 2>/dev/null; do sleep 1; done
+	@echo "emulator is ready"
+	SUVE_GCP_SECRETMANAGER_ENDPOINT=127.0.0.1:$(SUVE_GCP_EMULATOR_PORT) go test -tags=e2e -v -run TestGCP ./e2e/...
 
 clean: ## Clean build artifacts and stop containers
 	rm -rf bin/ *.out

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,6 +13,16 @@ services:
       retries: 10
       start_period: 15s
 
+  gcp-secretmanager:
+    # Google Cloud Secret Manager emulator (gRPC :9090, REST :8080), no auth,
+    # runs entirely offline. Used by the `e2e-gcp` target / CI job; the provider
+    # adapter targets it via SUVE_GCP_SECRETMANAGER_ENDPOINT.
+    profiles:
+      - gcp
+    image: ghcr.io/blackwell-systems/gcp-secret-manager-emulator-dual:latest
+    ports:
+      - "127.0.0.1:${SUVE_GCP_EMULATOR_PORT:-9090}:9090/tcp"
+
   ubuntu-22:
     profiles:
       - ubuntu-22

--- a/e2e/gcp_secret_test.go
+++ b/e2e/gcp_secret_test.go
@@ -1,0 +1,151 @@
+//go:build e2e
+
+//nolint:paralleltest // E2E subtests share state and run sequentially, not in parallel
+package e2e_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+
+	commands "github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/cli/commands/gcloud"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/detect"
+	"github.com/mpyw/suve/internal/provider/gcp"
+)
+
+// setupGCP skips the test unless the emulator endpoint is configured, and pins a
+// project id. The endpoint env var itself is provided by the CI job / make
+// target and read by the provider adapter's emulator seam.
+func setupGCP(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv(gcp.EmulatorEnvVar) == "" {
+		t.Skipf("%s not set; skipping GCP Secret Manager e2e", gcp.EmulatorEnvVar)
+	}
+
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "suve-e2e")
+}
+
+// runGcloud runs `suve gcloud <args...>` in-process through the gcloud command
+// group (whose Before hook resolves the project from GOOGLE_CLOUD_PROJECT) and
+// returns stdout.
+func runGcloud(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	var outBuf, errBuf bytes.Buffer
+
+	app := &cli.Command{
+		Name:      "suve",
+		Writer:    &outBuf,
+		ErrWriter: &errBuf,
+		Commands:  []*cli.Command{gcloud.Command()},
+	}
+
+	full := append([]string{"suve", "gcloud"}, args...)
+	err := app.Run(t.Context(), full)
+
+	return outBuf.String(), err
+}
+
+// TestGCPSecret_FullWorkflow exercises the gcloud secret commands against a
+// local Secret Manager emulator (no real Google Cloud account). It is skipped
+// unless SUVE_GCP_SECRETMANAGER_ENDPOINT points at a running emulator — see the
+// gcp-secretmanager service in compose.yaml and the `e2e-gcp` make target.
+func TestGCPSecret_FullWorkflow(t *testing.T) {
+	setupGCP(t)
+
+	const name = "suve-e2e-gcp-secret"
+
+	// Best-effort cleanup from a previous run.
+	_, _ = runGcloud(t, "secret", "delete", "--yes", name)
+
+	t.Run("create", func(t *testing.T) {
+		stdout, err := runGcloud(t, "secret", "create", name, "initial-value")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, name)
+	})
+
+	t.Run("show", func(t *testing.T) {
+		stdout, err := runGcloud(t, "secret", "show", "--raw", name)
+		require.NoError(t, err)
+		assert.Equal(t, "initial-value", stdout)
+	})
+
+	t.Run("update-adds-version", func(t *testing.T) {
+		_, err := runGcloud(t, "secret", "update", "--yes", name, "updated-value")
+		require.NoError(t, err)
+
+		stdout, err := runGcloud(t, "secret", "show", "--raw", name)
+		require.NoError(t, err)
+		assert.Equal(t, "updated-value", stdout)
+	})
+
+	t.Run("log-shows-two-versions", func(t *testing.T) {
+		stdout, err := runGcloud(t, "secret", "log", name)
+		require.NoError(t, err)
+		// Google Cloud versions are integers; after one update there are two.
+		assert.Contains(t, stdout, "1")
+		assert.Contains(t, stdout, "2")
+	})
+
+	t.Run("show-specific-version", func(t *testing.T) {
+		stdout, err := runGcloud(t, "secret", "show", "--raw", name+"#1")
+		require.NoError(t, err)
+		assert.Equal(t, "initial-value", stdout)
+	})
+
+	t.Run("diff", func(t *testing.T) {
+		stdout, err := runGcloud(t, "secret", "diff", name+"#1", name+"#2")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "initial-value")
+		assert.Contains(t, stdout, "updated-value")
+	})
+
+	t.Run("list", func(t *testing.T) {
+		stdout, err := runGcloud(t, "secret", "list")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, name)
+	})
+
+	// The flat `suve secret` alias must reach the same Google Cloud store (and
+	// thus the emulator). The detection logic that picks the alias target is
+	// env-only and unit-tested separately; here we force it to Google Cloud and
+	// confirm the flat command path resolves the project and hits the emulator.
+	t.Run("flat-alias-reaches-emulator", func(t *testing.T) {
+		var outBuf, errBuf bytes.Buffer
+
+		app := commands.MakeAppWithDetect(detect.Result{Secret: provider.ProviderGoogleCloud})
+		app.Writer = &outBuf
+		app.ErrWriter = &errBuf
+
+		err := app.Run(t.Context(), []string{"suve", "secret", "show", "--raw", name})
+		require.NoError(t, err)
+		assert.Equal(t, "updated-value", outBuf.String())
+	})
+
+	t.Run("tag-and-untag-labels", func(t *testing.T) {
+		_, err := runGcloud(t, "secret", "tag", name, "env=test")
+		require.NoError(t, err)
+
+		stdout, err := runGcloud(t, "secret", "show", name)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "env")
+
+		_, err = runGcloud(t, "secret", "untag", name, "env")
+		require.NoError(t, err)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		_, err := runGcloud(t, "secret", "delete", "--yes", name)
+		require.NoError(t, err)
+
+		_, err = runGcloud(t, "secret", "show", "--raw", name)
+		require.Error(t, err)
+	})
+}

--- a/internal/provider/gcp/gcp.go
+++ b/internal/provider/gcp/gcp.go
@@ -9,12 +9,40 @@ package gcp
 import (
 	"context"
 	"fmt"
+	"os"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
+	"google.golang.org/api/option"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/gcp/secret"
 )
+
+// EmulatorEnvVar is the environment variable that, when set (e.g. to
+// "localhost:9090"), points the Secret Manager client at a local emulator over
+// plaintext gRPC with no authentication. It is a testing seam only: in normal
+// use it is unset and the client uses Application Default Credentials over TLS.
+// Never set this in production.
+const EmulatorEnvVar = "SUVE_GCP_SECRETMANAGER_ENDPOINT"
+
+// newSecretManagerClient builds the Secret Manager client, honoring the
+// emulator seam (EmulatorEnvVar) when set.
+func newSecretManagerClient(ctx context.Context) (*secretmanager.Client, error) {
+	endpoint := os.Getenv(EmulatorEnvVar)
+	if endpoint == "" {
+		return secretmanager.NewClient(ctx)
+	}
+
+	// Emulator: dial plaintext gRPC and skip authentication entirely.
+	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to dial Google Cloud Secret Manager emulator at %s: %w", endpoint, err)
+	}
+
+	return secretmanager.NewClient(ctx, option.WithGRPCConn(conn), option.WithoutAuthentication())
+}
 
 // Factory builds Google Cloud-backed provider.Store values for a scope + kind.
 type Factory struct{}
@@ -28,7 +56,7 @@ var _ provider.Factory = Factory{}
 func (Factory) Store(ctx context.Context, scope provider.Scope, kind provider.Kind) (provider.Store, error) {
 	switch kind {
 	case provider.KindSecret:
-		client, err := secretmanager.NewClient(ctx)
+		client, err := newSecretManagerClient(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create Google Cloud Secret Manager client: %w", err)
 		}


### PR DESCRIPTION
## Summary

Adds **account-free** e2e coverage for `suve gcloud secret` using the [blackwell-systems Secret Manager emulator](https://github.com/blackwell-systems/gcp-secret-manager-emulator) (gRPC, no auth, fully offline). Unlike floci for AWS SSM, this emulator implements version history, so `log`/`diff`/version specifiers work.

## Changes
- **`internal/provider/gcp`**: env-gated emulator seam. When `SUVE_GCP_SECRETMANAGER_ENDPOINT` is set, the client dials it over plaintext gRPC with no auth (`option.WithGRPCConn` + `WithoutAuthentication`); otherwise the normal ADC path is untouched. Never active in production.
- **compose.yaml**: `gcp-secretmanager` service (gRPC :9090) behind a `gcp` profile (not started by the default `make up`).
- **Makefile**: `e2e-gcp` target (starts the emulator, waits, runs the GCP e2e).
- **.github/workflows/test.yml**: new `e2e-gcp` job with the emulator as a service container.
- **e2e/gcp_secret_test.go**: create / show / update (new version) / log (integer versions) / show#version / diff / list / tag+untag (labels) / delete, **plus** a subtest confirming the flat `suve secret` alias reaches the same store. Skips when the endpoint env is unset → the existing AWS e2e job is unaffected.

## On alias-resolution + emulators
The flat-alias detection needs **no** emulator-specific support: it is env-only (`GOOGLE_CLOUD_PROJECT` etc.) and endpoint-agnostic. The emulator seam lives in store construction, which the flat alias goes through too — the `flat-alias-reaches-emulator` subtest asserts this.

## Validation
`golangci-lint` 0 issues; e2e compiles; `actionlint` clean; arch-guard test passes (grpc/option are not confined SDKs). The new `e2e-gcp` CI job validates against the real emulator.

Next: Azure Key Vault + App Configuration emulators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155B8urnRZNHqfLrEnpxUE9