### PR TITLE
test(e2e): Azure Key Vault e2e via lowkey-vault + provider test hardening

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -167,6 +167,12 @@ jobs:
           - 8080:8080
         env:
           ASPNETCORE_HTTP_PORTS: 8080
+      # Azure Key Vault emulator (lowkey-vault, HTTPS :8443, self-signed cert,
+      # auth present-but-ignored), offline.
+      azure-keyvault:
+        image: nagyesta/lowkey-vault:7.3.0
+        ports:
+          - 8443:8443
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -180,12 +186,16 @@ jobs:
       - name: Wait for the App Configuration emulator
         run: timeout 60 bash -c 'until (echo > /dev/tcp/localhost/8080) 2>/dev/null; do sleep 1; done'
 
+      - name: Wait for the Key Vault emulator
+        run: timeout 60 bash -c 'until curl -sk -o /dev/null https://localhost:8443/ping; do sleep 1; done'
+
       - name: Run Azure e2e tests with coverage
         run: |
           COVERPKG=$(go list ./... | grep -v testutil | grep -v /e2e | grep -v internal/gui | grep -v /cmd/ | tr '\n' ',')
-          go test -v -race -tags e2e -run TestAzureAppConfig -coverprofile=coverage-e2e-azure.txt -covermode=atomic -coverpkg=$COVERPKG ./e2e/...
+          go test -v -race -tags e2e -run 'TestAzureAppConfig|TestAzureKeyVault' -coverprofile=coverage-e2e-azure.txt -covermode=atomic -coverpkg=$COVERPKG ./e2e/...
         env:
           SUVE_AZURE_APPCONFIG_CONNECTION_STRING: "Endpoint=http://localhost:8080;Id=abcd;Secret=c2VjcmV0"
+          SUVE_AZURE_KEYVAULT_ENDPOINT: "https://localhost:8443"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint e2e e2e-gcp e2e-azure up down clean coverage coverage-e2e coverage-all gui-dev gui-build gui-bindings ubuntu-22 ubuntu-24 x11-setup help
+.PHONY: build test lint e2e e2e-gcp e2e-azure e2e-azure-keyvault up down clean coverage coverage-e2e coverage-all gui-dev gui-build gui-bindings ubuntu-22 ubuntu-24 x11-setup help
 
 .DEFAULT_GOAL := help
 
@@ -26,6 +26,7 @@ endif
 SUVE_LOCALSTACK_EXTERNAL_PORT ?= 4566
 SUVE_GCP_EMULATOR_PORT ?= 9090
 SUVE_AZURE_APPCONFIG_PORT ?= 8080
+SUVE_AZURE_KEYVAULT_PORT ?= 8443
 COVERPKG = $(shell go list ./... | grep -v testutil | grep -v /e2e | grep -v internal/gui | grep -v /cmd/ | tr '\n' ',')
 
 help: ## Show this help
@@ -71,6 +72,13 @@ e2e-azure: ## Run Azure App Configuration E2E tests (starts the emulator)
 	@until bash -c 'echo > /dev/tcp/127.0.0.1/$(SUVE_AZURE_APPCONFIG_PORT)' 2>/dev/null; do sleep 1; done
 	@echo "emulator is ready"
 	SUVE_AZURE_APPCONFIG_CONNECTION_STRING="Endpoint=http://127.0.0.1:$(SUVE_AZURE_APPCONFIG_PORT);Id=abcd;Secret=c2VjcmV0" go test -tags=e2e -v -run TestAzureAppConfig ./e2e/...
+
+e2e-azure-keyvault: ## Run Azure Key Vault E2E tests (starts the lowkey-vault emulator)
+	SUVE_AZURE_KEYVAULT_PORT=$(SUVE_AZURE_KEYVAULT_PORT) docker compose --profile azure up -d azure-keyvault
+	@echo "Waiting for the Key Vault emulator on port $(SUVE_AZURE_KEYVAULT_PORT)..."
+	@until curl -sk -o /dev/null https://127.0.0.1:$(SUVE_AZURE_KEYVAULT_PORT)/ping 2>/dev/null; do sleep 1; done
+	@echo "emulator is ready"
+	SUVE_AZURE_KEYVAULT_ENDPOINT="https://127.0.0.1:$(SUVE_AZURE_KEYVAULT_PORT)" go test -tags=e2e -v -run TestAzureKeyVault ./e2e/...
 
 clean: ## Clean build artifacts and stop containers
 	rm -rf bin/ *.out

--- a/compose.yaml
+++ b/compose.yaml
@@ -40,6 +40,17 @@ services:
     environment:
       - ASPNETCORE_HTTP_PORTS=8080
 
+  azure-keyvault:
+    # Azure Key Vault emulator (lowkey-vault, HTTPS :8443, self-signed cert,
+    # auth present-but-ignored), runs entirely offline. Used by the
+    # `e2e-azure-keyvault` target / CI job; the provider adapter targets it via
+    # SUVE_AZURE_KEYVAULT_ENDPOINT (TLS verification + token challenge disabled).
+    profiles:
+      - azure
+    image: nagyesta/lowkey-vault:7.3.0
+    ports:
+      - "127.0.0.1:${SUVE_AZURE_KEYVAULT_PORT:-8443}:8443/tcp"
+
   ubuntu-22:
     profiles:
       - ubuntu-22

--- a/e2e/azure_keyvault_test.go
+++ b/e2e/azure_keyvault_test.go
@@ -1,0 +1,157 @@
+//go:build e2e
+
+//nolint:paralleltest // E2E subtests share state and run sequentially, not in parallel
+package e2e_test
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+
+	commands "github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/cli/commands/azure"
+	"github.com/mpyw/suve/internal/provider"
+	azureprovider "github.com/mpyw/suve/internal/provider/azure"
+	"github.com/mpyw/suve/internal/provider/detect"
+)
+
+// setupAzureKeyVault skips the test unless the Key Vault emulator endpoint is
+// configured, and pins a dummy vault name. The endpoint is provided by the CI
+// job / make target and read by the provider adapter's emulator seam; the vault
+// name is required by the CLI but ignored by the emulator (a single default
+// vault is served at the endpoint).
+func setupAzureKeyVault(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv(azureprovider.KeyVaultEndpointEnvVar) == "" {
+		t.Skipf("%s not set; skipping Azure Key Vault e2e", azureprovider.KeyVaultEndpointEnvVar)
+	}
+
+	t.Setenv("AZURE_KEYVAULT_NAME", "suve-e2e")
+}
+
+// runAzureSecret runs `suve azure secret <args...>` in-process through the azure
+// command group (whose Before hooks resolve the vault from AZURE_KEYVAULT_NAME)
+// and returns stdout.
+func runAzureSecret(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	var outBuf, errBuf bytes.Buffer
+
+	app := &cli.Command{
+		Name:      "suve",
+		Writer:    &outBuf,
+		ErrWriter: &errBuf,
+		Commands:  []*cli.Command{azure.Command()},
+	}
+
+	full := append([]string{"suve", "azure", "secret"}, args...)
+	err := app.Run(t.Context(), full)
+
+	return outBuf.String(), err
+}
+
+// TestAzureKeyVault_FullWorkflow exercises the azure secret commands against a
+// local Key Vault emulator (no real Azure account). It is skipped unless
+// SUVE_AZURE_KEYVAULT_ENDPOINT points at a running emulator — see the
+// azure-keyvault service in compose.yaml and the `e2e-azure-keyvault` make
+// target.
+//
+// Key Vault secrets are versioned by opaque id; this test relies on Git-like
+// ~SHIFT to reach older versions without depending on the concrete version id.
+func TestAzureKeyVault_FullWorkflow(t *testing.T) {
+	setupAzureKeyVault(t)
+
+	const name = "suve-e2e-kv-secret"
+
+	// Best-effort cleanup from a previous run.
+	_, _ = runAzureSecret(t, "delete", "--yes", name)
+
+	t.Run("create", func(t *testing.T) {
+		stdout, err := runAzureSecret(t, "create", name, "initial-value")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, name)
+	})
+
+	t.Run("show", func(t *testing.T) {
+		stdout, err := runAzureSecret(t, "show", "--raw", name)
+		require.NoError(t, err)
+		assert.Equal(t, "initial-value", stdout)
+	})
+
+	t.Run("update-adds-version", func(t *testing.T) {
+		// Key Vault version timestamps are second-granular and versions are
+		// ordered only by creation time (ids are opaque). Sleep past a second
+		// boundary so create and update land in distinct seconds, making
+		// ~SHIFT deterministic (matters for the emulator's fast round-trips).
+		time.Sleep(1100 * time.Millisecond)
+
+		_, err := runAzureSecret(t, "update", "--yes", name, "updated-value")
+		require.NoError(t, err)
+
+		stdout, err := runAzureSecret(t, "show", "--raw", name)
+		require.NoError(t, err)
+		assert.Equal(t, "updated-value", stdout)
+	})
+
+	t.Run("show-previous-via-shift", func(t *testing.T) {
+		stdout, err := runAzureSecret(t, "show", "--raw", name+"~1")
+		require.NoError(t, err)
+		assert.Equal(t, "initial-value", stdout)
+	})
+
+	t.Run("log-shows-two-versions", func(t *testing.T) {
+		stdout, err := runAzureSecret(t, "log", name)
+		require.NoError(t, err)
+		// Two versions after one update; log lists each version header.
+		assert.GreaterOrEqual(t, strings.Count(stdout, "Version "), 2)
+	})
+
+	t.Run("diff", func(t *testing.T) {
+		stdout, err := runAzureSecret(t, "diff", name+"~1", name)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "initial-value")
+		assert.Contains(t, stdout, "updated-value")
+	})
+
+	t.Run("list", func(t *testing.T) {
+		stdout, err := runAzureSecret(t, "list")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, name)
+	})
+
+	// The flat `suve secret` alias must reach the same Azure Key Vault (and thus
+	// the emulator). The detection logic that picks the alias target is env-only
+	// and unit-tested separately; here we force it to Azure and confirm the flat
+	// command path resolves the vault and hits the emulator.
+	t.Run("flat-alias-reaches-emulator", func(t *testing.T) {
+		var outBuf, errBuf bytes.Buffer
+
+		app := commands.MakeAppWithDetect(detect.Result{Secret: provider.ProviderAzure})
+		app.Writer = &outBuf
+		app.ErrWriter = &errBuf
+
+		err := app.Run(t.Context(), []string{"suve", "secret", "show", "--raw", name})
+		require.NoError(t, err)
+		assert.Equal(t, "updated-value", outBuf.String())
+	})
+
+	// Note: tag/untag are not exercised here. The suve adapter tags the current
+	// version via UpdateSecretProperties with an empty version path segment,
+	// which real Azure accepts but lowkey-vault rejects (405). Tag behavior is
+	// covered by the keyvault adapter unit tests instead.
+
+	t.Run("delete", func(t *testing.T) {
+		_, err := runAzureSecret(t, "delete", "--yes", name)
+		require.NoError(t, err)
+
+		_, err = runAzureSecret(t, "show", "--raw", name)
+		require.Error(t, err)
+	})
+}

