### PR TITLE
feat(gui): backend prep for multi-cloud (staging guard, scope validation, per-provider parsers) (#276)

### DIFF
--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -41,6 +41,27 @@ var registry = func() *provider.Registry {
 // errInvalidProvider is returned when SelectScope is given an unknown provider.
 var errInvalidProvider = stringError("invalid provider: must be 'aws', 'googlecloud', or 'azure'")
 
+// Scope-validation errors surfaced by SelectScope. The wording is
+// GUI-appropriate (it names the field, not the CLI flag), since the frontend
+// collects these values through form inputs rather than command-line flags.
+var (
+	// errGoogleCloudProjectRequired is returned when a Google Cloud scope omits
+	// the project id.
+	errGoogleCloudProjectRequired = stringError("Google Cloud project ID is required")
+	// errAzureScopeRequired is returned when an Azure scope specifies neither a
+	// Key Vault name nor an App Configuration store name, so no service could be
+	// resolved.
+	errAzureScopeRequired = stringError("Azure requires a Key Vault name (for secrets) and/or an App Configuration store name (for parameters)")
+)
+
+// errStagingNonAWS is returned by every staging binding when the active scope is
+// not AWS. Staging in the GUI is AWS-only until scope-keyed multi-provider
+// staging lands (#270); the working store is resolved once via AWS STS and
+// cached, so applying it under a non-AWS scope would push AWS-staged entries
+// into the selected provider. The guard rejects that path before any network
+// call (no GetAWSIdentity), so selecting Google Cloud/Azure cannot corrupt data.
+var errStagingNonAWS = stringError("staging is only available for AWS (multi-provider staging is not yet supported)")
+
 // defaultScope is the initial read/write scope (AWS). The AWS factory builds
 // its SSM/Secrets Manager client from the ambient AWS config (region from
 // env/profile), so only the Provider field is needed.
@@ -147,16 +168,25 @@ func (a *App) SelectScope(sel ScopeSelection) error {
 	return nil
 }
 
-// scopeFromSelection maps a frontend selection to a provider.Scope. For Azure a
-// single scope carries both VaultName and StoreName, so the registry can build
-// either the Key Vault (secret) or App Configuration (param) store from it.
+// scopeFromSelection maps a frontend selection to a provider.Scope, rejecting
+// selections whose required fields are empty. For Azure a single scope carries
+// both VaultName and StoreName, so the registry can build either the Key Vault
+// (secret) or App Configuration (param) store from it; at least one must be set.
 func scopeFromSelection(sel ScopeSelection) (provider.Scope, error) {
 	switch provider.Provider(sel.Provider) {
 	case provider.ProviderAWS:
 		return provider.Scope{Provider: provider.ProviderAWS}, nil
 	case provider.ProviderGoogleCloud:
+		if sel.ProjectID == "" {
+			return provider.Scope{}, errGoogleCloudProjectRequired
+		}
+
 		return provider.GoogleCloudScope(sel.ProjectID), nil
 	case provider.ProviderAzure:
+		if sel.VaultName == "" && sel.StoreName == "" {
+			return provider.Scope{}, errAzureScopeRequired
+		}
+
 		return provider.Scope{
 			Provider:       provider.ProviderAzure,
 			SubscriptionID: sel.SubscriptionID,
@@ -175,6 +205,40 @@ func (a *App) currentScope() provider.Scope {
 	defer a.scopeMu.RUnlock()
 
 	return a.scope
+}
+
+// GetCurrentScope returns the active read/write scope as a ScopeSelection so the
+// frontend can prefill its provider/scope forms (including the env-derived
+// initial values from GOOGLE_CLOUD_PROJECT / AZURE_*) instead of silently wiping
+// the backend scope on first render.
+func (a *App) GetCurrentScope() *ScopeSelection {
+	return selectionFromScope(a.currentScope())
+}
+
+// selectionFromScope is the inverse of scopeFromSelection: it projects a
+// provider.Scope back to the frontend DTO. Fields irrelevant to the provider
+// stay empty.
+func selectionFromScope(s provider.Scope) *ScopeSelection {
+	return &ScopeSelection{
+		Provider:       string(s.Provider),
+		ProjectID:      s.ProjectID,
+		SubscriptionID: s.SubscriptionID,
+		ResourceGroup:  s.ResourceGroup,
+		VaultName:      s.VaultName,
+		StoreName:      s.StoreName,
+	}
+}
+
+// requireAWSStaging guards the staging bindings: it returns errStagingNonAWS
+// when the active scope is not AWS, before any network call. Every staging
+// binding calls this first so that selecting Google Cloud/Azure cannot apply
+// AWS-staged entries into another provider (see errStagingNonAWS).
+func (a *App) requireAWSStaging() error {
+	if a.currentScope().Provider != provider.ProviderAWS {
+		return errStagingNonAWS
+	}
+
+	return nil
 }
 
 // =============================================================================
@@ -205,6 +269,13 @@ func (a *App) secretStore() (provider.Store, error) {
 }
 
 func (a *App) getStagingStore() (store.ReadWriteOperator, error) {
+	// Reject non-AWS scopes before touching AWS STS or the cached store; the
+	// cached working store is keyed to the AWS identity it was built for, so
+	// serving it under a non-AWS scope is the corruption path we guard against.
+	if err := a.requireAWSStaging(); err != nil {
+		return nil, err
+	}
+
 	a.stagingStoreMu.Lock()
 	defer a.stagingStoreMu.Unlock()
 

--- a/internal/gui/capabilities_internal_test.go
+++ b/internal/gui/capabilities_internal_test.go
@@ -1,0 +1,117 @@
+//go:build production || dev
+
+package gui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider"
+)
+
+// findService returns the ServiceCapability for (provider, service) from the
+// capability descriptor, failing the test when absent.
+func findService(t *testing.T, caps []ProviderCapability, prov, service string) ServiceCapability {
+	t.Helper()
+
+	for _, p := range caps {
+		if p.Provider != prov {
+			continue
+		}
+
+		for _, s := range p.Services {
+			if s.Service == service {
+				return s
+			}
+		}
+	}
+
+	t.Fatalf("no capability for provider %q service %q", prov, service)
+
+	return ServiceCapability{}
+}
+
+// TestApp_Capabilities_StagingAndDeleteFlags pins the staging/delete capability
+// values that drive control visibility, so a stray edit to providers.go is
+// caught. Staging is AWS-only until #270; force-delete/recovery-window are AWS
+// Secrets Manager only.
+func TestApp_Capabilities_StagingAndDeleteFlags(t *testing.T) {
+	t.Parallel()
+
+	caps := (&App{}).Capabilities()
+
+	tests := []struct {
+		provider          string
+		service           string
+		hasStaging        bool
+		hasForceDelete    bool
+		hasRecoveryWindow bool
+		hasRestore        bool
+	}{
+		{string(provider.ProviderAWS), "param", true, false, false, false},
+		{string(provider.ProviderAWS), "secret", true, true, true, true},
+		{string(provider.ProviderGoogleCloud), "secret", false, false, false, false},
+		{string(provider.ProviderAzure), "param", false, false, false, false},
+		{string(provider.ProviderAzure), "secret", false, false, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider+"/"+tt.service, func(t *testing.T) {
+			t.Parallel()
+
+			svc := findService(t, caps, tt.provider, tt.service)
+			assert.Equal(t, tt.hasStaging, svc.HasStaging, "HasStaging")
+			assert.Equal(t, tt.hasForceDelete, svc.HasForceDelete, "HasForceDelete")
+			assert.Equal(t, tt.hasRecoveryWindow, svc.HasRecoveryWindow, "HasRecoveryWindow")
+			assert.Equal(t, tt.hasRestore, svc.HasRestore, "HasRestore")
+		})
+	}
+}
+
+// TestApp_Capabilities_OnlyAWSHasStaging is a stronger invariant: no non-AWS
+// service may advertise staging until multi-provider staging lands.
+func TestApp_Capabilities_OnlyAWSHasStaging(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range (&App{}).Capabilities() {
+		for _, s := range p.Services {
+			if p.Provider != string(provider.ProviderAWS) {
+				assert.False(t, s.HasStaging, "%s/%s must not have staging", p.Provider, s.Service)
+			}
+		}
+	}
+}
+
+func TestApp_ParamTypeOptions_ScopeAware(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		provider  provider.Provider
+		wantEmpty bool
+	}{
+		{name: "aws returns ssm types", provider: provider.ProviderAWS, wantEmpty: false},
+		{name: "azure app config has no types", provider: provider.ProviderAzure, wantEmpty: true},
+		{name: "googlecloud has no param types", provider: provider.ProviderGoogleCloud, wantEmpty: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := appWithProvider(tt.provider)
+
+			opts := app.ParamTypeOptions()
+			if tt.wantEmpty {
+				assert.Empty(t, opts)
+			} else {
+				require.NotEmpty(t, opts)
+				assert.Contains(t, opts, "String")
+				assert.Contains(t, opts, "SecureString")
+				assert.Contains(t, opts, "StringList")
+			}
+		})
+	}
+}

--- a/internal/gui/frontend/wailsjs/go/gui/App.d.ts
+++ b/internal/gui/frontend/wailsjs/go/gui/App.d.ts
@@ -8,6 +8,8 @@ export function DetectProviders():Promise<gui.DetectResult>;
 
 export function GetAWSIdentity():Promise<gui.AWSIdentityResult>;
 
+export function GetCurrentScope():Promise<gui.ScopeSelection>;
+
 export function InitialProvider():Promise<string>;
 
 export function ParamAddTag(arg1:string,arg2:string,arg3:string):Promise<void>;

--- a/internal/gui/frontend/wailsjs/go/gui/App.js
+++ b/internal/gui/frontend/wailsjs/go/gui/App.js
@@ -14,6 +14,10 @@ export function GetAWSIdentity() {
   return window['go']['gui']['App']['GetAWSIdentity']();
 }
 
+export function GetCurrentScope() {
+  return window['go']['gui']['App']['GetCurrentScope']();
+}
+
 export function InitialProvider() {
   return window['go']['gui']['App']['InitialProvider']();
 }

--- a/internal/gui/frontend/wailsjs/go/models.ts
+++ b/internal/gui/frontend/wailsjs/go/models.ts
@@ -254,11 +254,14 @@ export namespace gui {
 	    hasVersionSpecifiers: boolean;
 	    hasTags: boolean;
 	    hasRestore: boolean;
-	
+	    hasStaging: boolean;
+	    hasForceDelete: boolean;
+	    hasRecoveryWindow: boolean;
+
 	    static createFrom(source: any = {}) {
 	        return new ServiceCapability(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.service = source["service"];
@@ -267,6 +270,9 @@ export namespace gui {
 	        this.hasVersionSpecifiers = source["hasVersionSpecifiers"];
 	        this.hasTags = source["hasTags"];
 	        this.hasRestore = source["hasRestore"];
+	        this.hasStaging = source["hasStaging"];
+	        this.hasForceDelete = source["hasForceDelete"];
+	        this.hasRecoveryWindow = source["hasRecoveryWindow"];
 	    }
 	}
 	export class ProviderCapability {

--- a/internal/gui/param.go
+++ b/internal/gui/param.go
@@ -10,7 +10,6 @@ import (
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/usecase/param"
-	"github.com/mpyw/suve/internal/version/paramversion"
 )
 
 // =============================================================================
@@ -127,7 +126,7 @@ func (a *App) ParamList(prefix string, recursive bool, withValue bool, filter st
 
 // ParamShow shows a parameter value.
 func (a *App) ParamShow(specStr string) (*ParamShowResult, error) {
-	spec, err := paramversion.Parse(specStr)
+	spec, err := a.parseParamSpec(specStr)
 	if err != nil {
 		return nil, err
 	}
@@ -205,12 +204,12 @@ func (a *App) ParamLog(name string, maxResults int32) (*ParamLogResult, error) {
 
 // ParamDiff compares two parameter versions.
 func (a *App) ParamDiff(spec1Str, spec2Str string) (*ParamDiffResult, error) {
-	spec1, err := paramversion.Parse(spec1Str)
+	spec1, err := a.parseParamSpec(spec1Str)
 	if err != nil {
 		return nil, err
 	}
 
-	spec2, err := paramversion.Parse(spec2Str)
+	spec2, err := a.parseParamSpec(spec2Str)
 	if err != nil {
 		return nil, err
 	}
@@ -336,6 +335,12 @@ func (a *App) ParamRemoveTag(name, key string) error {
 // ParamTypeOptions returns the selectable parameter type display names for the
 // current provider (AWS: "String", "SecureString", "StringList"). The frontend
 // renders its type dropdown from this list instead of hardcoding SSM strings.
+// Only AWS SSM has a value type; Azure App Configuration values are untyped, so
+// the list is empty there and the frontend hides the Type dropdown.
 func (a *App) ParamTypeOptions() []string {
+	if a.currentScope().Provider != provider.ProviderAWS {
+		return []string{}
+	}
+
 	return paramtype.Options()
 }

--- a/internal/gui/providers.go
+++ b/internal/gui/providers.go
@@ -105,6 +105,19 @@ type ServiceCapability struct {
 	// HasRestore is true when a soft-deleted item can be restored (AWS Secrets
 	// Manager only).
 	HasRestore bool `json:"hasRestore"`
+	// HasStaging is true when the GUI's staging workflow applies to this
+	// service. It is AWS-only until scope-keyed multi-provider staging lands
+	// (#270); the frontend hides the staging tab/banner/checkbox when false.
+	HasStaging bool `json:"hasStaging"`
+	// HasForceDelete is true when an immediate (no-recovery-window) delete is
+	// offered (AWS Secrets Manager only). The frontend hides the force-delete
+	// checkbox otherwise.
+	HasForceDelete bool `json:"hasForceDelete"`
+	// HasRecoveryWindow is true when a soft delete schedules a recovery window
+	// whose end date can be surfaced (AWS Secrets Manager only). Other providers
+	// delete immediately or govern retention by policy, so no "recoverable until"
+	// date is shown.
+	HasRecoveryWindow bool `json:"hasRecoveryWindow"`
 }
 
 // ProviderCapability describes a provider and the services it offers.
@@ -134,8 +147,16 @@ func (a *App) Capabilities() []ProviderCapability {
 			DisplayName: "AWS",
 			ScopeFields: []string{},
 			Services: []ServiceCapability{
-				{Service: "param", DisplayName: "Param", HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: false},
-				{Service: "secret", DisplayName: "Secret", HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: true},
+				{
+					Service: "param", DisplayName: "Param",
+					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: false,
+					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false,
+				},
+				{
+					Service: "secret", DisplayName: "Secret",
+					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: true,
+					HasStaging: true, HasForceDelete: true, HasRecoveryWindow: true,
+				},
 			},
 		},
 		{
@@ -143,7 +164,11 @@ func (a *App) Capabilities() []ProviderCapability {
 			DisplayName: "Google Cloud",
 			ScopeFields: []string{"project"},
 			Services: []ServiceCapability{
-				{Service: "secret", DisplayName: "Secret", HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: false},
+				{
+					Service: "secret", DisplayName: "Secret",
+					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: false,
+					HasStaging: false, HasForceDelete: false, HasRecoveryWindow: false,
+				},
 			},
 		},
 		{
@@ -152,8 +177,16 @@ func (a *App) Capabilities() []ProviderCapability {
 			ScopeFields: []string{"subscription", "resourceGroup"},
 			Services: []ServiceCapability{
 				// App Configuration is unversioned and cannot write tags.
-				{Service: "param", DisplayName: "App Configuration", HasVersionHistory: false, HasVersionSpecifiers: false, HasTags: false, HasRestore: false},
-				{Service: "secret", DisplayName: "Key Vault", HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: false},
+				{
+					Service: "param", DisplayName: "App Configuration",
+					HasVersionHistory: false, HasVersionSpecifiers: false, HasTags: false, HasRestore: false,
+					HasStaging: false, HasForceDelete: false, HasRecoveryWindow: false,
+				},
+				{
+					Service: "secret", DisplayName: "Key Vault",
+					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: false,
+					HasStaging: false, HasForceDelete: false, HasRecoveryWindow: false,
+				},
 			},
 		},
 	}

--- a/internal/gui/scope_internal_test.go
+++ b/internal/gui/scope_internal_test.go
@@ -1,0 +1,200 @@
+//go:build production || dev
+
+package gui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider"
+)
+
+func TestApp_SelectScope(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		sel       ScopeSelection
+		wantErr   error
+		wantScope provider.Scope
+	}{
+		{
+			name:      "aws (no fields required)",
+			sel:       ScopeSelection{Provider: "aws"},
+			wantScope: provider.Scope{Provider: provider.ProviderAWS},
+		},
+		{
+			name:      "googlecloud with project",
+			sel:       ScopeSelection{Provider: "googlecloud", ProjectID: "my-project"},
+			wantScope: provider.GoogleCloudScope("my-project"),
+		},
+		{
+			name:    "googlecloud missing project",
+			sel:     ScopeSelection{Provider: "googlecloud"},
+			wantErr: errGoogleCloudProjectRequired,
+		},
+		{
+			name: "azure with vault only",
+			sel:  ScopeSelection{Provider: "azure", SubscriptionID: "sub", ResourceGroup: "rg", VaultName: "vault"},
+			wantScope: provider.Scope{
+				Provider: provider.ProviderAzure, SubscriptionID: "sub", ResourceGroup: "rg", VaultName: "vault",
+			},
+		},
+		{
+			name: "azure with store only",
+			sel:  ScopeSelection{Provider: "azure", SubscriptionID: "sub", ResourceGroup: "rg", StoreName: "store"},
+			wantScope: provider.Scope{
+				Provider: provider.ProviderAzure, SubscriptionID: "sub", ResourceGroup: "rg", StoreName: "store",
+			},
+		},
+		{
+			name: "azure with both vault and store",
+			sel:  ScopeSelection{Provider: "azure", SubscriptionID: "sub", ResourceGroup: "rg", VaultName: "vault", StoreName: "store"},
+			wantScope: provider.Scope{
+				Provider: provider.ProviderAzure, SubscriptionID: "sub", ResourceGroup: "rg", VaultName: "vault", StoreName: "store",
+			},
+		},
+		{
+			name:    "azure missing both vault and store",
+			sel:     ScopeSelection{Provider: "azure", SubscriptionID: "sub", ResourceGroup: "rg"},
+			wantErr: errAzureScopeRequired,
+		},
+		{
+			name:    "unknown provider",
+			sel:     ScopeSelection{Provider: "oracle"},
+			wantErr: errInvalidProvider,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := NewApp(provider.ProviderAWS)
+
+			err := app.SelectScope(tt.sel)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				// A rejected selection must not mutate the active scope.
+				assert.Equal(t, provider.Scope{Provider: provider.ProviderAWS}, app.currentScope())
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantScope, app.currentScope())
+		})
+	}
+}
+
+func TestApp_GetCurrentScope_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sel  ScopeSelection
+	}{
+		{name: "aws", sel: ScopeSelection{Provider: "aws"}},
+		{name: "googlecloud", sel: ScopeSelection{Provider: "googlecloud", ProjectID: "proj"}},
+		{
+			name: "azure key vault + app config",
+			sel:  ScopeSelection{Provider: "azure", SubscriptionID: "sub", ResourceGroup: "rg", VaultName: "vault", StoreName: "store"},
+		},
+		{
+			// Only one Azure service configured: Key Vault (secret) available,
+			// App Configuration (param) absent. The readback must preserve the
+			// empty storeName so #267 can render the half-filled form.
+			name: "azure key vault only",
+			sel:  ScopeSelection{Provider: "azure", SubscriptionID: "sub", ResourceGroup: "rg", VaultName: "vault"},
+		},
+		{
+			// Mirror case: only App Configuration (param) available, no vault.
+			name: "azure app config only",
+			sel:  ScopeSelection{Provider: "azure", SubscriptionID: "sub", ResourceGroup: "rg", StoreName: "store"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := NewApp(provider.ProviderAWS)
+			require.NoError(t, app.SelectScope(tt.sel))
+
+			got := app.GetCurrentScope()
+			require.NotNil(t, got)
+			// Each input populates only provider-relevant fields, so the
+			// readback must equal it verbatim — including the empty side of a
+			// one-sided Azure scope (vault-only / store-only).
+			assert.Equal(t, &tt.sel, got)
+		})
+	}
+}
+
+// TestApp_GetCurrentScope_EnvDerivedInitialScope verifies that the env-derived
+// initial scope (no SelectScope yet) is surfaced for form prefill.
+func TestApp_GetCurrentScope_EnvDerivedInitialScope(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "env-project")
+
+	app := NewApp(provider.ProviderGoogleCloud)
+
+	got := app.GetCurrentScope()
+	require.NotNil(t, got)
+	assert.Equal(t, string(provider.ProviderGoogleCloud), got.Provider)
+	assert.Equal(t, "env-project", got.ProjectID)
+}
+
+func TestApp_GetCurrentScope_EnvDerivedAzure(t *testing.T) {
+	t.Setenv("AZURE_SUBSCRIPTION_ID", "env-sub")
+	t.Setenv("AZURE_RESOURCE_GROUP", "env-rg")
+	t.Setenv("AZURE_KEYVAULT_NAME", "env-vault")
+	t.Setenv("AZURE_APPCONFIG_NAME", "env-store")
+
+	app := NewApp(provider.ProviderAzure)
+
+	got := app.GetCurrentScope()
+	require.NotNil(t, got)
+	assert.Equal(t, string(provider.ProviderAzure), got.Provider)
+	assert.Equal(t, "env-sub", got.SubscriptionID)
+	assert.Equal(t, "env-rg", got.ResourceGroup)
+	assert.Equal(t, "env-vault", got.VaultName)
+	assert.Equal(t, "env-store", got.StoreName)
+}
+
+// TestApp_GetCurrentScope_EnvDerivedAzure_VaultOnly covers a one-sided Azure
+// environment: only the Key Vault (secret) side is configured, so App
+// Configuration (param) stays absent. AZURE_APPCONFIG_NAME is pinned empty so
+// the case is hermetic regardless of the ambient environment.
+func TestApp_GetCurrentScope_EnvDerivedAzure_VaultOnly(t *testing.T) {
+	t.Setenv("AZURE_SUBSCRIPTION_ID", "env-sub")
+	t.Setenv("AZURE_RESOURCE_GROUP", "env-rg")
+	t.Setenv("AZURE_KEYVAULT_NAME", "env-vault")
+	t.Setenv("AZURE_APPCONFIG_NAME", "")
+
+	app := NewApp(provider.ProviderAzure)
+
+	got := app.GetCurrentScope()
+	require.NotNil(t, got)
+	assert.Equal(t, string(provider.ProviderAzure), got.Provider)
+	assert.Equal(t, "env-vault", got.VaultName)
+	assert.Empty(t, got.StoreName)
+}
+
+// TestApp_GetCurrentScope_EnvDerivedAzure_StoreOnly is the mirror: only App
+// Configuration (param) is configured; Key Vault stays absent.
+func TestApp_GetCurrentScope_EnvDerivedAzure_StoreOnly(t *testing.T) {
+	t.Setenv("AZURE_SUBSCRIPTION_ID", "env-sub")
+	t.Setenv("AZURE_RESOURCE_GROUP", "env-rg")
+	t.Setenv("AZURE_KEYVAULT_NAME", "")
+	t.Setenv("AZURE_APPCONFIG_NAME", "env-store")
+
+	app := NewApp(provider.ProviderAzure)
+
+	got := app.GetCurrentScope()
+	require.NotNil(t, got)
+	assert.Equal(t, string(provider.ProviderAzure), got.Provider)
+	assert.Empty(t, got.VaultName)
+	assert.Equal(t, "env-store", got.StoreName)
+}

--- a/internal/gui/secret.go
+++ b/internal/gui/secret.go
@@ -9,7 +9,6 @@ import (
 	awssecret "github.com/mpyw/suve/internal/provider/aws/secret"
 	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/usecase/secret"
-	"github.com/mpyw/suve/internal/version/secretversion"
 )
 
 // errRestoreUnsupported is returned when the active provider does not support
@@ -137,7 +136,7 @@ func (a *App) SecretList(prefix string, withValue bool, filter string, _ int, _ 
 
 // SecretShow shows a secret value.
 func (a *App) SecretShow(specStr string) (*SecretShowResult, error) {
-	spec, err := secretversion.Parse(specStr)
+	spec, err := a.parseSecretSpec(specStr)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +284,11 @@ func (a *App) SecretDelete(name string, force bool) (*SecretDeleteResult, error)
 	}
 	// The provider Delete returns only an error; when not forcing, compute the
 	// scheduled deletion date client-side (now + AWS default recovery window).
-	if !force {
+	// Only AWS Secrets Manager has a recovery window: Google Cloud deletes
+	// immediately and Key Vault retention is governed by vault policy, so a
+	// synthetic "recoverable until" date there would be false. Gate on the
+	// active provider (mirrors ServiceCapability.HasRecoveryWindow).
+	if !force && a.currentScope().Provider == provider.ProviderAWS {
 		const defaultRecoveryWindowDays = 30
 
 		r.DeletionDate = timeutil.FormatRFC3339(time.Now().AddDate(0, 0, defaultRecoveryWindowDays))
@@ -326,12 +329,12 @@ func (a *App) SecretRemoveTag(name, key string) error {
 
 // SecretDiff compares two secret versions.
 func (a *App) SecretDiff(spec1Str, spec2Str string) (*SecretDiffResult, error) {
-	spec1, err := secretversion.Parse(spec1Str)
+	spec1, err := a.parseSecretSpec(spec1Str)
 	if err != nil {
 		return nil, err
 	}
 
-	spec2, err := secretversion.Parse(spec2Str)
+	spec2, err := a.parseSecretSpec(spec2Str)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/gui/specparse.go
+++ b/internal/gui/specparse.go
@@ -1,0 +1,92 @@
+//go:build production || dev
+
+package gui
+
+import (
+	"strconv"
+
+	"github.com/samber/lo"
+
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/version/azureappconfigversion"
+	"github.com/mpyw/suve/internal/version/azurekvversion"
+	"github.com/mpyw/suve/internal/version/gcloudversion"
+	"github.com/mpyw/suve/internal/version/paramversion"
+	"github.com/mpyw/suve/internal/version/secretversion"
+)
+
+// Per-provider version-spec parsing.
+//
+// The param/secret usecases the GUI drives are typed to *paramversion.Spec /
+// *secretversion.Spec, but the grammar that is legal depends on the active
+// provider. Parsing every input with the AWS grammar mis-handles other
+// providers — most visibly it splits an Azure App Configuration key that
+// legally contains '#' or '~' into a bogus name+version. These helpers select
+// the correct grammar (mirroring the CLI's per-provider parsers) and then adapt
+// the result back into the usecase's spec type.
+//
+// The adaptation round-trips through the neutral name+suffix contract: the
+// usecase reconstructs a suffix string from the returned spec and hands
+// name+suffix to provider.Reader.Resolve, which re-parses it with the
+// provider's OWN grammar (see each adapter's Resolve). So carrying the parsed
+// name and an equivalent absolute/shift in a paramversion/secretversion spec is
+// sufficient — the suffix bytes are grammar-agnostic (#id / :label / ~N).
+
+// parseParamSpec parses a parameter version spec with the grammar of the active
+// provider and adapts it to the *paramversion.Spec the param usecase expects.
+//
+//   - AWS   -> paramversion (name#N~shift).
+//   - Azure -> App Configuration is unversioned; azureappconfigversion accepts a
+//     bare name only and rejects any specifier, so a key containing '#'/'~' gets
+//     a clean error instead of a mis-split.
+func (a *App) parseParamSpec(specStr string) (*paramversion.Spec, error) {
+	switch a.currentScope().Provider {
+	case provider.ProviderAzure:
+		spec, err := azureappconfigversion.Parse(specStr)
+		if err != nil {
+			return nil, err
+		}
+
+		// App Configuration has no absolute/shift specifier, so the equivalent
+		// paramversion spec is a bare name (empty suffix).
+		return &paramversion.Spec{Name: spec.Name}, nil
+	default:
+		return paramversion.Parse(specStr)
+	}
+}
+
+// parseSecretSpec parses a secret version spec with the grammar of the active
+// provider and adapts it to the *secretversion.Spec the secret usecase expects.
+//
+//   - AWS          -> secretversion (name#id | :label, plus ~shift).
+//   - Google Cloud -> gcloudversion (integer #N, ~shift; ':' labels rejected).
+//   - Azure        -> azurekvversion (opaque #id, ~shift; ':' labels rejected).
+func (a *App) parseSecretSpec(specStr string) (*secretversion.Spec, error) {
+	switch a.currentScope().Provider {
+	case provider.ProviderGoogleCloud:
+		spec, err := gcloudversion.Parse(specStr)
+		if err != nil {
+			return nil, err
+		}
+
+		out := &secretversion.Spec{Name: spec.Name, Shift: spec.Shift}
+		if spec.Absolute.Version != nil {
+			out.Absolute.ID = lo.ToPtr(strconv.FormatInt(*spec.Absolute.Version, 10))
+		}
+
+		return out, nil
+	case provider.ProviderAzure:
+		spec, err := azurekvversion.Parse(specStr)
+		if err != nil {
+			return nil, err
+		}
+
+		return &secretversion.Spec{
+			Name:     spec.Name,
+			Absolute: secretversion.AbsoluteSpec{ID: spec.Absolute.ID},
+			Shift:    spec.Shift,
+		}, nil
+	default:
+		return secretversion.Parse(specStr)
+	}
+}

--- a/internal/gui/specparse_internal_test.go
+++ b/internal/gui/specparse_internal_test.go
@@ -1,0 +1,156 @@
+//go:build production || dev
+
+package gui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/version/azureappconfigversion"
+	"github.com/mpyw/suve/internal/version/gcloudversion"
+)
+
+func appWithProvider(p provider.Provider) *App {
+	return &App{scope: provider.Scope{Provider: p}}
+}
+
+func TestApp_parseParamSpec(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		provider    provider.Provider
+		input       string
+		wantName    string
+		wantVersion *int64
+		wantShift   int
+		wantErr     error
+	}{
+		{
+			name: "aws bare name", provider: provider.ProviderAWS,
+			input: "/my/param", wantName: "/my/param",
+		},
+		{
+			name: "aws with version", provider: provider.ProviderAWS,
+			input: "/my/param#3", wantName: "/my/param", wantVersion: ptrInt64(3),
+		},
+		{
+			name: "aws with shift", provider: provider.ProviderAWS,
+			input: "/my/param~2", wantName: "/my/param", wantShift: 2,
+		},
+		{
+			name: "azure bare key", provider: provider.ProviderAzure,
+			input: "my-key", wantName: "my-key",
+		},
+		{
+			name: "azure key with slashes", provider: provider.ProviderAzure,
+			input: "app/config/timeout", wantName: "app/config/timeout",
+		},
+		{
+			// The key regression: '#' in an App Configuration key must NOT be
+			// split into name+version (as the AWS grammar would); it is rejected
+			// with a clean unsupported-versioning error.
+			name: "azure key containing hash is rejected, not mis-split", provider: provider.ProviderAzure,
+			input: "my-key#3", wantErr: azureappconfigversion.ErrVersioningUnsupported,
+		},
+		{
+			name: "azure key with tilde is rejected", provider: provider.ProviderAzure,
+			input: "my-key~1", wantErr: azureappconfigversion.ErrVersioningUnsupported,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := appWithProvider(tt.provider)
+
+			spec, err := app.parseParamSpec(tt.input)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantName, spec.Name)
+			assert.Equal(t, tt.wantVersion, spec.Absolute.Version)
+			assert.Equal(t, tt.wantShift, spec.Shift)
+		})
+	}
+}
+
+func TestApp_parseSecretSpec(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		provider  provider.Provider
+		input     string
+		wantName  string
+		wantID    *string
+		wantLabel *string
+		wantShift int
+		wantErr   error
+	}{
+		{
+			name: "aws version id", provider: provider.ProviderAWS,
+			input: "sec#abc123", wantName: "sec", wantID: ptrStr("abc123"),
+		},
+		{
+			name: "aws staging label", provider: provider.ProviderAWS,
+			input: "sec:AWSCURRENT", wantName: "sec", wantLabel: ptrStr("AWSCURRENT"),
+		},
+		{
+			// Google Cloud integer version adapts to a secretversion ID whose
+			// suffix ("#3") the Secret Manager adapter re-parses as integer 3.
+			name: "google cloud integer version", provider: provider.ProviderGoogleCloud,
+			input: "sec#3", wantName: "sec", wantID: ptrStr("3"),
+		},
+		{
+			name: "google cloud with shift", provider: provider.ProviderGoogleCloud,
+			input: "sec#5~2", wantName: "sec", wantID: ptrStr("5"), wantShift: 2,
+		},
+		{
+			// Google Cloud has no staging labels: a colon specifier must be
+			// rejected, not folded into the name (which the AWS grammar accepts).
+			name: "google cloud label rejected", provider: provider.ProviderGoogleCloud,
+			input: "sec:prod", wantErr: gcloudversion.ErrLabelUnsupported,
+		},
+		{
+			name: "azure key vault opaque id", provider: provider.ProviderAzure,
+			input: "sec#deadbeef01", wantName: "sec", wantID: ptrStr("deadbeef01"),
+		},
+		{
+			name: "azure with shift", provider: provider.ProviderAzure,
+			input: "sec~1", wantName: "sec", wantShift: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := appWithProvider(tt.provider)
+
+			spec, err := app.parseSecretSpec(tt.input)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantName, spec.Name)
+			assert.Equal(t, tt.wantID, spec.Absolute.ID)
+			assert.Equal(t, tt.wantLabel, spec.Absolute.Label)
+			assert.Equal(t, tt.wantShift, spec.Shift)
+		})
+	}
+}
+
+func ptrInt64(v int64) *int64 { return &v }
+func ptrStr(v string) *string { return &v }

--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -689,6 +689,10 @@ type StagingFileStatusResult struct {
 
 // StagingFileStatus checks if the staging file exists and whether it's encrypted.
 func (a *App) StagingFileStatus() (*StagingFileStatusResult, error) {
+	if err := a.requireAWSStaging(); err != nil {
+		return nil, err
+	}
+
 	identity, err := infra.GetAWSIdentity(a.ctx)
 	if err != nil {
 		return nil, err
@@ -725,6 +729,10 @@ func (a *App) StagingFileStatus() (*StagingFileStatusResult, error) {
 // selector. It is the shared prelude of StagingDrain and StagingPersist. An
 // empty service yields the zero staging.Service (all services).
 func (a *App) stashStores(service, passphrase string) (stash, working *file.Store, svc staging.Service, err error) {
+	if err := a.requireAWSStaging(); err != nil {
+		return nil, nil, "", err
+	}
+
 	identity, err := infra.GetAWSIdentity(a.ctx)
 	if err != nil {
 		return nil, nil, "", err
@@ -829,6 +837,10 @@ type StagingDropResult struct {
 // StagingDrop deletes the staging file without loading it into memory.
 // This works even for encrypted files since it just deletes the file directly.
 func (a *App) StagingDrop() (*StagingDropResult, error) {
+	if err := a.requireAWSStaging(); err != nil {
+		return nil, err
+	}
+
 	identity, err := infra.GetAWSIdentity(a.ctx)
 	if err != nil {
 		return nil, err

--- a/internal/gui/staging_guard_internal_test.go
+++ b/internal/gui/staging_guard_internal_test.go
@@ -1,0 +1,132 @@
+//go:build production || dev
+
+package gui
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mpyw/suve/internal/provider"
+)
+
+// TestApp_StagingBindings_RejectNonAWS asserts that every staging binding
+// returns errStagingNonAWS under a non-AWS scope. Because the guard runs before
+// any infra.GetAWSIdentity call, the returned error is the sentinel (not an STS
+// failure): if GetAWSIdentity were reached, an unauthenticated test environment
+// would surface a different error (or block on the network) instead.
+func TestApp_StagingBindings_RejectNonAWS(t *testing.T) {
+	t.Parallel()
+
+	// Each binding invoked with harmless arguments; only the error is checked.
+	bindings := map[string]func(a *App) error{
+		"StagingStatus": func(a *App) error {
+			_, err := a.StagingStatus()
+
+			return err
+		},
+		"StagingApply": func(a *App) error {
+			_, err := a.StagingApply("param", false)
+
+			return err
+		},
+		"StagingReset": func(a *App) error {
+			_, err := a.StagingReset("param")
+
+			return err
+		},
+		"StagingAdd": func(a *App) error {
+			_, err := a.StagingAdd("param", "n", "v")
+
+			return err
+		},
+		"StagingEdit": func(a *App) error {
+			_, err := a.StagingEdit("param", "n", "v")
+
+			return err
+		},
+		"StagingDelete": func(a *App) error {
+			_, err := a.StagingDelete("param", "n", false, 0)
+
+			return err
+		},
+		"StagingUnstage": func(a *App) error {
+			_, err := a.StagingUnstage("param", "n")
+
+			return err
+		},
+		"StagingAddTag": func(a *App) error {
+			_, err := a.StagingAddTag("param", "n", "k", "v")
+
+			return err
+		},
+		"StagingRemoveTag": func(a *App) error {
+			_, err := a.StagingRemoveTag("param", "n", "k")
+
+			return err
+		},
+		"StagingCancelAddTag": func(a *App) error {
+			_, err := a.StagingCancelAddTag("param", "n", "k")
+
+			return err
+		},
+		"StagingCancelRemoveTag": func(a *App) error {
+			_, err := a.StagingCancelRemoveTag("param", "n", "k")
+
+			return err
+		},
+		"StagingCheckStatus": func(a *App) error {
+			_, err := a.StagingCheckStatus("param", "n")
+
+			return err
+		},
+		"StagingDiff": func(a *App) error {
+			_, err := a.StagingDiff("param", "n")
+
+			return err
+		},
+		"StagingFileStatus": func(a *App) error {
+			_, err := a.StagingFileStatus()
+
+			return err
+		},
+		"StagingDrain": func(a *App) error {
+			_, err := a.StagingDrain("param", "", false, "merge")
+
+			return err
+		},
+		"StagingPersist": func(a *App) error {
+			_, err := a.StagingPersist("param", "", false, "overwrite")
+
+			return err
+		},
+		"StagingDrop": func(a *App) error {
+			_, err := a.StagingDrop()
+
+			return err
+		},
+	}
+
+	scopes := map[string]provider.Scope{
+		"googlecloud": {Provider: provider.ProviderGoogleCloud, ProjectID: "p"},
+		"azure":       {Provider: provider.ProviderAzure, VaultName: "v"},
+	}
+
+	for scopeName, scope := range scopes {
+		t.Run(scopeName, func(t *testing.T) {
+			t.Parallel()
+
+			for bindingName, call := range bindings {
+				t.Run(bindingName, func(t *testing.T) {
+					t.Parallel()
+
+					app := NewApp(provider.ProviderAWS)
+					app.scope = scope
+
+					err := call(app)
+					assert.ErrorIs(t, err, errStagingNonAWS)
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #276. Part of #250.

Backend-only groundwork every frontend child of #250 depends on. No DTO shape changes beyond the capability fields and the `GetCurrentScope` readback (which reuses `ScopeSelection`); no usecase restructuring.

## What

1. **Staging provider guard (critical).** `requireAWSStaging()` runs before any AWS STS call in `getStagingStore`/`stashStores`/`StagingFileStatus`/`StagingDrop`, so every staging binding rejects a non-AWS scope with a clear error rather than pushing AWS-staged entries into the selected provider (the pre-#270 corruption path).
2. **`SelectScope` validation.** Reject empty required fields per provider (GCP `projectId`; Azure `vaultName` and/or `storeName`), with GUI-appropriate wording (no `--flag` references).
3. **`GetCurrentScope` readback.** New binding returning the active `ScopeSelection` (incl. env-derived initial scope from `GOOGLE_CLOUD_PROJECT` / `AZURE_*`) so #266/#267 can prefill forms.
4. **Capability extensions.** `HasStaging` / `HasForceDelete` / `HasRecoveryWindow` (AWS only). `SecretDelete` no longer fabricates a "recoverable until" date for providers without a recovery window.
5. **Scope-aware `ParamTypeOptions`.** Empty for non-AWS (Azure App Configuration is untyped).
6. **Per-provider spec parsing.** `parseParamSpec`/`parseSecretSpec` select the grammar by `currentScope().Provider`, fixing App Config keys containing `#`/`~` being mis-split by the AWS grammar. The parsed name+suffix round-trips through `provider.Reader.Resolve` (which re-parses with the provider's own grammar), so the existing usecases stay unchanged.

## Tests

Go unit tests: `SelectScope` table, `GetCurrentScope` round-trip (incl. env), staging-guard across **all** bindings (asserts the sentinel error, proving the guard short-circuits before `GetAWSIdentity`), `Capabilities()` exact-value assertions, scope-aware `ParamTypeOptions`, and spec-parser dispatch (incl. `#` in an App Config key name). `models.ts` + wailsjs stubs updated; `dto_contract` stays green.

Verified locally: `go test -tags dev ./internal/gui/` and `golangci-lint run --build-tags=e2e,production ./internal/gui/...` (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SPyCZL1EWNiYBe17j4ocM