### PR TITLE
feat(gui): provider/scope selector + capability-driven UI (#266)

### DIFF
--- a/internal/gui/frontend/src/App.svelte
+++ b/internal/gui/frontend/src/App.svelte
@@ -1,19 +1,177 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { GetAWSIdentity, StagingStatus } from '../wailsjs/go/gui/App';
+  import {
+    Capabilities,
+    DetectProviders,
+    GetAWSIdentity,
+    GetCurrentScope,
+    InitialProvider,
+    SelectScope,
+    StagingStatus,
+  } from '../wailsjs/go/gui/App';
+  import type { gui } from '../wailsjs/go/models';
   import ParamView from './lib/ParamView.svelte';
   import { withRetry } from './lib/retry';
   import SecretView from './lib/SecretView.svelte';
   import Sidebar from './lib/Sidebar.svelte';
   import StagingView from './lib/StagingView.svelte';
+  import { parseError } from './lib/viewUtils';
 
-  let activeView: 'param' | 'secret' | 'staging' = $state('param');
+  type ViewKey = 'param' | 'secret' | 'staging';
+
+  // ---- Provider / scope: single source of truth for the whole app ----------
+  let capabilities = $state<gui.ProviderCapability[]>([]);
+  let provider = $state(''); // '' until resolved/selected → selector prompt
+  let scope = $state<gui.ScopeSelection | null>(null);
+  let scopeReady = $state(false); // SelectScope resolved for the current provider
+  let initializing = $state(true);
+  let initError = $state('');
+  let scopeError = $state('');
+
+  // ---- View / sidebar state --------------------------------------------------
+  let activeView: ViewKey = $state('param');
   let stagingCount = $state(0);
   let accountId = $state('');
   let region = $state('');
   let profile = $state('');
 
-  function handleNavigate(view: 'param' | 'secret' | 'staging') {
+  // ---- Derived capability lookups -------------------------------------------
+  const activeProvider = $derived(capabilities.find((c) => c.provider === provider) ?? null);
+  const services = $derived(activeProvider?.services ?? []);
+  const hasAnyStaging = $derived(services.some((s) => s.hasStaging));
+  const isAWS = $derived(provider === 'aws');
+
+  // scopeKey drives the {#key} full remount: any provider/scope change swaps it,
+  // so views re-initialize from scratch and no in-flight response from the old
+  // scope can land in the new one.
+  const scopeKey = $derived(
+    scope
+      ? [provider, scope.projectId, scope.subscriptionId, scope.resourceGroup, scope.vaultName, scope.storeName].join('|')
+      : provider,
+  );
+
+  // effectiveView clamps activeView to a service the provider actually offers
+  // (Google Cloud has no param; the Staging tab is hidden when no service supports it),
+  // so switching providers never leaves a blank pane.
+  const effectiveView = $derived.by((): ViewKey => {
+    if (activeView === 'staging') {
+      return hasAnyStaging ? 'staging' : ((services[0]?.service as ViewKey) ?? 'param');
+    }
+    if (services.some((s) => s.service === activeView)) return activeView;
+    return (services[0]?.service as ViewKey) ?? 'param';
+  });
+
+  const paramCap = $derived(services.find((s) => s.service === 'param') ?? null);
+  const secretCap = $derived(services.find((s) => s.service === 'secret') ?? null);
+
+  // ---- Startup: gate before fetch -------------------------------------------
+  // No GetAWSIdentity / StagingStatus until the provider is known AND is AWS —
+  // this kills the ~5s STS retry storm in non-AWS environments.
+  onMount(async () => {
+    try {
+      capabilities = await withRetry(() => Capabilities());
+      scope = await withRetry(() => GetCurrentScope());
+
+      let picked = await withRetry(() => InitialProvider());
+      if (!picked) {
+        const detected = await withRetry(() => DetectProviders());
+        picked = uniqueActiveProvider(detected);
+      }
+
+      if (picked) {
+        await selectProvider(picked);
+      }
+    } catch (e) {
+      initError = parseError(e);
+    } finally {
+      initializing = false;
+    }
+  });
+
+  // uniqueActiveProvider returns the sole provider active across param+secret,
+  // or '' when zero or two-plus are active (mirrors the backend rule).
+  function uniqueActiveProvider(d: gui.DetectResult): string {
+    const active = new Set<string>([...(d.paramActive ?? []), ...(d.secretActive ?? [])]);
+    if (active.size !== 1) return '';
+    const [only] = active;
+    return only ?? '';
+  }
+
+  function buildSelection(p: string): gui.ScopeSelection {
+    return {
+      provider: p,
+      projectId: p === 'googlecloud' ? (scope?.projectId ?? '') : '',
+      subscriptionId: p === 'azure' ? (scope?.subscriptionId ?? '') : '',
+      resourceGroup: p === 'azure' ? (scope?.resourceGroup ?? '') : '',
+      vaultName: p === 'azure' ? (scope?.vaultName ?? '') : '',
+      storeName: p === 'azure' ? (scope?.storeName ?? '') : '',
+    } as gui.ScopeSelection;
+  }
+
+  function hasRequiredScope(sel: gui.ScopeSelection): boolean {
+    switch (sel.provider) {
+      case 'aws':
+        return true;
+      case 'googlecloud':
+        return !!sel.projectId;
+      case 'azure':
+        return !!sel.vaultName || !!sel.storeName;
+      default:
+        return false;
+    }
+  }
+
+  // selectProvider switches the active provider. When the (env-prefilled) scope
+  // already has the required fields it applies immediately; otherwise it leaves
+  // scopeReady=false so the sidebar shows the scope form.
+  async function selectProvider(p: string) {
+    provider = p;
+    scopeReady = false;
+    scopeError = '';
+    resetIdentity();
+
+    const sel = buildSelection(p);
+    if (hasRequiredScope(sel)) {
+      await applyScope(sel);
+    }
+  }
+
+  // applyScope validates+commits the scope server-side, then (AWS only) loads
+  // identity and the staging badge.
+  async function applyScope(sel: gui.ScopeSelection) {
+    scopeError = '';
+    try {
+      await SelectScope(sel);
+      scope = await GetCurrentScope();
+      provider = sel.provider;
+      scopeReady = true;
+      resetIdentity();
+      if (sel.provider === 'aws') {
+        await loadAWSIdentity();
+        await loadStagingCount();
+      }
+    } catch (e) {
+      scopeReady = false;
+      scopeError = parseError(e);
+    }
+  }
+
+  function resetIdentity() {
+    stagingCount = 0;
+    accountId = '';
+    region = '';
+    profile = '';
+  }
+
+  function handleSelectProvider(p: string) {
+    selectProvider(p);
+  }
+
+  function handleSelectScope(sel: gui.ScopeSelection) {
+    applyScope(sel);
+  }
+
+  function handleNavigate(view: ViewKey) {
     activeView = view;
   }
 
@@ -22,48 +180,80 @@
   }
 
   async function loadStagingCount() {
+    // Steady-state, AWS-only: no retry wrapping (a real failure must not hammer).
     try {
-      const status = await withRetry(() => StagingStatus());
-      stagingCount = (status?.param?.length || 0) + (status?.secret?.length || 0);
-    } catch (e) {
+      const staged = await StagingStatus();
+      stagingCount = (staged?.param?.length ?? 0) + (staged?.secret?.length ?? 0);
+    } catch {
       stagingCount = 0;
     }
   }
 
   function handleStagingChange() {
-    loadStagingCount();
+    if (isAWS) loadStagingCount();
   }
 
   async function loadAWSIdentity() {
     try {
       const identity = await GetAWSIdentity();
-      accountId = identity?.accountId || '';
-      region = identity?.region || '';
-      profile = identity?.profile || '';
-    } catch (e) {
-      // AWS identity may not be available (e.g., no credentials)
+      accountId = identity?.accountId ?? '';
+      region = identity?.region ?? '';
+      profile = identity?.profile ?? '';
+    } catch {
       accountId = '';
       region = '';
       profile = '';
     }
   }
-
-  onMount(() => {
-    loadStagingCount();
-    loadAWSIdentity();
-  });
 </script>
 
 <div class="app">
-  <Sidebar {activeView} {stagingCount} {accountId} {region} {profile} onnavigate={handleNavigate} />
+  <Sidebar
+    {capabilities}
+    {provider}
+    {services}
+    {hasAnyStaging}
+    {scope}
+    {scopeReady}
+    activeView={effectiveView}
+    {stagingCount}
+    {accountId}
+    {region}
+    {profile}
+    onnavigate={handleNavigate}
+    onselectprovider={handleSelectProvider}
+    onselectscope={handleSelectScope}
+  />
 
   <main class="main-content">
-    {#if activeView === 'param'}
-      <ParamView onnavigatetostaging={() => handleNavigate('staging')} onstagingchange={handleStagingChange} />
-    {:else if activeView === 'secret'}
-      <SecretView onnavigatetostaging={() => handleNavigate('staging')} onstagingchange={handleStagingChange} />
-    {:else if activeView === 'staging'}
-      <StagingView oncountchange={handleStagingCountChange} />
+    {#if initializing}
+      <div class="app-status">Loading…</div>
+    {:else if initError}
+      <div class="app-status app-error">Failed to initialize: {initError}</div>
+    {:else if !provider}
+      <div class="app-status">Select a provider to begin.</div>
+    {:else if !scopeReady}
+      <div class="app-status">
+        {scopeError || 'Enter the required scope in the sidebar to continue.'}
+      </div>
+    {:else}
+      {#key scopeKey}
+        {#if effectiveView === 'param' && paramCap}
+          <ParamView
+            capability={paramCap}
+            onnavigatetostaging={() => handleNavigate('staging')}
+            onstagingchange={handleStagingChange}
+          />
+        {:else if effectiveView === 'secret' && secretCap}
+          <SecretView
+            capability={secretCap}
+            onnavigatetostaging={() => handleNavigate('staging')}
+            onstagingchange={handleStagingChange}
+          />
+        {:else if effectiveView === 'staging' && hasAnyStaging}
+          <StagingView oncountchange={handleStagingCountChange} />
+        {/if}
+      {/key}
     {/if}
   </main>
 </div>
@@ -79,5 +269,20 @@
   .main-content {
     flex: 1;
     overflow: hidden;
+  }
+
+  .app-status {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    padding: 24px;
+    color: #a0a0a0;
+    font-size: 14px;
+    text-align: center;
+  }
+
+  .app-error {
+    color: #e94560;
   }
 </style>

--- a/internal/gui/frontend/src/lib/ParamView.svelte
+++ b/internal/gui/frontend/src/lib/ParamView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import { ParamAddTag, ParamDelete, ParamDiff, ParamList, ParamLog, ParamRemoveTag, ParamSet, ParamShow, ParamTypeOptions, StagingAdd, StagingAddTag, StagingCheckStatus, StagingDelete, StagingEdit, StagingRemoveTag } from '../../wailsjs/go/gui/App';
   import type { gui } from '../../wailsjs/go/models';
   import DiffDisplay from './DiffDisplay.svelte';
@@ -7,7 +7,6 @@
   import EyeIcon from './icons/EyeIcon.svelte';
   import EyeOffIcon from './icons/EyeOffIcon.svelte';
   import Modal from './Modal.svelte';
-  import { withRetry } from './retry';
   import StagingBanner from './StagingBanner.svelte';
   import TagList from './TagList.svelte';
   import { createDiffMode } from './useDiffMode.svelte';
@@ -15,15 +14,26 @@
   import './common.css';
 
   interface Props {
+    capability?: gui.ServiceCapability;
     onnavigatetostaging?: () => void;
     onstagingchange?: () => void;
   }
 
-  let { onnavigatetostaging, onstagingchange }: Props = $props();
+  let { capability, onnavigatetostaging, onstagingchange }: Props = $props();
+
+  // Capability-driven visibility. Absent capability defaults to AWS-like (true)
+  // so the component degrades safely if mounted without one.
+  const stagingEnabled = $derived(capability?.hasStaging ?? true);
+  const tagsEnabled = $derived(capability?.hasTags ?? true);
+  const historyEnabled = $derived(capability?.hasVersionHistory ?? true);
 
   const PAGE_SIZE = 50;
   const debounce = createDebouncer(300);
   const diffMode = createDiffMode<number>();
+
+  // A pending filter debounce must not fire a stray List after a {#key} remount
+  // into a different provider.
+  onDestroy(() => debounce.cancel());
 
   let prefix = $state('');
   let filter = $state('');
@@ -57,6 +67,10 @@
   let modalLoading = $state(false);
   let modalError = $state('');
   let immediateMode = $state(false);
+  // When staging is unavailable, every write is immediate (no staging toggle).
+  const immediate = $derived(immediateMode || !stagingEnabled);
+  // The Type dropdown is scope-aware: empty options (Azure App Config) hide it.
+  const typeEnabled = $derived(paramTypeOptions.length > 0);
 
   // Diff state
   let diffResult: gui.ParamDiffResult | null = $state(null);
@@ -166,18 +180,24 @@
     showValue = withValue;
     stagingStatus = null;
     try {
-      const [detail, log, staging] = await Promise.all([
-        ParamShow(name),
-        ParamLog(name, 10),
-        withRetry(() => StagingCheckStatus('param', name))
-      ]);
+      const [detail, log] = await Promise.all([ParamShow(name), ParamLog(name, 10)]);
       paramDetail = detail;
       paramLog = log?.entries || [];
-      stagingStatus = staging;
     } catch (e) {
       error = parseError(e);
     } finally {
       detailLoading = false;
+    }
+
+    // Staging status is decoupled from the detail fetch: only for
+    // staging-capable providers, and a failure just means no banner — it must
+    // never break the detail pane.
+    if (stagingEnabled) {
+      try {
+        stagingStatus = await StagingCheckStatus('param', name);
+      } catch {
+        stagingStatus = null;
+      }
     }
   }
 
@@ -216,7 +236,7 @@
     modalError = '';
     try {
       const isEdit = paramDetail && selectedParam === setForm.name;
-      if (immediateMode) {
+      if (immediate) {
         await ParamSet(setForm.name, setForm.value, setForm.type);
         await loadParams({ prefix, filter, recursive, withValue });
         if (isEdit) {
@@ -253,7 +273,7 @@
     modalLoading = true;
     modalError = '';
     try {
-      if (immediateMode) {
+      if (immediate) {
         await ParamDelete(deleteTarget);
         if (selectedParam === deleteTarget) {
           closeDetail();
@@ -312,7 +332,7 @@
     tagLoading = true;
     tagError = '';
     try {
-      if (immediateMode) {
+      if (immediate) {
         await ParamAddTag(selectedParam, tagForm.key, tagForm.value);
       } else {
         await StagingAddTag('param', selectedParam, tagForm.key, tagForm.value);
@@ -338,7 +358,7 @@
     removeTagLoading = true;
     removeTagError = '';
     try {
-      if (immediateMode) {
+      if (immediate) {
         await ParamRemoveTag(selectedParam, removeTagTarget);
       } else {
         await StagingRemoveTag('param', selectedParam, removeTagTarget);
@@ -437,7 +457,7 @@
           <div class="detail-actions">
             <button class="btn-action-sm" onclick={() => selectedParam && openSetModal(selectedParam)}>Edit</button>
             <button class="btn-action-sm btn-danger" onclick={() => selectedParam && openDeleteModal(selectedParam)}>Delete</button>
-            {#if paramLog.length >= 2}
+            {#if historyEnabled && paramLog.length >= 2}
               <button class="btn-action-sm" class:active={diffMode.active} onclick={diffMode.toggle}>
                 {diffMode.active ? 'Cancel' : 'Compare'}
               </button>
@@ -448,7 +468,9 @@
           </div>
         </div>
 
-        <StagingBanner {stagingStatus} onnavigate={onnavigatetostaging} />
+        {#if stagingEnabled}
+          <StagingBanner {stagingStatus} onnavigate={onnavigatetostaging} />
+        {/if}
 
         {#if detailLoading}
           <div class="loading">Loading...</div>
@@ -478,14 +500,18 @@
             </div>
 
             <div class="detail-meta">
-              <div class="meta-item">
-                <span class="meta-label">Version</span>
-                <span class="meta-value">{paramDetail.version}</span>
-              </div>
-              <div class="meta-item">
-                <span class="meta-label">Type</span>
-                <span class="meta-value">{paramDetail.type}</span>
-              </div>
+              {#if historyEnabled}
+                <div class="meta-item">
+                  <span class="meta-label">Version</span>
+                  <span class="meta-value">{paramDetail.version}</span>
+                </div>
+              {/if}
+              {#if typeEnabled}
+                <div class="meta-item">
+                  <span class="meta-label">Type</span>
+                  <span class="meta-value">{paramDetail.type}</span>
+                </div>
+              {/if}
               <div class="meta-item">
                 <span class="meta-label">Last Modified</span>
                 <span class="meta-value">{formatDate(paramDetail.lastModified)}</span>
@@ -499,9 +525,11 @@
               </div>
             {/if}
 
-            <TagList tags={paramDetail.tags} serviceClass="param" onadd={openTagModal} onremove={openRemoveTagModal} />
+            {#if tagsEnabled}
+              <TagList tags={paramDetail.tags} serviceClass="param" onadd={openTagModal} onremove={openRemoveTagModal} />
+            {/if}
 
-            {#if paramLog.length > 0}
+            {#if historyEnabled && paramLog.length > 0}
               <div class="detail-section">
                 <div class="section-header">
                   <h4>Version History</h4>
@@ -571,14 +599,16 @@
         disabled={!!paramDetail && selectedParam === setForm.name}
       />
     </div>
-    <div class="form-group">
-      <label for="param-type">Type</label>
-      <select id="param-type" class="form-input" bind:value={setForm.type}>
-        {#each paramTypeOptions as typeOption}
-          <option value={typeOption}>{typeOption}</option>
-        {/each}
-      </select>
-    </div>
+    {#if typeEnabled}
+      <div class="form-group">
+        <label for="param-type">Type</label>
+        <select id="param-type" class="form-input" bind:value={setForm.type}>
+          {#each paramTypeOptions as typeOption}
+            <option value={typeOption}>{typeOption}</option>
+          {/each}
+        </select>
+      </div>
+    {/if}
     <div class="form-group">
       <label for="param-value">Value</label>
       <textarea
@@ -589,14 +619,16 @@
         rows="5"
       ></textarea>
     </div>
-    <label class="checkbox-label immediate-checkbox">
-      <input type="checkbox" bind:checked={immediateMode} />
-      <span>Apply immediately (skip staging)</span>
-    </label>
+    {#if stagingEnabled}
+      <label class="checkbox-label immediate-checkbox">
+        <input type="checkbox" bind:checked={immediateMode} />
+        <span>Apply immediately (skip staging)</span>
+      </label>
+    {/if}
     <div class="form-actions">
       <button type="button" class="btn-secondary" onclick={() => showSetModal = false}>Cancel</button>
       <button type="submit" class="btn-primary" disabled={modalLoading}>
-        {modalLoading ? (immediateMode ? 'Saving...' : 'Staging...') : (immediateMode ? 'Save' : 'Stage')}
+        {modalLoading ? (immediate ? 'Saving...' : 'Staging...') : (immediate ? 'Save' : 'Stage')}
       </button>
     </div>
   </form>
@@ -610,15 +642,17 @@
     {/if}
     <p>Are you sure you want to delete this parameter?</p>
     <code class="delete-target param">{deleteTarget}</code>
-    <p class="warning">{immediateMode ? 'This action cannot be undone.' : 'This will stage a delete operation.'}</p>
-    <label class="checkbox-label immediate-checkbox">
-      <input type="checkbox" bind:checked={immediateMode} />
-      <span>Apply immediately (skip staging)</span>
-    </label>
+    <p class="warning">{immediate ? 'This action cannot be undone.' : 'This will stage a delete operation.'}</p>
+    {#if stagingEnabled}
+      <label class="checkbox-label immediate-checkbox">
+        <input type="checkbox" bind:checked={immediateMode} />
+        <span>Apply immediately (skip staging)</span>
+      </label>
+    {/if}
     <div class="form-actions">
       <button type="button" class="btn-secondary" onclick={() => showDeleteModal = false}>Cancel</button>
       <button type="button" class="btn-danger" onclick={handleDelete} disabled={modalLoading}>
-        {modalLoading ? (immediateMode ? 'Deleting...' : 'Staging...') : (immediateMode ? 'Delete' : 'Stage Delete')}
+        {modalLoading ? (immediate ? 'Deleting...' : 'Staging...') : (immediate ? 'Delete' : 'Stage Delete')}
       </button>
     </div>
   </div>
@@ -632,15 +666,17 @@
     {/if}
     <p>Are you sure you want to remove this tag?</p>
     <code class="delete-target param">{removeTagTarget}</code>
-    <p class="warning">{immediateMode ? 'This action will take effect immediately.' : 'This will stage a tag removal operation.'}</p>
-    <label class="checkbox-label immediate-checkbox">
-      <input type="checkbox" bind:checked={immediateMode} />
-      <span>Apply immediately (skip staging)</span>
-    </label>
+    <p class="warning">{immediate ? 'This action will take effect immediately.' : 'This will stage a tag removal operation.'}</p>
+    {#if stagingEnabled}
+      <label class="checkbox-label immediate-checkbox">
+        <input type="checkbox" bind:checked={immediateMode} />
+        <span>Apply immediately (skip staging)</span>
+      </label>
+    {/if}
     <div class="form-actions">
       <button type="button" class="btn-secondary" onclick={() => showRemoveTagModal = false}>Cancel</button>
       <button type="button" class="btn-danger" onclick={handleRemoveTag} disabled={removeTagLoading}>
-        {removeTagLoading ? (immediateMode ? 'Removing...' : 'Staging...') : (immediateMode ? 'Remove' : 'Stage Remove')}
+        {removeTagLoading ? (immediate ? 'Removing...' : 'Staging...') : (immediate ? 'Remove' : 'Stage Remove')}
       </button>
     </div>
   </div>
@@ -689,14 +725,16 @@
         placeholder="tag-value"
       />
     </div>
-    <label class="checkbox-label immediate-checkbox">
-      <input type="checkbox" bind:checked={immediateMode} />
-      <span>Apply immediately (skip staging)</span>
-    </label>
+    {#if stagingEnabled}
+      <label class="checkbox-label immediate-checkbox">
+        <input type="checkbox" bind:checked={immediateMode} />
+        <span>Apply immediately (skip staging)</span>
+      </label>
+    {/if}
     <div class="form-actions">
       <button type="button" class="btn-secondary" onclick={() => showTagModal = false}>Cancel</button>
       <button type="submit" class="btn-primary" disabled={tagLoading}>
-        {tagLoading ? (immediateMode ? 'Adding...' : 'Staging...') : (immediateMode ? 'Add Tag' : 'Stage Tag')}
+        {tagLoading ? (immediate ? 'Adding...' : 'Staging...') : (immediate ? 'Add Tag' : 'Stage Tag')}
       </button>
     </div>
   </form>

--- a/internal/gui/frontend/src/lib/SecretView.svelte
+++ b/internal/gui/frontend/src/lib/SecretView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import { SecretAddTag, SecretCreate, SecretDelete, SecretDiff, SecretList, SecretLog, SecretRemoveTag, SecretRestore, SecretShow, SecretUpdate, StagingAdd, StagingAddTag, StagingCheckStatus, StagingDelete, StagingEdit, StagingRemoveTag } from '../../wailsjs/go/gui/App';
   import type { gui } from '../../wailsjs/go/models';
   import DiffDisplay from './DiffDisplay.svelte';
@@ -7,7 +7,6 @@
   import EyeIcon from './icons/EyeIcon.svelte';
   import EyeOffIcon from './icons/EyeOffIcon.svelte';
   import Modal from './Modal.svelte';
-  import { withRetry } from './retry';
   import StagingBanner from './StagingBanner.svelte';
   import TagList from './TagList.svelte';
   import { createDiffMode } from './useDiffMode.svelte';
@@ -15,15 +14,28 @@
   import './common.css';
 
   interface Props {
+    capability?: gui.ServiceCapability;
     onnavigatetostaging?: () => void;
     onstagingchange?: () => void;
   }
 
-  let { onnavigatetostaging, onstagingchange }: Props = $props();
+  let { capability, onnavigatetostaging, onstagingchange }: Props = $props();
+
+  // Capability-driven visibility. Absent capability defaults to AWS-like (true).
+  const stagingEnabled = $derived(capability?.hasStaging ?? true);
+  const tagsEnabled = $derived(capability?.hasTags ?? true);
+  const historyEnabled = $derived(capability?.hasVersionHistory ?? true);
+  const restoreEnabled = $derived(capability?.hasRestore ?? true);
+  const forceDeleteEnabled = $derived(capability?.hasForceDelete ?? true);
+  const recoveryWindowEnabled = $derived(capability?.hasRecoveryWindow ?? true);
 
   const PAGE_SIZE = 50;
   const debounce = createDebouncer(300);
   const diffMode = createDiffMode<string>();
+
+  // Cancel a pending filter debounce on unmount so it can't fire against a new
+  // provider after a {#key} remount.
+  onDestroy(() => debounce.cancel());
 
   let prefix = $state('');
   let filter = $state('');
@@ -81,6 +93,8 @@
   let modalLoading = $state(false);
   let modalError = $state('');
   let immediateMode = $state(false); // When false (default), changes are staged
+  // When staging is unavailable, every write is immediate (no staging toggle).
+  const immediate = $derived(immediateMode || !stagingEnabled);
 
   // Diff state
   let diffResult: gui.SecretDiffResult | null = $state(null);
@@ -167,18 +181,23 @@
     showValue = withValue;
     stagingStatus = null;
     try {
-      const [detail, log, staging] = await Promise.all([
-        SecretShow(name),
-        SecretLog(name, 10),
-        withRetry(() => StagingCheckStatus('secret', name))
-      ]);
+      const [detail, log] = await Promise.all([SecretShow(name), SecretLog(name, 10)]);
       secretDetail = detail;
       secretLog = log?.entries || [];
-      stagingStatus = staging;
     } catch (e) {
       error = parseError(e);
     } finally {
       detailLoading = false;
+    }
+
+    // Decoupled staging status: only for staging-capable providers; a failure
+    // just means no banner and never breaks the detail pane.
+    if (stagingEnabled) {
+      try {
+        stagingStatus = await StagingCheckStatus('secret', name);
+      } catch {
+        stagingStatus = null;
+      }
     }
   }
 
@@ -210,7 +229,7 @@
     modalLoading = true;
     modalError = '';
     try {
-      if (immediateMode) {
+      if (immediate) {
         await SecretCreate(createForm.name, createForm.value);
         await loadSecrets({ prefix, filter, withValue });
       } else {
@@ -243,7 +262,7 @@
     modalLoading = true;
     modalError = '';
     try {
-      if (immediateMode) {
+      if (immediate) {
         await SecretUpdate(editForm.name, editForm.value);
         await Promise.all([
           loadSecrets({ prefix, filter, withValue }),
@@ -275,7 +294,7 @@
     modalLoading = true;
     modalError = '';
     try {
-      if (immediateMode) {
+      if (immediate) {
         await SecretDelete(deleteTarget, forceDelete);
         if (selectedSecret === deleteTarget) {
           closeDetail();
@@ -355,7 +374,7 @@
     tagLoading = true;
     tagError = '';
     try {
-      if (immediateMode) {
+      if (immediate) {
         await SecretAddTag(selectedSecret, tagForm.key, tagForm.value);
       } else {
         await StagingAddTag('secret', selectedSecret, tagForm.key, tagForm.value);
@@ -381,7 +400,7 @@
     removeTagLoading = true;
     removeTagError = '';
     try {
-      if (immediateMode) {
+      if (immediate) {
         await SecretRemoveTag(selectedSecret, removeTagTarget);
       } else {
         await StagingRemoveTag('secret', selectedSecret, removeTagTarget);
@@ -428,9 +447,11 @@
     <button class="btn-secondary" onclick={openCreateModal}>
       + New
     </button>
-    <button class="btn-secondary btn-restore" onclick={() => openRestoreModal('')}>
-      Restore
-    </button>
+    {#if restoreEnabled}
+      <button class="btn-secondary btn-restore" onclick={() => openRestoreModal('')}>
+        Restore
+      </button>
+    {/if}
   </div>
 
   {#if error}
@@ -485,7 +506,9 @@
           </div>
         </div>
 
-        <StagingBanner {stagingStatus} onnavigate={onnavigatetostaging} />
+        {#if stagingEnabled}
+          <StagingBanner {stagingStatus} onnavigate={onnavigatetostaging} />
+        {/if}
 
         {#if detailLoading}
           <div class="loading">Loading...</div>
@@ -547,9 +570,11 @@
               </div>
             {/if}
 
-            <TagList tags={secretDetail.tags} serviceClass="secret" onadd={openTagModal} onremove={openRemoveTagModal} />
+            {#if tagsEnabled}
+              <TagList tags={secretDetail.tags} serviceClass="secret" onadd={openTagModal} onremove={openRemoveTagModal} />
+            {/if}
 
-            {#if secretLog.length > 0}
+            {#if historyEnabled && secretLog.length > 0}
               <div class="detail-section">
                 <div class="section-header-history">
                   <h4>Version History</h4>
@@ -635,14 +660,16 @@
         rows="5"
       ></textarea>
     </div>
-    <label class="checkbox-label immediate-checkbox">
-      <input type="checkbox" bind:checked={immediateMode} />
-      <span>Apply immediately (skip staging)</span>
-    </label>
+    {#if stagingEnabled}
+      <label class="checkbox-label immediate-checkbox">
+        <input type="checkbox" bind:checked={immediateMode} />
+        <span>Apply immediately (skip staging)</span>
+      </label>
+    {/if}
     <div class="form-actions">
       <button type="button" class="btn-secondary" onclick={() => showCreateModal = false}>Cancel</button>
       <button type="submit" class="btn-primary" disabled={modalLoading}>
-        {modalLoading ? (immediateMode ? 'Creating...' : 'Staging...') : (immediateMode ? 'Create' : 'Stage')}
+        {modalLoading ? (immediate ? 'Creating...' : 'Staging...') : (immediate ? 'Create' : 'Stage')}
       </button>
     </div>
   </form>
@@ -673,14 +700,16 @@
         rows="8"
       ></textarea>
     </div>
-    <label class="checkbox-label immediate-checkbox">
-      <input type="checkbox" bind:checked={immediateMode} />
-      <span>Apply immediately (skip staging)</span>
-    </label>
+    {#if stagingEnabled}
+      <label class="checkbox-label immediate-checkbox">
+        <input type="checkbox" bind:checked={immediateMode} />
+        <span>Apply immediately (skip staging)</span>
+      </label>
+    {/if}
     <div class="form-actions">
       <button type="button" class="btn-secondary" onclick={() => showEditModal = false}>Cancel</button>
       <button type="submit" class="btn-primary" disabled={modalLoading}>
-        {modalLoading ? (immediateMode ? 'Saving...' : 'Staging...') : (immediateMode ? 'Save' : 'Stage')}
+        {modalLoading ? (immediate ? 'Saving...' : 'Staging...') : (immediate ? 'Save' : 'Stage')}
       </button>
     </div>
   </form>
@@ -694,29 +723,35 @@
     {/if}
     <p>Are you sure you want to delete this secret?</p>
     <code class="delete-target secret">{deleteTarget}</code>
-    <label class="checkbox-label force-delete">
-      <input type="checkbox" bind:checked={forceDelete} />
-      <span>Force delete (skip recovery window)</span>
-    </label>
+    {#if forceDeleteEnabled}
+      <label class="checkbox-label force-delete">
+        <input type="checkbox" bind:checked={forceDelete} />
+        <span>Force delete (skip recovery window)</span>
+      </label>
+    {/if}
     <p class="warning">
-      {#if immediateMode}
+      {#if immediate}
         {#if forceDelete}
           This will permanently delete the secret immediately!
-        {:else}
+        {:else if recoveryWindowEnabled}
           The secret will be scheduled for deletion with a recovery window.
+        {:else}
+          This will delete the secret.
         {/if}
       {:else}
         This will stage a delete operation.
       {/if}
     </p>
-    <label class="checkbox-label immediate-checkbox">
-      <input type="checkbox" bind:checked={immediateMode} />
-      <span>Apply immediately (skip staging)</span>
-    </label>
+    {#if stagingEnabled}
+      <label class="checkbox-label immediate-checkbox">
+        <input type="checkbox" bind:checked={immediateMode} />
+        <span>Apply immediately (skip staging)</span>
+      </label>
+    {/if}
     <div class="form-actions">
       <button type="button" class="btn-secondary" onclick={() => showDeleteModal = false}>Cancel</button>
       <button type="button" class="btn-danger" onclick={handleDelete} disabled={modalLoading}>
-        {modalLoading ? (immediateMode ? 'Deleting...' : 'Staging...') : (immediateMode ? 'Delete' : 'Stage Delete')}
+        {modalLoading ? (immediate ? 'Deleting...' : 'Staging...') : (immediate ? 'Delete' : 'Stage Delete')}
       </button>
     </div>
   </div>
@@ -791,14 +826,16 @@
         placeholder="tag-value"
       />
     </div>
-    <label class="checkbox-label immediate-checkbox">
-      <input type="checkbox" bind:checked={immediateMode} />
-      <span>Apply immediately (skip staging)</span>
-    </label>
+    {#if stagingEnabled}
+      <label class="checkbox-label immediate-checkbox">
+        <input type="checkbox" bind:checked={immediateMode} />
+        <span>Apply immediately (skip staging)</span>
+      </label>
+    {/if}
     <div class="form-actions">
       <button type="button" class="btn-secondary" onclick={() => showTagModal = false}>Cancel</button>
       <button type="submit" class="btn-primary" disabled={tagLoading}>
-        {tagLoading ? (immediateMode ? 'Adding...' : 'Staging...') : (immediateMode ? 'Add Tag' : 'Stage Tag')}
+        {tagLoading ? (immediate ? 'Adding...' : 'Staging...') : (immediate ? 'Add Tag' : 'Stage Tag')}
       </button>
     </div>
   </form>
@@ -812,15 +849,17 @@
     {/if}
     <p>Are you sure you want to remove this tag?</p>
     <code class="delete-target secret">{removeTagTarget}</code>
-    <p class="warning">{immediateMode ? 'This action will take effect immediately.' : 'This will stage a tag removal operation.'}</p>
-    <label class="checkbox-label immediate-checkbox">
-      <input type="checkbox" bind:checked={immediateMode} />
-      <span>Apply immediately (skip staging)</span>
-    </label>
+    <p class="warning">{immediate ? 'This action will take effect immediately.' : 'This will stage a tag removal operation.'}</p>
+    {#if stagingEnabled}
+      <label class="checkbox-label immediate-checkbox">
+        <input type="checkbox" bind:checked={immediateMode} />
+        <span>Apply immediately (skip staging)</span>
+      </label>
+    {/if}
     <div class="form-actions">
       <button type="button" class="btn-secondary" onclick={() => showRemoveTagModal = false}>Cancel</button>
       <button type="button" class="btn-danger" onclick={handleRemoveTag} disabled={removeTagLoading}>
-        {removeTagLoading ? (immediateMode ? 'Removing...' : 'Staging...') : (immediateMode ? 'Remove' : 'Stage Remove')}
+        {removeTagLoading ? (immediate ? 'Removing...' : 'Staging...') : (immediate ? 'Remove' : 'Stage Remove')}
       </button>
     </div>
   </div>

--- a/internal/gui/frontend/src/lib/Sidebar.svelte
+++ b/internal/gui/frontend/src/lib/Sidebar.svelte
@@ -1,17 +1,85 @@
 <script lang="ts">
+  import type { gui } from '../../wailsjs/go/models';
+
+  type ViewKey = 'param' | 'secret' | 'staging';
+
   interface Props {
-    activeView?: 'param' | 'secret' | 'staging';
+    capabilities?: gui.ProviderCapability[];
+    provider?: string;
+    services?: gui.ServiceCapability[];
+    hasAnyStaging?: boolean;
+    scope?: gui.ScopeSelection | null;
+    scopeReady?: boolean;
+    activeView?: ViewKey;
     stagingCount?: number;
     accountId?: string;
     region?: string;
     profile?: string;
-    onnavigate?: (view: 'param' | 'secret' | 'staging') => void;
+    onnavigate?: (view: ViewKey) => void;
+    onselectprovider?: (provider: string) => void;
+    onselectscope?: (sel: gui.ScopeSelection) => void;
   }
 
-  let { activeView = 'param', stagingCount = 0, accountId = '', region = '', profile = '', onnavigate }: Props = $props();
+  let {
+    capabilities = [],
+    provider = '',
+    services = [],
+    hasAnyStaging = false,
+    scope = null,
+    scopeReady = false,
+    activeView = 'param',
+    stagingCount = 0,
+    accountId = '',
+    region = '',
+    profile = '',
+    onnavigate,
+    onselectprovider,
+    onselectscope,
+  }: Props = $props();
 
-  function navigate(view: 'param' | 'secret' | 'staging') {
+  // Service key → stable nav icon/letter (labels come from capability names).
+  const NAV_ICON: Record<string, string> = { param: 'P', secret: 'S' };
+
+  // Google Cloud project form state (prefilled from the backend's current scope).
+  let projectInput = $state('');
+  $effect(() => {
+    // Re-seed the project field whenever the provider or prefilled scope changes.
+    projectInput = provider === 'googlecloud' ? (scope?.projectId ?? '') : '';
+  });
+
+  // Move keyboard focus to the active tab after a provider switch, so a clamped
+  // view (e.g. Google Cloud dropping the Param tab) doesn't strand focus on a gone tab.
+  let navEl: HTMLElement | undefined = $state();
+  let lastProvider = '';
+  $effect(() => {
+    if (provider !== lastProvider && scopeReady && navEl) {
+      lastProvider = provider;
+      const active = navEl.querySelector<HTMLButtonElement>('.nav-item.active');
+      active?.focus();
+    }
+  });
+
+  function navigate(view: ViewKey) {
     onnavigate?.(view);
+  }
+
+  function handleProviderChange(e: Event) {
+    const value = (e.currentTarget as HTMLSelectElement).value;
+    onselectprovider?.(value);
+  }
+
+  function submitProject(e: SubmitEvent) {
+    e.preventDefault();
+    const projectId = projectInput.trim();
+    if (!projectId) return;
+    onselectscope?.({
+      provider: 'googlecloud',
+      projectId,
+      subscriptionId: '',
+      resourceGroup: '',
+      vaultName: '',
+      storeName: '',
+    } as gui.ScopeSelection);
   }
 </script>
 
@@ -21,54 +89,119 @@
     <span class="logo-sub">Secret Unified Versioning Explorer</span>
   </div>
 
-  <nav class="nav">
-    <button
-      class="nav-item"
-      class:active={activeView === 'param'}
-      onclick={() => navigate('param')}
-    >
-      <span class="nav-icon">P</span>
-      <span class="nav-label">Parameters</span>
-    </button>
-
-    <button
-      class="nav-item"
-      class:active={activeView === 'secret'}
-      onclick={() => navigate('secret')}
-    >
-      <span class="nav-icon">S</span>
-      <span class="nav-label">Secrets</span>
-    </button>
-
-    <button
-      class="nav-item"
-      class:active={activeView === 'staging'}
-      onclick={() => navigate('staging')}
-    >
-      <span class="nav-icon">*</span>
-      <span class="nav-label">Staging</span>
-      {#if stagingCount > 0}
-        <span class="staging-count">{stagingCount}</span>
+  <!-- Provider selector -->
+  <div class="provider-select">
+    <label class="provider-label" for="provider-select">Provider</label>
+    <select id="provider-select" class="provider-dropdown" value={provider} onchange={handleProviderChange}>
+      {#if !provider}
+        <option value="" disabled selected>Select provider…</option>
       {/if}
-    </button>
-  </nav>
+      {#each capabilities as cap}
+        <option value={cap.provider} disabled={cap.provider === 'azure'}>
+          {cap.displayName}{cap.provider === 'azure' ? ' (coming soon)' : ''}
+        </option>
+      {/each}
+    </select>
+  </div>
 
-  {#if accountId && region}
+  <!-- Scope form: only shown when the selected provider still needs input -->
+  {#if provider === 'googlecloud' && !scopeReady}
+    <form class="scope-form" onsubmit={submitProject}>
+      <label class="scope-label" for="gcloud-project">Project ID</label>
+      <input
+        id="gcloud-project"
+        class="scope-input"
+        type="text"
+        placeholder="my-project"
+        bind:value={projectInput}
+      />
+      <button type="submit" class="scope-submit" disabled={!projectInput.trim()}>Connect</button>
+    </form>
+  {:else if provider === 'azure' && !scopeReady}
+    <div class="scope-hint">Azure scope setup ships next.</div>
+  {/if}
+
+  <!-- Navigation tabs: capability-driven, only once a scope is active -->
+  {#if scopeReady}
+    <nav class="nav" bind:this={navEl}>
+      {#each services as svc}
+        <button
+          class="nav-item"
+          class:active={activeView === svc.service}
+          onclick={() => navigate(svc.service as ViewKey)}
+        >
+          <span class="nav-icon">{NAV_ICON[svc.service] ?? svc.displayName.charAt(0)}</span>
+          <span class="nav-label" title={svc.displayName}>{svc.displayName}</span>
+        </button>
+      {/each}
+
+      {#if hasAnyStaging}
+        <button
+          class="nav-item"
+          class:active={activeView === 'staging'}
+          onclick={() => navigate('staging')}
+        >
+          <span class="nav-icon">*</span>
+          <span class="nav-label">Staging</span>
+          {#if stagingCount > 0}
+            <span class="staging-count">{stagingCount}</span>
+          {/if}
+        </button>
+      {/if}
+    </nav>
+  {/if}
+
+  <!-- Identity / scope info -->
+  {#if scopeReady && provider === 'aws' && accountId && region}
     <div class="aws-info">
       {#if profile}
         <div class="aws-info-row">
           <span class="aws-info-label">Profile</span>
-          <span class="aws-info-value aws-info-profile">{profile}</span>
+          <span class="aws-info-value aws-info-profile" title={profile}>{profile}</span>
         </div>
       {/if}
       <div class="aws-info-row">
         <span class="aws-info-label">Account</span>
-        <span class="aws-info-value">{accountId}</span>
+        <span class="aws-info-value" title={accountId}>{accountId}</span>
       </div>
       <div class="aws-info-row">
         <span class="aws-info-label">Region</span>
-        <span class="aws-info-value">{region}</span>
+        <span class="aws-info-value" title={region}>{region}</span>
       </div>
+    </div>
+  {:else if scopeReady && provider === 'googlecloud' && scope?.projectId}
+    <div class="aws-info scope-info">
+      <div class="aws-info-row">
+        <span class="aws-info-label">Project</span>
+        <span class="aws-info-value" title={scope.projectId}>{scope.projectId}</span>
+      </div>
+    </div>
+  {:else if scopeReady && provider === 'azure'}
+    <div class="aws-info scope-info">
+      {#if scope?.subscriptionId}
+        <div class="aws-info-row">
+          <span class="aws-info-label">Subscription</span>
+          <span class="aws-info-value" title={scope.subscriptionId}>{scope.subscriptionId}</span>
+        </div>
+      {/if}
+      {#if scope?.resourceGroup}
+        <div class="aws-info-row">
+          <span class="aws-info-label">Resource Group</span>
+          <span class="aws-info-value" title={scope.resourceGroup}>{scope.resourceGroup}</span>
+        </div>
+      {/if}
+      {#if scope?.vaultName}
+        <div class="aws-info-row">
+          <span class="aws-info-label">Key Vault</span>
+          <span class="aws-info-value" title={scope.vaultName}>{scope.vaultName}</span>
+        </div>
+      {/if}
+      {#if scope?.storeName}
+        <div class="aws-info-row">
+          <span class="aws-info-label">App Config</span>
+          <span class="aws-info-value" title={scope.storeName}>{scope.storeName}</span>
+        </div>
+      {/if}
     </div>
   {/if}
 </aside>
@@ -100,6 +233,77 @@
     color: #666;
     display: block;
     margin-top: 2px;
+  }
+
+  .provider-select {
+    padding: 12px 16px 4px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .provider-label {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #666;
+  }
+
+  .provider-dropdown {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 6px 8px;
+    background: #252542;
+    color: #fff;
+    border: 1px solid #2d2d44;
+    border-radius: 6px;
+    font-size: 13px;
+  }
+
+  .scope-form {
+    padding: 8px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+
+  .scope-label {
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #666;
+  }
+
+  .scope-input {
+    width: 100%;
+    box-sizing: border-box;
+    padding: 6px 8px;
+    background: #252542;
+    color: #fff;
+    border: 1px solid #2d2d44;
+    border-radius: 6px;
+    font-size: 13px;
+  }
+
+  .scope-submit {
+    padding: 6px 8px;
+    background: #e94560;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    font-size: 13px;
+    cursor: pointer;
+  }
+
+  .scope-submit:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .scope-hint {
+    padding: 8px 16px;
+    font-size: 11px;
+    color: #888;
   }
 
   .nav {
@@ -137,6 +341,7 @@
   .nav-icon {
     width: 24px;
     height: 24px;
+    flex-shrink: 0;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -148,11 +353,16 @@
 
   .nav-label {
     flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .staging-count {
     min-width: 18px;
     height: 18px;
+    flex-shrink: 0;
     display: flex;
     align-items: center;
     justify-content: center;
@@ -180,17 +390,23 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 8px;
     padding: 4px 0;
   }
 
   .aws-info-label {
     color: #666;
+    flex-shrink: 0;
   }
 
   .aws-info-value {
     color: #a0a0a0;
     font-family: monospace;
     font-size: 10px;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   .aws-info-profile {

--- a/internal/gui/frontend/src/lib/viewUtils.ts
+++ b/internal/gui/frontend/src/lib/viewUtils.ts
@@ -46,15 +46,35 @@ export function getOperationColor(operation: string): string {
 }
 
 /**
+ * A debounced runner. Call it with a callback to (re)arm the timer; call
+ * `.cancel()` to drop any pending callback — required on component unmount so a
+ * pending filter debounce cannot fire a stray call against a newly-selected
+ * provider after a `{#key}` remount.
+ */
+export interface Debouncer {
+  (callback: () => void): void;
+  cancel: () => void;
+}
+
+/**
  * Create a debounced function
  */
-export function createDebouncer(delayMs: number = 300) {
+export function createDebouncer(delayMs: number = 300): Debouncer {
   let timer: ReturnType<typeof setTimeout> | null = null;
 
-  return (callback: () => void) => {
+  const run = ((callback: () => void) => {
     if (timer) clearTimeout(timer);
     timer = setTimeout(callback, delayMs);
+  }) as Debouncer;
+
+  run.cancel = () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
   };
+
+  return run;
 }
 
 /**

--- a/internal/gui/frontend/tests/accessibility.spec.ts
+++ b/internal/gui/frontend/tests/accessibility.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import {
   setupWailsMocks,
   waitForItemList,
+  createGoogleCloudState,
 } from './fixtures/wails-mock';
 
 // ============================================================================
@@ -120,5 +121,37 @@ test.describe('Accessibility - Modals', () => {
 
     await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Stage' })).toBeVisible();
+  });
+});
+
+// ============================================================================
+// Accessibility - Provider selector (#266)
+// ============================================================================
+
+test.describe('Accessibility - Provider selector', () => {
+  test('provider selector is labeled', async ({ page }) => {
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForItemList(page);
+
+    await expect(page.getByLabel('Provider')).toBeVisible();
+  });
+
+  test('provider selector is keyboard-focusable', async ({ page }) => {
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForItemList(page);
+
+    await page.locator('#provider-select').focus();
+    await expect(page.locator('#provider-select')).toBeFocused();
+  });
+
+  test('focus lands on the active tab after a provider clamp', async ({ page }) => {
+    await setupWailsMocks(page, createGoogleCloudState());
+    await page.goto('/');
+    await waitForItemList(page);
+
+    // Google Cloud has no Param tab; focus moves to the active Secret tab.
+    await expect(page.locator('.nav').getByRole('button', { name: /Secret/i })).toBeFocused();
   });
 });

--- a/internal/gui/frontend/tests/app.spec.ts
+++ b/internal/gui/frontend/tests/app.spec.ts
@@ -12,34 +12,34 @@ test.describe('App Navigation', () => {
   });
 
   test('should show sidebar with navigation items', async ({ page }) => {
-    await expect(page.getByRole('button', { name: /Parameters/i })).toBeVisible();
-    await expect(page.getByRole('button', { name: /Secrets/i })).toBeVisible();
-    await expect(page.getByRole('button', { name: /Staging/i })).toBeVisible();
+    await expect(page.locator('.nav').getByRole('button', { name: /Param/i })).toBeVisible();
+    await expect(page.locator('.nav').getByRole('button', { name: /Secret/i })).toBeVisible();
+    await expect(page.locator('.nav').getByRole('button', { name: /Staging/i })).toBeVisible();
   });
 
   test('should highlight active navigation item', async ({ page }) => {
     // Parameters should be active by default
-    const paramsBtn = page.getByRole('button', { name: /Parameters/i });
+    const paramsBtn = page.locator('.nav').getByRole('button', { name: /Param/i });
     await expect(paramsBtn).toHaveClass(/active/);
 
     // Click on Secrets and verify it becomes active
-    await page.getByRole('button', { name: /Secrets/i }).click();
-    await expect(page.getByRole('button', { name: /Secrets/i })).toHaveClass(/active/);
+    await page.locator('.nav').getByRole('button', { name: /Secret/i }).click();
+    await expect(page.locator('.nav').getByRole('button', { name: /Secret/i })).toHaveClass(/active/);
 
     // Click on Staging and verify it becomes active
-    await page.getByRole('button', { name: /Staging/i }).click();
-    await expect(page.getByRole('button', { name: /Staging/i })).toHaveClass(/active/);
+    await page.locator('.nav').getByRole('button', { name: /Staging/i }).click();
+    await expect(page.locator('.nav').getByRole('button', { name: /Staging/i })).toHaveClass(/active/);
   });
 
   test('should persist active view when refreshing data', async ({ page }) => {
     // Navigate to Secrets
-    await page.getByRole('button', { name: /Secrets/i }).click();
-    await expect(page.getByRole('button', { name: /Secrets/i })).toHaveClass(/active/);
+    await page.locator('.nav').getByRole('button', { name: /Secret/i }).click();
+    await expect(page.locator('.nav').getByRole('button', { name: /Secret/i })).toHaveClass(/active/);
 
     // Click refresh - view should stay on Secrets
     const refreshBtn = page.getByRole('button', { name: /Refresh/i });
     await refreshBtn.click();
-    await expect(page.getByRole('button', { name: /Secrets/i })).toHaveClass(/active/);
+    await expect(page.locator('.nav').getByRole('button', { name: /Secret/i })).toHaveClass(/active/);
   });
 });
 
@@ -67,7 +67,7 @@ test.describe('Secrets View Initial State', () => {
   test.beforeEach(async ({ page }) => {
     await setupWailsMocks(page);
     await page.goto('/');
-    await page.getByRole('button', { name: /Secrets/i }).click();
+    await page.locator('.nav').getByRole('button', { name: /Secret/i }).click();
   });
 
   test('should have a refresh button', async ({ page }) => {
@@ -110,7 +110,7 @@ test.describe('Empty State Handling', () => {
     };
     await setupWailsMocks(page, emptyState);
     await page.goto('/');
-    await page.getByRole('button', { name: /Secrets/i }).click();
+    await page.locator('.nav').getByRole('button', { name: /Secret/i }).click();
     await page.waitForSelector('.filter-bar');
 
     await expect(page.locator('.item-button')).toHaveCount(0);
@@ -212,8 +212,8 @@ test.describe('Error Recovery', () => {
     await expect(page.locator('.detail-panel')).not.toBeVisible();
 
     // Should be able to navigate to another view
-    await page.getByRole('button', { name: /Secrets/i }).click();
-    await expect(page.getByRole('button', { name: /Secrets/i })).toHaveClass(/active/);
+    await page.locator('.nav').getByRole('button', { name: /Secret/i }).click();
+    await expect(page.locator('.nav').getByRole('button', { name: /Secret/i })).toHaveClass(/active/);
   });
 
   test('should allow navigation after cancelling modal', async ({ page }) => {
@@ -230,7 +230,7 @@ test.describe('Error Recovery', () => {
     await expect(page.locator('.modal-backdrop')).not.toBeVisible();
 
     // Should be able to navigate
-    await page.getByRole('button', { name: /Staging/i }).click();
-    await expect(page.getByRole('button', { name: /Staging/i })).toHaveClass(/active/);
+    await page.locator('.nav').getByRole('button', { name: /Staging/i }).click();
+    await expect(page.locator('.nav').getByRole('button', { name: /Staging/i })).toHaveClass(/active/);
   });
 });

--- a/internal/gui/frontend/tests/e2e-workflows.spec.ts
+++ b/internal/gui/frontend/tests/e2e-workflows.spec.ts
@@ -87,7 +87,7 @@ test.describe('E2E - Secret CRUD Workflow', () => {
   test.beforeEach(async ({ page }) => {
     await setupWailsMocks(page);
     await page.goto('/');
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
   });
 
@@ -246,11 +246,11 @@ test.describe('Cross-Service Operations', () => {
     await waitForItemList(page);
 
     // Navigate to Secrets
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
 
     // Navigate back to Parameters
-    await navigateTo(page, 'Parameters');
+    await navigateTo(page, 'Param');
     await waitForItemList(page);
 
     // Should still show item list

--- a/internal/gui/frontend/tests/edge-cases.spec.ts
+++ b/internal/gui/frontend/tests/edge-cases.spec.ts
@@ -163,7 +163,7 @@ test.describe('Form Validation', () => {
   });
 
   test('should show error when creating secret without name', async ({ page }) => {
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
     await page.getByRole('button', { name: '+ New' }).click();
     await page.locator('#secret-value').fill('some-value');
@@ -172,7 +172,7 @@ test.describe('Form Validation', () => {
   });
 
   test('should show error when creating secret without value', async ({ page }) => {
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
     await page.getByRole('button', { name: '+ New' }).click();
     await page.locator('#secret-name').fill('test-secret');
@@ -260,7 +260,7 @@ test.describe('Pagination - Secrets', () => {
   test.beforeEach(async ({ page }) => {
     await setupWailsMocks(page, createPaginationTestState(25));
     await page.goto('/');
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
   });
 
@@ -302,7 +302,7 @@ test.describe('API Error Handling - Secret List', () => {
   test('should display error banner when SecretList fails', async ({ page }) => {
     await setupWailsMocks(page, createErrorState('SecretList', 'Access denied'));
     await page.goto('/');
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await expect(page.locator('.error-banner')).toBeVisible();
     await expect(page.getByText('Access denied')).toBeVisible();
   });
@@ -336,7 +336,7 @@ test.describe('API Error Handling - Create Operations', () => {
       ...createErrorState('SecretCreate', 'Secret quota exceeded'),
     });
     await page.goto('/');
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForViewLoaded(page);
 
     // Open create modal and try to create secret in immediate mode
@@ -409,7 +409,7 @@ test.describe('Empty States', () => {
   test('should show empty state message for secrets', async ({ page }) => {
     await setupWailsMocks(page, { secrets: [] });
     await page.goto('/');
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForViewLoaded(page);
 
     await expect(page.locator('.empty-state')).toBeVisible();

--- a/internal/gui/frontend/tests/filter-search.spec.ts
+++ b/internal/gui/frontend/tests/filter-search.spec.ts
@@ -76,7 +76,7 @@ test.describe('Secret Filtering', () => {
   test.beforeEach(async ({ page }) => {
     await setupWailsMocks(page, createFilterTestState());
     await page.goto('/');
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
   });
 
@@ -275,7 +275,7 @@ test.describe('Secret View Mode - Show Values Toggle', () => {
   test.beforeEach(async ({ page }) => {
     await setupWailsMocks(page, createFilterTestState());
     await page.goto('/');
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForViewLoaded(page);
   });
 
@@ -328,11 +328,11 @@ test.describe('Navigation State', () => {
 
   test('should have filter bar available after navigation', async ({ page }) => {
     // Navigate away
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForViewLoaded(page);
 
     // Navigate back
-    await navigateTo(page, 'Parameters');
+    await navigateTo(page, 'Param');
 
     // Filter bar should be present
     await waitForViewLoaded(page);

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -588,6 +588,123 @@ export function createNoAWSIdentityState(): Partial<MockState> {
   };
 }
 
+// ---- Provider-selection states (multi-cloud) ------------------------------
+
+function emptyScope(provider: string): ScopeSelection {
+  return { provider, projectId: '', subscriptionId: '', resourceGroup: '', vaultName: '', storeName: '' };
+}
+
+/**
+ * Launched into Google Cloud (as `suve googlecloud --gui` would), project
+ * prefilled — so the app resolves a ready scope without a prompt.
+ */
+export function createGoogleCloudState(overrides: Partial<MockState> = {}): Partial<MockState> {
+  return {
+    initialProvider: 'googlecloud',
+    currentScope: { ...emptyScope('googlecloud'), projectId: 'my-project' },
+    detectResult: {
+      param: '',
+      secret: 'googlecloud',
+      stage: '',
+      paramActive: [],
+      secretActive: ['googlecloud'],
+      stageActive: [],
+    },
+    // Google Cloud secret versions are integers and carry no ARN/staging labels.
+    secrets: [
+      { name: 'gcloud-secret-1', value: 'v1', arn: '', versionStage: [] },
+      { name: 'gcloud-secret-2', value: 'v2', arn: '', versionStage: [] },
+    ],
+    secretVersions: {
+      'gcloud-secret-1': [
+        { versionId: '2', stages: [], value: 'v2', isCurrent: true, created: new Date().toISOString() },
+        { versionId: '1', stages: [], value: 'v1', isCurrent: false, created: new Date(Date.now() - 86400000).toISOString() },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * Launched into Azure with vault + store present (as env/CLI would supply),
+ * so both Key Vault (secret) and App Configuration (param) mount. The selector
+ * option stays disabled ("greyed") until #267 adds the scope form.
+ */
+export function createAzureState(overrides: Partial<MockState> = {}): Partial<MockState> {
+  return {
+    initialProvider: 'azure',
+    currentScope: {
+      ...emptyScope('azure'),
+      subscriptionId: '00000000-0000-0000-0000-000000000000',
+      resourceGroup: 'rg',
+      vaultName: 'my-vault',
+      storeName: 'my-store',
+    },
+    detectResult: {
+      param: 'azure',
+      secret: 'azure',
+      stage: '',
+      paramActive: ['azure'],
+      secretActive: ['azure'],
+      stageActive: [],
+    },
+    // App Configuration values are untyped/unversioned; Key Vault has no ARN.
+    params: [{ name: 'app/config/key', type: 'String', value: 'v' }],
+    secrets: [{ name: 'kv-secret', value: 'v', arn: '', versionStage: [] }],
+    // Key Vault versions are opaque hex ids with no AWS staging labels.
+    secretVersions: {
+      'kv-secret': [
+        { versionId: 'a1b2c3d4e5f6', stages: [], value: 'v', isCurrent: true, created: new Date().toISOString() },
+      ],
+    },
+    ...overrides,
+  };
+}
+
+/**
+ * No explicit initial provider and two providers active → the app must show a
+ * selector prompt and preselect nothing.
+ */
+export function createAmbiguousProviderState(): Partial<MockState> {
+  return {
+    initialProvider: '',
+    currentScope: emptyScope(''),
+    detectResult: {
+      param: '',
+      secret: '',
+      stage: '',
+      paramActive: ['aws'],
+      secretActive: ['googlecloud'],
+      stageActive: [],
+    },
+  };
+}
+
+/**
+ * No explicit initial provider and nothing active → selector prompt, no crash.
+ */
+export function createNoActiveProviderState(): Partial<MockState> {
+  return {
+    initialProvider: '',
+    currentScope: emptyScope(''),
+    detectResult: {
+      param: '',
+      secret: '',
+      stage: '',
+      paramActive: [],
+      secretActive: [],
+      stageActive: [],
+    },
+  };
+}
+
+/**
+ * Read the binding invocations recorded by the mock (see __wailsCalls).
+ */
+export async function getRecordedCalls(page: Page): Promise<string[]> {
+  return page.evaluate(() => ((window as any).__wailsCalls as string[]) ?? []);
+}
+
 // ============================================================================
 // Main Mock Setup Function
 // ============================================================================
@@ -598,6 +715,11 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
   await page.addInitScript((mockState: MockState) => {
     // Track state changes during test
     const state = JSON.parse(JSON.stringify(mockState));
+
+    // Records binding invocations so specs can assert e.g. that no
+    // GetAWSIdentity / StagingStatus fires under a non-AWS scope (mount gating).
+    const calls: string[] = [];
+    (window as any).__wailsCalls = calls;
 
     const mockApp = {
       // Provider selection / capabilities (multi-cloud)
@@ -636,6 +758,7 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
 
       // AWS Identity
       GetAWSIdentity: async () => {
+        calls.push('GetAWSIdentity');
         if (state.simulateError?.operation === 'GetAWSIdentity') {
           throw new Error(state.simulateError.message);
         }
@@ -902,12 +1025,15 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
       },
 
       // Staging operations
-      StagingStatus: async () => ({
-        param: state.stagedParam,
-        secret: state.stagedSecret,
-        paramTags: state.stagedParamTags,
-        secretTags: state.stagedSecretTags,
-      }),
+      StagingStatus: async () => {
+        calls.push('StagingStatus');
+        return {
+          param: state.stagedParam,
+          secret: state.stagedSecret,
+          paramTags: state.stagedParamTags,
+          secretTags: state.stagedSecretTags,
+        };
+      },
       StagingDiff: async (service: string, _passphrase?: string) => {
         const staged = service === 'param' ? state.stagedParam : state.stagedSecret;
         const tagStaged = service === 'param' ? state.stagedParamTags : state.stagedSecretTags;
@@ -1210,7 +1336,9 @@ export type NavLabel =
   | 'App Configuration';
 
 export async function navigateTo(page: Page, view: NavLabel) {
-  await page.getByRole('button', { name: new RegExp(view, 'i') }).click();
+  // Scope to the sidebar nav so a short capability label (e.g. "Secret") does
+  // not collide with item names that contain the same word (e.g. "my-secret").
+  await page.locator('.nav').getByRole('button', { name: new RegExp(view, 'i') }).click();
 }
 
 /**

--- a/internal/gui/frontend/tests/keyboard-focus.spec.ts
+++ b/internal/gui/frontend/tests/keyboard-focus.spec.ts
@@ -151,7 +151,7 @@ test.describe('Focus After Operations', () => {
     await clickItemByName(page, '/app/config');
     await expect(page.locator('.detail-panel')).toBeVisible();
 
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
 
     // Detail panel should be closed

--- a/internal/gui/frontend/tests/provider-selection.spec.ts
+++ b/internal/gui/frontend/tests/provider-selection.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupWailsMocks,
+  createGoogleCloudState,
+  createAzureState,
+  createAmbiguousProviderState,
+  createNoActiveProviderState,
+  createStagedForPushState,
+  getRecordedCalls,
+  waitForItemList,
+  waitForViewLoaded,
+  navigateTo,
+  clickItemByName,
+} from './fixtures/wails-mock';
+
+const nav = (page: import('@playwright/test').Page) => page.locator('.nav');
+
+test.describe('Provider selection', () => {
+  test.describe('Initial pick', () => {
+    test('AWS preselected, no prompt', async ({ page }) => {
+      await setupWailsMocks(page);
+      await page.goto('/');
+      await waitForViewLoaded(page);
+
+      await expect(page.locator('#provider-select')).toHaveValue('aws');
+      await expect(nav(page).getByRole('button', { name: /Param/i })).toBeVisible();
+      await expect(page.getByText('Select a provider')).toHaveCount(0);
+    });
+
+    test('ambiguous detection → selector prompt, nothing preselected', async ({ page }) => {
+      await setupWailsMocks(page, createAmbiguousProviderState());
+      await page.goto('/');
+
+      await expect(page.getByText('Select a provider to begin.')).toBeVisible();
+      await expect(page.locator('#provider-select')).toHaveValue('');
+      // No tabs until a scope is active.
+      await expect(nav(page)).toHaveCount(0);
+    });
+
+    test('zero active providers → prompt, no crash', async ({ page }) => {
+      await setupWailsMocks(page, createNoActiveProviderState());
+      await page.goto('/');
+
+      await expect(page.getByText('Select a provider to begin.')).toBeVisible();
+      await expect(page.locator('.logo-text')).toContainText('suve');
+    });
+  });
+
+  test.describe('Google Cloud', () => {
+    test('no Param tab, no Staging tab; secret view active', async ({ page }) => {
+      await setupWailsMocks(page, createGoogleCloudState());
+      await page.goto('/');
+      await waitForItemList(page);
+
+      await expect(nav(page).getByRole('button', { name: /Param/i })).toHaveCount(0);
+      await expect(nav(page).getByRole('button', { name: /Staging/i })).toHaveCount(0);
+      const secretTab = nav(page).getByRole('button', { name: /Secret/i });
+      await expect(secretTab).toBeVisible();
+      await expect(secretTab).toHaveClass(/active/);
+    });
+
+    test('sidebar shows project, not AWS account/region', async ({ page }) => {
+      await setupWailsMocks(page, createGoogleCloudState());
+      await page.goto('/');
+      await waitForItemList(page);
+
+      await expect(page.getByText('my-project')).toBeVisible();
+      await expect(page.locator('.aws-info-profile')).toHaveCount(0);
+    });
+
+    test('no GetAWSIdentity / StagingStatus calls under a Google Cloud scope', async ({ page }) => {
+      await setupWailsMocks(page, createGoogleCloudState());
+      await page.goto('/');
+      await waitForItemList(page);
+
+      const calls = await getRecordedCalls(page);
+      expect(calls).not.toContain('GetAWSIdentity');
+      expect(calls).not.toContain('StagingStatus');
+    });
+
+    test('secret detail: no Restore, no staging banner (capability-gated)', async ({ page }) => {
+      await setupWailsMocks(page, createGoogleCloudState());
+      await page.goto('/');
+      await waitForItemList(page);
+
+      // Restore lives in the toolbar; hidden because gcloud secret hasRestore=false.
+      await expect(page.locator('.btn-restore')).toHaveCount(0);
+
+      await clickItemByName(page, 'gcloud-secret-1');
+      await expect(page.locator('.detail-panel')).toBeVisible();
+      await expect(page.locator('.staging-banner')).toHaveCount(0);
+      // No ARN section (empty arn) — presence-gated (#268).
+      await expect(page.locator('.arn-display')).toHaveCount(0);
+    });
+  });
+
+  test.describe('Azure', () => {
+    test('is greyed-out (disabled) in the provider selector', async ({ page }) => {
+      await setupWailsMocks(page);
+      await page.goto('/');
+      await waitForViewLoaded(page);
+
+      await expect(page.locator('#provider-select option[value="azure"]')).toBeDisabled();
+    });
+
+    test('App Configuration (param): no Type dropdown, no version history, no tags', async ({ page }) => {
+      await setupWailsMocks(page, createAzureState());
+      await page.goto('/');
+      await waitForItemList(page);
+
+      // Default view clamps to the first service (param = App Configuration).
+      await clickItemByName(page, 'app/config/key');
+      await expect(page.locator('.detail-panel')).toBeVisible();
+      // Unversioned + untagged.
+      await expect(page.getByRole('heading', { name: 'Version History' })).toHaveCount(0);
+      await expect(page.locator('.tags-list')).toHaveCount(0);
+
+      // New-item modal has no Type dropdown (ParamTypeOptions empty).
+      await page.getByRole('button', { name: '+ New' }).click();
+      await expect(page.locator('#param-type')).toHaveCount(0);
+    });
+
+    test('Key Vault (secret): version history yes, Restore no', async ({ page }) => {
+      await setupWailsMocks(page, createAzureState());
+      await page.goto('/');
+      await waitForItemList(page);
+      await navigateTo(page, 'Key Vault');
+      await waitForItemList(page);
+
+      await expect(page.locator('.btn-restore')).toHaveCount(0);
+      await clickItemByName(page, 'kv-secret');
+      await expect(page.locator('.detail-panel')).toBeVisible();
+    });
+  });
+
+  test.describe('Provider switch', () => {
+    test('switching AWS → Google Cloud remounts (detail closed, Param tab gone)', async ({ page }) => {
+      await setupWailsMocks(page);
+      await page.goto('/');
+      await waitForItemList(page);
+
+      // Open an AWS param detail.
+      await clickItemByName(page, '/app/config');
+      await expect(page.locator('.detail-panel')).toBeVisible();
+
+      // Switch provider → Google Cloud needs a project first.
+      await page.locator('#provider-select').selectOption('googlecloud');
+      await page.locator('#gcloud-project').fill('switch-project');
+      await page.getByRole('button', { name: 'Connect' }).click();
+      await waitForItemList(page);
+
+      // Remounted into Google Cloud: the AWS detail is gone and there is no Param tab.
+      await expect(page.locator('.detail-panel')).toHaveCount(0);
+      await expect(nav(page).getByRole('button', { name: /Param/i })).toHaveCount(0);
+    });
+
+    test('staging badge resets when switching to a non-AWS provider', async ({ page }) => {
+      await setupWailsMocks(page, createStagedForPushState());
+      await page.goto('/');
+      await waitForItemList(page);
+
+      // AWS has staged changes → badge present.
+      await expect(page.locator('.staging-count')).toBeVisible();
+
+      await page.locator('#provider-select').selectOption('googlecloud');
+      await page.locator('#gcloud-project').fill('switch-project');
+      await page.getByRole('button', { name: 'Connect' }).click();
+      await waitForItemList(page);
+
+      // No Staging tab (and hence no badge) under Google Cloud.
+      await expect(page.locator('.staging-count')).toHaveCount(0);
+    });
+  });
+});

--- a/internal/gui/frontend/tests/secret.spec.ts
+++ b/internal/gui/frontend/tests/secret.spec.ts
@@ -16,7 +16,7 @@ test.describe('Secret CRUD Operations', () => {
   test.beforeEach(async ({ page }) => {
     await setupWailsMocks(page);
     await page.goto('/');
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
   });
 
@@ -325,7 +325,7 @@ test.describe('Secret Edge Cases', () => {
     test('should handle empty secret list gracefully', async ({ page }) => {
       await setupWailsMocks(page, { secrets: [] });
       await page.goto('/');
-      await navigateTo(page, 'Secrets');
+      await navigateTo(page, 'Secret');
       // Wait for filter bar (always present even when list is empty)
       await page.waitForSelector('.filter-bar');
       await expect(page.locator('.item-button')).toHaveCount(0);
@@ -334,7 +334,7 @@ test.describe('Secret Edge Cases', () => {
     test('should still allow creating new secret when list is empty', async ({ page }) => {
       await setupWailsMocks(page, { secrets: [] });
       await page.goto('/');
-      await navigateTo(page, 'Secrets');
+      await navigateTo(page, 'Secret');
       await page.waitForSelector('.filter-bar');
       await openCreateModal(page);
       await expect(page.locator('.modal-backdrop')).toBeVisible();
@@ -343,7 +343,7 @@ test.describe('Secret Edge Cases', () => {
     test('should still show restore button when list is empty', async ({ page }) => {
       await setupWailsMocks(page, { secrets: [] });
       await page.goto('/');
-      await navigateTo(page, 'Secrets');
+      await navigateTo(page, 'Secret');
       await page.waitForSelector('.filter-bar');
       await expect(page.getByRole('button', { name: 'Restore' })).toBeVisible();
     });
@@ -353,7 +353,7 @@ test.describe('Secret Edge Cases', () => {
     test('should display multiple tags for secret', async ({ page }) => {
       await setupWailsMocks(page, createMultiTagState());
       await page.goto('/');
-      await navigateTo(page, 'Secrets');
+      await navigateTo(page, 'Secret');
       await waitForItemList(page);
       await clickItemByName(page, 'my-secret');
       await expect(page.locator('.tag-item')).toHaveCount(2);
@@ -362,7 +362,7 @@ test.describe('Secret Edge Cases', () => {
     test('should allow adding tag to secret with existing tags', async ({ page }) => {
       await setupWailsMocks(page, createMultiTagState());
       await page.goto('/');
-      await navigateTo(page, 'Secrets');
+      await navigateTo(page, 'Secret');
       await waitForItemList(page);
       await clickItemByName(page, 'my-secret');
       await page.getByRole('button', { name: '+ Add' }).click();
@@ -378,7 +378,7 @@ test.describe('Secret Edge Cases', () => {
     test('should handle secret with no tags', async ({ page }) => {
       await setupWailsMocks(page, createNoTagsState());
       await page.goto('/');
-      await navigateTo(page, 'Secrets');
+      await navigateTo(page, 'Secret');
       await waitForItemList(page);
       await clickItemByName(page, 'my-secret');
       await expect(page.locator('.tag-item')).toHaveCount(0);
@@ -387,7 +387,7 @@ test.describe('Secret Edge Cases', () => {
     test('should show add tag button even when no tags exist', async ({ page }) => {
       await setupWailsMocks(page, createNoTagsState());
       await page.goto('/');
-      await navigateTo(page, 'Secrets');
+      await navigateTo(page, 'Secret');
       await waitForItemList(page);
       await clickItemByName(page, 'my-secret');
       await expect(page.getByRole('button', { name: '+ Add' })).toBeVisible();
@@ -401,7 +401,7 @@ test.describe('Secret Edge Cases', () => {
       };
       await setupWailsMocks(page, jsonSecret);
       await page.goto('/');
-      await navigateTo(page, 'Secrets');
+      await navigateTo(page, 'Secret');
       await waitForItemList(page);
       await clickItemByName(page, 'json-secret');
       await expect(page.locator('.detail-panel')).toBeVisible();
@@ -413,7 +413,7 @@ test.describe('Secret Edge Cases', () => {
       };
       await setupWailsMocks(page, complexJson);
       await page.goto('/');
-      await navigateTo(page, 'Secrets');
+      await navigateTo(page, 'Secret');
       await waitForItemList(page);
       await clickItemByName(page, 'complex-secret');
       await expect(page.locator('.detail-panel')).toBeVisible();
@@ -425,7 +425,7 @@ test.describe('Secret Edge Cases', () => {
       };
       await setupWailsMocks(page, plaintext);
       await page.goto('/');
-      await navigateTo(page, 'Secrets');
+      await navigateTo(page, 'Secret');
       await waitForItemList(page);
       await clickItemByName(page, 'plaintext-secret');
       await expect(page.locator('.detail-panel')).toBeVisible();
@@ -439,7 +439,7 @@ test.describe('Secret Edge Cases', () => {
       };
       await setupWailsMocks(page, specialName);
       await page.goto('/');
-      await navigateTo(page, 'Secrets');
+      await navigateTo(page, 'Secret');
       await waitForItemList(page);
       await clickItemByName(page, 'my-secret_v2.0-test');
       await expect(page.locator('.detail-panel')).toBeVisible();
@@ -451,7 +451,7 @@ test.describe('Secret Edge Cases', () => {
       };
       await setupWailsMocks(page, specialValue);
       await page.goto('/');
-      await navigateTo(page, 'Secrets');
+      await navigateTo(page, 'Secret');
       await waitForItemList(page);
       await clickItemByName(page, 'special-secret');
       await expect(page.locator('.detail-panel')).toBeVisible();
@@ -469,7 +469,7 @@ test.describe('Secret provider-neutral presence gating (#268)', () => {
       secretTags: {},
     } as Partial<MockState>);
     await page.goto('/');
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
     await clickItemByName(page, 'neutral-secret');
     await expect(page.locator('.detail-panel')).toBeVisible();

--- a/internal/gui/frontend/tests/staging.spec.ts
+++ b/internal/gui/frontend/tests/staging.spec.ts
@@ -132,7 +132,7 @@ test.describe('Staging from Secret View', () => {
   test.beforeEach(async ({ page }) => {
     await setupWailsMocks(page);
     await page.goto('/');
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
   });
 
@@ -503,7 +503,7 @@ test.describe('Navigation and State', () => {
     await expect(page.locator('.modal-backdrop')).not.toBeVisible();
 
     // Navigate to Secrets
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
 
     // Navigate to Staging - changes should still be there
@@ -525,7 +525,7 @@ test.describe('Navigation and State', () => {
     await page.waitForFunction(() => document.querySelector('.entry-item') !== null);
 
     // Go to parameters
-    await navigateTo(page, 'Parameters');
+    await navigateTo(page, 'Param');
     await waitForItemList(page);
 
     // Go back to staging

--- a/internal/gui/frontend/tests/stress-robustness.spec.ts
+++ b/internal/gui/frontend/tests/stress-robustness.spec.ts
@@ -34,8 +34,8 @@ test.describe('Rapid Operations', () => {
   test('should handle rapid navigation switching', async ({ page }) => {
     // Switch between views rapidly
     for (let i = 0; i < 3; i++) {
-      await navigateTo(page, 'Secrets');
-      await navigateTo(page, 'Parameters');
+      await navigateTo(page, 'Secret');
+      await navigateTo(page, 'Param');
       await navigateTo(page, 'Staging');
     }
 
@@ -115,7 +115,7 @@ test.describe('State Consistency', () => {
     await expect(page.locator('.modal-backdrop')).not.toBeVisible();
 
     // Now navigate
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
 
     // Should still be functional
@@ -153,7 +153,7 @@ test.describe('Large Dataset Handling', () => {
 
     await setupWailsMocks(page, { secrets: manySecrets });
     await page.goto('/');
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
 
     // Should render items
@@ -223,7 +223,7 @@ test.describe('Error State Recovery', () => {
     await expect(page.locator('.error-banner')).toBeVisible();
 
     // Navigate to a different view
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
 
     // Should show new view
     await expect(page.locator('.item-list, .error-banner')).toBeVisible();
@@ -297,9 +297,9 @@ test.describe('Memory Management', () => {
   test('should handle many view switches', async ({ page }) => {
     // Switch views many times
     for (let i = 0; i < 10; i++) {
-      await navigateTo(page, 'Secrets');
+      await navigateTo(page, 'Secret');
       await waitForViewLoaded(page);
-      await navigateTo(page, 'Parameters');
+      await navigateTo(page, 'Param');
       await waitForViewLoaded(page);
     }
 
@@ -421,7 +421,7 @@ test.describe('Edge Case Combinations', () => {
     await expect(page.locator('.modal-backdrop')).not.toBeVisible();
 
     // Navigate
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
 
     // App should be functional
@@ -436,10 +436,10 @@ test.describe('Edge Case Combinations', () => {
     await expect(page.locator('.error-banner')).toBeVisible();
 
     // Navigate to secrets
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
 
     // Navigate back
-    await navigateTo(page, 'Parameters');
+    await navigateTo(page, 'Param');
 
     // Should show error or retry
     await expect(page.locator('.filter-bar')).toBeVisible();

--- a/internal/gui/frontend/tests/ui-interaction.spec.ts
+++ b/internal/gui/frontend/tests/ui-interaction.spec.ts
@@ -39,7 +39,7 @@ test.describe('Refresh and Loading', () => {
   });
 
   test('should refresh secrets view', async ({ page }) => {
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
 
     const refreshBtn = page.getByRole('button', { name: /Refresh/i });
@@ -158,8 +158,8 @@ test.describe('Detail Panel Navigation', () => {
     await expect(page.locator('.detail-panel')).toBeVisible();
 
     // Switch to secrets and back
-    await navigateTo(page, 'Secrets');
-    await navigateTo(page, 'Parameters');
+    await navigateTo(page, 'Secret');
+    await navigateTo(page, 'Param');
 
     // Detail panel should be closed after view switch
     await expect(page.locator('.detail-panel')).not.toBeVisible();
@@ -360,10 +360,10 @@ test.describe('Concurrent Operations', () => {
 
   test('should handle rapid view switching', async ({ page }) => {
     // Switch views rapidly
-    await navigateTo(page, 'Secrets');
-    await navigateTo(page, 'Parameters');
+    await navigateTo(page, 'Secret');
+    await navigateTo(page, 'Param');
     await navigateTo(page, 'Staging');
-    await navigateTo(page, 'Parameters');
+    await navigateTo(page, 'Param');
 
     // Should end on Parameters view
     await waitForViewLoaded(page);
@@ -404,7 +404,7 @@ test.describe('Loading States', () => {
     await waitForItemList(page);
 
     // Switch to secrets
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
 
     // Should eventually show secrets view
     await waitForItemList(page);
@@ -435,7 +435,7 @@ test.describe('Restore Secret Feature', () => {
   test.beforeEach(async ({ page }) => {
     await setupWailsMocks(page);
     await page.goto('/');
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
   });
 
@@ -480,12 +480,12 @@ test.describe('Navigation State Reset', () => {
     await expect(page.locator('.detail-panel')).toBeVisible();
 
     // Navigate to secrets
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
 
     // Detail panel should be for secrets now or closed
     // Navigate back to parameters
-    await navigateTo(page, 'Parameters');
+    await navigateTo(page, 'Param');
     await waitForItemList(page);
 
     // Previous selection should be cleared

--- a/internal/gui/frontend/tests/version-history.spec.ts
+++ b/internal/gui/frontend/tests/version-history.spec.ts
@@ -113,7 +113,7 @@ test.describe('Secret Version History', () => {
   test.beforeEach(async ({ page }) => {
     await setupWailsMocks(page, createVersionHistoryState());
     await page.goto('/');
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
   });
 
@@ -219,14 +219,14 @@ test.describe('Value Masking', () => {
   });
 
   test('should mask secret value by default', async ({ page }) => {
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
     await clickItemByName(page, 'my-secret');
     await expect(page.locator('.value-display.masked')).toBeVisible();
   });
 
   test('should toggle secret value visibility', async ({ page }) => {
-    await navigateTo(page, 'Secrets');
+    await navigateTo(page, 'Secret');
     await waitForItemList(page);
     await clickItemByName(page, 'my-secret');
 

--- a/internal/gui/frontend/tests/viewport.spec.ts
+++ b/internal/gui/frontend/tests/viewport.spec.ts
@@ -4,6 +4,7 @@ import {
   waitForItemList,
   waitForViewLoaded,
   clickItemByName,
+  createAzureState,
 } from './fixtures/wails-mock';
 
 // ============================================================================
@@ -73,5 +74,38 @@ test.describe('Viewport - Large Desktop', () => {
     // Both panels should be visible
     await expect(page.locator('.list-panel')).toBeVisible();
     await expect(page.locator('.detail-panel')).toBeVisible();
+  });
+});
+
+// ============================================================================
+// Viewport - Provider selector & sidebar overflow (#266)
+// ============================================================================
+
+test.describe('Viewport - Provider selector', () => {
+  test('provider selector visible and no horizontal overflow at 375px', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForViewLoaded(page);
+
+    await expect(page.locator('#provider-select')).toBeVisible();
+    const noOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+    );
+    expect(noOverflow).toBe(true);
+  });
+
+  test('long Azure scope values (UUID) do not overflow the sidebar', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await setupWailsMocks(page, createAzureState());
+    await page.goto('/');
+    await waitForItemList(page);
+
+    // Sidebar shows a 36-char subscription UUID + "App Configuration" label,
+    // all ellipsized rather than widening the layout.
+    const noOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+    );
+    expect(noOverflow).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #266. Blocks #267. Part of #250.

The largest child: introduce provider/scope selection end-to-end. `App.svelte` becomes the single source of truth for provider + scope; the view components are capability-driven via props and fully remount on any scope change.

## Architecture (audit guardrails)

- **`App.svelte` owns capabilities/provider/scope.** Children receive the active `ServiceCapability` as a prop — no child calls `DetectProviders`/`Capabilities`.
- **Full remount via `{#key scopeKey}`** around the main pane, so no in-flight response from the old scope lands in the new one. Residual leaks handled: the staging badge resets on provider switch, and the 300 ms filter debouncers are cancelled on unmount (`createDebouncer` gains `.cancel()`).
- **Gate before fetch.** Startup: `Capabilities` → `InitialProvider`/`DetectProviders` → `GetCurrentScope` prefill → `SelectScope`; `GetAWSIdentity`/`StagingStatus` fire **only when `provider === 'aws'`** (kills the ~5 s STS retry storm off-AWS).
- **`activeView` clamp** (derived `effectiveView`) to a service the provider offers (Google Cloud has no param; Staging hidden when unsupported); focus moves to the active tab after a clamp.
- **Staging decoupled from detail fetch**: `StagingCheckStatus` runs separately and only when the service `HasStaging`; a failure means no banner, never a broken pane.
- **`withRetry` scoped down** to the Wails-startup binding calls only.

## Capability-driven UI

- Sidebar provider selector (display names from `Capabilities`; **Azure disabled "coming soon"** until #267), GCP project input, generalized identity panel (AWS account/region · Google Cloud project · Azure subscription/RG/vault/store) with nowrap + ellipsis + `title` to fix the 200 px overflow.
- Tabs from capability display names — AWS {Param, Secret}, Google Cloud {Secret}, Azure {App Configuration, Key Vault}; internal keys stay `param`/`secret`.
- Per-view gating: Type dropdown (empty `ParamTypeOptions`), Restore (`hasRestore`), force-delete/recovery-window (`hasForceDelete`/`hasRecoveryWindow`), Version History + Compare (`hasVersionHistory`), tag editors (`hasTags`), and **all staging UI** (`hasStaging` → banner/checkbox/Stage buttons hidden, writes forced immediate).

## Tests

New `provider-selection.spec.ts`: initial pick (AWS preselected; ambiguous/zero → prompt), Google Cloud tab clamp + **no `GetAWSIdentity`/`StagingStatus` calls** + capability gating, Azure greyed + App Configuration / Key Vault gating, provider-switch remount (detail closed, Param tab gone), staging-badge reset. Plus a11y (labeled + keyboard-operable selector, focus after clamp) and viewport (selector + 36-char Azure UUID at 375 px, no overflow).

The mock records `GetAWSIdentity`/`StagingStatus` for the gating assertions and gained provider-state factories; `navigateTo` scopes to the sidebar nav (so the short "Secret" label doesn't collide with `my-secret`); existing specs' tab labels updated to Param/Secret.

**485 chromium specs pass**; `npm run ci` (biome + svelte-check) clean; gui Go tests + `golangci-lint` + Naming Convention green. No Go changes (backend landed in #276).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SPyCZL1EWNiYBe17j4ocM