--- a/internal/provider/azure/appconfig/appconfig_test.go
+++ b/internal/provider/azure/appconfig/appconfig_test.go
@@ -24,6 +24,14 @@ func preconditionFailed() error {
 	return &azcore.ResponseError{StatusCode: http.StatusPreconditionFailed}
 }
 
+func conflict() error {
+	return &azcore.ResponseError{StatusCode: http.StatusConflict}
+}
+
+func serverError() error {
+	return &azcore.ResponseError{StatusCode: http.StatusInternalServerError}
+}
+
 // mockClient is a configurable in-test implementation of appconfig.Client.
 type mockClient struct {
 	getFunc    func(ctx context.Context, key string) (azappconfig.GetSettingResponse, error)
@@ -110,6 +118,40 @@ func TestGet_NotFound(t *testing.T) {
 	require.ErrorIs(t, err, provider.ErrNotFound)
 }
 
+func TestGet_NoTags(t *testing.T) {
+	t.Parallel()
+
+	m := &mockClient{
+		getFunc: func(_ context.Context, key string) (azappconfig.GetSettingResponse, error) {
+			return azappconfig.GetSettingResponse{Setting: azappconfig.Setting{
+				Key:   lo.ToPtr(key),
+				Value: lo.ToPtr("v"),
+			}}, nil
+		},
+	}
+	store := appconfig.New(m)
+
+	entry, err := store.Get(t.Context(), "app/timeout", provider.VersionRef{})
+	require.NoError(t, err)
+	assert.Nil(t, entry.Tags)
+}
+
+func TestGet_Error(t *testing.T) {
+	t.Parallel()
+
+	m := &mockClient{
+		getFunc: func(_ context.Context, _ string) (azappconfig.GetSettingResponse, error) {
+			return azappconfig.GetSettingResponse{}, serverError()
+		},
+	}
+	store := appconfig.New(m)
+
+	_, err := store.Get(t.Context(), "app/timeout", provider.VersionRef{})
+	require.Error(t, err)
+	require.NotErrorIs(t, err, provider.ErrNotFound)
+	assert.Contains(t, err.Error(), "get setting")
+}
+
 func TestHistory_Unsupported(t *testing.T) {
 	t.Parallel()
 
@@ -140,18 +182,58 @@ func TestList(t *testing.T) {
 	assert.Equal(t, []string{"alpha", "beta"}, names)
 }
 
-func TestCreate_AlreadyExists(t *testing.T) {
+func TestList_Error(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		addFunc: func(_ context.Context, _, _ string) (azappconfig.AddSettingResponse, error) {
-			return azappconfig.AddSettingResponse{}, preconditionFailed()
+		listFunc: func(_ context.Context) ([]azappconfig.Setting, error) {
+			return nil, serverError()
 		},
 	}
 	store := appconfig.New(m)
 
-	_, err := store.Create(t.Context(), "existing", "v", domain.ValueTypePlaintext, "")
-	require.ErrorIs(t, err, provider.ErrAlreadyExists)
+	_, err := store.List(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list settings")
+}
+
+func TestCreate_AlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	for name, errFn := range map[string]func() error{
+		"precondition_failed": preconditionFailed,
+		"conflict":            conflict,
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			m := &mockClient{
+				addFunc: func(_ context.Context, _, _ string) (azappconfig.AddSettingResponse, error) {
+					return azappconfig.AddSettingResponse{}, errFn()
+				},
+			}
+			store := appconfig.New(m)
+
+			_, err := store.Create(t.Context(), "existing", "v", domain.ValueTypePlaintext, "")
+			require.ErrorIs(t, err, provider.ErrAlreadyExists)
+		})
+	}
+}
+
+func TestCreate_Error(t *testing.T) {
+	t.Parallel()
+
+	m := &mockClient{
+		addFunc: func(_ context.Context, _, _ string) (azappconfig.AddSettingResponse, error) {
+			return azappconfig.AddSettingResponse{}, serverError()
+		},
+	}
+	store := appconfig.New(m)
+
+	_, err := store.Create(t.Context(), "new-key", "v", domain.ValueTypePlaintext, "")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, provider.ErrAlreadyExists)
+	assert.Contains(t, err.Error(), "create setting")
 }
 
 func TestCreate_New(t *testing.T) {
@@ -197,6 +279,21 @@ func TestPut(t *testing.T) {
 	assert.Empty(t, version.ID)
 }
 
+func TestPut_Error(t *testing.T) {
+	t.Parallel()
+
+	m := &mockClient{
+		setFunc: func(_ context.Context, _, _ string) (azappconfig.SetSettingResponse, error) {
+			return azappconfig.SetSettingResponse{}, serverError()
+		},
+	}
+	store := appconfig.New(m)
+
+	_, err := store.Put(t.Context(), "app/timeout", "60", domain.ValueTypePlaintext, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "set setting")
+}
+
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
@@ -213,6 +310,36 @@ func TestDelete(t *testing.T) {
 
 	require.NoError(t, store.Delete(t.Context(), "app/timeout"))
 	assert.Equal(t, "app/timeout", deleted)
+}
+
+func TestDelete_NotFound(t *testing.T) {
+	t.Parallel()
+
+	m := &mockClient{
+		deleteFunc: func(_ context.Context, _ string) (azappconfig.DeleteSettingResponse, error) {
+			return azappconfig.DeleteSettingResponse{}, notFound()
+		},
+	}
+	store := appconfig.New(m)
+
+	err := store.Delete(t.Context(), "missing")
+	require.ErrorIs(t, err, provider.ErrNotFound)
+}
+
+func TestDelete_Error(t *testing.T) {
+	t.Parallel()
+
+	m := &mockClient{
+		deleteFunc: func(_ context.Context, _ string) (azappconfig.DeleteSettingResponse, error) {
+			return azappconfig.DeleteSettingResponse{}, serverError()
+		},
+	}
+	store := appconfig.New(m)
+
+	err := store.Delete(t.Context(), "app/timeout")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, provider.ErrNotFound)
+	assert.Contains(t, err.Error(), "delete setting")
 }
 
 func TestTagUntag_Unsupported(t *testing.T) {

--- a/internal/provider/azure/azure.go
+++ b/internal/provider/azure/azure.go
@@ -13,10 +13,14 @@ package azure
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
@@ -34,6 +38,26 @@ import (
 // make target); it permits HMAC credentials over plain HTTP, so it must never be
 // set against a production store.
 const AppConfigConnStringEnvVar = "SUVE_AZURE_APPCONFIG_CONNECTION_STRING"
+
+// KeyVaultEndpointEnvVar is the environment variable that, when set, points the
+// Key Vault adapter at an emulator (e.g. https://localhost:8443) instead of the
+// real https://<vault>.vault.azure.net endpoint with DefaultAzureCredential. It
+// is an emulator-only seam for offline e2e tests (see the azure-keyvault service
+// in compose.yaml and the `e2e-azure-keyvault` make target); it disables TLS
+// verification and token challenge checks and sends a dummy token, so it must
+// never be set against a production vault.
+const KeyVaultEndpointEnvVar = "SUVE_AZURE_KEYVAULT_ENDPOINT"
+
+// emulatorCredential is a no-op azcore.TokenCredential for the Key Vault
+// emulator seam. Emulators (e.g. lowkey-vault) check for the presence of a
+// bearer token but ignore its value; this returns a static one. Never used
+// against real Azure.
+type emulatorCredential struct{}
+
+func (emulatorCredential) GetToken(_ context.Context, _ policy.TokenRequestOptions) (azcore.AccessToken, error) {
+	//nolint:gosec // "suve-emulator" is a dummy token for the emulator, not a real credential
+	return azcore.AccessToken{Token: "suve-emulator", ExpiresOn: time.Now().Add(time.Hour)}, nil
+}
 
 // Factory builds Azure-backed provider.Store values for a scope + kind.
 type Factory struct{}
@@ -60,6 +84,28 @@ func (Factory) Store(ctx context.Context, scope provider.Scope, kind provider.Ki
 func keyVaultStore(_ context.Context, scope provider.Scope) (provider.Store, error) {
 	if scope.VaultName == "" {
 		return nil, fmt.Errorf("no Azure Key Vault specified: set --vault-name")
+	}
+
+	// Emulator seam: an endpoint override (offline e2e) targets a local Key
+	// Vault emulator with a self-signed cert and no real auth, so it disables
+	// TLS verification and token challenge checks and sends a dummy token.
+	if endpoint := os.Getenv(KeyVaultEndpointEnvVar); endpoint != "" {
+		httpClient := &http.Client{
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec // emulator-only seam
+			},
+		}
+		opts := &azsecrets.ClientOptions{
+			ClientOptions:                        azcore.ClientOptions{Transport: httpClient},
+			DisableChallengeResourceVerification: true,
+		}
+
+		client, err := azsecrets.NewClient(endpoint, emulatorCredential{}, opts)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create Azure Key Vault client for emulator: %w", err)
+		}
+
+		return keyvault.New(keyvault.Wrap(client)), nil
 	}
 
 	cred, err := azidentity.NewDefaultAzureCredential(nil)

--- a/internal/provider/azure/azure_test.go
+++ b/internal/provider/azure/azure_test.go
@@ -39,3 +39,25 @@ func TestAppConfigStore_ConnectionStringError(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "connection string")
 }
+
+// TestKeyVaultStore_RequiresVaultName verifies a missing vault name is a clear
+// error mentioning --vault-name before any client construction.
+func TestKeyVaultStore_RequiresVaultName(t *testing.T) {
+	t.Parallel()
+
+	_, err := azure.Factory{}.Store(t.Context(), provider.Scope{}, provider.KindSecret)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--vault-name")
+}
+
+// TestKeyVaultStore_EmulatorSeam exercises the Key Vault emulator seam: with the
+// endpoint env var set to a well-formed URL plus a vault name, Store returns a
+// non-nil store and no error. azsecrets.NewClient is lazy, so this does not hit
+// the network at construction time.
+func TestKeyVaultStore_EmulatorSeam(t *testing.T) {
+	t.Setenv(azure.KeyVaultEndpointEnvVar, "https://localhost:8443")
+
+	store, err := azure.Factory{}.Store(t.Context(), provider.Scope{VaultName: "suve-test"}, provider.KindSecret)
+	require.NoError(t, err)
+	assert.NotNil(t, store)
+}

--- a/internal/provider/azure/keyvault/keyvault_resolve_test.go
+++ b/internal/provider/azure/keyvault/keyvault_resolve_test.go
@@ -1,0 +1,348 @@
+package keyvault_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/domain"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/azure/keyvault"
+)
+
+// serverError returns a non-404 Key Vault error, which must NOT map to
+// provider.ErrNotFound.
+func serverError() error {
+	return &azcore.ResponseError{StatusCode: http.StatusInternalServerError}
+}
+
+// verPair is a (version id, created time) pair for building version-list
+// fixtures. A nil created time means the version has no Created attribute.
+type verPair struct {
+	version string
+	created *time.Time
+}
+
+// versionsFixture builds a listVersFunc returning the given version pairs.
+func versionsFixture(pairs ...verPair) func(context.Context, string) ([]*azsecrets.SecretProperties, error) {
+	return func(_ context.Context, name string) ([]*azsecrets.SecretProperties, error) {
+		out := make([]*azsecrets.SecretProperties, 0, len(pairs))
+		for _, p := range pairs {
+			out = append(out, &azsecrets.SecretProperties{
+				ID:         secretID(name, p.version),
+				Attributes: &azsecrets.SecretAttributes{Created: p.created},
+			})
+		}
+
+		return out, nil
+	}
+}
+
+// at returns a pointer to a fixed-year (2024) UTC date, for building ordered
+// version timestamps in tests.
+func at(mo time.Month, d int) *time.Time {
+	t := time.Date(2024, mo, d, 0, 0, 0, 0, time.UTC)
+
+	return &t
+}
+
+// TestResolve_ShiftResolution exhaustively covers the ~SHIFT resolution logic,
+// which is the most provider-difference-prone path: Key Vault versions are
+// opaque ids ordered only by creation time, so shifts walk a sorted list.
+func TestResolve_ShiftResolution(t *testing.T) {
+	t.Parallel()
+
+	// Three versions, distinct timestamps: v3 (newest) .. v1 (oldest).
+	threeVersions := versionsFixture(
+		verPair{"v1", at(1, 1)},
+		verPair{"v3", at(3, 15)},
+		verPair{"v2", at(2, 10)},
+	)
+
+	tests := []struct {
+		name    string
+		spec    string
+		want    string // expected resolved version id
+		wantErr string // substring; empty means no error
+	}{
+		{name: "no shift is current", spec: "", want: ""},
+		{name: "shift one back", spec: "~1", want: "v2"},
+		{name: "shift two back reaches oldest", spec: "~2", want: "v1"},
+		{name: "cumulative shift ~1~1", spec: "~1~1", want: "v1"},
+		{name: "bare tilde is one back", spec: "~", want: "v2"},
+		{name: "double tilde is two back", spec: "~~", want: "v1"},
+		{name: "shift out of range", spec: "~3", wantErr: "out of range"},
+		{name: "absolute id then shift", spec: "#v3~1", want: "v2"},
+		{name: "absolute id no shift needs no ordering", spec: "#v2", want: "v2"},
+		{name: "absolute id then shift to oldest", spec: "#v3~2", want: "v1"},
+		{name: "absolute id not found with shift", spec: "#ghost~1", wantErr: "version not found"},
+		{name: "absolute id shift out of range", spec: "#v1~1", wantErr: "out of range"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := keyvault.New(&mockClient{listVersFunc: threeVersions})
+			ref, err := store.Resolve(t.Context(), "my-secret", tc.spec)
+
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, ref.ID())
+		})
+	}
+}
+
+// TestResolve_ShiftWithNoVersions verifies a shift against a secret with no
+// versions is a clear error, not a panic or out-of-range index.
+func TestResolve_ShiftWithNoVersions(t *testing.T) {
+	t.Parallel()
+
+	m := &mockClient{
+		listVersFunc: func(_ context.Context, _ string) ([]*azsecrets.SecretProperties, error) {
+			return nil, nil
+		},
+	}
+	store := keyvault.New(m)
+
+	_, err := store.Resolve(t.Context(), "my-secret", "~1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no versions")
+}
+
+// TestResolve_ShiftListError verifies a listing failure during shift resolution
+// is surfaced (and not-found is mapped to provider.ErrNotFound).
+func TestResolve_ShiftListError(t *testing.T) {
+	t.Parallel()
+
+	m := &mockClient{
+		listVersFunc: func(_ context.Context, _ string) ([]*azsecrets.SecretProperties, error) {
+			return nil, notFound()
+		},
+	}
+	store := keyvault.New(m)
+
+	_, err := store.Resolve(t.Context(), "my-secret", "~1")
+	require.ErrorIs(t, err, provider.ErrNotFound)
+}
+
+// TestResolve_OrderingEqualTimestamps documents the emulator-relevant behavior:
+// Key Vault Created timestamps are second-granular, so two versions written in
+// the same second are indistinguishable by time. The sort is STABLE, so it
+// preserves the input (server) order — newest-first sort keeps the first input
+// element at index 0. This is why a fast create+update in e2e needs a delay.
+func TestResolve_OrderingEqualTimestamps(t *testing.T) {
+	t.Parallel()
+
+	same := at(5, 20)
+	m := &mockClient{
+		listVersFunc: versionsFixture(
+			verPair{"first", same},
+			verPair{"second", same},
+		),
+	}
+	store := keyvault.New(m)
+
+	// Stable sort preserves input order for equal timestamps: index 0 is "first".
+	cur, err := store.Resolve(t.Context(), "my-secret", "")
+	require.NoError(t, err)
+	assert.True(t, cur.IsLatest())
+
+	prev, err := store.Resolve(t.Context(), "my-secret", "~1")
+	require.NoError(t, err)
+	assert.Equal(t, "second", prev.ID())
+}
+
+// TestHistory_NilCreatedSortsLast verifies versions with no Created timestamp
+// are ordered after those that have one (newest-first), rather than crashing.
+func TestHistory_NilCreatedSortsLast(t *testing.T) {
+	t.Parallel()
+
+	m := &mockClient{
+		listVersFunc: versionsFixture(
+			verPair{"no-time", nil},
+			verPair{"dated", at(1, 5)},
+		),
+	}
+	store := keyvault.New(m)
+
+	versions, err := store.History(t.Context(), "my-secret")
+	require.NoError(t, err)
+	require.Len(t, versions, 2)
+	// Dated version is "newer" than the one with no timestamp.
+	assert.Equal(t, "dated", versions[0].ID)
+	assert.Equal(t, "no-time", versions[1].ID)
+}
+
+// TestHistory_ListError verifies History surfaces a listing error (mapped to
+// provider.ErrNotFound for a 404).
+func TestHistory_ListError(t *testing.T) {
+	t.Parallel()
+
+	m := &mockClient{
+		listVersFunc: func(_ context.Context, _ string) ([]*azsecrets.SecretProperties, error) {
+			return nil, notFound()
+		},
+	}
+	store := keyvault.New(m)
+
+	_, err := store.History(t.Context(), "my-secret")
+	require.ErrorIs(t, err, provider.ErrNotFound)
+}
+
+// TestGet_ByExplicitVersion verifies a resolved opaque version id is passed
+// through to GetSecret (the version-specific read path).
+func TestGet_ByExplicitVersion(t *testing.T) {
+	t.Parallel()
+
+	var gotVersion string
+
+	m := &mockClient{
+		getFunc: func(_ context.Context, name, version string) (azsecrets.GetSecretResponse, error) {
+			gotVersion = version
+
+			return azsecrets.GetSecretResponse{Secret: azsecrets.Secret{
+				ID:    secretID(name, version),
+				Value: lo.ToPtr("older-value"),
+			}}, nil
+		},
+	}
+	store := keyvault.New(m)
+
+	entry, err := store.Get(t.Context(), "my-secret", provider.NewVersionRef("abc123"))
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", gotVersion)
+	assert.Equal(t, "older-value", entry.Value)
+}
+
+// TestGet_NilFieldsTolerated verifies a response with a nil ID and nil Enabled
+// flag does not crash and yields empty version id / no label.
+func TestGet_NilFieldsTolerated(t *testing.T) {
+	t.Parallel()
+
+	m := &mockClient{
+		getFunc: func(_ context.Context, _, _ string) (azsecrets.GetSecretResponse, error) {
+			return azsecrets.GetSecretResponse{Secret: azsecrets.Secret{
+				ID:         nil,
+				Value:      lo.ToPtr("v"),
+				Attributes: &azsecrets.SecretAttributes{Enabled: nil},
+			}}, nil
+		},
+	}
+	store := keyvault.New(m)
+
+	entry, err := store.Get(t.Context(), "my-secret", provider.VersionRef{})
+	require.NoError(t, err)
+	assert.Empty(t, entry.Version.ID)
+	assert.Empty(t, entry.Version.Label)
+}
+
+// TestStore_ErrorPaths covers the non-not-found error branches of the write and
+// list operations, ensuring they wrap the operation rather than masquerading as
+// not-found.
+func TestStore_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("list error", func(t *testing.T) {
+		t.Parallel()
+
+		store := keyvault.New(&mockClient{
+			listFunc: func(_ context.Context) ([]*azsecrets.SecretProperties, error) {
+				return nil, serverError()
+			},
+		})
+		_, err := store.List(t.Context())
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, provider.ErrNotFound)
+	})
+
+	t.Run("create existence-check error", func(t *testing.T) {
+		t.Parallel()
+
+		store := keyvault.New(&mockClient{
+			getFunc: func(_ context.Context, _, _ string) (azsecrets.GetSecretResponse, error) {
+				return azsecrets.GetSecretResponse{}, serverError()
+			},
+		})
+		_, err := store.Create(t.Context(), "s", "v", domain.ValueTypeSecret, "")
+		require.Error(t, err)
+		assert.NotErrorIs(t, err, provider.ErrAlreadyExists)
+	})
+
+	t.Run("put error", func(t *testing.T) {
+		t.Parallel()
+
+		store := keyvault.New(&mockClient{
+			setFunc: func(_ context.Context, _ string, _ azsecrets.SetSecretParameters) (azsecrets.SetSecretResponse, error) {
+				return azsecrets.SetSecretResponse{}, serverError()
+			},
+		})
+		_, err := store.Put(t.Context(), "s", "v", domain.ValueTypeSecret, "")
+		require.Error(t, err)
+	})
+
+	t.Run("delete error", func(t *testing.T) {
+		t.Parallel()
+
+		store := keyvault.New(&mockClient{
+			deleteFunc: func(_ context.Context, _ string) (azsecrets.DeleteSecretResponse, error) {
+				return azsecrets.DeleteSecretResponse{}, serverError()
+			},
+		})
+		err := store.Delete(t.Context(), "s")
+		require.Error(t, err)
+	})
+
+	t.Run("tag current-tags fetch error", func(t *testing.T) {
+		t.Parallel()
+
+		store := keyvault.New(&mockClient{
+			getFunc: func(_ context.Context, _, _ string) (azsecrets.GetSecretResponse, error) {
+				return azsecrets.GetSecretResponse{}, serverError()
+			},
+		})
+		err := store.Tag(t.Context(), "s", map[string]string{"env": "prod"})
+		require.Error(t, err)
+	})
+
+	t.Run("untag update error", func(t *testing.T) {
+		t.Parallel()
+
+		store := keyvault.New(&mockClient{
+			getFunc: func(_ context.Context, name, _ string) (azsecrets.GetSecretResponse, error) {
+				return azsecrets.GetSecretResponse{Secret: azsecrets.Secret{
+					ID:   secretID(name, "v1"),
+					Tags: map[string]*string{"env": lo.ToPtr("prod")},
+				}}, nil
+			},
+			updateFunc: func(_ context.Context, _, _ string, _ updParams) (updResp, error) {
+				return updResp{}, serverError()
+			},
+		})
+		err := store.Untag(t.Context(), "s", []string{"env"})
+		require.Error(t, err)
+	})
+
+	t.Run("empty tag/untag is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		// No client funcs set: if Tag/Untag tried to call the client with an
+		// empty set, the nil func would panic. They must short-circuit.
+		store := keyvault.New(&mockClient{})
+		require.NoError(t, store.Tag(t.Context(), "s", nil))
+		require.NoError(t, store.Untag(t.Context(), "s", nil))
+	})
+}

