### PR TITLE
ci: run the Windows GUI Playwright test on every PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -265,7 +265,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     defaults:
       run:
         working-directory: internal/gui/frontend
@@ -477,42 +477,6 @@ jobs:
             suve --version
             suve --help
           '
-
-  gui-test-windows:
-    name: GUI Test (Playwright) (Windows)
-    runs-on: windows-latest
-    if: >-
-      github.ref == 'refs/heads/main' ||
-      contains(github.event.head_commit.message, '[CI: windows]')
-    defaults:
-      run:
-        working-directory: internal/gui/frontend
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Set up toolchain (mise)
-        uses: jdx/mise-action@v4
-        with:
-          install_args: "node"
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
-
-      - name: Run Playwright tests
-        run: npm test
-
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@v6
-        if: ${{ !cancelled() }}
-        with:
-          name: playwright-report-windows-latest
-          path: internal/gui/frontend/playwright-report/
-          retention-days: 30
 
   platform-test:
     name: Platform Test (${{ matrix.os }})


### PR DESCRIPTION
The `gui-test-windows` job was gated behind `github.ref == 'refs/heads/main' || commit message contains '[CI: windows]'`, so the **Windows GUI Playwright test was skipped on pull requests** (it showed up as "GUI Test (Playwright) (Windows): skipped").

This folds `windows-latest` into the main `gui-test` matrix (`ubuntu-latest` + `macos-latest` + `windows-latest`) and removes the separate gated job, so the Windows GUI test **runs on every PR and push** — establishing the gate before the multi-cloud GUI work lands.

Note: the repo currently has **no branch protection**, so this makes the Windows check *run and be visible* on PRs, but "cannot merge unless it passes" additionally requires enabling it as a **required status check** in branch protection (needs repo admin — happy to do it if you grant the scope, or you can toggle it in Settings → Branches).

Part of #269 · Epic #250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155B8urnRZNHqfLrEnpxUE9