### PR TITLE
test(e2e): Azure App Configuration e2e via a forked emulator

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -141,6 +141,38 @@ jobs:
         env:
           SUVE_GCP_SECRETMANAGER_ENDPOINT: localhost:9090
 
+  e2e-azure:
+    name: E2E Test (Azure)
+    runs-on: ubuntu-latest
+    services:
+      # Azure App Configuration emulator (HTTP :8080, HMAC over plain HTTP),
+      # offline. A fork of tnc1997/azure-app-configuration-emulator patched to
+      # interoperate with the official Azure SDKs.
+      # https://github.com/mpyw/azure-app-configuration-emulator
+      azure-appconfig:
+        image: ghcr.io/mpyw/azure-app-configuration-emulator:latest
+        ports:
+          - 8080:8080
+        env:
+          ASPNETCORE_HTTP_PORTS: 8080
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up toolchain (mise)
+        uses: jdx/mise-action@v4
+        with:
+          install_args: "go"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for the App Configuration emulator
+        run: timeout 60 bash -c 'until (echo > /dev/tcp/localhost/8080) 2>/dev/null; do sleep 1; done'
+
+      - name: Run Azure e2e tests
+        run: go test -v -tags e2e -run TestAzureAppConfig ./e2e/...
+        env:
+          SUVE_AZURE_APPCONFIG_CONNECTION_STRING: "Endpoint=http://localhost:8080;Id=abcd;Secret=c2VjcmV0"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,10 +168,22 @@ jobs:
       - name: Wait for the App Configuration emulator
         run: timeout 60 bash -c 'until (echo > /dev/tcp/localhost/8080) 2>/dev/null; do sleep 1; done'
 
-      - name: Run Azure e2e tests
-        run: go test -v -tags e2e -run TestAzureAppConfig ./e2e/...
+      - name: Run Azure e2e tests with coverage
+        run: |
+          COVERPKG=$(go list ./... | grep -v testutil | grep -v /e2e | grep -v internal/gui | grep -v /cmd/ | tr '\n' ',')
+          go test -v -race -tags e2e -run TestAzureAppConfig -coverprofile=coverage-e2e-azure.txt -covermode=atomic -coverpkg=$COVERPKG ./e2e/...
         env:
           SUVE_AZURE_APPCONFIG_CONNECTION_STRING: "Endpoint=http://localhost:8080;Id=abcd;Secret=c2VjcmV0"
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage-e2e-azure.txt
+          flags: e2e
+          name: codecov-suve-e2e-azure
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        continue-on-error: true
 
   lint:
     name: Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,10 +136,22 @@ jobs:
       - name: Wait for the Secret Manager emulator
         run: timeout 60 bash -c 'until (echo > /dev/tcp/localhost/9090) 2>/dev/null; do sleep 1; done'
 
-      - name: Run Google Cloud e2e tests
-        run: go test -v -tags e2e -run TestGCP ./e2e/...
+      - name: Run Google Cloud e2e tests with coverage
+        run: |
+          COVERPKG=$(go list ./... | grep -v testutil | grep -v /e2e | grep -v internal/gui | grep -v /cmd/ | tr '\n' ',')
+          go test -v -race -tags e2e -run TestGCP -coverprofile=coverage-e2e-gcp.txt -covermode=atomic -coverpkg=$COVERPKG ./e2e/...
         env:
           SUVE_GCP_SECRETMANAGER_ENDPOINT: localhost:9090
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage-e2e-gcp.txt
+          flags: e2e
+          name: codecov-suve-e2e-gcp
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        continue-on-error: true
 
   e2e-azure:
     name: E2E Test (Azure)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint e2e e2e-gcp up down clean coverage coverage-e2e coverage-all gui-dev gui-build gui-bindings ubuntu-22 ubuntu-24 x11-setup help
+.PHONY: build test lint e2e e2e-gcp e2e-azure up down clean coverage coverage-e2e coverage-all gui-dev gui-build gui-bindings ubuntu-22 ubuntu-24 x11-setup help
 
 .DEFAULT_GOAL := help
 
@@ -25,6 +25,7 @@ endif
 
 SUVE_LOCALSTACK_EXTERNAL_PORT ?= 4566
 SUVE_GCP_EMULATOR_PORT ?= 9090
+SUVE_AZURE_APPCONFIG_PORT ?= 8080
 COVERPKG = $(shell go list ./... | grep -v testutil | grep -v /e2e | grep -v internal/gui | grep -v /cmd/ | tr '\n' ',')
 
 help: ## Show this help