--- a/internal/provider/gcp/gcp_test.go
+++ b/internal/provider/gcp/gcp_test.go
@@ -1,0 +1,125 @@
+package gcp_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/gcp"
+)
+
+// TestEmulatorEnvVar pins the emulator seam env var name; callers (and docs)
+// depend on this exact string.
+func TestEmulatorEnvVar(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "SUVE_GCP_SECRETMANAGER_ENDPOINT", gcp.EmulatorEnvVar)
+}
+
+// TestFactory_Store_UnsupportedKind verifies that Google Cloud (which has no
+// parameter store) rejects KindParam and any unknown kind with
+// provider.ErrUnsupportedKind, without touching the network.
+func TestFactory_Store_UnsupportedKind(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		kind provider.Kind
+	}{
+		{name: "param has no google cloud backend", kind: provider.KindParam},
+		{name: "unknown kind", kind: provider.Kind("bogus")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store, err := gcp.Factory{}.Store(t.Context(), provider.GoogleCloudScope("my-project"), tt.kind)
+			require.ErrorIs(t, err, provider.ErrUnsupportedKind)
+			assert.Nil(t, store)
+		})
+	}
+}
+
+// TestFactory_Store_EmulatorSeam exercises the EmulatorEnvVar seam. These
+// subtests mutate a process-global env var via t.Setenv, so they must not run
+// in parallel.
+func TestFactory_Store_EmulatorSeam(t *testing.T) {
+	t.Run("valid endpoint builds a store over plaintext gRPC", func(t *testing.T) {
+		// A well-formed target dials lazily: the client is constructed without
+		// any network round-trip, so this succeeds offline.
+		t.Setenv(gcp.EmulatorEnvVar, "localhost:9090")
+
+		store, err := gcp.Factory{}.Store(t.Context(), provider.GoogleCloudScope("my-project"), provider.KindSecret)
+		require.NoError(t, err)
+		assert.NotNil(t, store)
+	})
+
+	t.Run("unparsable endpoint surfaces a clear dial error", func(t *testing.T) {
+		// A control character makes gRPC target parsing fail synchronously,
+		// exercising the emulator dial-error branch.
+		t.Setenv(gcp.EmulatorEnvVar, "\tbad-endpoint")
+
+		store, err := gcp.Factory{}.Store(t.Context(), provider.GoogleCloudScope("my-project"), provider.KindSecret)
+		require.Error(t, err)
+		assert.Nil(t, store)
+		assert.Contains(t, err.Error(), "failed to create Google Cloud Secret Manager client")
+		assert.Contains(t, err.Error(), "emulator")
+	})
+
+	t.Run("no emulator falls through to the ADC client constructor", func(t *testing.T) {
+		// With the seam unset the client is built from Application Default
+		// Credentials. The outcome depends on ambient credentials, so accept
+		// either a constructed store or a wrapped construction error, while
+		// still exercising the non-emulator branch.
+		t.Setenv(gcp.EmulatorEnvVar, "")
+
+		store, err := gcp.Factory{}.Store(t.Context(), provider.GoogleCloudScope("my-project"), provider.KindSecret)
+		if err != nil {
+			assert.Nil(t, store)
+			assert.Contains(t, err.Error(), "failed to create Google Cloud Secret Manager client")
+		} else {
+			assert.NotNil(t, store)
+		}
+	})
+}
+
+// TestRegister verifies Register wires the Google Cloud factory into an existing
+// registry under provider.ProviderGoogleCloud. Resolution is proven indirectly:
+// a registered factory yields ErrUnsupportedKind for KindParam, whereas an
+// unregistered provider would yield ErrNoFactory.
+func TestRegister(t *testing.T) {
+	t.Parallel()
+
+	reg := provider.NewRegistry()
+	gcp.Register(reg)
+
+	_, err := reg.Store(t.Context(), provider.GoogleCloudScope("my-project"), provider.KindParam)
+	require.ErrorIs(t, err, provider.ErrUnsupportedKind)
+	assert.NotErrorIs(t, err, provider.ErrNoFactory)
+}
+
+// TestNewRegistry verifies NewRegistry returns a registry with only the Google
+// Cloud provider registered.
+func TestNewRegistry(t *testing.T) {
+	t.Parallel()
+
+	reg := gcp.NewRegistry()
+
+	t.Run("google cloud is registered", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := reg.Store(t.Context(), provider.GoogleCloudScope("my-project"), provider.KindParam)
+		require.ErrorIs(t, err, provider.ErrUnsupportedKind)
+		assert.NotErrorIs(t, err, provider.ErrNoFactory)
+	})
+
+	t.Run("other providers are not registered", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := reg.Store(t.Context(), provider.AWSScope("123456789012", "us-east-1"), provider.KindSecret)
+		require.ErrorIs(t, err, provider.ErrNoFactory)
+	})
+}

