### PR TITLE
feat(stage): Azure Key Vault + App Configuration staging workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ This file provides guidance to Claude Code when working with code in this reposi
    - `secret` (aliases: `sm`) - AWS Secrets Manager
    - `gcloud` - Google Cloud (`secret` = Secret Manager)
    - `azure` - Azure (`secret` = Key Vault, `param` = App Configuration)
-   - `stage` (alias: `stg`) - Staging operations (AWS + Google Cloud)
+   - `stage` (alias: `stg`) - Staging operations (AWS + Google Cloud + Azure)
 
 ## Architecture
 
@@ -128,7 +128,7 @@ suve/
 │   │
 │   ├── updatecheck/              # Non-blocking update-check notification (#209)
 │   │
-│   ├── staging/                  # Staging core functionality (AWS + Google Cloud)
+│   ├── staging/                  # Staging core functionality (AWS + Google Cloud + Azure)
 │   │   ├── cli/                  # Staging CLI wrappers (service-specific)
 │   │   ├── transition/           # Reducer-based state machine (state/action/reducer/executor)
 │   │   └── store/                # Storage backend

--- a/README.md
+++ b/README.md
@@ -480,14 +480,16 @@ where ~SHIFT = ~ | ~N  (repeatable, cumulative)
 | [AWS Parameter Store](docs/aws.md) | `aws param` | ✅ numeric | ✅ tags | ✅ | ✅ | shared config/env/role |
 | [AWS Secrets Manager](docs/aws.md) | `aws secret` | ✅ UUID + staging labels | ✅ tags | ✅ | ✅ | shared config/env/role |
 | [Google Cloud Secret Manager](docs/gcloud.md) | `gcloud secret` | ✅ integer (`latest`) | ✅ labels | ✅ | 🔜 [#250](https://github.com/mpyw/suve/issues/250) | Application Default Credentials |
-| [Azure Key Vault](docs/azure.md) | `azure secret` | ✅ opaque id | ✅ tags | 🔜 [#247](https://github.com/mpyw/suve/issues/247) | 🔜 [#250](https://github.com/mpyw/suve/issues/250) | DefaultAzureCredential |
-| [Azure App Configuration](docs/azure.md) | `azure param` | ❌ unversioned | ❌ unsupported¹ | 🔜 [#247](https://github.com/mpyw/suve/issues/247) | 🔜 [#250](https://github.com/mpyw/suve/issues/250) | DefaultAzureCredential |
+| [Azure Key Vault](docs/azure.md) | `azure secret` | ✅ opaque id | ✅ tags | ✅ | 🔜 [#250](https://github.com/mpyw/suve/issues/250) | DefaultAzureCredential |
+| [Azure App Configuration](docs/azure.md) | `azure param` | ❌ unversioned | ❌ unsupported¹ | ✅³ | 🔜 [#250](https://github.com/mpyw/suve/issues/250) | DefaultAzureCredential |
 
 Read/write operations (`show`, `log`, `diff`, `list`, `create`, `update`, `delete`, `tag`, `untag`) are available on every backend, with these caveats: `restore` is AWS Secrets Manager only; on Azure App Configuration `log` reports history unsupported and `tag`/`untag` return an unsupported error; version specifiers (`#VERSION`, `~SHIFT`, `:LABEL`) are rejected on App Configuration. Only AWS Secrets Manager has staging labels (`:AWSCURRENT` etc.).
 
 ¹ The `azappconfig` SDK cannot write setting tags without clearing them, so tag writes are refused.
 
 ² The bundled GUI (`suve --gui`) is AWS-only today; multi-cloud GUI support is planned ([#250](https://github.com/mpyw/suve/issues/250)). The CLI supports all backends.
+
+³ App Configuration is unversioned, so staging uses **last-write-wins** (no modified-after conflict check) and `tag`/`untag` are unavailable (tags aren't writable).
 
 ### Provider selection
 
@@ -501,9 +503,10 @@ suve gcloud secret ... # Google Cloud Secret Manager
 suve gcloud stage  ... # Google Cloud staging
 suve azure secret  ... # Azure Key Vault
 suve azure param   ... # Azure App Configuration
+suve azure stage   ... # Azure staging (secret = Key Vault, param = App Configuration)
 ```
 
-For convenience, suve also exposes **bare top-level aliases** — `suve param`, `suve secret`, `suve stage` — but only when the environment makes the target unambiguous. `param`, `secret`, and `stage` are each resolved independently. Staging is supported for AWS and Google Cloud, so `stage` follows the same "exactly one active backend" rule (Azure staging is not yet available, see [#247](https://github.com/mpyw/suve/issues/247)):
+For convenience, suve also exposes **bare top-level aliases** — `suve param`, `suve secret`, `suve stage` — but only when the environment makes the target unambiguous. `param`, `secret`, and `stage` are each resolved independently. All backends support staging, so `stage` follows the same "exactly one active backend" rule (Azure is staging-active when either `AZURE_KEYVAULT_NAME` or `AZURE_APPCONFIG_NAME` is set):
 
 1. A backend is **active** when its identifying environment variable is set:
 
@@ -524,7 +527,8 @@ Examples (`—` = alias not exposed):
 | nothing set, `~/.aws/credentials` present | `aws` | `aws` | `aws` |
 | `AWS_PROFILE` | `aws` | `aws` | `aws` |
 | `GOOGLE_CLOUD_PROJECT` | — | `gcloud` | `gcloud` |
-| `AZURE_APPCONFIG_NAME` | `azure` | — | — |
+| `AZURE_KEYVAULT_NAME` | — | `azure` | `azure` |
+| `AZURE_APPCONFIG_NAME` | `azure` | — | `azure` |
 | `AWS_PROFILE` + `GOOGLE_CLOUD_PROJECT` | `aws` | — (ambiguous) | — (ambiguous) |
 | nothing set, no credentials file | — | — | — |
 
@@ -545,6 +549,7 @@ Explicit command groups (always available) and their bare aliases (exposed per t
 | Google Cloud Staging | `gcloud stage` (`stg`) | `stage` |
 | [Azure Key Vault](docs/azure.md) | `azure secret` | `secret` |
 | [Azure App Configuration](docs/azure.md) | `azure param` | `param` |
+| Azure Staging | `azure stage` (`stg`) | `stage` |
 
 ### AWS SSM Parameter Store
 
@@ -650,6 +655,21 @@ Secrets are versioned by opaque IDs and have no staging labels. Select the vault
 | [`suve azure secret tag`](docs/azure.md#suve-azure-secret-tag) | `<KEY>=<VALUE>...` | Add or update tags |
 | [`suve azure secret untag`](docs/azure.md#suve-azure-secret-untag) | `<KEY>...` | Remove tags |
 
+**Staging commands** (under `suve azure stage secret`):
+
+| Command | Options | Description |
+|---------|---------|-------------|
+| `suve azure stage secret add` | `--description=<TEXT>` | Stage a new secret |
+| `suve azure stage secret edit` | `--description=<TEXT>` | Stage a modification (new version) |
+| `suve azure stage secret delete` | | Stage a deletion |
+| `suve azure stage secret status` | `--verbose` (`-v`) | Show staged changes |
+| `suve azure stage secret diff` | `--parse-json` (`-j`)<br>`--no-pager` | Show staged vs Key Vault |
+| `suve azure stage secret apply` | `--yes`<br>`--ignore-conflicts` | Apply staged changes |
+| `suve azure stage secret reset` | `--all` | Unstage changes |
+| `suve azure stage secret tag` | `<KEY>=<VALUE>...` | Stage tag additions |
+| `suve azure stage secret untag` | `<KEY>...` | Stage tag removals |
+| `suve azure stage secret stash` | `push`/`pop`/`show`/`drop` | Save/restore staged changes |
+
 ### Azure App Configuration
 
 Unversioned key-value store. Version specifiers (`#VERSION`, `~SHIFT`, `:LABEL`) are rejected, `log` reports that history is unsupported, and `tag` / `untag` are unsupported (SDK limitation). Select the store with `--store-name` or the `AZURE_APPCONFIG_NAME` environment variable, plus the shared `azure` base flags described above. See [docs/azure.md](docs/azure.md) for details.
@@ -662,10 +682,23 @@ Unversioned key-value store. Version specifiers (`#VERSION`, `~SHIFT`, `:LABEL`)
 | [`suve azure param update`](docs/azure.md#suve-azure-param-update) | `--yes` | Update an existing key |
 | [`suve azure param delete`](docs/azure.md#suve-azure-param-delete) | `--yes` | Delete a key |
 
-> [!NOTE]
-> Azure Key Vault and App Configuration are not covered by the staging workflow. Staging (`suve stage`) is AWS-only.
+**Staging commands** (under `suve azure stage param`; unversioned → last-write-wins, no `tag`/`untag`):
 
-### Global Stage Commands
+| Command | Options | Description |
+|---------|---------|-------------|
+| `suve azure stage param add` | `--description=<TEXT>` | Stage a new setting |
+| `suve azure stage param edit` | `--description=<TEXT>` | Stage a modification |
+| `suve azure stage param delete` | | Stage a deletion |
+| `suve azure stage param status` | `--verbose` (`-v`) | Show staged changes |
+| `suve azure stage param diff` | `--parse-json` (`-j`)<br>`--no-pager` | Show staged vs App Configuration |
+| `suve azure stage param apply` | `--yes` | Apply staged changes |
+| `suve azure stage param reset` | `--all` | Unstage changes |
+| `suve azure stage param stash` | `push`/`pop`/`show`/`drop` | Save/restore staged changes |
+
+> [!NOTE]
+> Azure staging is **per-service**: `suve azure stage secret` (Key Vault) and `suve azure stage param` (App Configuration) keep separate staging state, so there is no cross-service `azure stage status`/`apply` aggregate (unlike `aws stage`).
+
+### Global Stage Commands (AWS)
 
 | Command | Options | Description |
 |---------|---------|-------------|

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -12,8 +12,12 @@ Azure splits into two services under `suve azure`:
 | `suve azure secret` | Key Vault | Versioned by opaque ids, no labels |
 | `suve azure param` | App Configuration | **Unversioned** (single current value) |
 
-> [!NOTE]
-> There is no staging workflow for Azure (staging is AWS-only).
+Azure also supports the local **staging workflow** via `suve azure stage` (or the bare `suve stage` alias when Azure is the only active staging backend). It is **per-service**, because Key Vault and App Configuration keep separate staging state:
+
+- `suve azure stage secret` — Key Vault secrets. Full workflow (`add`/`edit`/`delete`/`status`/`diff`/`apply`/`reset`/`tag`/`untag`/`stash`). Versions are immutable, so a staged `edit` applies as a new version.
+- `suve azure stage param` — App Configuration settings. Because App Configuration is **unversioned**, staging uses **last-write-wins** (no modified-after conflict check), and `tag`/`untag` are unavailable (tags aren't writable). Workflow: `add`/`edit`/`delete`/`status`/`diff`/`apply`/`reset`/`stash`.
+
+Unlike `aws stage`, there is no cross-service `azure stage status`/`apply` aggregate — the two services have distinct staging scopes. See the [staging workflow](../README.md#staging-workflow) overview for the general flow.
 
 ## Authentication and Configuration
 

--- a/e2e/azure_stage_test.go
+++ b/e2e/azure_stage_test.go
@@ -1,0 +1,195 @@
+//go:build e2e
+
+//nolint:paralleltest // E2E subtests share state and run sequentially, not in parallel
+package e2e_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+
+	"github.com/mpyw/suve/internal/cli/commands/azure"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/staging"
+	"github.com/mpyw/suve/internal/staging/store/file"
+)
+
+// runAzureStage runs `suve azure stage <args...>` in-process through the azure
+// command group and returns stdout.
+func runAzureStage(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+
+	var outBuf, errBuf bytes.Buffer
+
+	app := &cli.Command{
+		Name:      "suve",
+		Writer:    &outBuf,
+		ErrWriter: &errBuf,
+		Commands:  []*cli.Command{azure.Command()},
+	}
+
+	full := append([]string{"suve", "azure", "stage"}, args...)
+	err := app.Run(t.Context(), full)
+
+	return outBuf.String(), err
+}
+
+// TestAzureKeyVaultStage_Workflow exercises `suve azure stage secret`
+// status/diff/apply for update, create, and delete against a local Key Vault
+// emulator (lowkey-vault). Skipped unless the Key Vault emulator endpoint is set.
+func TestAzureKeyVaultStage_Workflow(t *testing.T) {
+	setupAzureKeyVault(t)
+	setupTempHome(t)
+
+	const (
+		updateName = "suve-e2e-az-kv-stage-update"
+		createName = "suve-e2e-az-kv-stage-create"
+		deleteName = "suve-e2e-az-kv-stage-delete"
+	)
+
+	cleanup := func() {
+		_, _ = runAzureSecret(t, "delete", "--yes", updateName)
+		_, _ = runAzureSecret(t, "delete", "--yes", createName)
+		_, _ = runAzureSecret(t, "delete", "--yes", deleteName)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	_, err := runAzureSecret(t, "create", updateName, "original")
+	require.NoError(t, err)
+	_, err = runAzureSecret(t, "create", deleteName, "to-be-deleted")
+	require.NoError(t, err)
+
+	// The Key Vault staging scope is keyed by (subscription, resource-group,
+	// vault); the emulator setup pins the vault name and leaves sub/rg empty.
+	store, err := file.NewStore(provider.AzureKeyVaultScope("", "", "suve-e2e"))
+	require.NoError(t, err)
+
+	now := time.Now()
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceSecret, updateName, staging.Entry{
+		Operation: staging.OperationUpdate, Value: lo.ToPtr("staged-value"), StagedAt: now,
+	}))
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceSecret, createName, staging.Entry{
+		Operation: staging.OperationCreate, Value: lo.ToPtr("created-value"), StagedAt: now,
+	}))
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceSecret, deleteName, staging.Entry{
+		Operation: staging.OperationDelete, StagedAt: now,
+	}))
+
+	t.Run("status", func(t *testing.T) {
+		stdout, err := runAzureStage(t, "secret", "status")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "Key Vault")
+		assert.Contains(t, stdout, updateName)
+		assert.Contains(t, stdout, createName)
+		assert.Contains(t, stdout, deleteName)
+	})
+
+	t.Run("diff", func(t *testing.T) {
+		stdout, err := runAzureStage(t, "secret", "diff")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "-original")
+		assert.Contains(t, stdout, "+staged-value")
+		assert.Contains(t, stdout, "+created-value")
+	})
+
+	t.Run("apply", func(t *testing.T) {
+		stdout, err := runAzureStage(t, "secret", "apply", "--yes")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, updateName)
+		assert.Contains(t, stdout, createName)
+		assert.Contains(t, stdout, deleteName)
+	})
+
+	t.Run("verify", func(t *testing.T) {
+		stdout, err := runAzureSecret(t, "show", "--raw", updateName)
+		require.NoError(t, err)
+		assert.Equal(t, "staged-value", stdout)
+
+		stdout, err = runAzureSecret(t, "show", "--raw", createName)
+		require.NoError(t, err)
+		assert.Equal(t, "created-value", stdout)
+
+		_, err = runAzureSecret(t, "show", "--raw", deleteName)
+		require.Error(t, err)
+	})
+
+	t.Run("status-empty-after-apply", func(t *testing.T) {
+		stdout, err := runAzureStage(t, "secret", "status")
+		require.NoError(t, err)
+		assert.NotContains(t, stdout, updateName)
+	})
+}
+
+// TestAzureAppConfigStage_Workflow exercises `suve azure stage param`
+// status/diff/apply against a local App Configuration emulator. App
+// Configuration is unversioned (last-write-wins) and tags are unsupported, so
+// only value operations are exercised.
+func TestAzureAppConfigStage_Workflow(t *testing.T) {
+	setupAzureAppConfig(t)
+	setupTempHome(t)
+
+	const (
+		updateName = "suve/e2e/az/ac/stage/update"
+		createName = "suve/e2e/az/ac/stage/create"
+	)
+
+	cleanup := func() {
+		_, _ = runAzureParam(t, "delete", "--yes", updateName)
+		_, _ = runAzureParam(t, "delete", "--yes", createName)
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	_, err := runAzureParam(t, "create", updateName, "original")
+	require.NoError(t, err)
+
+	store, err := file.NewStore(provider.AzureAppConfigScope("", "", "suve-e2e"))
+	require.NoError(t, err)
+
+	now := time.Now()
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, updateName, staging.Entry{
+		Operation: staging.OperationUpdate, Value: lo.ToPtr("staged-value"), StagedAt: now,
+	}))
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, createName, staging.Entry{
+		Operation: staging.OperationCreate, Value: lo.ToPtr("created-value"), StagedAt: now,
+	}))
+
+	t.Run("status", func(t *testing.T) {
+		stdout, err := runAzureStage(t, "param", "status")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "App Configuration")
+		assert.Contains(t, stdout, updateName)
+		assert.Contains(t, stdout, createName)
+	})
+
+	t.Run("diff", func(t *testing.T) {
+		stdout, err := runAzureStage(t, "param", "diff")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "-original")
+		assert.Contains(t, stdout, "+staged-value")
+		assert.Contains(t, stdout, "+created-value")
+	})
+
+	t.Run("apply", func(t *testing.T) {
+		stdout, err := runAzureStage(t, "param", "apply", "--yes")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, updateName)
+		assert.Contains(t, stdout, createName)
+	})
+
+	t.Run("verify", func(t *testing.T) {
+		stdout, err := runAzureParam(t, "show", "--raw", updateName)
+		require.NoError(t, err)
+		assert.Equal(t, "staged-value", stdout)
+
+		stdout, err = runAzureParam(t, "show", "--raw", createName)
+		require.NoError(t, err)
+		assert.Equal(t, "created-value", stdout)
+	})
+}

