### PR TITLE
test(gui): provider-aware Playwright mock + CI for stacked PRs and GUI coverage (#269)

### DIFF
--- a/.github/scripts/check-naming.sh
+++ b/.github/scripts/check-naming.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Enforce the Google Cloud naming convention: the bare acronym "GCP" must never
+# appear in the source. Use one of these instead:
+#   - "Google Cloud"  prose / display names
+#   - "gcloud"        CLI command group, package names, identifiers
+#   - "GoogleCloud"   Go provider identifier (provider.ProviderGoogleCloud)
+#
+# The only allowed occurrence is the third-party emulator image name
+# "gcp-secret-manager-emulator", which we do not control.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Word-boundary, case-insensitive match of "gcp" across tracked text files
+# (-I skips binary blobs). This script and the dependency manifests are excluded;
+# the allowlisted third-party image name is dropped afterwards.
+matches=$(
+  git grep -nIwi 'gcp' -- \
+    ':(exclude).github/scripts/check-naming.sh' \
+    ':(exclude)go.sum' \
+    ':(exclude)go.mod' \
+    ':(exclude)**/package-lock.json' \
+    ':(exclude)**/*.lock' \
+    | { grep -vi 'gcp-secret-manager-emulator' || true; }
+)
+
+if [[ -n "${matches}" ]]; then
+  echo "Forbidden 'GCP' acronym found. Use 'Google Cloud', 'gcloud', or 'GoogleCloud':" >&2
+  echo "${matches}" >&2
+  exit 1
+fi
+
+echo "Naming convention OK: no stray 'GCP' acronym."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,11 @@ name: Test
 on:
   push:
     branches: [main]
+  # Run on PRs against ANY base branch, not just main, so stacked PRs (whose
+  # base is another feature branch) still get the full test workflow instead of
+  # zero CI.
   pull_request:
-    branches: [main]
+    branches: ['**']
 
 permissions:
   contents: read
@@ -63,9 +66,21 @@ jobs:
       - name: Create dummy frontend dist
         run: mkdir -p internal/gui/frontend/dist && touch internal/gui/frontend/dist/index.html
 
-      - name: Run GUI Go tests
+      - name: Run GUI Go tests with coverage
         run: |
-          CGO_ENABLED=1 go test -v -race -tags=production,webkit2_41 ./internal/gui/...
+          CGO_ENABLED=1 go test -v -race -tags=production,webkit2_41 \
+            -coverprofile=coverage-gui.txt -covermode=atomic \
+            -coverpkg=./internal/gui/... ./internal/gui/...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage-gui.txt
+          flags: gui
+          name: codecov-suve-gui
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        continue-on-error: true
 
   e2e:
     name: E2E Test
@@ -236,6 +251,16 @@ jobs:
 
       - name: Run goroutinectx
         run: go run github.com/mpyw/goroutinectx/cmd/goroutinectx@v0.7.5 ./...
+
+  naming:
+    name: Naming Convention
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Check Google Cloud naming (no bare acronym)
+        run: bash .github/scripts/check-naming.sh
 
   frontend-lint:
     name: Frontend Lint

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,8 +5,8 @@ coverage:
   status:
     project:
       default:
-        # 2 (unit + e2e) + 3 (platform: linux, darwin, windows)
-        after_n_builds: 5
+        # 2 (unit + e2e) + 3 (platform: linux, darwin, windows) + 1 (gui)
+        after_n_builds: 6
     patch:
       default:
-        after_n_builds: 5
+        after_n_builds: 6

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -22,16 +22,25 @@ export interface Tag {
 
 export type StagedOperation = 'create' | 'update' | 'delete';
 
+export type Service = 'param' | 'secret';
+
 export interface StagedEntry {
   name: string;
   operation: StagedOperation;
   value?: string;
+  // Optional service classifier. When present, stash drain routes the entry by
+  // this field; otherwise it falls back to the AWS name-shape heuristic (a
+  // leading '/' means param). Google Cloud/Azure names have no such convention, so
+  // provider-aware fixtures should set this explicitly.
+  service?: Service;
 }
 
 export interface StagedTagEntry {
   name: string;
   addTags: Record<string, string>;
   removeTags: Record<string, string>;
+  // See StagedEntry.service.
+  service?: Service;
 }
 
 export interface ParamLogEntry {
@@ -54,6 +63,49 @@ export interface AWSIdentity {
   accountId: string;
   region: string;
   profile: string;
+}
+
+// ScopeSelection mirrors the Go binding DTO (internal/gui/app.go). Only the
+// fields relevant to the chosen provider are meaningful.
+export interface ScopeSelection {
+  provider: string;
+  projectId: string;
+  subscriptionId: string;
+  resourceGroup: string;
+  vaultName: string;
+  storeName: string;
+}
+
+// DetectResult mirrors the Go binding DTO (internal/gui/providers.go).
+export interface DetectResult {
+  param: string;
+  secret: string;
+  stage: string;
+  paramActive: string[];
+  secretActive: string[];
+  stageActive: string[];
+}
+
+// ServiceCapability / ProviderCapability mirror the Go binding DTOs
+// (internal/gui/providers.go). The default values in defaultCapabilities MUST
+// stay in lockstep with App.Capabilities() there.
+export interface ServiceCapability {
+  service: string;
+  displayName: string;
+  hasVersionHistory: boolean;
+  hasVersionSpecifiers: boolean;
+  hasTags: boolean;
+  hasRestore: boolean;
+  hasStaging: boolean;
+  hasForceDelete: boolean;
+  hasRecoveryWindow: boolean;
+}
+
+export interface ProviderCapability {
+  provider: string;
+  displayName: string;
+  scopeFields: string[];
+  services: ServiceCapability[];
 }
 
 export interface StashFileState {
@@ -83,6 +135,12 @@ export interface MockState {
   awsIdentity: AWSIdentity;
   // Stash file state
   stashFile: StashFileState;
+  // Provider selection (multi-cloud). Defaults describe an AWS-only environment
+  // so existing AWS specs are unaffected.
+  initialProvider: string;
+  currentScope: ScopeSelection;
+  detectResult: DetectResult;
+  capabilities: ProviderCapability[];
   // Error simulation
   simulateError?: {
     operation: string;
@@ -138,6 +196,66 @@ export function createStagedTags(
 // Preset States for Common Test Scenarios
 // ============================================================================
 
+/**
+ * Default AWS-only scope selection.
+ */
+export const awsScopeSelection: ScopeSelection = {
+  provider: 'aws',
+  projectId: '',
+  subscriptionId: '',
+  resourceGroup: '',
+  vaultName: '',
+  storeName: '',
+};
+
+/**
+ * Default provider detection result describing an AWS-only environment (the
+ * single uniquely-active provider across services).
+ */
+export const awsOnlyDetectResult: DetectResult = {
+  param: 'aws',
+  secret: 'aws',
+  stage: 'aws',
+  paramActive: ['aws'],
+  secretActive: ['aws'],
+  stageActive: ['aws'],
+};
+
+/**
+ * Static capability descriptor. This MUST stay a verbatim copy of
+ * App.Capabilities() in internal/gui/providers.go — dto_contract guards the
+ * DTO shape, not these values, so drift here silently diverges the mock from
+ * the backend.
+ */
+export const defaultCapabilities: ProviderCapability[] = [
+  {
+    provider: 'aws',
+    displayName: 'AWS',
+    scopeFields: [],
+    services: [
+      { service: 'param', displayName: 'Param', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false },
+      { service: 'secret', displayName: 'Secret', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, hasRestore: true, hasStaging: true, hasForceDelete: true, hasRecoveryWindow: true },
+    ],
+  },
+  {
+    provider: 'googlecloud',
+    displayName: 'Google Cloud',
+    scopeFields: ['project'],
+    services: [
+      { service: 'secret', displayName: 'Secret', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, hasRestore: false, hasStaging: false, hasForceDelete: false, hasRecoveryWindow: false },
+    ],
+  },
+  {
+    provider: 'azure',
+    displayName: 'Azure',
+    scopeFields: ['subscription', 'resourceGroup'],
+    services: [
+      { service: 'param', displayName: 'App Configuration', hasVersionHistory: false, hasVersionSpecifiers: false, hasTags: false, hasRestore: false, hasStaging: false, hasForceDelete: false, hasRecoveryWindow: false },
+      { service: 'secret', displayName: 'Key Vault', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, hasRestore: false, hasStaging: false, hasForceDelete: false, hasRecoveryWindow: false },
+    ],
+  },
+];
+
 export const defaultMockState: MockState = {
   params: [
     createParam('/app/config', 'config-value', 'String'),
@@ -187,6 +305,10 @@ export const defaultMockState: MockState = {
     entries: [],
     tags: [],
   },
+  initialProvider: 'aws',
+  currentScope: awsScopeSelection,
+  detectResult: awsOnlyDetectResult,
+  capabilities: defaultCapabilities,
 };
 
 /**
@@ -472,6 +594,40 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
     const state = JSON.parse(JSON.stringify(mockState));
 
     const mockApp = {
+      // Provider selection / capabilities (multi-cloud)
+      DetectProviders: async () => state.detectResult,
+      Capabilities: async () => state.capabilities,
+      InitialProvider: async () => state.initialProvider,
+      GetCurrentScope: async () => state.currentScope,
+      SelectScope: async (sel: any) => {
+        if (state.simulateError?.operation === 'SelectScope') {
+          throw new Error(state.simulateError.message);
+        }
+        // Mirror the backend validation (internal/gui/app.go) so provider-aware
+        // specs exercise the same error paths.
+        const p = sel?.provider;
+        if (p === 'googlecloud') {
+          if (!sel.projectId) {
+            throw new Error('Google Cloud project ID is required');
+          }
+        } else if (p === 'azure') {
+          if (!sel.vaultName && !sel.storeName) {
+            throw new Error('Azure requires a Key Vault name (for secrets) and/or an App Configuration store name (for parameters)');
+          }
+        } else if (p !== 'aws') {
+          throw new Error(`invalid provider: must be 'aws', 'googlecloud', or 'azure': ${JSON.stringify(p)}`);
+        }
+        // Keep only the provider-relevant fields, matching scopeFromSelection.
+        state.currentScope = {
+          provider: p,
+          projectId: p === 'googlecloud' ? (sel.projectId || '') : '',
+          subscriptionId: p === 'azure' ? (sel.subscriptionId || '') : '',
+          resourceGroup: p === 'azure' ? (sel.resourceGroup || '') : '',
+          vaultName: p === 'azure' ? (sel.vaultName || '') : '',
+          storeName: p === 'azure' ? (sel.storeName || '') : '',
+        };
+      },
+
       // AWS Identity
       GetAWSIdentity: async () => {
         if (state.simulateError?.operation === 'GetAWSIdentity') {
@@ -547,7 +703,10 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
           tags,
         };
       },
-      ParamTypeOptions: async () => ['String', 'SecureString', 'StringList'],
+      // Only AWS SSM has value types; Azure App Configuration is untyped
+      // (empty list hides the frontend Type dropdown).
+      ParamTypeOptions: async () =>
+        state.currentScope.provider === 'aws' ? ['String', 'SecureString', 'StringList'] : [],
       ParamLog: async (name: string, _limit?: number) => {
         const versions = state.paramVersions[name] || [
           { version: 1, value: 'current', type: 'String', isCurrent: true, lastModified: new Date().toISOString() },
@@ -885,15 +1044,22 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
           throw new Error('nothing to stash');
         }
 
+        // Tag each entry/tag with its originating service so drain can route
+        // without inferring from the name shape (which fails for Google Cloud/Azure).
+        const persistParamEntries = state.stagedParam.map((e: any) => ({ ...e, service: 'param' }));
+        const persistSecretEntries = state.stagedSecret.map((e: any) => ({ ...e, service: 'secret' }));
+        const persistParamTags = state.stagedParamTags.map((t: any) => ({ ...t, service: 'param' }));
+        const persistSecretTags = state.stagedSecretTags.map((t: any) => ({ ...t, service: 'secret' }));
+
         // Merge or overwrite file based on mode
         if (mode === 'merge' && state.stashFile.exists) {
           // Merge: combine with existing
-          state.stashFile.entries = [...state.stashFile.entries, ...state.stagedParam, ...state.stagedSecret];
-          state.stashFile.tags = [...state.stashFile.tags, ...state.stagedParamTags, ...state.stagedSecretTags];
+          state.stashFile.entries = [...state.stashFile.entries, ...persistParamEntries, ...persistSecretEntries];
+          state.stashFile.tags = [...state.stashFile.tags, ...persistParamTags, ...persistSecretTags];
         } else {
           // Overwrite: replace
-          state.stashFile.entries = [...state.stagedParam, ...state.stagedSecret];
-          state.stashFile.tags = [...state.stagedParamTags, ...state.stagedSecretTags];
+          state.stashFile.entries = [...persistParamEntries, ...persistSecretEntries];
+          state.stashFile.tags = [...persistParamTags, ...persistSecretTags];
         }
 
         // Update file state
@@ -931,20 +1097,27 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
         const fileEntries = state.stashFile.entries;
         const fileTags = state.stashFile.tags;
 
+        // Route each entry/tag by its explicit service when present, falling
+        // back to the AWS name-shape heuristic (leading '/' means param) for
+        // fixtures that predate the service field. This keeps AWS specs
+        // unchanged while working for Google Cloud/Azure names, which carry no '/'.
+        const isParam = (item: any) => (item.service ? item.service === 'param' : item.name.startsWith('/'));
+
         // Apply mode
         let merged = false;
         if (mode === 'merge' && agentHasChanges) {
           // Merge: combine file with agent
-          state.stagedParam = [...state.stagedParam, ...fileEntries.filter(e => e.name.startsWith('/'))];
-          state.stagedSecret = [...state.stagedSecret, ...fileEntries.filter(e => !e.name.startsWith('/'))];
-          state.stagedParamTags = [...state.stagedParamTags, ...fileTags];
+          state.stagedParam = [...state.stagedParam, ...fileEntries.filter(isParam)];
+          state.stagedSecret = [...state.stagedSecret, ...fileEntries.filter((e: any) => !isParam(e))];
+          state.stagedParamTags = [...state.stagedParamTags, ...fileTags.filter(isParam)];
+          state.stagedSecretTags = [...state.stagedSecretTags, ...fileTags.filter((t: any) => !isParam(t))];
           merged = true;
         } else {
           // Overwrite: replace agent with file
-          state.stagedParam = fileEntries.filter(e => e.name.startsWith('/'));
-          state.stagedSecret = fileEntries.filter(e => !e.name.startsWith('/'));
-          state.stagedParamTags = fileTags.filter(t => t.name.startsWith('/'));
-          state.stagedSecretTags = fileTags.filter(t => !t.name.startsWith('/'));
+          state.stagedParam = fileEntries.filter(isParam);
+          state.stagedSecret = fileEntries.filter((e: any) => !isParam(e));
+          state.stagedParamTags = fileTags.filter(isParam);
+          state.stagedSecretTags = fileTags.filter((t: any) => !isParam(t));
         }
 
         // Delete file unless keep=true
@@ -1014,9 +1187,23 @@ export async function waitForViewLoaded(page: Page) {
 }
 
 /**
- * Navigate to a specific view
+ * Navigate to a specific view.
+ *
+ * Accepts the legacy AWS labels ('Parameters'/'Secrets') as well as the
+ * capability display names surfaced by the provider-aware sidebar ('Param',
+ * 'Secret', 'Key Vault', 'App Configuration'), so provider-switching specs can
+ * target the right service button regardless of provider.
  */
-export async function navigateTo(page: Page, view: 'Parameters' | 'Secrets' | 'Staging') {
+export type NavLabel =
+  | 'Parameters'
+  | 'Secrets'
+  | 'Staging'
+  | 'Param'
+  | 'Secret'
+  | 'Key Vault'
+  | 'App Configuration';
+
+export async function navigateTo(page: Page, view: NavLabel) {
   await page.getByRole('button', { name: new RegExp(view, 'i') }).click();
 }
 

--- a/internal/gui/frontend/tests/wails-mock-providers.spec.ts
+++ b/internal/gui/frontend/tests/wails-mock-providers.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test';
+import { setupWailsMocks } from './fixtures/wails-mock';
+
+// Infrastructure test (not a feature spec): it exercises the provider-aware
+// mock bindings added for the multi-cloud GUI work (#269), so a regression in
+// the fixture is caught before the selector UI (#266) depends on them. It calls
+// the mock directly via page.evaluate and does not touch the UI, so it stays
+// valid regardless of whether App.svelte calls these bindings yet.
+test.describe('wails-mock provider bindings', () => {
+  test('new bindings return AWS-only defaults', async ({ page }) => {
+    await setupWailsMocks(page);
+    await page.goto('/');
+
+    const result = await page.evaluate(async () => {
+      const app = (window as any).go.gui.App;
+      return {
+        initial: await app.InitialProvider(),
+        scope: await app.GetCurrentScope(),
+        detect: await app.DetectProviders(),
+        caps: await app.Capabilities(),
+        types: await app.ParamTypeOptions(),
+      };
+    });
+
+    expect(result.initial).toBe('aws');
+    expect(result.scope.provider).toBe('aws');
+    expect(result.detect.secret).toBe('aws');
+    expect(result.detect.secretActive).toEqual(['aws']);
+    expect(result.caps.map((c: any) => c.provider)).toEqual(['aws', 'googlecloud', 'azure']);
+    // Staging is AWS-only until multi-provider staging lands.
+    const awsSecret = result.caps[0].services.find((s: any) => s.service === 'secret');
+    expect(awsSecret.hasStaging).toBe(true);
+    expect(awsSecret.hasRecoveryWindow).toBe(true);
+    const gcloudSecret = result.caps[1].services[0];
+    expect(gcloudSecret.hasStaging).toBe(false);
+    expect(result.types).toContain('SecureString');
+  });
+
+  test('SelectScope validates required fields and updates current scope', async ({ page }) => {
+    await setupWailsMocks(page);
+    await page.goto('/');
+
+    const result = await page.evaluate(async () => {
+      const app = (window as any).go.gui.App;
+      const errors: string[] = [];
+      try {
+        await app.SelectScope({ provider: 'googlecloud', projectId: '' });
+      } catch (e: any) {
+        errors.push(e.message);
+      }
+      try {
+        await app.SelectScope({ provider: 'azure', subscriptionId: 's', resourceGroup: 'r' });
+      } catch (e: any) {
+        errors.push(e.message);
+      }
+      await app.SelectScope({ provider: 'googlecloud', projectId: 'p1' });
+      const scope = await app.GetCurrentScope();
+      const types = await app.ParamTypeOptions();
+
+      return { errors, scope, types };
+    });
+
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0]).toContain('Google Cloud project ID is required');
+    expect(result.errors[1]).toContain('Azure requires');
+    expect(result.scope.provider).toBe('googlecloud');
+    expect(result.scope.projectId).toBe('p1');
+    // Non-AWS providers expose no SSM value types.
+    expect(result.types).toEqual([]);
+  });
+
+  test('SelectScope accepts a one-sided Azure scope (only one service available)', async ({ page }) => {
+    await setupWailsMocks(page);
+    await page.goto('/');
+
+    const result = await page.evaluate(async () => {
+      const app = (window as any).go.gui.App;
+
+      // Key Vault (secret) only — App Configuration (param) absent.
+      await app.SelectScope({ provider: 'azure', subscriptionId: 's', resourceGroup: 'r', vaultName: 'v' });
+      const vaultOnly = await app.GetCurrentScope();
+
+      // App Configuration (param) only — Key Vault (secret) absent.
+      await app.SelectScope({ provider: 'azure', subscriptionId: 's', resourceGroup: 'r', storeName: 'c' });
+      const storeOnly = await app.GetCurrentScope();
+
+      return { vaultOnly, storeOnly };
+    });
+
+    expect(result.vaultOnly.vaultName).toBe('v');
+    expect(result.vaultOnly.storeName).toBe('');
+    expect(result.storeOnly.storeName).toBe('c');
+    expect(result.storeOnly.vaultName).toBe('');
+  });
+
+  test('stash drain routes Google Cloud/Azure names by explicit service, not name shape', async ({ page }) => {
+    // Google Cloud/Azure secret names have no leading '/', so the legacy name-shape
+    // heuristic would misroute them to secrets. With an explicit service field
+    // they route correctly.
+    await setupWailsMocks(page, {
+      stashFile: {
+        exists: true,
+        encrypted: false,
+        entries: [
+          { name: 'gcloud-param-like', operation: 'create', value: 'v', service: 'param' },
+          { name: 'gcloud-secret', operation: 'create', value: 'v', service: 'secret' },
+        ],
+        tags: [],
+      },
+    });
+    await page.goto('/');
+
+    const result = await page.evaluate(async () => {
+      const app = (window as any).go.gui.App;
+      await app.StagingDrain('', '', false, 'overwrite');
+      return await app.StagingStatus();
+    });
+
+    expect(result.param.map((e: any) => e.name)).toEqual(['gcloud-param-like']);
+    expect(result.secret.map((e: any) => e.name)).toEqual(['gcloud-secret']);
+  });
+});


### PR DESCRIPTION
Closes #269. Blocks #266. Part of #250.

> **Stacked on #277** (base = `feat/issue-276-gui-backend-prep`). Review/merge #277 first; this PR's mock mirrors the bindings it adds. This PR is itself a stacked PR, so it also exercises the CI trigger fix below.

Test-infrastructure and CI only; no UI change. Lands before #266 because the generated wailsjs stubs hard-dereference `window.go.gui.App.<Method>` — the moment #266 calls `DetectProviders`/`Capabilities`/`InitialProvider`/`SelectScope`/`GetCurrentScope` on mount, every spec would fail at `page.goto('/')`.

## Mock generalization (`tests/fixtures/wails-mock.ts`)

- Stub the new bindings with AWS-only defaults: `DetectProviders`, `Capabilities`, `InitialProvider`, `GetCurrentScope`, and a validating `SelectScope` mirroring the backend error paths.
- `Capabilities` fixture copied **verbatim** from `internal/gui/providers.go` (incl. `hasStaging`/`hasForceDelete`/`hasRecoveryWindow`) and kept in lockstep.
- Extend `MockState` with provider-selection state behind AWS defaults, so the 15 existing specs are untouched.
- Route `StagingDrain` by an explicit per-entry `service` field (falling back to the AWS leading-`/` heuristic), so Google Cloud/Azure names are no longer misrouted.
- Scope-aware `ParamTypeOptions`; `navigateTo()` also accepts capability display names ("Key Vault", "App Configuration").
- Mock-contract infra spec covering the new bindings, incl. a **one-sided Azure** scope (only Key Vault, or only App Configuration, available).

## CI (`test.yml` / `codecov.yml`)

- `pull_request` now triggers on **all** base branches (`branches: ['**']`), so stacked PRs get the full workflow instead of zero CI. *(This PR proves it: it runs full CI against a feature-branch base.)*
- `gui-go-test` uploads coverage (`-coverprofile`, `flags: gui`); `after_n_builds` 5 → 6.
- **New "Naming Convention" job** (`.github/scripts/check-naming.sh`): fails the build on the bare `GCP` acronym. The convention is **`Google Cloud`** (prose) / **`gcloud`** (CLI/identifiers) / **`GoogleCloud`** (Go identifier). The third-party `gcp-secret-manager-emulator` image is allowlisted; binary/lock files are skipped.

## Tests

All 15 existing specs stay green (**461**) plus the mock-contract infra spec (**4**) → **465 passed** on chromium. `npm run ci` (biome + svelte-check) clean. Naming Convention CI job green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SPyCZL1EWNiYBe17j4ocM
