### PR TITLE
feat(gui): provider-neutral DTO renames + presence-gated AWS fields (#268)

### DIFF
--- a/internal/gui/frontend/src/lib/ParamView.svelte
+++ b/internal/gui/frontend/src/lib/ParamView.svelte
@@ -369,7 +369,7 @@
     <input
       type="text"
       class="filter-input prefix-input"
-      placeholder="Prefix (e.g., /prod/)"
+      placeholder="Filter by prefix"
       bind:value={prefix}
       oninput={handlePrefixInput}
     />

--- a/internal/gui/frontend/src/lib/SecretView.svelte
+++ b/internal/gui/frontend/src/lib/SecretView.svelte
@@ -517,14 +517,16 @@
                 <span class="meta-label">Version ID</span>
                 <span class="meta-value mono">{secretDetail.versionId}</span>
               </div>
-              <div class="meta-item">
-                <span class="meta-label">Labels</span>
-                <span class="meta-value">
-                  {#each secretDetail.versionStage || [] as stage}
-                    <span class="badge badge-stage">{stage}</span>
-                  {/each}
-                </span>
-              </div>
+              {#if (secretDetail.versionStage || []).length > 0}
+                <div class="meta-item">
+                  <span class="meta-label">Labels</span>
+                  <span class="meta-value">
+                    {#each secretDetail.versionStage || [] as stage}
+                      <span class="badge badge-stage">{stage}</span>
+                    {/each}
+                  </span>
+                </div>
+              {/if}
               <div class="meta-item">
                 <span class="meta-label">Created</span>
                 <span class="meta-value">{formatDate(secretDetail.createdDate)}</span>
@@ -538,10 +540,12 @@
               </div>
             {/if}
 
-            <div class="detail-section">
-              <h4>ARN</h4>
-              <code class="arn-display">{secretDetail.arn}</code>
-            </div>
+            {#if secretDetail.arn}
+              <div class="detail-section">
+                <h4>ARN</h4>
+                <code class="arn-display">{secretDetail.arn}</code>
+              </div>
+            {/if}
 
             <TagList tags={secretDetail.tags} serviceClass="secret" onadd={openTagModal} onremove={openRemoveTagModal} />
 
@@ -584,11 +588,13 @@
                           {/if}
                           <span class="history-date">{formatDate(logEntry.created)}</span>
                         </div>
-                        <div class="history-labels">
-                          {#each logEntry.stages || [] as stage}
-                            <span class="badge badge-stage small">{stage}</span>
-                          {/each}
-                        </div>
+                        {#if (logEntry.stages || []).length > 0}
+                          <div class="history-labels">
+                            {#each logEntry.stages || [] as stage}
+                              <span class="badge badge-stage small">{stage}</span>
+                            {/each}
+                          </div>
+                        {/if}
                         <pre class="history-value" class:masked={!showValue}>{showValue ? formatJsonValue(logEntry.value) : maskValue(logEntry.value)}</pre>
                       </div>
                     </li>

--- a/internal/gui/frontend/src/lib/StagingSection.svelte
+++ b/internal/gui/frontend/src/lib/StagingSection.svelte
@@ -129,11 +129,11 @@
             {#if viewMode === 'diff'}
               <div class="entry-diff">
                 <DiffDisplay
-                  oldValue={entry.awsValue || ''}
+                  oldValue={entry.remoteValue || ''}
                   newValue="(deleted)"
-                  oldLabel="AWS"
+                  oldLabel="Remote"
                   newLabel="Staged"
-                  oldSubLabel={entry.awsIdentifier || ''}
+                  oldSubLabel={entry.remoteIdentifier || ''}
                 />
               </div>
             {:else}
@@ -143,11 +143,11 @@
             {#if viewMode === 'diff' && entry.operation !== 'create'}
               <div class="entry-diff">
                 <DiffDisplay
-                  oldValue={entry.awsValue || ''}
+                  oldValue={entry.remoteValue || ''}
                   newValue={entry.stagedValue}
-                  oldLabel="AWS"
+                  oldLabel="Remote"
                   newLabel="Staged"
-                  oldSubLabel={entry.awsIdentifier || ''}
+                  oldSubLabel={entry.remoteIdentifier || ''}
                 />
               </div>
             {:else}

--- a/internal/gui/frontend/src/lib/StagingView.svelte
+++ b/internal/gui/frontend/src/lib/StagingView.svelte
@@ -83,15 +83,15 @@
     error = '';
     try {
       // Load diff data and file status in parallel
-      const [ssmResult, smResult, fileStatusResult] = await Promise.all([
+      const [paramResult, secretResult, fileStatusResult] = await Promise.all([
         withRetry(() => StagingDiff('param', '')),
         withRetry(() => StagingDiff('secret', '')),
         StagingFileStatus().catch(() => null) // Don't fail if file status check fails
       ]);
-      paramEntries = ssmResult?.entries?.filter(e => e.type !== 'autoUnstaged') || [];
-      secretEntries = smResult?.entries?.filter(e => e.type !== 'autoUnstaged') || [];
-      paramTagEntries = ssmResult?.tagEntries || [];
-      secretTagEntries = smResult?.tagEntries || [];
+      paramEntries = paramResult?.entries?.filter(e => e.type !== 'autoUnstaged') || [];
+      secretEntries = secretResult?.entries?.filter(e => e.type !== 'autoUnstaged') || [];
+      paramTagEntries = paramResult?.tagEntries || [];
+      secretTagEntries = secretResult?.tagEntries || [];
       fileStatus = fileStatusResult;
       // Emit count change for sidebar badge
       const totalCount = paramEntries.length + secretEntries.length + paramTagEntries.length + secretTagEntries.length;
@@ -625,7 +625,7 @@
       </div>
     {:else}
       <p>Apply staged changes to {getServiceName(applyService)}?</p>
-      <p class="info">This will push all staged changes to AWS.</p>
+      <p class="info">This will push all staged changes to the remote store.</p>
       <label class="checkbox-label">
         <input type="checkbox" bind:checked={ignoreConflicts} />
         <span>Ignore conflicts</span>

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -13,6 +13,12 @@ export interface Parameter {
 export interface Secret {
   name: string;
   value: string;
+  // Optional overrides for SecretShow. When omitted, SecretShow synthesizes an
+  // AWS-shaped ARN and an ['AWSCURRENT'] staging label (backward compatible).
+  // A provider without these (e.g. an empty arn / empty stages, as Google Cloud
+  // and Azure return) drives the presence-gated rendering in SecretView.
+  arn?: string;
+  versionStage?: string[];
 }
 
 export interface Tag {
@@ -819,9 +825,9 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
         const tags = state.secretTags[name] || [];
         return {
           name,
-          arn: `arn:aws:secretsmanager:us-east-1:123456789:secret:${name}`,
+          arn: secret?.arn !== undefined ? secret.arn : `arn:aws:secretsmanager:us-east-1:123456789:secret:${name}`,
           versionId: 'v1',
-          versionStage: ['AWSCURRENT'],
+          versionStage: secret?.versionStage !== undefined ? secret.versionStage : ['AWSCURRENT'],
           value: secret?.value || 'mock-secret',
           description: '',
           createdDate: new Date().toISOString(),
@@ -911,8 +917,8 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
             name: s.name,
             type: s.operation === 'create' ? 'create' : 'normal',
             operation: s.operation,
-            awsValue: s.operation === 'create' ? '' : 'aws-value',
-            awsIdentifier: s.operation === 'create' ? '' : '#1',
+            remoteValue: s.operation === 'create' ? '' : 'remote-value',
+            remoteIdentifier: s.operation === 'create' ? '' : '#1',
             stagedValue: s.value || '',
             description: '',
             warning: '',

--- a/internal/gui/frontend/tests/secret.spec.ts
+++ b/internal/gui/frontend/tests/secret.spec.ts
@@ -458,3 +458,32 @@ test.describe('Secret Edge Cases', () => {
     });
   });
 });
+
+test.describe('Secret provider-neutral presence gating (#268)', () => {
+  // A secret from a provider without an ARN or staging labels (as Google Cloud
+  // and Azure return) must not render the AWS-only ARN section or the Labels
+  // row — the fields are presence-gated, no capability flag involved.
+  test.beforeEach(async ({ page }) => {
+    await setupWailsMocks(page, {
+      secrets: [{ name: 'neutral-secret', value: 'v', arn: '', versionStage: [] }],
+      secretTags: {},
+    } as Partial<MockState>);
+    await page.goto('/');
+    await navigateTo(page, 'Secrets');
+    await waitForItemList(page);
+    await clickItemByName(page, 'neutral-secret');
+    await expect(page.locator('.detail-panel')).toBeVisible();
+  });
+
+  test('hides the ARN section when arn is empty', async ({ page }) => {
+    await expect(page.locator('.arn-display')).toHaveCount(0);
+  });
+
+  test('hides the Labels row when there are no staging labels', async ({ page }) => {
+    await expect(page.locator('.meta-label').filter({ hasText: 'Labels' })).toHaveCount(0);
+  });
+
+  test('still renders always-present metadata (Version ID)', async ({ page }) => {
+    await expect(page.locator('.meta-label').filter({ hasText: 'Version ID' })).toBeVisible();
+  });
+});

--- a/internal/gui/frontend/wailsjs/go/models.ts
+++ b/internal/gui/frontend/wailsjs/go/models.ts
@@ -732,8 +732,8 @@ export namespace gui {
 	    name: string;
 	    type: string;
 	    operation?: string;
-	    awsValue?: string;
-	    awsIdentifier?: string;
+	    remoteValue?: string;
+	    remoteIdentifier?: string;
 	    stagedValue?: string;
 	    description?: string;
 	    warning?: string;
@@ -747,8 +747,8 @@ export namespace gui {
 	        this.name = source["name"];
 	        this.type = source["type"];
 	        this.operation = source["operation"];
-	        this.awsValue = source["awsValue"];
-	        this.awsIdentifier = source["awsIdentifier"];
+	        this.remoteValue = source["remoteValue"];
+	        this.remoteIdentifier = source["remoteIdentifier"];
 	        this.stagedValue = source["stagedValue"];
 	        this.description = source["description"];
 	        this.warning = source["warning"];

--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -124,16 +124,19 @@ type StagingDiffResult struct {
 	TagEntries []StagingDiffTagEntry `json:"tagEntries"`
 }
 
-// StagingDiffEntry represents a single diff entry.
+// StagingDiffEntry represents a single diff entry. RemoteValue/RemoteIdentifier
+// are the current value and version identifier on the provider being compared
+// against (AWS today; the field names are provider-neutral so Google Cloud and
+// Azure fit without another rename).
 type StagingDiffEntry struct {
-	Name          string  `json:"name"`
-	Type          string  `json:"type"` // "normal", "create", "autoUnstaged", "warning"
-	Operation     string  `json:"operation,omitempty"`
-	AWSValue      string  `json:"awsValue,omitempty"`
-	AWSIdentifier string  `json:"awsIdentifier,omitempty"`
-	StagedValue   string  `json:"stagedValue,omitempty"`
-	Description   *string `json:"description,omitempty"`
-	Warning       string  `json:"warning,omitempty"`
+	Name             string  `json:"name"`
+	Type             string  `json:"type"` // "normal", "create", "autoUnstaged", "warning"
+	Operation        string  `json:"operation,omitempty"`
+	RemoteValue      string  `json:"remoteValue,omitempty"`
+	RemoteIdentifier string  `json:"remoteIdentifier,omitempty"`
+	StagedValue      string  `json:"stagedValue,omitempty"`
+	Description      *string `json:"description,omitempty"`
+	Warning          string  `json:"warning,omitempty"`
 }
 
 // StagingDiffTagEntry represents a single diff tag entry.
@@ -633,14 +636,14 @@ func (a *App) StagingDiff(service string, name string) (*StagingDiffResult, erro
 	entries := make([]StagingDiffEntry, len(result.Entries))
 	for i, e := range result.Entries {
 		entries[i] = StagingDiffEntry{
-			Name:          e.Name,
-			Type:          diffEntryTypeNames[e.Type],
-			Operation:     string(e.Operation),
-			AWSValue:      e.AWSValue,
-			AWSIdentifier: e.AWSIdentifier,
-			StagedValue:   e.StagedValue,
-			Description:   e.Description,
-			Warning:       e.Warning,
+			Name:             e.Name,
+			Type:             diffEntryTypeNames[e.Type],
+			Operation:        string(e.Operation),
+			RemoteValue:      e.AWSValue,
+			RemoteIdentifier: e.AWSIdentifier,
+			StagedValue:      e.StagedValue,
+			Description:      e.Description,
+			Warning:          e.Warning,
 		}
 	}
 


### PR DESCRIPTION
Closes #268. Blocks #266. Part of #250.

Mechanical provider-neutralization of AWS-shaped DTOs, labels, and fields. Lands **before #266** to cut rebase pain on the large selector PR. This is renames + render-if-present gating of **existing** fields only; capability-driven hiding, the identity sidebar, and the provider selector remain #266's scope.

## Go DTO rename (models.ts + dto_contract + mock in lockstep)

- `StagingDiffEntry.AWSValue/AWSIdentifier` → `RemoteValue/RemoteIdentifier` (json `remoteValue`/`remoteIdentifier`). The usecase layer keeps its field names; only the GUI DTO is neutralized. `dto_contract_internal_test.go` stays green (shape unchanged, keys renamed on both sides).
- `SecretDelete`'s AWS-only "+30d recovery" gating already landed in #276 (noted here for traceability).

## Frontend

- **StagingSection**: diff rows use `entry.remoteValue`/`entry.remoteIdentifier`; `oldLabel="AWS"` → `oldLabel="Remote"`.
- **SecretView**: the ARN section and the **Labels** (`versionStage`) row render **only when non-empty**, so Google Cloud / Azure secrets (no ARN, no staging labels) don't show empty AWS-only chrome. History staging-label badges gated likewise.
- **StagingView**: "push all staged changes to AWS" → "…to the remote store"; `ssmResult`/`smResult` → `paramResult`/`secretResult`.
- **ParamView**: AWS-shaped `"Prefix (e.g., /prod/)"` placeholder → neutral `"Filter by prefix"`.

## Tests

- New `secret.spec` presence-gating cases (ARN section + Labels row hidden when empty), driven by a **backward-compatible** mock `Secret` `arn`/`versionStage` override (existing secrets keep the AWS-shaped defaults, so the 15 existing specs are untouched).
- Grep acceptance: `grep -ri "awsValue\|awsIdentifier\|ssmResult" src/` → empty. Remaining literal `AWS` in `src/` is confined to `App.svelte`'s `GetAWSIdentity` wiring (identity sidebar = #266).
- **Playwright 468 passed** (chromium); `npm run ci` (biome + svelte-check) clean; gui Go tests + `golangci-lint` (production tags) green; Naming Convention check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SPyCZL1EWNiYBe17j4ocM