@@ -63,6 +64,13 @@ e2e-gcp: ## Run Google Cloud Secret Manager E2E tests (starts the emulator)
 	@until bash -c 'echo > /dev/tcp/127.0.0.1/$(SUVE_GCP_EMULATOR_PORT)' 2>/dev/null; do sleep 1; done
 	@echo "emulator is ready"
 	SUVE_GCP_SECRETMANAGER_ENDPOINT=127.0.0.1:$(SUVE_GCP_EMULATOR_PORT) go test -tags=e2e -v -run TestGCP ./e2e/...
+
+e2e-azure: ## Run Azure App Configuration E2E tests (starts the emulator)
+	SUVE_AZURE_APPCONFIG_PORT=$(SUVE_AZURE_APPCONFIG_PORT) docker compose --profile azure up -d azure-appconfig
+	@echo "Waiting for the Azure App Configuration emulator on port $(SUVE_AZURE_APPCONFIG_PORT)..."
+	@until bash -c 'echo > /dev/tcp/127.0.0.1/$(SUVE_AZURE_APPCONFIG_PORT)' 2>/dev/null; do sleep 1; done
+	@echo "emulator is ready"
+	SUVE_AZURE_APPCONFIG_CONNECTION_STRING="Endpoint=http://127.0.0.1:$(SUVE_AZURE_APPCONFIG_PORT);Id=abcd;Secret=c2VjcmV0" go test -tags=e2e -v -run TestAzureAppConfig ./e2e/...
 
 clean: ## Clean build artifacts and stop containers
 	rm -rf bin/ *.out

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,6 +23,23 @@ services:
     ports:
       - "127.0.0.1:${SUVE_GCP_EMULATOR_PORT:-9090}:9090/tcp"
 
+  azure-appconfig:
+    # Azure App Configuration emulator (HTTP :8080, HMAC auth over plain HTTP),
+    # runs entirely offline. Used by the `e2e-azure` target / CI job; the
+    # provider adapter targets it via SUVE_AZURE_APPCONFIG_CONNECTION_STRING.
+    #
+    # This is a fork of tnc1997/azure-app-configuration-emulator patched to
+    # interoperate with the official Azure SDKs (comma-separated HMAC parsing,
+    # UTC last_modified timestamps, Sync-Token response header). See
+    # https://github.com/mpyw/azure-app-configuration-emulator.
+    profiles:
+      - azure
+    image: ghcr.io/mpyw/azure-app-configuration-emulator:latest
+    ports:
+      - "127.0.0.1:${SUVE_AZURE_APPCONFIG_PORT:-8080}:8080/tcp"
+    environment:
+      - ASPNETCORE_HTTP_PORTS=8080
+
   ubuntu-22:
     profiles:
       - ubuntu-22