--- a/internal/provider/gcp/secret/secret_more_test.go
+++ b/internal/provider/gcp/secret/secret_more_test.go
@@ -1,0 +1,363 @@
+package secret_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/mpyw/suve/internal/domain"
+	"github.com/mpyw/suve/internal/provider"
+)
+
+// errBoom is a generic (non-gRPC) backend failure used to exercise the
+// non-NotFound / non-AlreadyExists error branches.
+var errBoom = errors.New("boom")
+
+func TestResolve_Errors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid spec is rejected at parse time", func(t *testing.T) {
+		t.Parallel()
+
+		store := newStore(&mockClient{})
+		_, err := store.Resolve(t.Context(), "my-secret", "#")
+		require.Error(t, err)
+	})
+
+	t.Run("shift on secret with no enabled versions", func(t *testing.T) {
+		t.Parallel()
+
+		m := &mockClient{
+			listVerFunc: func(_ context.Context, _ *secretmanagerpb.ListSecretVersionsRequest) ([]*secretmanagerpb.SecretVersion, error) {
+				return nil, nil
+			},
+		}
+		store := newStore(m)
+
+		_, err := store.Resolve(t.Context(), "my-secret", "~1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no enabled versions")
+	})
+
+	t.Run("shift from explicit version that is not enabled", func(t *testing.T) {
+		t.Parallel()
+
+		m := &mockClient{
+			listVerFunc: func(_ context.Context, _ *secretmanagerpb.ListSecretVersionsRequest) ([]*secretmanagerpb.SecretVersion, error) {
+				return []*secretmanagerpb.SecretVersion{
+					{Name: versionName(1), State: secretmanagerpb.SecretVersion_ENABLED},
+					{Name: versionName(2), State: secretmanagerpb.SecretVersion_ENABLED},
+				}, nil
+			},
+		}
+		store := newStore(m)
+
+		_, err := store.Resolve(t.Context(), "my-secret", "#9~1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found or not enabled")
+	})
+
+	t.Run("shift propagates list error", func(t *testing.T) {
+		t.Parallel()
+
+		m := &mockClient{
+			listVerFunc: func(_ context.Context, _ *secretmanagerpb.ListSecretVersionsRequest) ([]*secretmanagerpb.SecretVersion, error) {
+				return nil, errBoom
+			},
+		}
+		store := newStore(m)
+
+		_, err := store.Resolve(t.Context(), "my-secret", "~1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "list secret versions")
+	})
+}
+
+// TestGet_BestEffortMetadata covers Get when the version-metadata and label
+// lookups are unavailable: the value is still returned, Created stays nil, and
+// Tags is nil (mapLabels empty branch).
+func TestGet_BestEffortMetadata(t *testing.T) {
+	t.Parallel()
+
+	m := &mockClient{
+		accessFunc: func(_ context.Context, _ *secretmanagerpb.AccessSecretVersionRequest) (*secretmanagerpb.AccessSecretVersionResponse, error) {
+			return &secretmanagerpb.AccessSecretVersionResponse{
+				Name:    versionName(7),
+				Payload: &secretmanagerpb.SecretPayload{Data: []byte("v")},
+			}, nil
+		},
+		getVerFunc: func(_ context.Context, _ *secretmanagerpb.GetSecretVersionRequest) (*secretmanagerpb.SecretVersion, error) {
+			return nil, errBoom
+		},
+		getFunc: func(_ context.Context, _ *secretmanagerpb.GetSecretRequest) (*secretmanagerpb.Secret, error) {
+			return &secretmanagerpb.Secret{Name: "projects/my-project/secrets/my-secret"}, nil
+		},
+	}
+	store := newStore(m)
+
+	entry, err := store.Get(t.Context(), "my-secret", provider.VersionRef{})
+	require.NoError(t, err)
+	assert.Equal(t, "7", entry.Version.ID)
+	assert.Nil(t, entry.Version.Created)
+	assert.Nil(t, entry.Tags)
+}
+
+func TestHistory_Error(t *testing.T) {
+	t.Parallel()
+
+	m := &mockClient{
+		listVerFunc: func(_ context.Context, _ *secretmanagerpb.ListSecretVersionsRequest) ([]*secretmanagerpb.SecretVersion, error) {
+			return nil, errBoom
+		},
+	}
+	store := newStore(m)
+
+	_, err := store.History(t.Context(), "my-secret")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list secret versions")
+}
+
+// TestHistory_StateLabelsAndUnparsable covers the remaining stateLabel branches
+// (disabled, unspecified) plus versionInt/lastSegment on a name without a
+// numeric trailing segment.
+func TestHistory_StateLabelsAndUnparsable(t *testing.T) {
+	t.Parallel()
+
+	m := &mockClient{
+		listVerFunc: func(_ context.Context, _ *secretmanagerpb.ListSecretVersionsRequest) ([]*secretmanagerpb.SecretVersion, error) {
+			return []*secretmanagerpb.SecretVersion{
+				{Name: versionName(2), State: secretmanagerpb.SecretVersion_DISABLED},
+				{Name: "weird", State: secretmanagerpb.SecretVersion_STATE_UNSPECIFIED},
+				{Name: versionName(5), State: secretmanagerpb.SecretVersion_ENABLED},
+			}, nil
+		},
+	}
+	store := newStore(m)
+
+	versions, err := store.History(t.Context(), "my-secret")
+	require.NoError(t, err)
+	require.Len(t, versions, 3)
+
+	// Numeric versions sort newest-first; the unparsable name (versionInt == -1)
+	// sorts last.
+	assert.Equal(t, "5", versions[0].ID)
+	assert.Equal(t, "enabled", versions[0].Label)
+	assert.Equal(t, "2", versions[1].ID)
+	assert.Equal(t, "disabled", versions[1].Label)
+	assert.Equal(t, "weird", versions[2].ID)
+	assert.Empty(t, versions[2].Label)
+}
+
+func TestList_Error(t *testing.T) {
+	t.Parallel()
+
+	m := &mockClient{
+		listFunc: func(_ context.Context, _ *secretmanagerpb.ListSecretsRequest) ([]*secretmanagerpb.Secret, error) {
+			return nil, errBoom
+		},
+	}
+	store := newStore(m)
+
+	_, err := store.List(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list secrets")
+}
+
+func TestCreate_Errors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create fails with a generic error", func(t *testing.T) {
+		t.Parallel()
+
+		m := &mockClient{
+			createFunc: func(_ context.Context, _ *secretmanagerpb.CreateSecretRequest) (*secretmanagerpb.Secret, error) {
+				return nil, errBoom
+			},
+		}
+		store := newStore(m)
+
+		_, err := store.Create(t.Context(), "my-secret", "v", domain.ValueTypeSecret, "")
+		require.Error(t, err)
+		require.NotErrorIs(t, err, provider.ErrAlreadyExists)
+		assert.Contains(t, err.Error(), "create secret")
+	})
+
+	t.Run("add version fails after create", func(t *testing.T) {
+		t.Parallel()
+
+		m := &mockClient{
+			createFunc: func(_ context.Context, _ *secretmanagerpb.CreateSecretRequest) (*secretmanagerpb.Secret, error) {
+				return &secretmanagerpb.Secret{Name: "projects/my-project/secrets/my-secret"}, nil
+			},
+			addFunc: func(_ context.Context, _ *secretmanagerpb.AddSecretVersionRequest) (*secretmanagerpb.SecretVersion, error) {
+				return nil, errBoom
+			},
+		}
+		store := newStore(m)
+
+		_, err := store.Create(t.Context(), "my-secret", "v", domain.ValueTypeSecret, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "add secret version")
+	})
+}
+
+func TestPut_Errors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("add fails with a non-NotFound error", func(t *testing.T) {
+		t.Parallel()
+
+		m := &mockClient{
+			addFunc: func(_ context.Context, _ *secretmanagerpb.AddSecretVersionRequest) (*secretmanagerpb.SecretVersion, error) {
+				return nil, status.Error(codes.PermissionDenied, "denied")
+			},
+		}
+		store := newStore(m)
+
+		_, err := store.Put(t.Context(), "my-secret", "v", domain.ValueTypeSecret, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "add secret version")
+	})
+
+	t.Run("concurrent create is tolerated", func(t *testing.T) {
+		t.Parallel()
+
+		var addCalls int
+
+		m := &mockClient{
+			addFunc: func(_ context.Context, _ *secretmanagerpb.AddSecretVersionRequest) (*secretmanagerpb.SecretVersion, error) {
+				addCalls++
+				if addCalls == 1 {
+					return nil, status.Error(codes.NotFound, "no secret")
+				}
+
+				return &secretmanagerpb.SecretVersion{Name: versionName(1)}, nil
+			},
+			createFunc: func(_ context.Context, _ *secretmanagerpb.CreateSecretRequest) (*secretmanagerpb.Secret, error) {
+				return nil, status.Error(codes.AlreadyExists, "raced")
+			},
+		}
+		store := newStore(m)
+
+		v, err := store.Put(t.Context(), "my-secret", "v", domain.ValueTypeSecret, "")
+		require.NoError(t, err)
+		assert.Equal(t, "1", v.ID)
+		assert.Equal(t, 2, addCalls)
+	})
+
+	t.Run("create fails with a non-AlreadyExists error", func(t *testing.T) {
+		t.Parallel()
+
+		m := &mockClient{
+			addFunc: func(_ context.Context, _ *secretmanagerpb.AddSecretVersionRequest) (*secretmanagerpb.SecretVersion, error) {
+				return nil, status.Error(codes.NotFound, "no secret")
+			},
+			createFunc: func(_ context.Context, _ *secretmanagerpb.CreateSecretRequest) (*secretmanagerpb.Secret, error) {
+				return nil, errBoom
+			},
+		}
+		store := newStore(m)
+
+		_, err := store.Put(t.Context(), "my-secret", "v", domain.ValueTypeSecret, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "create secret")
+	})
+
+	t.Run("add fails after create during upsert", func(t *testing.T) {
+		t.Parallel()
+
+		var addCalls int
+
+		m := &mockClient{
+			addFunc: func(_ context.Context, _ *secretmanagerpb.AddSecretVersionRequest) (*secretmanagerpb.SecretVersion, error) {
+				addCalls++
+				if addCalls == 1 {
+					return nil, status.Error(codes.NotFound, "no secret")
+				}
+
+				return nil, errBoom
+			},
+			createFunc: func(_ context.Context, _ *secretmanagerpb.CreateSecretRequest) (*secretmanagerpb.Secret, error) {
+				return &secretmanagerpb.Secret{Name: "projects/my-project/secrets/my-secret"}, nil
+			},
+		}
+		store := newStore(m)
+
+		_, err := store.Put(t.Context(), "my-secret", "v", domain.ValueTypeSecret, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "add secret version")
+		assert.Equal(t, 2, addCalls)
+	})
+}
+
+func TestTagUntag_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("tag with no additions is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		// No mock funcs set: if any client call happened it would panic.
+		store := newStore(&mockClient{})
+		require.NoError(t, store.Tag(t.Context(), "my-secret", nil))
+	})
+
+	t.Run("untag with no keys is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		store := newStore(&mockClient{})
+		require.NoError(t, store.Untag(t.Context(), "my-secret", nil))
+	})
+
+	t.Run("tag propagates get-secret error", func(t *testing.T) {
+		t.Parallel()
+
+		m := &mockClient{
+			getFunc: func(_ context.Context, _ *secretmanagerpb.GetSecretRequest) (*secretmanagerpb.Secret, error) {
+				return nil, status.Error(codes.NotFound, "missing")
+			},
+		}
+		store := newStore(m)
+
+		err := store.Tag(t.Context(), "my-secret", map[string]string{"k": "v"})
+		require.ErrorIs(t, err, provider.ErrNotFound)
+	})
+
+	t.Run("untag propagates get-secret error", func(t *testing.T) {
+		t.Parallel()
+
+		m := &mockClient{
+			getFunc: func(_ context.Context, _ *secretmanagerpb.GetSecretRequest) (*secretmanagerpb.Secret, error) {
+				return nil, errBoom
+			},
+		}
+		store := newStore(m)
+
+		err := store.Untag(t.Context(), "my-secret", []string{"k"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "get secret")
+	})
+
+	t.Run("tag propagates update-secret error", func(t *testing.T) {
+		t.Parallel()
+
+		m := &mockClient{
+			getFunc: func(_ context.Context, _ *secretmanagerpb.GetSecretRequest) (*secretmanagerpb.Secret, error) {
+				return &secretmanagerpb.Secret{Labels: map[string]string{"env": "prod"}}, nil
+			},
+			updateFunc: func(_ context.Context, _ *secretmanagerpb.UpdateSecretRequest) (*secretmanagerpb.Secret, error) {
+				return nil, errBoom
+			},
+		}
+		store := newStore(m)
+
+		err := store.Tag(t.Context(), "my-secret", map[string]string{"team": "backend"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "update secret labels")
+	})
+}

--- a/internal/version/azureappconfigversion/spec_test.go
+++ b/internal/version/azureappconfigversion/spec_test.go
@@ -81,6 +81,35 @@ func TestParse(t *testing.T) {
 			wantErr: true,
 		},
 
+		// Additional accepted bare names (no version specifier present).
+		{
+			name:     "name with @ allowed",
+			input:    "user@example.com",
+			wantName: "user@example.com",
+		},
+		{
+			name:     "shift zero collapses to a bare name",
+			input:    "my-key~0",
+			wantName: "my-key",
+		},
+
+		// Additional rejected version specifiers.
+		{
+			name:    "cumulative shift rejected",
+			input:   "my-key~1~2",
+			wantErr: true,
+		},
+		{
+			name:    "version id with shift rejected",
+			input:   "my-key#abc~1",
+			wantErr: true,
+		},
+		{
+			name:    "multiple colons rejected",
+			input:   "a:b:c",
+			wantErr: true,
+		},
+
 		// Empty-input errors are surfaced (not normalized to unsupported).
 		{
 			name:    "empty input",
@@ -121,8 +150,30 @@ func TestParse_VersionSpecErrorIsUnsupported(t *testing.T) {
 	}
 }
 
+// TestParse_EmptyErrorsNotNormalized verifies that empty-input and empty-name
+// errors from the shared grammar are surfaced unchanged rather than being
+// collapsed into ErrVersioningUnsupported.
+func TestParse_EmptyErrorsNotNormalized(t *testing.T) {
+	t.Parallel()
+
+	for _, input := range []string{"", "   "} {
+		_, err := azureappconfigversion.Parse(input)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, azureappconfigversion.ErrVersioningUnsupported, "input=%q", input)
+	}
+}
+
 func TestParseDiffArgs(t *testing.T) {
 	t.Parallel()
+
+	t.Run("single bare key compares against itself", func(t *testing.T) {
+		t.Parallel()
+
+		spec1, spec2, err := azureappconfigversion.ParseDiffArgs([]string{"key-a"})
+		require.NoError(t, err)
+		assert.Equal(t, "key-a", spec1.Name)
+		assert.Equal(t, "key-a", spec2.Name)
+	})
 
 	t.Run("two bare keys compared", func(t *testing.T) {
 		t.Parallel()
@@ -137,6 +188,34 @@ func TestParseDiffArgs(t *testing.T) {
 		t.Parallel()
 
 		_, _, err := azureappconfigversion.ParseDiffArgs([]string{"my-key#1"})
+		require.Error(t, err)
+	})
+
+	t.Run("name plus specifier-only arg rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := azureappconfigversion.ParseDiffArgs([]string{"my-key", "#1"})
+		require.Error(t, err)
+	})
+
+	t.Run("three args rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := azureappconfigversion.ParseDiffArgs([]string{"my-key", "#1", "#2"})
+		require.Error(t, err)
+	})
+
+	t.Run("no args rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := azureappconfigversion.ParseDiffArgs([]string{})
+		require.Error(t, err)
+	})
+
+	t.Run("too many args rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := azureappconfigversion.ParseDiffArgs([]string{"a", "b", "c", "d"})
 		require.Error(t, err)
 	})
 }

