### PR TITLE
feat(gui): make --gui a per-provider alias

### DIFF
--- a/cmd/suve/gui.go
+++ b/cmd/suve/gui.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"os"
 	"strings"
 
@@ -12,20 +13,90 @@ import (
 
 	"github.com/mpyw/suve/internal/cli/commands"
 	"github.com/mpyw/suve/internal/gui"
+	"github.com/mpyw/suve/internal/provider"
 )
 
+// errInvalidGUIProvider is returned when a bare `suve --gui` cannot resolve a
+// single active provider from the environment (0 or 2+ active). The user must
+// choose explicitly with `suve <provider> --gui`.
+var errInvalidGUIProvider = errors.New(
+	"--gui: cannot determine a unique active provider from the environment; " +
+		"launch a specific one with `suve aws --gui`, `suve gcloud --gui`, or `suve azure --gui`",
+)
+
+// launchGUI runs the GUI with the given initial provider and exits. It is the
+// short-circuit used by the --gui flags' Before hooks.
+func launchGUI(ctx context.Context, initial provider.Provider) (context.Context, error) {
+	if err := gui.Run(initial); err != nil {
+		return ctx, err
+	}
+
+	os.Exit(0)
+
+	return ctx, nil
+}
+
+// groupProvider maps a top-level command group name to its provider, or "" when
+// the command is not a provider group.
+func groupProvider(name string) provider.Provider {
+	switch name {
+	case "aws":
+		return provider.ProviderAWS
+	case "gcloud":
+		return provider.ProviderGoogleCloud
+	case "azure":
+		return provider.ProviderAzure
+	default:
+		return ""
+	}
+}
+
 func registerGUIFlag() {
+	// Bare `suve --gui`: initial provider resolved from the environment.
 	commands.App.Flags = append(commands.App.Flags, &cli.BoolFlag{
 		Name:  "gui",
-		Usage: "Launch GUI mode",
+		Usage: "Launch GUI mode (bare form picks the uniquely-active provider)",
 	})
 	commands.App.Before = func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
 		if cmd.Bool("gui") {
-			if err := gui.Run(); err != nil {
-				return ctx, err
+			initial := gui.InitialProviderFromEnv()
+			if initial == "" {
+				return ctx, errInvalidGUIProvider
 			}
 
-			os.Exit(0)
+			return launchGUI(ctx, initial)
+		}
+
+		return ctx, nil
+	}
+
+	// Per-provider `suve <group> --gui`: launch with that provider pre-selected.
+	for _, group := range commands.App.Commands {
+		p := groupProvider(group.Name)
+		if p == "" {
+			continue
+		}
+
+		attachGUIFlag(group, p)
+	}
+}
+
+// attachGUIFlag adds a --gui flag to a provider group and wraps its Before hook
+// so `suve <group> --gui` launches the GUI with that provider.
+func attachGUIFlag(group *cli.Command, p provider.Provider) {
+	group.Flags = append(group.Flags, &cli.BoolFlag{
+		Name:  "gui",
+		Usage: "Launch GUI mode for this provider",
+	})
+
+	inner := group.Before
+	group.Before = func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+		if cmd.Bool("gui") {
+			return launchGUI(ctx, p)
+		}
+
+		if inner != nil {
+			return inner(ctx, cmd)
 		}
 
 		return ctx, nil

--- a/gui/main.go
+++ b/gui/main.go
@@ -9,7 +9,9 @@ import (
 )
 
 func main() {
-	if err := gui.Run(); err != nil {
+	// The standalone Wails dev/build entry resolves the initial provider from
+	// the environment (same as a bare `suve --gui`).
+	if err := gui.Run(gui.InitialProviderFromEnv()); err != nil {
 		log.Fatal("Error: ", err.Error())
 	}
 }

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -6,6 +6,7 @@ package gui
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/mpyw/suve/internal/infra"
@@ -57,6 +58,12 @@ var defaultScope = provider.Scope{Provider: provider.ProviderAWS}
 type App struct {
 	ctx context.Context
 
+	// initialProvider is the provider the GUI was launched with (from
+	// `suve <provider> --gui`, or the resolved unique-active provider for a bare
+	// `suve --gui`). Empty means no explicit choice. Surfaced to the frontend
+	// via InitialProvider for the initial selection.
+	initialProvider provider.Provider
+
 	// scope is the current read/write provider scope, selected from the
 	// frontend via SelectScope. Guarded by scopeMu.
 	scope   provider.Scope
@@ -67,9 +74,41 @@ type App struct {
 	stagingStoreMu sync.Mutex // protects stagingStore initialization
 }
 
-// NewApp creates a new App application struct.
-func NewApp() *App {
-	return &App{scope: defaultScope}
+// NewApp creates a new App with the given initial provider. The initial
+// read/write scope is derived from that provider using the ambient environment
+// (project / subscription / resource-group / vault / store); an empty provider
+// defaults to AWS.
+func NewApp(initial provider.Provider) *App {
+	return &App{
+		initialProvider: initial,
+		scope:           initialScope(initial),
+	}
+}
+
+// initialScope derives the launch scope for a provider from the environment.
+func initialScope(p provider.Provider) provider.Scope {
+	switch p {
+	case provider.ProviderGoogleCloud:
+		return provider.GoogleCloudScope(os.Getenv("GOOGLE_CLOUD_PROJECT"))
+	case provider.ProviderAzure:
+		return provider.Scope{
+			Provider:       provider.ProviderAzure,
+			SubscriptionID: os.Getenv("AZURE_SUBSCRIPTION_ID"),
+			ResourceGroup:  os.Getenv("AZURE_RESOURCE_GROUP"),
+			VaultName:      os.Getenv("AZURE_KEYVAULT_NAME"),
+			StoreName:      os.Getenv("AZURE_APPCONFIG_NAME"),
+		}
+	case provider.ProviderAWS:
+		return provider.Scope{Provider: provider.ProviderAWS}
+	default:
+		return defaultScope
+	}
+}
+
+// InitialProvider returns the provider the GUI was launched with (empty when no
+// explicit `--gui` provider was chosen), so the frontend can pre-select it.
+func (a *App) InitialProvider() string {
+	return string(a.initialProvider)
 }
 
 // Startup is called when the app starts.

--- a/internal/gui/app_internal_test.go
+++ b/internal/gui/app_internal_test.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider"
 )
 
 func TestStringError_Error(t *testing.T) {
@@ -25,7 +27,7 @@ func TestErrInvalidService(t *testing.T) {
 func TestNewApp(t *testing.T) {
 	t.Parallel()
 
-	app := NewApp()
+	app := NewApp(provider.ProviderAWS)
 	assert.NotNil(t, app)
 	// Verify the staging store is nil (lazy initialization).
 	assert.Nil(t, app.stagingStore)
@@ -34,7 +36,7 @@ func TestNewApp(t *testing.T) {
 func TestApp_Startup(t *testing.T) {
 	t.Parallel()
 
-	app := NewApp()
+	app := NewApp(provider.ProviderAWS)
 	assert.Nil(t, app.ctx)
 
 	app.Startup(t.Context())

--- a/internal/gui/frontend/wailsjs/go/gui/App.d.ts
+++ b/internal/gui/frontend/wailsjs/go/gui/App.d.ts
@@ -8,6 +8,8 @@ export function DetectProviders():Promise<gui.DetectResult>;
 
 export function GetAWSIdentity():Promise<gui.AWSIdentityResult>;
 
+export function InitialProvider():Promise<string>;
+
 export function ParamAddTag(arg1:string,arg2:string,arg3:string):Promise<void>;
 
 export function ParamDelete(arg1:string):Promise<gui.ParamDeleteResult>;

--- a/internal/gui/frontend/wailsjs/go/gui/App.js
+++ b/internal/gui/frontend/wailsjs/go/gui/App.js
@@ -14,6 +14,10 @@ export function GetAWSIdentity() {
   return window['go']['gui']['App']['GetAWSIdentity']();
 }
 
+export function InitialProvider() {
+  return window['go']['gui']['App']['InitialProvider']();
+}
+
 export function ParamAddTag(arg1, arg2, arg3) {
   return window['go']['gui']['App']['ParamAddTag'](arg1, arg2, arg3);
 }

--- a/internal/gui/providers.go
+++ b/internal/gui/providers.go
@@ -40,6 +40,40 @@ func (a *App) DetectProviders() *DetectResult {
 	}
 }
 
+// InitialProviderFromEnv resolves the initial provider for a bare `suve --gui`
+// (and the standalone Wails entry) from the environment: the uniquely-active
+// provider across services, or "" when zero or two-plus are active (the
+// frontend then shows the selector). Env-only; no network calls.
+func InitialProviderFromEnv() provider.Provider {
+	return uniqueActiveProvider(detect.Resolve(detect.OSEnvironment()))
+}
+
+// uniqueActiveProvider returns the sole provider active across the param and
+// secret services, or "" when zero or two-or-more distinct providers are
+// active. Mirrors the CLI's per-service "exactly one active" rule, applied to
+// the union across services for the GUI's initial provider pick.
+func uniqueActiveProvider(r detect.Result) provider.Provider {
+	seen := make(map[provider.Provider]struct{})
+
+	for _, p := range r.SecretActive {
+		seen[p] = struct{}{}
+	}
+
+	for _, p := range r.ParamActive {
+		seen[p] = struct{}{}
+	}
+
+	if len(seen) != 1 {
+		return ""
+	}
+
+	for p := range seen {
+		return p
+	}
+
+	return ""
+}
+
 func providerStrings(ps []provider.Provider) []string {
 	out := make([]string, 0, len(ps))
 	for _, p := range ps {

--- a/internal/gui/providers_internal_test.go
+++ b/internal/gui/providers_internal_test.go
@@ -1,0 +1,71 @@
+//go:build production || dev
+
+package gui
+
+import (
+	"testing"
+
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/detect"
+)
+
+func TestUniqueActiveProvider(t *testing.T) {
+	t.Parallel()
+
+	aws := provider.ProviderAWS
+	gcloud := provider.ProviderGoogleCloud
+	az := provider.ProviderAzure
+
+	tests := []struct {
+		name   string
+		result detect.Result
+		want   provider.Provider
+	}{
+		{
+			name:   "none active -> empty",
+			result: detect.Result{},
+			want:   "",
+		},
+		{
+			name:   "single provider (secret only) -> that provider",
+			result: detect.Result{SecretActive: []provider.Provider{gcloud}},
+			want:   gcloud,
+		},
+		{
+			name:   "single provider (param only) -> that provider",
+			result: detect.Result{ParamActive: []provider.Provider{az}},
+			want:   az,
+		},
+		{
+			name: "same provider across both services -> that provider",
+			result: detect.Result{
+				ParamActive:  []provider.Provider{aws},
+				SecretActive: []provider.Provider{aws},
+			},
+			want: aws,
+		},
+		{
+			name: "two distinct providers -> empty (ambiguous)",
+			result: detect.Result{
+				ParamActive:  []provider.Provider{aws},
+				SecretActive: []provider.Provider{gcloud},
+			},
+			want: "",
+		},
+		{
+			name:   "two active in one service -> empty (ambiguous)",
+			result: detect.Result{SecretActive: []provider.Provider{aws, az}},
+			want:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := uniqueActiveProvider(tt.result); got != tt.want {
+				t.Errorf("uniqueActiveProvider() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/gui/run.go
+++ b/internal/gui/run.go
@@ -6,11 +6,14 @@ import (
 	"github.com/wailsapp/wails/v2"
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
+
+	"github.com/mpyw/suve/internal/provider"
 )
 
-// Run starts the GUI application.
-func Run() error {
-	app := NewApp()
+// Run starts the GUI application with the given initial provider selection
+// (empty means "no explicit choice" — the frontend falls back to env detection).
+func Run(initial provider.Provider) error {
+	app := NewApp(initial)
 
 	opts := &options.App{
 		Title:  "suve",

--- a/internal/gui/staging_integration_internal_test.go
+++ b/internal/gui/staging_integration_internal_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/mpyw/suve/internal/maputil"
+	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store/file"
 	"github.com/mpyw/suve/internal/staging/store/testutil"
@@ -23,7 +24,7 @@ import (
 func setupTestApp(t *testing.T) *App {
 	t.Helper()
 
-	app := NewApp()
+	app := NewApp(provider.ProviderAWS)
 	app.Startup(t.Context())
 	app.stagingStore = testutil.NewMockStore()
 


### PR DESCRIPTION
`--gui` was a **global** flag that always launched the AWS GUI. This makes it a per-provider alias.

## Behavior
- `suve aws --gui` / `suve gcloud --gui` / `suve azure --gui` — launch with that provider pre-selected (a `--gui` flag on each provider group whose `Before` short-circuits to the GUI).
- **Bare `suve --gui`** — resolves the *uniquely-active* provider from the environment (union across services). When 0 or 2+ are active it **errors** (directing to `suve <provider> --gui`) rather than launching — consistent with the flat `param`/`secret`/`stage` alias rule ("omittable only when uniquely resolvable"). Plain-AWS users (creds file, no env) still get AWS via the detect fallback.

## Backend
- `gui.Run(initial provider.Provider)`; `NewApp` seeds the initial read/write scope from the launch provider using ambient env (GCP project; Azure subscription/resource-group/vault/store); empty → AWS.
- New `InitialProvider()` binding surfaces the launch provider to the frontend (consumed by the selector in #266). Bindings regenerated.

## Tests
- Resolution logic extracted to the pure `uniqueActiveProvider` helper in `internal/gui`, unit-tested for **0 / 1 / same-provider-both-services / 2+** cases (run by the `gui-go-test` CI job) — same policy as the CLI aliases.
- Verified: builds (`-tags dev`), GUI Go tests pass, ambiguous `--gui` errors without launching, production-tag lint clean, `svelte-check` 0 errors.

Closes #265 · part of the #250 epic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155B8urnRZNHqfLrEnpxUE9