--- a/e2e/azure_appconfig_test.go
+++ b/e2e/azure_appconfig_test.go
@@ -1,0 +1,127 @@
+//go:build e2e
+
+//nolint:paralleltest // E2E subtests share state and run sequentially, not in parallel
+package e2e_test
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+
+	commands "github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/cli/commands/azure"
+	"github.com/mpyw/suve/internal/provider"
+	azureprovider "github.com/mpyw/suve/internal/provider/azure"
+	"github.com/mpyw/suve/internal/provider/detect"
+)
+
+// setupAzureAppConfig skips the test unless the App Configuration emulator
+// connection string is configured, and pins a dummy store name. The connection
+// string is provided by the CI job / make target and read by the provider
+// adapter's emulator seam; the store name is required by the CLI but ignored by
+// the emulator (the endpoint is embedded in the connection string).
+func setupAzureAppConfig(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv(azureprovider.AppConfigConnStringEnvVar) == "" {
+		t.Skipf("%s not set; skipping Azure App Configuration e2e", azureprovider.AppConfigConnStringEnvVar)
+	}
+
+	t.Setenv("AZURE_APPCONFIG_NAME", "suve-e2e")
+}
+
+// runAzureParam runs `suve azure param <args...>` in-process through the azure
+// command group (whose Before hooks resolve the store from AZURE_APPCONFIG_NAME)
+// and returns stdout.
+func runAzureParam(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	var outBuf, errBuf bytes.Buffer
+
+	app := &cli.Command{
+		Name:      "suve",
+		Writer:    &outBuf,
+		ErrWriter: &errBuf,
+		Commands:  []*cli.Command{azure.Command()},
+	}
+
+	full := append([]string{"suve", "azure", "param"}, args...)
+	err := app.Run(t.Context(), full)
+
+	return outBuf.String(), err
+}
+
+// TestAzureAppConfig_FullWorkflow exercises the azure param commands against a
+// local App Configuration emulator (no real Azure account). It is skipped unless
+// SUVE_AZURE_APPCONFIG_CONNECTION_STRING points at a running emulator — see the
+// azure-appconfig service in compose.yaml and the `e2e-azure` make target.
+//
+// App Configuration is UNVERSIONED: there is no version history, so this test
+// exercises create/show/update/list/tag/delete but no version-specific paths.
+func TestAzureAppConfig_FullWorkflow(t *testing.T) {
+	setupAzureAppConfig(t)
+
+	const name = "suve/e2e/azure/param"
+
+	// Best-effort cleanup from a previous run.
+	_, _ = runAzureParam(t, "delete", "--yes", name)
+
+	t.Run("create", func(t *testing.T) {
+		stdout, err := runAzureParam(t, "create", name, "initial-value")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, name)
+	})
+
+	t.Run("show", func(t *testing.T) {
+		stdout, err := runAzureParam(t, "show", "--raw", name)
+		require.NoError(t, err)
+		assert.Equal(t, "initial-value", stdout)
+	})
+
+	t.Run("update-replaces-value", func(t *testing.T) {
+		_, err := runAzureParam(t, "update", "--yes", name, "updated-value")
+		require.NoError(t, err)
+
+		stdout, err := runAzureParam(t, "show", "--raw", name)
+		require.NoError(t, err)
+		assert.Equal(t, "updated-value", stdout)
+	})
+
+	t.Run("list", func(t *testing.T) {
+		stdout, err := runAzureParam(t, "list")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, name)
+	})
+
+	// The flat `suve param` alias must reach the same Azure App Configuration
+	// store (and thus the emulator). The detection logic that picks the alias
+	// target is env-only and unit-tested separately; here we force it to Azure
+	// and confirm the flat command path resolves the store and hits the emulator.
+	t.Run("flat-alias-reaches-emulator", func(t *testing.T) {
+		var outBuf, errBuf bytes.Buffer
+
+		app := commands.MakeAppWithDetect(detect.Result{Param: provider.ProviderAzure})
+		app.Writer = &outBuf
+		app.ErrWriter = &errBuf
+
+		err := app.Run(t.Context(), []string{"suve", "param", "show", "--raw", name})
+		require.NoError(t, err)
+		assert.Equal(t, "updated-value", outBuf.String())
+	})
+
+	// Note: tag/untag are intentionally not exercised here. Azure App
+	// Configuration tags are not writable via the azappconfig SDK, so the
+	// adapter rejects tag mutation with a clear error by design.
+
+	t.Run("delete", func(t *testing.T) {
+		_, err := runAzureParam(t, "delete", "--yes", name)
+		require.NoError(t, err)
+
+		_, err = runAzureParam(t, "show", "--raw", name)
+		require.Error(t, err)
+	})
+}