--- a/internal/cli/commands/app.go
+++ b/internal/cli/commands/app.go
@@ -118,8 +118,7 @@ func flatStageCommand(p provider.Provider) *cli.Command {
 	case provider.ProviderGoogleCloud:
 		return gcloud.FlatStageCommand("stage")
 	case provider.ProviderAzure:
-		// Azure is not yet staging-capable.
-		return nil
+		return azure.FlatStageCommand("stage")
 	}
 
 	return nil

--- a/internal/cli/commands/azure/command.go
+++ b/internal/cli/commands/azure/command.go
@@ -52,6 +52,7 @@ identity, Azure CLI, ...).`,
 		Commands: []*cli.Command{
 			secret.Command(),
 			param.Command(),
+			StageCommand(),
 		},
 		CommandNotFound: cliinternal.CommandNotFound,
 	}

--- a/internal/cli/commands/azure/stage.go
+++ b/internal/cli/commands/azure/stage.go
@@ -1,0 +1,147 @@
+package azure
+
+import (
+	"context"
+
+	"github.com/urfave/cli/v3"
+
+	cliinternal "github.com/mpyw/suve/internal/cli/commands/internal"
+	"github.com/mpyw/suve/internal/staging"
+	stgcli "github.com/mpyw/suve/internal/staging/cli"
+)
+
+// keyVaultStageConfig is the staging config for Azure Key Vault secrets. The
+// ScopeResolver keys on-disk staging state by the resolved vault.
+func keyVaultStageConfig() stgcli.CommandConfig {
+	return stgcli.CommandConfig{
+		CommandName:   "secret",
+		ItemName:      "secret",
+		Factory:       cliinternal.AzureKeyVaultSecretStrategyFactory,
+		ParserFactory: staging.AzureKeyVaultSecretParserFactory,
+		ScopeResolver: cliinternal.AzureKeyVaultStagingScopeResolver,
+	}
+}
+
+// appConfigStageConfig is the staging config for Azure App Configuration. The
+// ScopeResolver keys on-disk staging state by the resolved store.
+func appConfigStageConfig() stgcli.CommandConfig {
+	return stgcli.CommandConfig{
+		CommandName:   "param",
+		ItemName:      "setting",
+		Factory:       cliinternal.AzureAppConfigParamStrategyFactory,
+		ParserFactory: staging.AzureAppConfigParamParserFactory,
+		ScopeResolver: cliinternal.AzureAppConfigStagingScopeResolver,
+	}
+}
+
+// keyVaultStageSubcommands are the full staging subcommands for Key Vault
+// (tags are supported).
+func keyVaultStageSubcommands(cfg stgcli.CommandConfig) []*cli.Command {
+	return []*cli.Command{
+		stgcli.NewAddCommand(cfg),
+		stgcli.NewEditCommand(cfg),
+		stgcli.NewDeleteCommand(cfg),
+		stgcli.NewStatusCommand(cfg),
+		stgcli.NewDiffCommand(cfg),
+		stgcli.NewApplyCommand(cfg),
+		stgcli.NewResetCommand(cfg),
+		stgcli.NewTagCommand(cfg),
+		stgcli.NewUntagCommand(cfg),
+		stgcli.NewStashCommand(cfg),
+	}
+}
+
+// appConfigStageSubcommands are the staging subcommands for App Configuration.
+// tag/untag are omitted: App Configuration setting tags are not writable.
+func appConfigStageSubcommands(cfg stgcli.CommandConfig) []*cli.Command {
+	return []*cli.Command{
+		stgcli.NewAddCommand(cfg),
+		stgcli.NewEditCommand(cfg),
+		stgcli.NewDeleteCommand(cfg),
+		stgcli.NewStatusCommand(cfg),
+		stgcli.NewDiffCommand(cfg),
+		stgcli.NewApplyCommand(cfg),
+		stgcli.NewResetCommand(cfg),
+		stgcli.NewStashCommand(cfg),
+	}
+}
+
+// keyVaultStageGroup is the "secret" staging subgroup (Key Vault). It owns the
+// --vault-name flag and resolves it into the context for the scope resolver.
+func keyVaultStageGroup() *cli.Command {
+	return &cli.Command{
+		Name:  "secret",
+		Usage: "Staging operations for Azure Key Vault secrets",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "vault-name",
+				Usage:   "Azure Key Vault name (defaults to $AZURE_KEYVAULT_NAME)",
+				Sources: cli.EnvVars("AZURE_KEYVAULT_NAME"),
+			},
+		},
+		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+			return cliinternal.WithAzureVaultName(ctx, cmd.String("vault-name")), nil
+		},
+		Commands:        keyVaultStageSubcommands(keyVaultStageConfig()),
+		CommandNotFound: cliinternal.CommandNotFound,
+	}
+}
+
+// appConfigStageGroup is the "param" staging subgroup (App Configuration). It
+// owns the --store-name flag and resolves it into the context.
+func appConfigStageGroup() *cli.Command {
+	return &cli.Command{
+		Name:  "param",
+		Usage: "Staging operations for Azure App Configuration settings",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "store-name",
+				Usage:   "Azure App Configuration store name (defaults to $AZURE_APPCONFIG_NAME)",
+				Sources: cli.EnvVars("AZURE_APPCONFIG_NAME"),
+			},
+		},
+		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+			return cliinternal.WithAzureStoreName(ctx, cmd.String("store-name")), nil
+		},
+		Commands:        appConfigStageSubcommands(appConfigStageConfig()),
+		CommandNotFound: cliinternal.CommandNotFound,
+	}
+}
+
+const stageDescription = `Stage changes locally before applying to Azure.
+
+Azure staging is per-service, because Key Vault and App Configuration keep
+separate staging state:
+  - "suve azure stage secret" stages Key Vault secrets (opaque-versioned).
+  - "suve azure stage param"  stages App Configuration settings (unversioned,
+    last-write-wins; tags are not writable, so tag/untag are unavailable).
+
+EXAMPLES:
+   suve azure stage secret add my-secret     Stage a new Key Vault secret
+   suve azure stage secret apply             Apply staged Key Vault changes
+   suve azure stage param edit my-setting    Edit and stage an App Config setting
+   suve azure stage param apply              Apply staged App Config changes`
+
+// StageCommand returns the "azure stage" command with the secret (Key Vault) and
+// param (App Configuration) staging subgroups.
+func StageCommand() *cli.Command {
+	return &cli.Command{
+		Name:            "stage",
+		Aliases:         []string{"stg"},
+		Usage:           "Manage staged changes for Azure Key Vault and App Configuration",
+		Description:     stageDescription,
+		Commands:        []*cli.Command{keyVaultStageGroup(), appConfigStageGroup()},
+		CommandNotFound: cliinternal.CommandNotFound,
+	}
+}
+
+// FlatStageCommand returns the Azure stage command as a standalone top-level
+// command named `name` (e.g. "stage"), folding in the base subscription /
+// resource-group flags and hook. Used for the flat `suve stage` alias when
+// Azure is the uniquely active staging provider.
+func FlatStageCommand(name string) *cli.Command {
+	c := StageCommand()
+	c.Name = name
+
+	return foldBase(c)
+}

--- a/internal/cli/commands/internal/client.go
+++ b/internal/cli/commands/internal/client.go
@@ -227,3 +227,61 @@ func GoogleCloudStagingScopeResolver(ctx context.Context) (staging.ResolvedScope
 		Target: "project " + project,
 	}, nil
 }
+
+// AzureKeyVaultSecretStrategyFactory builds a staging FullStrategy for Azure Key
+// Vault secrets, wrapping a provider.Store resolved for the context's vault. It
+// satisfies staging.StrategyFactory.
+func AzureKeyVaultSecretStrategyFactory(ctx context.Context) (staging.FullStrategy, error) {
+	store, err := AzureKeyVaultStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return staging.NewAzureKeyVaultSecretStrategy(store), nil
+}
+
+// AzureAppConfigParamStrategyFactory builds a staging FullStrategy for Azure App
+// Configuration, wrapping a provider.Store resolved for the context's store. It
+// satisfies staging.StrategyFactory.
+func AzureAppConfigParamStrategyFactory(ctx context.Context) (staging.FullStrategy, error) {
+	store, err := AzureAppConfigStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return staging.NewAzureAppConfigParamStrategy(store), nil
+}
+
+// AzureKeyVaultStagingScopeResolver resolves the Azure Key Vault staging scope
+// from the subscription / resource group / vault stashed in the context (see
+// WithAzureBase / WithAzureVaultName). It performs no network calls.
+func AzureKeyVaultStagingScopeResolver(ctx context.Context) (staging.ResolvedScope, error) {
+	sc := azureScopeFromContext(ctx)
+	if sc.vaultName == "" {
+		return staging.ResolvedScope{}, errors.New(
+			"no Azure Key Vault specified: set --vault-name or the AZURE_KEYVAULT_NAME environment variable",
+		)
+	}
+
+	return staging.ResolvedScope{
+		Scope:  provider.AzureKeyVaultScope(sc.subscription, sc.resourceGroup, sc.vaultName),
+		Target: "vault " + sc.vaultName,
+	}, nil
+}
+
+// AzureAppConfigStagingScopeResolver resolves the Azure App Configuration
+// staging scope from the subscription / resource group / store stashed in the
+// context (see WithAzureBase / WithAzureStoreName). It performs no network calls.
+func AzureAppConfigStagingScopeResolver(ctx context.Context) (staging.ResolvedScope, error) {
+	sc := azureScopeFromContext(ctx)
+	if sc.storeName == "" {
+		return staging.ResolvedScope{}, errors.New(
+			"no Azure App Configuration store specified: set --store-name or the AZURE_APPCONFIG_NAME environment variable",
+		)
+	}
+
+	return staging.ResolvedScope{
+		Scope:  provider.AzureAppConfigScope(sc.subscription, sc.resourceGroup, sc.storeName),
+		Target: "store " + sc.storeName,
+	}, nil
+}

--- a/internal/provider/detect/detect.go
+++ b/internal/provider/detect/detect.go
@@ -53,7 +53,8 @@ type Result struct {
 	// Stage names the single active provider for the staging workflow, or an
 	// empty Provider ("") when staging is not uniquely resolvable (0 or 2+
 	// staging-capable providers active). Staging is supported for AWS (param +
-	// secret) and Google Cloud (secret); Azure is not yet staging-capable.
+	// secret), Google Cloud (secret), and Azure (Key Vault secret / App
+	// Configuration param).
 	Stage provider.Provider
 
 	// ParamActive and SecretActive list every provider active for that service,
@@ -126,13 +127,17 @@ func Resolve(env Environment) Result {
 	}
 
 	// Staging-capable providers in stable order: AWS (param + secret), Google
-	// Cloud (secret). Azure is not yet staging-capable.
+	// Cloud (secret), Azure (Key Vault secret and/or App Configuration param).
 	if awsActive {
 		res.StageActive = append(res.StageActive, provider.ProviderAWS)
 	}
 
 	if gcloudSecret {
 		res.StageActive = append(res.StageActive, provider.ProviderGoogleCloud)
+	}
+
+	if azureSecret || azureParam {
+		res.StageActive = append(res.StageActive, provider.ProviderAzure)
 	}
 
 	res.Secret = unique(res.SecretActive)

--- a/internal/provider/detect/detect_test.go
+++ b/internal/provider/detect/detect_test.go
@@ -1,6 +1,7 @@
 package detect_test
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -156,15 +157,22 @@ func TestResolve(t *testing.T) {
 			assert.Equal(t, tt.wantParam != "", got.FlatParam(), "FlatParam")
 			assert.Equal(t, tt.wantSecret != "", got.FlatSecret(), "FlatSecret")
 
-			// Staging-capable providers are AWS and Google Cloud (both appear in
-			// the secret active set when active). Stage is the unique active
-			// staging provider, or "" when 0 or 2+ are active.
+			// Staging-capable providers, in stable order (AWS, Google Cloud,
+			// Azure): AWS/Google Cloud when active for secret; Azure when active
+			// for EITHER service. Stage is the unique active one, or "" for 0/2+.
 			var wantStageSet []provider.Provider
 
-			for _, p := range tt.wantSecretSet {
-				if p == provider.ProviderAWS || p == provider.ProviderGoogleCloud {
-					wantStageSet = append(wantStageSet, p)
-				}
+			if slices.Contains(tt.wantSecretSet, provider.ProviderAWS) {
+				wantStageSet = append(wantStageSet, provider.ProviderAWS)
+			}
+
+			if slices.Contains(tt.wantSecretSet, provider.ProviderGoogleCloud) {
+				wantStageSet = append(wantStageSet, provider.ProviderGoogleCloud)
+			}
+
+			if slices.Contains(tt.wantSecretSet, provider.ProviderAzure) ||
+				slices.Contains(tt.wantParamSet, provider.ProviderAzure) {
+				wantStageSet = append(wantStageSet, provider.ProviderAzure)
 			}
 
 			wantStage := provider.Provider("")

--- a/internal/staging/azure_appconfig_param.go
+++ b/internal/staging/azure_appconfig_param.go
@@ -1,0 +1,190 @@
+package staging
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/samber/lo"
+
+	"github.com/mpyw/suve/internal/domain"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/version/azureappconfigversion"
+)
+
+// ErrAppConfigTagsUnsupported is returned when staged tag changes are applied to
+// Azure App Configuration, whose SDK cannot write setting tags. The azure param
+// stage group does not expose tag/untag, so this is a defensive guard.
+var ErrAppConfigTagsUnsupported = errors.New(
+	"tag mutation is not supported by Azure App Configuration",
+)
+
+// AzureAppConfigParamStrategy implements the staging strategies for Azure App
+// Configuration. App Configuration is UNVERSIONED, so:
+//
+//   - Version specifiers (#VERSION, ~SHIFT, :LABEL) are rejected at parse time
+//     via azureappconfigversion.
+//   - Conflict detection is disabled (last-write-wins): FetchLastModified and
+//     the edit base time return zero, so apply never reports a modified-after
+//     conflict. Apply overwrites unconditionally.
+//   - Tag mutation is unsupported (the azappconfig SDK cannot write tags), so
+//     ApplyTags returns ErrAppConfigTagsUnsupported and the azure param stage
+//     group omits tag/untag.
+//
+// A nil store yields a parser-only strategy (ParseName/ParseSpec).
+type AzureAppConfigParamStrategy struct {
+	store provider.Store
+}
+
+// NewAzureAppConfigParamStrategy creates an Azure App Configuration staging
+// strategy over the given provider store. A nil store is allowed for
+// parser-only use.
+func NewAzureAppConfigParamStrategy(store provider.Store) *AzureAppConfigParamStrategy {
+	return &AzureAppConfigParamStrategy{store: store}
+}
+
+// Service returns the service type.
+func (s *AzureAppConfigParamStrategy) Service() Service { return ServiceParam }
+
+// ServiceName returns the user-friendly service name.
+func (s *AzureAppConfigParamStrategy) ServiceName() string { return "App Configuration" }
+
+// ItemName returns the item name for messages.
+func (s *AzureAppConfigParamStrategy) ItemName() string { return "setting" }
+
+// HasDeleteOptions returns false: App Configuration has no delete options.
+func (s *AzureAppConfigParamStrategy) HasDeleteOptions() bool { return false }
+
+// Apply applies a staged operation to Azure App Configuration.
+func (s *AzureAppConfigParamStrategy) Apply(ctx context.Context, name string, entry Entry) error {
+	switch entry.Operation {
+	case OperationCreate:
+		return s.applyCreate(ctx, name, entry)
+	case OperationUpdate:
+		return s.applyUpdate(ctx, name, entry)
+	case OperationDelete:
+		return s.applyDelete(ctx, name)
+	default:
+		return fmt.Errorf("unknown operation: %s", entry.Operation)
+	}
+}
+
+func (s *AzureAppConfigParamStrategy) applyCreate(ctx context.Context, name string, entry Entry) error {
+	if _, err := s.store.Create(ctx, name, lo.FromPtr(entry.Value), domain.ValueTypePlaintext, lo.FromPtr(entry.Description)); err != nil {
+		return fmt.Errorf("failed to create setting: %w", err)
+	}
+
+	return nil
+}
+
+func (s *AzureAppConfigParamStrategy) applyUpdate(ctx context.Context, name string, entry Entry) error {
+	if entry.Value == nil {
+		return nil
+	}
+
+	// Last-write-wins: Put overwrites the current value unconditionally.
+	if _, err := s.store.Put(ctx, name, *entry.Value, domain.ValueTypePlaintext, lo.FromPtr(entry.Description)); err != nil {
+		return fmt.Errorf("failed to update setting: %w", err)
+	}
+
+	return nil
+}
+
+func (s *AzureAppConfigParamStrategy) applyDelete(ctx context.Context, name string) error {
+	if err := s.store.Delete(ctx, name); err != nil {
+		if errors.Is(err, provider.ErrNotFound) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to delete setting: %w", err)
+	}
+
+	return nil
+}
+
+// ApplyTags is unsupported for App Configuration.
+func (s *AzureAppConfigParamStrategy) ApplyTags(_ context.Context, _ string, _ TagEntry) error {
+	return ErrAppConfigTagsUnsupported
+}
+
+// FetchLastModified returns zero time: App Configuration staging uses
+// last-write-wins, so no modified-after conflict is ever reported.
+func (s *AzureAppConfigParamStrategy) FetchLastModified(_ context.Context, _ string) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+// FetchCurrent fetches the current value from App Configuration for diffing.
+// App Configuration is unversioned, so the identifier is empty.
+func (s *AzureAppConfigParamStrategy) FetchCurrent(ctx context.Context, name string) (*FetchResult, error) {
+	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &FetchResult{Value: entry.Value}, nil
+}
+
+// FetchCurrentTags fetches the current tags. App Configuration tags are not
+// mutable and not surfaced here; returns nil.
+func (s *AzureAppConfigParamStrategy) FetchCurrentTags(_ context.Context, _ string) (map[string]string, error) {
+	return nil, nil //nolint:nilnil // intentional: App Configuration tags are not staged
+}
+
+// ParseName parses and validates a name. Any version specifier is rejected by
+// azureappconfigversion.
+func (s *AzureAppConfigParamStrategy) ParseName(input string) (string, error) {
+	spec, err := azureappconfigversion.Parse(input)
+	if err != nil {
+		return "", err
+	}
+
+	return spec.Name, nil
+}
+
+// FetchCurrentValue fetches the current value for editing. LastModified is left
+// zero so the edit flow records no conflict base (last-write-wins).
+func (s *AzureAppConfigParamStrategy) FetchCurrentValue(ctx context.Context, name string) (*EditFetchResult, error) {
+	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
+	if err != nil {
+		if errors.Is(err, provider.ErrNotFound) {
+			return nil, &ResourceNotFoundError{Err: err}
+		}
+
+		return nil, err
+	}
+
+	return &EditFetchResult{Value: entry.Value}, nil
+}
+
+// ParseSpec parses a name for reset. App Configuration is unversioned, so a
+// version is never present (specifiers are rejected at parse time).
+func (s *AzureAppConfigParamStrategy) ParseSpec(input string) (name string, hasVersion bool, err error) {
+	spec, err := azureappconfigversion.Parse(input)
+	if err != nil {
+		return "", false, err
+	}
+
+	return spec.Name, false, nil
+}
+
+// FetchVersion fetches the current value. Version specifiers are rejected at
+// parse time, so this only ever resolves the current (unversioned) value.
+func (s *AzureAppConfigParamStrategy) FetchVersion(ctx context.Context, input string) (value string, versionLabel string, err error) {
+	spec, err := azureappconfigversion.Parse(input)
+	if err != nil {
+		return "", "", err
+	}
+
+	entry, err := s.store.Get(ctx, spec.Name, provider.VersionRef{})
+	if err != nil {
+		return "", "", err
+	}
+
+	return entry.Value, "current", nil
+}
+
+// AzureAppConfigParamParserFactory yields a parser-only strategy.
+func AzureAppConfigParamParserFactory() Parser {
+	return NewAzureAppConfigParamStrategy(nil)
+}

--- a/internal/staging/azure_appconfig_param_test.go
+++ b/internal/staging/azure_appconfig_param_test.go
@@ -1,0 +1,334 @@
+package staging_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/domain"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/providermock"
+	"github.com/mpyw/suve/internal/staging"
+)
+
+func TestAzureAppConfigParamStrategy_BasicMethods(t *testing.T) {
+	t.Parallel()
+
+	s := staging.NewAzureAppConfigParamStrategy(nil)
+
+	assert.Equal(t, staging.ServiceParam, s.Service())
+	assert.Equal(t, "App Configuration", s.ServiceName())
+	assert.Equal(t, "setting", s.ItemName())
+	// App Configuration has no delete options.
+	assert.False(t, s.HasDeleteOptions())
+}
+
+func TestAzureAppConfigParamStrategy_Apply(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create", func(t *testing.T) {
+		t.Parallel()
+
+		var created string
+
+		store := &providermock.Store{
+			CreateFunc: func(_ context.Context, name, value string, vt domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
+				created = name
+
+				assert.Equal(t, "v1", value)
+				assert.Equal(t, domain.ValueTypePlaintext, vt)
+
+				return domain.Version{}, nil
+			},
+		}
+		s := staging.NewAzureAppConfigParamStrategy(store)
+
+		err := s.Apply(t.Context(), "cfg", staging.Entry{Operation: staging.OperationCreate, Value: lo.ToPtr("v1")})
+		require.NoError(t, err)
+		assert.Equal(t, "cfg", created)
+	})
+
+	t.Run("update overwrites via Put (last-write-wins)", func(t *testing.T) {
+		t.Parallel()
+
+		var putCalled bool
+
+		store := &providermock.Store{
+			PutFunc: func(_ context.Context, _, value string, vt domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
+				putCalled = true
+
+				assert.Equal(t, "v2", value)
+				assert.Equal(t, domain.ValueTypePlaintext, vt)
+
+				return domain.Version{}, nil
+			},
+		}
+		s := staging.NewAzureAppConfigParamStrategy(store)
+
+		err := s.Apply(t.Context(), "cfg", staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("v2")})
+		require.NoError(t, err)
+		assert.True(t, putCalled)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		t.Parallel()
+
+		var deleted string
+
+		store := &providermock.Store{
+			DeleteFunc: func(_ context.Context, name string, _ ...provider.DeleteOption) error {
+				deleted = name
+
+				return nil
+			},
+		}
+		s := staging.NewAzureAppConfigParamStrategy(store)
+
+		err := s.Apply(t.Context(), "cfg", staging.Entry{Operation: staging.OperationDelete})
+		require.NoError(t, err)
+		assert.Equal(t, "cfg", deleted)
+	})
+
+	t.Run("delete already-gone is success", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			DeleteFunc: func(_ context.Context, name string, _ ...provider.DeleteOption) error {
+				return secretNotFound(name)
+			},
+		}
+		s := staging.NewAzureAppConfigParamStrategy(store)
+
+		require.NoError(t, s.Apply(t.Context(), "cfg", staging.Entry{Operation: staging.OperationDelete}))
+	})
+
+	t.Run("unknown operation errors", func(t *testing.T) {
+		t.Parallel()
+
+		s := staging.NewAzureAppConfigParamStrategy(&providermock.Store{})
+		err := s.Apply(t.Context(), "cfg", staging.Entry{Operation: staging.Operation("bogus")})
+		require.Error(t, err)
+	})
+}
+
+func TestAzureAppConfigParamStrategy_ErrorWrapping(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("boom")
+
+	t.Run("create error is wrapped", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			CreateFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
+				return domain.Version{}, boom
+			},
+		}
+		s := staging.NewAzureAppConfigParamStrategy(store)
+		err := s.Apply(t.Context(), "cfg", staging.Entry{Operation: staging.OperationCreate, Value: lo.ToPtr("v")})
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("update with nil value is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		s := staging.NewAzureAppConfigParamStrategy(&providermock.Store{})
+		require.NoError(t, s.Apply(t.Context(), "cfg", staging.Entry{Operation: staging.OperationUpdate}))
+	})
+
+	t.Run("update error is wrapped", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			PutFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
+				return domain.Version{}, boom
+			},
+		}
+		s := staging.NewAzureAppConfigParamStrategy(store)
+		err := s.Apply(t.Context(), "cfg", staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("v")})
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("delete error (non-not-found) is wrapped", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			DeleteFunc: func(_ context.Context, _ string, _ ...provider.DeleteOption) error { return boom },
+		}
+		err := staging.NewAzureAppConfigParamStrategy(store).Apply(t.Context(), "cfg", staging.Entry{Operation: staging.OperationDelete})
+		require.ErrorIs(t, err, boom)
+	})
+}
+
+// TestAzureAppConfigParamStrategy_LastWriteWins asserts the last-write-wins
+// semantics: FetchLastModified always returns zero time and never touches the
+// store, so no modified-after conflict is ever reported.
+func TestAzureAppConfigParamStrategy_LastWriteWins(t *testing.T) {
+	t.Parallel()
+
+	// A store whose funcs would panic if called: FetchLastModified must not
+	// call the store at all.
+	got, err := staging.NewAzureAppConfigParamStrategy(&providermock.Store{}).FetchLastModified(t.Context(), "cfg")
+	require.NoError(t, err)
+	assert.True(t, got.IsZero())
+}
+
+// TestAzureAppConfigParamStrategy_ApplyTagsUnsupported asserts tag mutation is
+// rejected.
+func TestAzureAppConfigParamStrategy_ApplyTagsUnsupported(t *testing.T) {
+	t.Parallel()
+
+	s := staging.NewAzureAppConfigParamStrategy(&providermock.Store{})
+	err := s.ApplyTags(t.Context(), "cfg", staging.TagEntry{Add: map[string]string{"k": "v"}})
+	require.ErrorIs(t, err, staging.ErrAppConfigTagsUnsupported)
+}
+
+func TestAzureAppConfigParamStrategy_Fetch(t *testing.T) {
+	t.Parallel()
+
+	t.Run("FetchCurrent returns value with empty identifier", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+				return &domain.Entry{Name: name, Value: "current"}, nil
+			},
+		}
+		fr, err := staging.NewAzureAppConfigParamStrategy(store).FetchCurrent(t.Context(), "cfg")
+		require.NoError(t, err)
+		assert.Equal(t, "current", fr.Value)
+		assert.Empty(t, fr.Identifier)
+	})
+
+	t.Run("FetchCurrent propagates error", func(t *testing.T) {
+		t.Parallel()
+
+		boom := errors.New("boom")
+		store := &providermock.Store{
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) { return nil, boom },
+		}
+		_, err := staging.NewAzureAppConfigParamStrategy(store).FetchCurrent(t.Context(), "cfg")
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("FetchCurrentTags returns nil", func(t *testing.T) {
+		t.Parallel()
+
+		tags, err := staging.NewAzureAppConfigParamStrategy(&providermock.Store{}).FetchCurrentTags(t.Context(), "cfg")
+		require.NoError(t, err)
+		assert.Nil(t, tags)
+	})
+
+	t.Run("FetchCurrentValue returns value with zero LastModified", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+				return &domain.Entry{Name: name, Value: "current"}, nil
+			},
+		}
+		result, err := staging.NewAzureAppConfigParamStrategy(store).FetchCurrentValue(t.Context(), "cfg")
+		require.NoError(t, err)
+		assert.Equal(t, "current", result.Value)
+		assert.True(t, result.LastModified.IsZero())
+	})
+
+	t.Run("FetchCurrentValue: not-found maps to ResourceNotFoundError, other errors pass through", func(t *testing.T) {
+		t.Parallel()
+
+		notFound := &providermock.Store{
+			GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+				return nil, secretNotFound(name)
+			},
+		}
+		_, err := staging.NewAzureAppConfigParamStrategy(notFound).FetchCurrentValue(t.Context(), "cfg")
+
+		var rnf *staging.ResourceNotFoundError
+
+		require.ErrorAs(t, err, &rnf)
+
+		boom := errors.New("boom")
+		errStore := &providermock.Store{
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) { return nil, boom },
+		}
+		_, err = staging.NewAzureAppConfigParamStrategy(errStore).FetchCurrentValue(t.Context(), "cfg")
+		require.ErrorIs(t, err, boom)
+	})
+}
+
+func TestAzureAppConfigParamStrategy_ParseAndVersion(t *testing.T) {
+	t.Parallel()
+
+	s := staging.NewAzureAppConfigParamStrategy(&providermock.Store{})
+
+	t.Run("ParseName: bare name ok, specifiers rejected", func(t *testing.T) {
+		t.Parallel()
+
+		name, err := s.ParseName("cfg")
+		require.NoError(t, err)
+		assert.Equal(t, "cfg", name)
+
+		for _, spec := range []string{"cfg#1", "cfg~1", "cfg:lbl"} {
+			_, err := s.ParseName(spec)
+			require.Error(t, err, spec)
+		}
+	})
+
+	t.Run("ParseSpec: bare name has no version, specifier errors", func(t *testing.T) {
+		t.Parallel()
+
+		name, hasVersion, err := s.ParseSpec("cfg")
+		require.NoError(t, err)
+		assert.Equal(t, "cfg", name)
+		assert.False(t, hasVersion)
+
+		_, _, err = s.ParseSpec("cfg#1")
+		require.Error(t, err)
+	})
+
+	t.Run("FetchVersion resolves current for a bare name", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			GetFunc: func(_ context.Context, _ string, ref provider.VersionRef) (*domain.Entry, error) {
+				assert.True(t, ref.IsLatest())
+
+				return &domain.Entry{Value: "current"}, nil
+			},
+		}
+		value, label, err := staging.NewAzureAppConfigParamStrategy(store).FetchVersion(t.Context(), "cfg")
+		require.NoError(t, err)
+		assert.Equal(t, "current", value)
+		assert.Equal(t, "current", label)
+	})
+
+	t.Run("FetchVersion rejects a version specifier", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := s.FetchVersion(t.Context(), "cfg#1")
+		require.Error(t, err)
+	})
+
+	t.Run("FetchVersion propagates get error", func(t *testing.T) {
+		t.Parallel()
+
+		boom := errors.New("boom")
+		store := &providermock.Store{
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) { return nil, boom },
+		}
+		_, _, err := staging.NewAzureAppConfigParamStrategy(store).FetchVersion(t.Context(), "cfg")
+		require.ErrorIs(t, err, boom)
+	})
+}
+
+func TestAzureAppConfigParamParserFactory(t *testing.T) {
+	t.Parallel()
+
+	p := staging.AzureAppConfigParamParserFactory()
+	assert.Equal(t, staging.ServiceParam, p.Service())
+	assert.False(t, p.HasDeleteOptions())
+}

--- a/internal/staging/azure_keyvault_secret.go
+++ b/internal/staging/azure_keyvault_secret.go
@@ -1,0 +1,258 @@
+package staging
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/samber/lo"
+
+	"github.com/mpyw/suve/internal/domain"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/version/azurekvversion"
+)
+
+// AzureKeyVaultSecretStrategy implements the staging strategies for Azure Key
+// Vault secrets. Like the other strategies it is backed by a provider.Store and
+// carries no cloud SDK dependency. Key Vault specifics:
+//
+//   - Versions are opaque ids, parsed with azurekvversion (#ID, ~SHIFT); a
+//     staged "edit" applies as a new version via Put.
+//   - There are no force / recovery-window delete options (delete is a soft
+//     delete), so HasDeleteOptions reports false.
+//   - Tags are writable, so tag/untag staging is supported.
+//   - Conflict detection uses the secret's last-modified timestamp, like AWS.
+//
+// A nil store yields a parser-only strategy (ParseName/ParseSpec).
+type AzureKeyVaultSecretStrategy struct {
+	store provider.Store
+}
+
+// NewAzureKeyVaultSecretStrategy creates an Azure Key Vault staging strategy
+// over the given provider store. A nil store is allowed for parser-only use.
+func NewAzureKeyVaultSecretStrategy(store provider.Store) *AzureKeyVaultSecretStrategy {
+	return &AzureKeyVaultSecretStrategy{store: store}
+}
+
+// Service returns the service type.
+func (s *AzureKeyVaultSecretStrategy) Service() Service { return ServiceSecret }
+
+// ServiceName returns the user-friendly service name.
+func (s *AzureKeyVaultSecretStrategy) ServiceName() string { return "Key Vault" }
+
+// ItemName returns the item name for messages.
+func (s *AzureKeyVaultSecretStrategy) ItemName() string { return "secret" } //nolint:goconst // per-strategy item name literal
+
+// HasDeleteOptions returns false: Azure Key Vault has no force / recovery-window
+// delete options in this abstraction.
+func (s *AzureKeyVaultSecretStrategy) HasDeleteOptions() bool { return false }
+
+// Apply applies a staged operation to Azure Key Vault.
+func (s *AzureKeyVaultSecretStrategy) Apply(ctx context.Context, name string, entry Entry) error {
+	switch entry.Operation {
+	case OperationCreate:
+		return s.applyCreate(ctx, name, entry)
+	case OperationUpdate:
+		return s.applyUpdate(ctx, name, entry)
+	case OperationDelete:
+		return s.applyDelete(ctx, name)
+	default:
+		return fmt.Errorf("unknown operation: %s", entry.Operation)
+	}
+}
+
+func (s *AzureKeyVaultSecretStrategy) applyCreate(ctx context.Context, name string, entry Entry) error {
+	if _, err := s.store.Create(ctx, name, lo.FromPtr(entry.Value), domain.ValueTypeSecret, lo.FromPtr(entry.Description)); err != nil {
+		return fmt.Errorf("failed to create secret: %w", err)
+	}
+
+	return nil
+}
+
+func (s *AzureKeyVaultSecretStrategy) applyUpdate(ctx context.Context, name string, entry Entry) error {
+	if entry.Value == nil {
+		return nil
+	}
+
+	// Key Vault versions are immutable: Put adds a new version.
+	if _, err := s.store.Put(ctx, name, *entry.Value, domain.ValueTypeSecret, lo.FromPtr(entry.Description)); err != nil {
+		return fmt.Errorf("failed to update secret: %w", err)
+	}
+
+	return nil
+}
+
+func (s *AzureKeyVaultSecretStrategy) applyDelete(ctx context.Context, name string) error {
+	if err := s.store.Delete(ctx, name); err != nil {
+		if errors.Is(err, provider.ErrNotFound) {
+			return nil
+		}
+
+		return fmt.Errorf("failed to delete secret: %w", err)
+	}
+
+	return nil
+}
+
+// ApplyTags applies staged tag changes to the secret.
+func (s *AzureKeyVaultSecretStrategy) ApplyTags(ctx context.Context, name string, tagEntry TagEntry) error {
+	if len(tagEntry.Add) > 0 {
+		if err := s.store.Tag(ctx, name, tagEntry.Add); err != nil {
+			return err
+		}
+	}
+
+	if tagEntry.Remove.Len() > 0 {
+		if err := s.store.Untag(ctx, name, tagEntry.Remove.Values()); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// FetchLastModified returns the last modified time of the secret. Returns zero
+// time if the secret doesn't exist.
+func (s *AzureKeyVaultSecretStrategy) FetchLastModified(ctx context.Context, name string) (time.Time, error) {
+	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
+	if err != nil {
+		if errors.Is(err, provider.ErrNotFound) {
+			return time.Time{}, nil
+		}
+
+		return time.Time{}, fmt.Errorf("failed to get secret: %w", err)
+	}
+
+	if entry.Modified != nil {
+		return *entry.Modified, nil
+	}
+
+	return time.Time{}, nil
+}
+
+// FetchCurrent fetches the current value from Key Vault for diffing.
+func (s *AzureKeyVaultSecretStrategy) FetchCurrent(ctx context.Context, name string) (*FetchResult, error) {
+	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &FetchResult{
+		Value:      entry.Value,
+		Identifier: "#" + entry.Version.ID,
+	}, nil
+}
+
+// FetchCurrentTags fetches the current tags from Key Vault.
+func (s *AzureKeyVaultSecretStrategy) FetchCurrentTags(ctx context.Context, name string) (map[string]string, error) {
+	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
+	if err != nil {
+		if errors.Is(err, provider.ErrNotFound) {
+			return nil, nil //nolint:nilnil // intentional: no tags for non-existent resource
+		}
+
+		return nil, fmt.Errorf("failed to get secret: %w", err)
+	}
+
+	if len(entry.Tags) == 0 {
+		return nil, nil //nolint:nilnil // intentional: resource exists but has no tags
+	}
+
+	tags := make(map[string]string, len(entry.Tags))
+	for _, tag := range entry.Tags {
+		tags[tag.Key] = tag.Value
+	}
+
+	return tags, nil
+}
+
+// ParseName parses and validates a name for editing (no version specifier).
+func (s *AzureKeyVaultSecretStrategy) ParseName(input string) (string, error) {
+	spec, err := azurekvversion.Parse(input)
+	if err != nil {
+		return "", err
+	}
+
+	if spec.Absolute.ID != nil || spec.Shift > 0 {
+		return "", fmt.Errorf("stage diff requires a secret name without version specifier")
+	}
+
+	return spec.Name, nil
+}
+
+// FetchCurrentValue fetches the current value from Key Vault for editing.
+func (s *AzureKeyVaultSecretStrategy) FetchCurrentValue(ctx context.Context, name string) (*EditFetchResult, error) {
+	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
+	if err != nil {
+		if errors.Is(err, provider.ErrNotFound) {
+			return nil, &ResourceNotFoundError{Err: err}
+		}
+
+		return nil, err
+	}
+
+	result := &EditFetchResult{Value: entry.Value}
+	if entry.Modified != nil {
+		result.LastModified = *entry.Modified
+	}
+
+	return result, nil
+}
+
+// ParseSpec parses a version spec string for reset.
+func (s *AzureKeyVaultSecretStrategy) ParseSpec(input string) (name string, hasVersion bool, err error) {
+	spec, err := azurekvversion.Parse(input)
+	if err != nil {
+		return "", false, err
+	}
+
+	hasVersion = spec.Absolute.ID != nil || spec.Shift > 0
+
+	return spec.Name, hasVersion, nil
+}
+
+// FetchVersion fetches the value for a specific version.
+func (s *AzureKeyVaultSecretStrategy) FetchVersion(ctx context.Context, input string) (value string, versionLabel string, err error) {
+	spec, err := azurekvversion.Parse(input)
+	if err != nil {
+		return "", "", err
+	}
+
+	ref, err := s.store.Resolve(ctx, spec.Name, azureKVSpecSuffix(spec))
+	if err != nil {
+		return "", "", err
+	}
+
+	entry, err := s.store.Get(ctx, spec.Name, ref)
+	if err != nil {
+		return "", "", err
+	}
+
+	return entry.Value, "#" + entry.Version.ID, nil
+}
+
+// azureKVSpecSuffix reconstructs the version-spec suffix (the part after the
+// name) so that name+suffix re-parses to an equivalent spec.
+func azureKVSpecSuffix(spec *azurekvversion.Spec) string {
+	var b strings.Builder
+
+	if spec.Absolute.ID != nil {
+		b.WriteString("#")
+		b.WriteString(*spec.Absolute.ID)
+	}
+
+	if spec.Shift > 0 {
+		b.WriteString("~")
+		b.WriteString(strconv.Itoa(spec.Shift))
+	}
+
+	return b.String()
+}
+
+// AzureKeyVaultSecretParserFactory yields a parser-only strategy.
+func AzureKeyVaultSecretParserFactory() Parser {
+	return NewAzureKeyVaultSecretStrategy(nil)
+}

--- a/internal/staging/azure_keyvault_secret.go
+++ b/internal/staging/azure_keyvault_secret.go
@@ -44,7 +44,7 @@ func (s *AzureKeyVaultSecretStrategy) Service() Service { return ServiceSecret }
 func (s *AzureKeyVaultSecretStrategy) ServiceName() string { return "Key Vault" }
 
 // ItemName returns the item name for messages.
-func (s *AzureKeyVaultSecretStrategy) ItemName() string { return "secret" } //nolint:goconst // per-strategy item name literal
+func (s *AzureKeyVaultSecretStrategy) ItemName() string { return itemNameSecret }
 
 // HasDeleteOptions returns false: Azure Key Vault has no force / recovery-window
 // delete options in this abstraction.

--- a/internal/staging/azure_keyvault_secret_test.go
+++ b/internal/staging/azure_keyvault_secret_test.go
@@ -1,0 +1,471 @@
+package staging_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/domain"
+	"github.com/mpyw/suve/internal/maputil"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/providermock"
+	"github.com/mpyw/suve/internal/staging"
+)
+
+func TestAzureKeyVaultSecretStrategy_BasicMethods(t *testing.T) {
+	t.Parallel()
+
+	s := staging.NewAzureKeyVaultSecretStrategy(nil)
+
+	assert.Equal(t, staging.ServiceSecret, s.Service())
+	assert.Equal(t, "Key Vault", s.ServiceName())
+	assert.Equal(t, "secret", s.ItemName())
+	// Key Vault has no force / recovery-window delete options.
+	assert.False(t, s.HasDeleteOptions())
+}
+
+func TestAzureKeyVaultSecretStrategy_Apply(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create", func(t *testing.T) {
+		t.Parallel()
+
+		var created string
+
+		store := &providermock.Store{
+			CreateFunc: func(_ context.Context, name, value string, vt domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
+				created = name
+
+				assert.Equal(t, "v1", value)
+				assert.Equal(t, domain.ValueTypeSecret, vt)
+
+				return domain.Version{ID: "abc"}, nil
+			},
+		}
+		s := staging.NewAzureKeyVaultSecretStrategy(store)
+
+		err := s.Apply(t.Context(), "sec", staging.Entry{Operation: staging.OperationCreate, Value: lo.ToPtr("v1")})
+		require.NoError(t, err)
+		assert.Equal(t, "sec", created)
+	})
+
+	t.Run("update adds a version via Put", func(t *testing.T) {
+		t.Parallel()
+
+		var putCalled bool
+
+		store := &providermock.Store{
+			PutFunc: func(_ context.Context, _, value string, vt domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
+				putCalled = true
+
+				assert.Equal(t, "v2", value)
+				assert.Equal(t, domain.ValueTypeSecret, vt)
+
+				return domain.Version{ID: "def"}, nil
+			},
+		}
+		s := staging.NewAzureKeyVaultSecretStrategy(store)
+
+		err := s.Apply(t.Context(), "sec", staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("v2")})
+		require.NoError(t, err)
+		assert.True(t, putCalled)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		t.Parallel()
+
+		var deleted string
+
+		store := &providermock.Store{
+			DeleteFunc: func(_ context.Context, name string, _ ...provider.DeleteOption) error {
+				deleted = name
+
+				return nil
+			},
+		}
+		s := staging.NewAzureKeyVaultSecretStrategy(store)
+
+		err := s.Apply(t.Context(), "sec", staging.Entry{Operation: staging.OperationDelete})
+		require.NoError(t, err)
+		assert.Equal(t, "sec", deleted)
+	})
+
+	t.Run("delete already-gone is success", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			DeleteFunc: func(_ context.Context, name string, _ ...provider.DeleteOption) error {
+				return secretNotFound(name)
+			},
+		}
+		s := staging.NewAzureKeyVaultSecretStrategy(store)
+
+		require.NoError(t, s.Apply(t.Context(), "sec", staging.Entry{Operation: staging.OperationDelete}))
+	})
+
+	t.Run("unknown operation errors", func(t *testing.T) {
+		t.Parallel()
+
+		s := staging.NewAzureKeyVaultSecretStrategy(&providermock.Store{})
+		err := s.Apply(t.Context(), "sec", staging.Entry{Operation: staging.Operation("bogus")})
+		require.Error(t, err)
+	})
+}
+
+func TestAzureKeyVaultSecretStrategy_ApplyTags(t *testing.T) {
+	t.Parallel()
+
+	var added map[string]string
+
+	var removed []string
+
+	store := &providermock.Store{
+		TagFunc: func(_ context.Context, _ string, add map[string]string) error {
+			added = add
+
+			return nil
+		},
+		UntagFunc: func(_ context.Context, _ string, keys []string) error {
+			removed = keys
+
+			return nil
+		},
+	}
+	s := staging.NewAzureKeyVaultSecretStrategy(store)
+
+	err := s.ApplyTags(t.Context(), "sec", staging.TagEntry{
+		Add:    map[string]string{"env": "prod"},
+		Remove: maputil.NewSet("old"),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"env": "prod"}, added)
+	assert.Equal(t, []string{"old"}, removed)
+}
+
+func TestAzureKeyVaultSecretStrategy_FetchLastModified(t *testing.T) {
+	t.Parallel()
+
+	mod := time.Date(2024, 3, 4, 5, 6, 7, 0, time.UTC)
+
+	t.Run("returns modified time", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) {
+				return &domain.Entry{Modified: &mod}, nil
+			},
+		}
+		got, err := staging.NewAzureKeyVaultSecretStrategy(store).FetchLastModified(t.Context(), "sec")
+		require.NoError(t, err)
+		assert.Equal(t, mod, got)
+	})
+
+	t.Run("not found yields zero time, no error", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+				return nil, secretNotFound(name)
+			},
+		}
+		got, err := staging.NewAzureKeyVaultSecretStrategy(store).FetchLastModified(t.Context(), "sec")
+		require.NoError(t, err)
+		assert.True(t, got.IsZero())
+	})
+
+	t.Run("nil Modified yields zero time", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) {
+				return &domain.Entry{Value: "v"}, nil
+			},
+		}
+		got, err := staging.NewAzureKeyVaultSecretStrategy(store).FetchLastModified(t.Context(), "sec")
+		require.NoError(t, err)
+		assert.True(t, got.IsZero())
+	})
+}
+
+func TestAzureKeyVaultSecretStrategy_FetchAndTags(t *testing.T) {
+	t.Parallel()
+
+	mod := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	store := &providermock.Store{
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{
+				Name:     name,
+				Value:    "current",
+				Version:  domain.Version{ID: "abc123"},
+				Modified: &mod,
+				Tags:     []domain.Tag{{Key: "env", Value: "prod"}},
+			}, nil
+		},
+	}
+	s := staging.NewAzureKeyVaultSecretStrategy(store)
+
+	fr, err := s.FetchCurrent(t.Context(), "sec")
+	require.NoError(t, err)
+	assert.Equal(t, "current", fr.Value)
+	assert.Equal(t, "#abc123", fr.Identifier)
+
+	tags, err := s.FetchCurrentTags(t.Context(), "sec")
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"env": "prod"}, tags)
+
+	efr, err := s.FetchCurrentValue(t.Context(), "sec")
+	require.NoError(t, err)
+	assert.Equal(t, "current", efr.Value)
+	assert.Equal(t, mod, efr.LastModified)
+}
+
+func TestAzureKeyVaultSecretStrategy_ParseAndResolve(t *testing.T) {
+	t.Parallel()
+
+	s := staging.NewAzureKeyVaultSecretStrategy(&providermock.Store{})
+
+	t.Run("ParseName rejects version specifiers", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := s.ParseName("sec#abc123")
+		require.Error(t, err)
+
+		_, err = s.ParseName("sec~1")
+		require.Error(t, err)
+
+		name, err := s.ParseName("sec")
+		require.NoError(t, err)
+		assert.Equal(t, "sec", name)
+	})
+
+	t.Run("ParseSpec detects opaque version", func(t *testing.T) {
+		t.Parallel()
+
+		name, hasVersion, err := s.ParseSpec("sec#abc123")
+		require.NoError(t, err)
+		assert.Equal(t, "sec", name)
+		assert.True(t, hasVersion)
+
+		_, hasVersion, err = s.ParseSpec("sec")
+		require.NoError(t, err)
+		assert.False(t, hasVersion)
+	})
+
+	t.Run("FetchVersion resolves opaque id suffix", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+				assert.Equal(t, "#abc123", spec)
+
+				return provider.NewVersionRef("abc123"), nil
+			},
+			GetFunc: func(_ context.Context, _ string, ref provider.VersionRef) (*domain.Entry, error) {
+				assert.Equal(t, "abc123", ref.ID())
+
+				return &domain.Entry{Value: "old", Version: domain.Version{ID: "abc123"}}, nil
+			},
+		}
+		value, label, err := staging.NewAzureKeyVaultSecretStrategy(store).FetchVersion(t.Context(), "sec#abc123")
+		require.NoError(t, err)
+		assert.Equal(t, "old", value)
+		assert.Equal(t, "#abc123", label)
+	})
+
+	t.Run("FetchVersion reconstructs id + shift suffix", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+				assert.Equal(t, "#abc123~1", spec)
+
+				return provider.NewVersionRef("older"), nil
+			},
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) {
+				return &domain.Entry{Value: "v", Version: domain.Version{ID: "older"}}, nil
+			},
+		}
+		_, _, err := staging.NewAzureKeyVaultSecretStrategy(store).FetchVersion(t.Context(), "sec#abc123~1")
+		require.NoError(t, err)
+	})
+}
+
+func TestAzureKeyVaultSecretStrategy_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	boom := errors.New("boom")
+
+	t.Run("create error is wrapped", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			CreateFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
+				return domain.Version{}, boom
+			},
+		}
+		s := staging.NewAzureKeyVaultSecretStrategy(store)
+		err := s.Apply(t.Context(), "s", staging.Entry{Operation: staging.OperationCreate, Value: lo.ToPtr("v")})
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("update with nil value is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		s := staging.NewAzureKeyVaultSecretStrategy(&providermock.Store{})
+		require.NoError(t, s.Apply(t.Context(), "s", staging.Entry{Operation: staging.OperationUpdate}))
+	})
+
+	t.Run("update error is wrapped", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			PutFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
+				return domain.Version{}, boom
+			},
+		}
+		s := staging.NewAzureKeyVaultSecretStrategy(store)
+		err := s.Apply(t.Context(), "s", staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("v")})
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("delete error (non-not-found) is wrapped", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			DeleteFunc: func(_ context.Context, _ string, _ ...provider.DeleteOption) error { return boom },
+		}
+		err := staging.NewAzureKeyVaultSecretStrategy(store).Apply(t.Context(), "s", staging.Entry{Operation: staging.OperationDelete})
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("ApplyTags surfaces tag and untag errors", func(t *testing.T) {
+		t.Parallel()
+
+		tagErr := &providermock.Store{TagFunc: func(_ context.Context, _ string, _ map[string]string) error { return boom }}
+		err := staging.NewAzureKeyVaultSecretStrategy(tagErr).ApplyTags(t.Context(), "s", staging.TagEntry{Add: map[string]string{"k": "v"}})
+		require.ErrorIs(t, err, boom)
+
+		untagErr := &providermock.Store{UntagFunc: func(_ context.Context, _ string, _ []string) error { return boom }}
+		err = staging.NewAzureKeyVaultSecretStrategy(untagErr).ApplyTags(t.Context(), "s", staging.TagEntry{Remove: maputil.NewSet("k")})
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("FetchLastModified wraps non-not-found error", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) { return nil, boom },
+		}
+		_, err := staging.NewAzureKeyVaultSecretStrategy(store).FetchLastModified(t.Context(), "s")
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("FetchCurrent propagates error", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) { return nil, boom },
+		}
+		_, err := staging.NewAzureKeyVaultSecretStrategy(store).FetchCurrent(t.Context(), "s")
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("FetchCurrentTags: not-found and empty yield nil, error wrapped", func(t *testing.T) {
+		t.Parallel()
+
+		notFound := &providermock.Store{
+			GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+				return nil, secretNotFound(name)
+			},
+		}
+		tags, err := staging.NewAzureKeyVaultSecretStrategy(notFound).FetchCurrentTags(t.Context(), "s")
+		require.NoError(t, err)
+		assert.Nil(t, tags)
+
+		empty := &providermock.Store{
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) {
+				return &domain.Entry{}, nil
+			},
+		}
+		tags, err = staging.NewAzureKeyVaultSecretStrategy(empty).FetchCurrentTags(t.Context(), "s")
+		require.NoError(t, err)
+		assert.Nil(t, tags)
+
+		errStore := &providermock.Store{
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) { return nil, boom },
+		}
+		_, err = staging.NewAzureKeyVaultSecretStrategy(errStore).FetchCurrentTags(t.Context(), "s")
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("FetchCurrentValue: not-found maps to ResourceNotFoundError, other errors pass through", func(t *testing.T) {
+		t.Parallel()
+
+		notFound := &providermock.Store{
+			GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+				return nil, secretNotFound(name)
+			},
+		}
+		_, err := staging.NewAzureKeyVaultSecretStrategy(notFound).FetchCurrentValue(t.Context(), "s")
+
+		var rnf *staging.ResourceNotFoundError
+
+		require.ErrorAs(t, err, &rnf)
+
+		errStore := &providermock.Store{
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) { return nil, boom },
+		}
+		_, err = staging.NewAzureKeyVaultSecretStrategy(errStore).FetchCurrentValue(t.Context(), "s")
+		require.ErrorIs(t, err, boom)
+	})
+
+	t.Run("parse errors surface", func(t *testing.T) {
+		t.Parallel()
+
+		s := staging.NewAzureKeyVaultSecretStrategy(&providermock.Store{})
+
+		_, err := s.ParseName("sec:label")
+		require.Error(t, err)
+
+		_, _, err = s.ParseSpec("sec:label")
+		require.Error(t, err)
+
+		_, _, err = s.FetchVersion(t.Context(), "sec:label")
+		require.Error(t, err)
+	})
+
+	t.Run("FetchVersion propagates resolve and get errors", func(t *testing.T) {
+		t.Parallel()
+
+		resolveErr := &providermock.Store{
+			ResolveFunc: func(_ context.Context, _, _ string) (provider.VersionRef, error) {
+				return provider.VersionRef{}, boom
+			},
+		}
+		_, _, err := staging.NewAzureKeyVaultSecretStrategy(resolveErr).FetchVersion(t.Context(), "sec#abc")
+		require.ErrorIs(t, err, boom)
+
+		getErr := &providermock.Store{
+			ResolveFunc: func(_ context.Context, _, _ string) (provider.VersionRef, error) {
+				return provider.NewVersionRef("abc"), nil
+			},
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) { return nil, boom },
+		}
+		_, _, err = staging.NewAzureKeyVaultSecretStrategy(getErr).FetchVersion(t.Context(), "sec#abc")
+		require.ErrorIs(t, err, boom)
+	})
+}
+
+func TestAzureKeyVaultSecretParserFactory(t *testing.T) {
+	t.Parallel()
+
+	p := staging.AzureKeyVaultSecretParserFactory()
+	assert.Equal(t, staging.ServiceSecret, p.Service())
+	assert.False(t, p.HasDeleteOptions())
+}

--- a/internal/staging/gcloud_secret.go
+++ b/internal/staging/gcloud_secret.go
@@ -49,7 +49,7 @@ func (s *GoogleCloudSecretStrategy) ServiceName() string {
 
 // ItemName returns the item name for messages.
 func (s *GoogleCloudSecretStrategy) ItemName() string {
-	return "secret"
+	return itemNameSecret
 }
 
 // HasDeleteOptions returns false: Google Cloud Secret Manager has no force /

--- a/internal/staging/secret.go
+++ b/internal/staging/secret.go
@@ -41,7 +41,7 @@ func (s *SecretStrategy) ServiceName() string {
 
 // ItemName returns the item name for messages.
 func (s *SecretStrategy) ItemName() string {
-	return "secret"
+	return itemNameSecret
 }
 
 // HasDeleteOptions returns true as Secrets Manager has delete options.

--- a/internal/staging/service.go
+++ b/internal/staging/service.go
@@ -5,6 +5,11 @@ import (
 	"time"
 )
 
+// itemNameSecret is the display item name shared by the secret staging
+// strategies (AWS Secrets Manager, Google Cloud Secret Manager, Azure Key
+// Vault). Centralizing it avoids repeating the literal across strategies.
+const itemNameSecret = "secret"
+
 // ResourceNotFoundError indicates a resource was not found in AWS.
 type ResourceNotFoundError struct {
 	Err error


### PR DESCRIPTION
Completes multi-provider staging (#247) by bringing the local-staging → apply workflow to **both Azure services**, reusing the provider-driven generalization from the Google Cloud staging PR (#261).

## Per-service (by design)

Azure staging is **per-service** because Key Vault and App Configuration have distinct staging scope keys (`azure/<sub>/<rg>/keyvault|appconfig/<name>`) — keying them separately prevents applying secrets staged for one vault/store to another. So, unlike `aws stage`, there is **no cross-service `azure stage status/apply` aggregate**; each service is a full independent workflow:

- **`suve azure stage secret`** — Key Vault. Opaque-id versions (a staged `edit` applies as a new version), tags supported, `LastModified`-based conflict detection. Full workflow incl. `tag`/`untag`/`stash`.
- **`suve azure stage param`** — App Configuration. **Unversioned → last-write-wins**: `FetchLastModified` returns zero and `edit` records no conflict base, so `apply` never reports a modified-after conflict. Tags aren't writable, so `tag`/`untag` are omitted.

## Wiring

Two new staging strategies (`azurekvversion` / `azureappconfigversion` parsers), per-service scope resolvers + strategy factories, the `azure stage` group (secret + param subgroups, each owning its `--vault-name` / `--store-name` flag), the flat `suve stage` alias for Azure, and `detect` now treats Azure as staging-capable when either service is active.

## Testing

- Unit tests for both strategies (100% of the new source), incl. the last-write-wins and tags-unsupported semantics.
- e2e (`e2e/azure_stage_test.go`): status/diff/apply for update/create/delete against **lowkey-vault** (Key Vault) and the **forked App Configuration emulator** — both run in the existing `e2e-azure` CI job (matched by the `TestAzureAppConfig|TestAzureKeyVault` filter). Verified locally on fresh emulators.
- Full unit suite + `golangci-lint` green.

Docs: README feature matrix + command reference + provider-selection examples; docs/azure.md staging section.

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155B8urnRZNHqfLrEnpxUE9