--- a/internal/version/azurekvversion/spec_test.go
+++ b/internal/version/azurekvversion/spec_test.go
@@ -106,6 +106,76 @@ func TestParse(t *testing.T) {
 			input:   "   ",
 			wantErr: true,
 		},
+
+		// Additional valid forms (opaque ids may contain letters, digits, dashes).
+		{
+			name:     "version id with dashes and uppercase",
+			input:    "my-secret#ABC-123",
+			wantName: "my-secret",
+			wantID:   lo.ToPtr("ABC-123"),
+		},
+		{
+			name:     "name with @ allowed",
+			input:    "user@example.com",
+			wantName: "user@example.com",
+		},
+		{
+			name:     "name with slashes and id",
+			input:    "a/b/c#abc",
+			wantName: "a/b/c",
+			wantID:   lo.ToPtr("abc"),
+		},
+		{
+			name:     "id with cumulative shifts",
+			input:    "my-secret#abc~1~2",
+			wantName: "my-secret",
+			wantID:   lo.ToPtr("abc"),
+			wantShif: 3,
+		},
+		{
+			name:     "large numeric shift",
+			input:    "my-secret~100",
+			wantName: "my-secret",
+			wantShif: 100,
+		},
+		{
+			name:     "numeric shift zero is a no-op",
+			input:    "my-secret~0",
+			wantName: "my-secret",
+			wantShif: 0,
+		},
+		{
+			name:     "tilde followed by minus is part of the name",
+			input:    "my-secret~-1",
+			wantName: "my-secret~-1",
+		},
+
+		// Additional rejected forms.
+		{
+			name:    "id stops at underscore then shift parse fails",
+			input:   "my-secret#a_b",
+			wantErr: true,
+		},
+		{
+			name:    "multiple absolute specifiers rejected",
+			input:   "sec#id1#id2",
+			wantErr: true,
+		},
+		{
+			name:    "empty name (version at start)",
+			input:   "#abc",
+			wantErr: true,
+		},
+		{
+			name:    "empty name (shift at start)",
+			input:   "~1",
+			wantErr: true,
+		},
+		{
+			name:    "label after version rejected",
+			input:   "my-secret#abc:latest",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -135,6 +205,17 @@ func TestParse_LabelErrorMessage(t *testing.T) {
 	require.ErrorIs(t, err, azurekvversion.ErrLabelUnsupported)
 }
 
+// TestParse_LabelAfterVersionRejected exercises the ':' reject path reached
+// AFTER a valid '#' specifier: parseAbsolute advances past "#abc" and then hits
+// ':', invoking the label parser's Apply (which returns ErrLabelUnsupported).
+func TestParse_LabelAfterVersionRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := azurekvversion.Parse("my-secret#abc:latest")
+	require.Error(t, err)
+	require.ErrorIs(t, err, azurekvversion.ErrLabelUnsupported)
+}
+
 func TestParseDiffArgs(t *testing.T) {
 	t.Parallel()
 
@@ -154,6 +235,47 @@ func TestParseDiffArgs(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, lo.ToPtr("abc"), spec1.Absolute.ID)
 		assert.Equal(t, lo.ToPtr("def"), spec2.Absolute.ID)
+	})
+
+	t.Run("mixed format: full spec plus specifier-only", func(t *testing.T) {
+		t.Parallel()
+
+		spec1, spec2, err := azurekvversion.ParseDiffArgs([]string{"my-secret#abc", "#def"})
+		require.NoError(t, err)
+		assert.Equal(t, lo.ToPtr("abc"), spec1.Absolute.ID)
+		assert.Equal(t, lo.ToPtr("def"), spec2.Absolute.ID)
+	})
+
+	t.Run("partial spec: name plus specifier-only is swapped", func(t *testing.T) {
+		t.Parallel()
+
+		spec1, spec2, err := azurekvversion.ParseDiffArgs([]string{"my-secret", "#abc"})
+		require.NoError(t, err)
+		assert.Equal(t, lo.ToPtr("abc"), spec1.Absolute.ID)
+		assert.Nil(t, spec2.Absolute.ID)
+	})
+
+	t.Run("three args: name plus two specifiers", func(t *testing.T) {
+		t.Parallel()
+
+		spec1, spec2, err := azurekvversion.ParseDiffArgs([]string{"my-secret", "#abc", "#def"})
+		require.NoError(t, err)
+		assert.Equal(t, lo.ToPtr("abc"), spec1.Absolute.ID)
+		assert.Equal(t, lo.ToPtr("def"), spec2.Absolute.ID)
+	})
+
+	t.Run("no args rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := azurekvversion.ParseDiffArgs([]string{})
+		require.Error(t, err)
+	})
+
+	t.Run("too many args rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := azurekvversion.ParseDiffArgs([]string{"a", "b", "c", "d"})
+		require.Error(t, err)
 	})
 
 	t.Run("label rejected", func(t *testing.T) {

--- a/internal/version/gcpversion/spec_test.go
+++ b/internal/version/gcpversion/spec_test.go
@@ -122,6 +122,81 @@ func TestParse(t *testing.T) {
 			input:   "   ",
 			wantErr: true,
 		},
+
+		// Additional valid forms (integer versions, allowed name chars, shifts).
+		{
+			name:        "version zero accepted (positivity not enforced at parse time)",
+			input:       "my-secret#0",
+			wantName:    "my-secret",
+			wantVersion: lo.ToPtr(int64(0)),
+		},
+		{
+			name:     "name with @ allowed",
+			input:    "user@example.com",
+			wantName: "user@example.com",
+		},
+		{
+			name:      "name with @ and shift",
+			input:     "user@example.com~1",
+			wantName:  "user@example.com",
+			wantShift: 1,
+		},
+		{
+			name:        "name with slashes and version",
+			input:       "a/b/c#3",
+			wantName:    "a/b/c",
+			wantVersion: lo.ToPtr(int64(3)),
+		},
+		{
+			name:     "name with dots and mixed case",
+			input:    "MY-secret.v2",
+			wantName: "MY-secret.v2",
+		},
+		{
+			name:        "version with cumulative shifts",
+			input:       "my-secret#5~1~2",
+			wantName:    "my-secret",
+			wantVersion: lo.ToPtr(int64(5)),
+			wantShift:   3,
+		},
+		{
+			name:      "large cumulative shift",
+			input:     "my-secret~10~20",
+			wantName:  "my-secret",
+			wantShift: 30,
+		},
+		{
+			name:      "numeric shift zero is a no-op",
+			input:     "my-secret~0",
+			wantName:  "my-secret",
+			wantShift: 0,
+		},
+		{
+			name:     "tilde followed by minus is part of the name",
+			input:    "my-secret~-1",
+			wantName: "my-secret~-1",
+		},
+
+		// Additional rejected forms.
+		{
+			name:    "multiple absolute specifiers rejected",
+			input:   "my#3#4",
+			wantErr: true,
+		},
+		{
+			name:    "empty name (version at start)",
+			input:   "#3",
+			wantErr: true,
+		},
+		{
+			name:    "empty name (shift at start)",
+			input:   "~1",
+			wantErr: true,
+		},
+		// NOTE: version-overflow ("#99999999999999999999999999") and
+		// label-after-version ("#3:latest") are exercised by dedicated tests
+		// (TestParse_VersionOverflow, TestParse_LabelAfterVersionRejected) that
+		// assert the specific error, so they are omitted here.
 	}
 
 	for _, tt := range tests {
@@ -151,6 +226,27 @@ func TestParse_LabelErrorMessage(t *testing.T) {
 	require.ErrorIs(t, err, gcpversion.ErrLabelUnsupported)
 }
 
+// TestParse_LabelAfterVersionRejected exercises the ':' reject path reached
+// AFTER a valid '#' specifier: parseAbsolute advances past "#3" and then hits
+// ':', invoking the label parser's Apply (which returns ErrLabelUnsupported).
+func TestParse_LabelAfterVersionRejected(t *testing.T) {
+	t.Parallel()
+
+	_, err := gcpversion.Parse("my-secret#3:latest")
+	require.Error(t, err)
+	require.ErrorIs(t, err, gcpversion.ErrLabelUnsupported)
+}
+
+// TestParse_VersionOverflow exercises the strconv.ParseInt failure branch when
+// the integer version cannot fit in int64.
+func TestParse_VersionOverflow(t *testing.T) {
+	t.Parallel()
+
+	_, err := gcpversion.Parse("my-secret#99999999999999999999999999")
+	require.Error(t, err)
+	require.ErrorContains(t, err, "out of range")
+}
+
 func TestParseDiffArgs(t *testing.T) {
 	t.Parallel()
 
@@ -170,6 +266,47 @@ func TestParseDiffArgs(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, lo.ToPtr(int64(1)), spec1.Absolute.Version)
 		assert.Equal(t, lo.ToPtr(int64(2)), spec2.Absolute.Version)
+	})
+
+	t.Run("mixed format: full spec plus specifier-only", func(t *testing.T) {
+		t.Parallel()
+
+		spec1, spec2, err := gcpversion.ParseDiffArgs([]string{"my-secret#1", "#2"})
+		require.NoError(t, err)
+		assert.Equal(t, lo.ToPtr(int64(1)), spec1.Absolute.Version)
+		assert.Equal(t, lo.ToPtr(int64(2)), spec2.Absolute.Version)
+	})
+
+	t.Run("partial spec: name plus specifier-only is swapped", func(t *testing.T) {
+		t.Parallel()
+
+		spec1, spec2, err := gcpversion.ParseDiffArgs([]string{"my-secret", "#3"})
+		require.NoError(t, err)
+		assert.Equal(t, lo.ToPtr(int64(3)), spec1.Absolute.Version)
+		assert.Nil(t, spec2.Absolute.Version)
+	})
+
+	t.Run("three args: name plus two specifiers", func(t *testing.T) {
+		t.Parallel()
+
+		spec1, spec2, err := gcpversion.ParseDiffArgs([]string{"my-secret", "#1", "#2"})
+		require.NoError(t, err)
+		assert.Equal(t, lo.ToPtr(int64(1)), spec1.Absolute.Version)
+		assert.Equal(t, lo.ToPtr(int64(2)), spec2.Absolute.Version)
+	})
+
+	t.Run("no args rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := gcpversion.ParseDiffArgs([]string{})
+		require.Error(t, err)
+	})
+
+	t.Run("too many args rejected", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := gcpversion.ParseDiffArgs([]string{"a", "b", "c", "d"})
+		require.Error(t, err)
 	})
 
 	t.Run("label rejected", func(t *testing.T) {


### PR DESCRIPTION
Adds offline e2e coverage for the Azure **Key Vault** (`secret`) command group — the last provider/service without emulator-backed e2e — and substantially hardens unit tests across the provider adapters and version parsers.

## Key Vault e2e

- **Emulator seam**: `SUVE_AZURE_KEYVAULT_ENDPOINT`, when set, builds the `azsecrets` client against a local emulator with insecure TLS, `DisableChallengeResourceVerification`, and a dummy token credential. Emulator-only; must never be set against a production vault.
- **Emulator**: [nagyesta/lowkey-vault](https://github.com/nagyesta/lowkey-vault) (HTTPS :8443, self-signed cert, auth present-but-ignored). Added as a `compose.yaml` service (`azure` profile), a `make e2e-azure-keyvault` target, and folded into the `e2e-azure` CI job (which now starts both Azure emulators).
- **Coverage**: `create` / `show` / `update` / `show~1` / `log` / `diff` / `list` / `delete` plus the flat `suve secret` alias path.

Two emulator/provider quirks found and handled:
1. Key Vault `created` timestamps are **second-granular** — a fast create+update land in the same second, making created-time ordering (and thus `~SHIFT`) ambiguous. The e2e spaces the two writes by a second.
2. lowkey-vault returns **405** for the empty-version tag `PATCH` (`/secrets/{name}/`) that real Azure accepts as "current version". `tag`/`untag` are covered by unit tests instead.

## Unit-test hardening

Centered on the version-ordering/shift bug above and on provider-difference-prone code.

| package | before | after |
|---|---|---|
| `provider/gcp` | 0.0% | **100%** |
| `provider/gcp/secret` | 69.8% | **83.4%** |
| `provider/azure` (seams) | 23.8% | **45.2%** |
| `provider/azure/appconfig` | 71.2% | **80.3%** |
| `provider/azure/keyvault` | 67.1% | **83.9%** |
| `version/gcpversion` | 75.0% | **100%** |
| `version/azurekvversion` | 88.9% | **100%** |
| `version/azureappconfigversion` | 76.9% | 76.9% (remaining lines are unreachable defensive closures) |

The keyvault tests exhaustively cover `~SHIFT` resolution (out-of-range, absolute-id+shift, not-found, no-versions) and ordering semantics (equal / nil `created` timestamps), plus the write/tag error paths. The version-parser tests lock down each provider's distinct specifier rules (GCP integer versions, Key Vault opaque ids, App Config rejecting all specifiers).

No production code changed except the additive Key Vault emulator seam. No bugs found in existing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155B8urnRZNHqfLrEnpxUE9