--- a/internal/provider/azure/azure.go
+++ b/internal/provider/azure/azure.go
@@ -14,7 +14,9 @@ package azure
 import (
 	"context"
 	"fmt"
+	"os"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
@@ -23,6 +25,15 @@ import (
 	"github.com/mpyw/suve/internal/provider/azure/appconfig"
 	"github.com/mpyw/suve/internal/provider/azure/keyvault"
 )
+
+// AppConfigConnStringEnvVar is the environment variable that, when set, points
+// the App Configuration adapter at an emulator via a connection string
+// (Endpoint=...;Id=...;Secret=...) instead of the real https://<store>.azconfig.io
+// endpoint with DefaultAzureCredential. It is an emulator-only seam for offline
+// e2e tests (see the azure-appconfig service in compose.yaml and the `e2e-azure`
+// make target); it permits HMAC credentials over plain HTTP, so it must never be
+// set against a production store.
+const AppConfigConnStringEnvVar = "SUVE_AZURE_APPCONFIG_CONNECTION_STRING"
 
 // Factory builds Azure-backed provider.Store values for a scope + kind.
 type Factory struct{}
@@ -70,6 +81,21 @@ func keyVaultStore(_ context.Context, scope provider.Scope) (provider.Store, err
 func appConfigStore(_ context.Context, scope provider.Scope) (provider.Store, error) {
 	if scope.StoreName == "" {
 		return nil, fmt.Errorf("no Azure App Configuration store specified: set --store-name")
+	}
+
+	// Emulator seam: a connection string (offline e2e) bypasses the real
+	// endpoint + DefaultAzureCredential and allows HMAC auth over plain HTTP.
+	if connStr := os.Getenv(AppConfigConnStringEnvVar); connStr != "" {
+		opts := &azappconfig.ClientOptions{
+			ClientOptions: azcore.ClientOptions{InsecureAllowCredentialWithHTTP: true},
+		}
+
+		client, err := azappconfig.NewClientFromConnectionString(connStr, opts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Azure App Configuration client from connection string: %w", err)
+		}
+
+		return appconfig.New(appconfig.Wrap(client)), nil
 	}
 
 	cred, err := azidentity.NewDefaultAzureCredential(nil)

--- a/internal/provider/azure/azure_test.go
+++ b/internal/provider/azure/azure_test.go
@@ -1,0 +1,41 @@
+package azure_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/azure"
+)
+
+// TestStore_UnsupportedKind verifies an unknown kind yields ErrUnsupportedKind.
+func TestStore_UnsupportedKind(t *testing.T) {
+	t.Parallel()
+
+	_, err := azure.Factory{}.Store(t.Context(), provider.Scope{}, provider.Kind("bogus"))
+	require.ErrorIs(t, err, provider.ErrUnsupportedKind)
+}
+
+// TestAppConfigStore_RequiresStoreName verifies a missing store name is a clear
+// error before any client construction.
+func TestAppConfigStore_RequiresStoreName(t *testing.T) {
+	t.Parallel()
+
+	_, err := azure.Factory{}.Store(t.Context(), provider.Scope{}, provider.KindParam)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--store-name")
+}
+
+// TestAppConfigStore_ConnectionStringError exercises the emulator seam: with the
+// connection-string env var set to a malformed value, the App Configuration
+// store construction fails from NewClientFromConnectionString rather than
+// falling through to DefaultAzureCredential.
+func TestAppConfigStore_ConnectionStringError(t *testing.T) {
+	t.Setenv(azure.AppConfigConnStringEnvVar, "this-is-not-a-valid-connection-string")
+
+	_, err := azure.Factory{}.Store(t.Context(), provider.Scope{StoreName: "suve-test"}, provider.KindParam)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection string")
+}


### PR DESCRIPTION
Adds offline e2e coverage for the Azure App Configuration (`param`) command group, mirroring the AWS/GCP e2e setup: an env-gated emulator seam in the provider adapter, a `compose.yaml` service (`azure` profile), a `make e2e-azure` target, and an `e2e-azure` CI job.

## Why a fork

The upstream [tnc1997/azure-app-configuration-emulator](https://github.com/tnc1997/azure-app-configuration-emulator) does not interoperate with the **official Azure SDKs**, so it can't be driven by suve's real code paths. Three divergences from real Azure App Configuration (all verified locally against `azure-sdk-for-go`):

1. **HMAC `Authorization` parsing** — the SDKs send a comma-separated parameter list; upstream only accepts `&`-separated values and rejects the request via `AuthenticationHeaderValue.TryParse` before the HMAC handler ever runs.
2. **`last_modified` timestamps** — upstream emits `+00:00` offsets that `System.Text.Json` escapes to `+`, which the SDK's RFC3339 parser rejects (should be `Z`).
3. **Missing `Sync-Token` header** — the SDKs dereference it unconditionally (nil-panic), including on the `204 No Content` returned when deleting a non-existent key.

Fixed in a patched fork published to `ghcr.io/mpyw/azure-app-configuration-emulator` (public image): https://github.com/mpyw/azure-app-configuration-emulator

## Provider seam

`SUVE_AZURE_APPCONFIG_CONNECTION_STRING`, when set, builds the `azappconfig` client from a connection string with `InsecureAllowCredentialWithHTTP` (HMAC over plain HTTP) instead of the real endpoint + `DefaultAzureCredential`. Emulator-only; must never be set against a production store.

## Coverage

`create` / `show` / `update` / `list` / `delete` plus the flat `suve param` alias path. `tag`/`untag` are intentionally omitted — App Configuration tags are not writable via the `azappconfig` SDK, so the adapter rejects tag mutation by design.

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155B8urnRZNHqfLrEnpxUE9