### PR TITLE
feat(gui): Azure scope input forms — un-grey Azure (#267)

### DIFF
--- a/internal/gui/frontend/src/App.svelte
+++ b/internal/gui/frontend/src/App.svelte
@@ -35,11 +35,31 @@
   let region = $state('');
   let profile = $state('');
 
+  // pendingProvider is a provider the user selected that still needs scope input:
+  // its form shows in the sidebar while the previously-active provider stays
+  // mounted, so a rejected/incomplete scope never tears down a working view.
+  let pendingProvider = $state('');
+
   // ---- Derived capability lookups -------------------------------------------
   const activeProvider = $derived(capabilities.find((c) => c.provider === provider) ?? null);
-  const services = $derived(activeProvider?.services ?? []);
+  const allServices = $derived(activeProvider?.services ?? []);
+  // Azure enables a service tab only when its scope name is set (vaultName → Key
+  // Vault secret; storeName → App Configuration param), so a vault-only user
+  // sees no param tab and vice versa. Other providers expose all their services.
+  const services = $derived(
+    provider === 'azure'
+      ? allServices.filter((s) => (s.service === 'secret' ? !!scope?.vaultName : !!scope?.storeName))
+      : allServices,
+  );
   const hasAnyStaging = $derived(services.some((s) => s.hasStaging));
   const isAWS = $derived(provider === 'aws');
+
+  // Which provider the sidebar scope form is for, and its prefill values
+  // (localStorage-cached last scope, else the backend's current scope).
+  const formProvider = $derived(pendingProvider || provider);
+  const formPrefill = $derived(
+    readCachedScope(formProvider) ?? (scope?.provider === formProvider ? scope : null),
+  );
 
   // scopeKey drives the {#key} full remount: any provider/scope change swaps it,
   // so views re-initialize from scratch and no in-flight response from the old
@@ -79,7 +99,7 @@
       }
 
       if (picked) {
-        await selectProvider(picked);
+        await handleSelectProvider(picked);
       }
     } catch (e) {
       initError = parseError(e);
@@ -97,15 +117,42 @@
     return only ?? '';
   }
 
+  // buildSelection assembles the auto-apply candidate from the best prefill
+  // source (localStorage-cached scope, else the backend's env-derived scope).
   function buildSelection(p: string): gui.ScopeSelection {
+    const src = readCachedScope(p) ?? (scope?.provider === p ? scope : null);
     return {
       provider: p,
-      projectId: p === 'googlecloud' ? (scope?.projectId ?? '') : '',
-      subscriptionId: p === 'azure' ? (scope?.subscriptionId ?? '') : '',
-      resourceGroup: p === 'azure' ? (scope?.resourceGroup ?? '') : '',
-      vaultName: p === 'azure' ? (scope?.vaultName ?? '') : '',
-      storeName: p === 'azure' ? (scope?.storeName ?? '') : '',
+      projectId: p === 'googlecloud' ? (src?.projectId ?? '') : '',
+      subscriptionId: p === 'azure' ? (src?.subscriptionId ?? '') : '',
+      resourceGroup: p === 'azure' ? (src?.resourceGroup ?? '') : '',
+      vaultName: p === 'azure' ? (src?.vaultName ?? '') : '',
+      storeName: p === 'azure' ? (src?.storeName ?? '') : '',
     } as gui.ScopeSelection;
+  }
+
+  // ---- localStorage persistence of the last-applied scope per provider ------
+  function scopeStorageKey(p: string): string {
+    return `suve.scope.${p}`;
+  }
+
+  function readCachedScope(p: string): gui.ScopeSelection | null {
+    if (!p || typeof localStorage === 'undefined') return null;
+    try {
+      const raw = localStorage.getItem(scopeStorageKey(p));
+      return raw ? (JSON.parse(raw) as gui.ScopeSelection) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function persistScope(sel: gui.ScopeSelection): void {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      localStorage.setItem(scopeStorageKey(sel.provider), JSON.stringify(sel));
+    } catch {
+      // localStorage may be unavailable (private mode); persistence is best-effort.
+    }
   }
 
   function hasRequiredScope(sel: gui.ScopeSelection): boolean {
@@ -121,37 +168,52 @@
     }
   }
 
-  // selectProvider switches the active provider. When the (env-prefilled) scope
-  // already has the required fields it applies immediately; otherwise it leaves
-  // scopeReady=false so the sidebar shows the scope form.
-  async function selectProvider(p: string) {
-    provider = p;
-    scopeReady = false;
+  // handleSelectProvider is invoked from the provider dropdown (and at startup).
+  // If the prefilled scope already satisfies the provider it applies at once;
+  // otherwise it parks the choice in pendingProvider so the sidebar shows the
+  // scope form WITHOUT tearing down the currently-active provider's views.
+  async function handleSelectProvider(p: string) {
     scopeError = '';
-    resetIdentity();
 
     const sel = buildSelection(p);
     if (hasRequiredScope(sel)) {
       await applyScope(sel);
+    } else {
+      pendingProvider = p;
     }
   }
 
+  // handleSelectScope is invoked when a scope form is submitted.
+  async function handleSelectScope(sel: gui.ScopeSelection) {
+    await applyScope(sel);
+  }
+
+  // handleCancelScope dismisses a pending scope form (Escape), returning to the
+  // active provider (or the "select a provider" prompt when none is active).
+  function handleCancelScope() {
+    pendingProvider = '';
+    scopeError = '';
+  }
+
   // applyScope validates+commits the scope server-side, then (AWS only) loads
-  // identity and the staging badge.
-  async function applyScope(sel: gui.ScopeSelection) {
+  // identity and the staging badge. On success it switches the active provider
+  // and clears the pending form; on rejection it leaves the previous provider
+  // active (its lists keep working) and surfaces the error in the form.
+  async function applyScope(sel: gui.ScopeSelection): Promise<void> {
     scopeError = '';
     try {
       await SelectScope(sel);
       scope = await GetCurrentScope();
       provider = sel.provider;
+      pendingProvider = '';
       scopeReady = true;
+      persistScope(sel);
       resetIdentity();
       if (sel.provider === 'aws') {
         await loadAWSIdentity();
         await loadStagingCount();
       }
     } catch (e) {
-      scopeReady = false;
       scopeError = parseError(e);
     }
   }
@@ -161,14 +223,6 @@
     accountId = '';
     region = '';
     profile = '';
-  }
-
-  function handleSelectProvider(p: string) {
-    selectProvider(p);
-  }
-
-  function handleSelectScope(sel: gui.ScopeSelection) {
-    applyScope(sel);
   }
 
   function handleNavigate(view: ViewKey) {
@@ -211,10 +265,13 @@
   <Sidebar
     {capabilities}
     {provider}
+    {pendingProvider}
     {services}
     {hasAnyStaging}
     {scope}
     {scopeReady}
+    formScope={formPrefill}
+    {scopeError}
     activeView={effectiveView}
     {stagingCount}
     {accountId}
@@ -223,6 +280,7 @@
     onnavigate={handleNavigate}
     onselectprovider={handleSelectProvider}
     onselectscope={handleSelectScope}
+    oncancelscope={handleCancelScope}
   />
 
   <main class="main-content">
@@ -230,13 +288,7 @@
       <div class="app-status">Loading…</div>
     {:else if initError}
       <div class="app-status app-error">Failed to initialize: {initError}</div>
-    {:else if !provider}
-      <div class="app-status">Select a provider to begin.</div>
-    {:else if !scopeReady}
-      <div class="app-status">
-        {scopeError || 'Enter the required scope in the sidebar to continue.'}
-      </div>
-    {:else}
+    {:else if provider && scopeReady}
       {#key scopeKey}
         {#if effectiveView === 'param' && paramCap}
           <ParamView
@@ -254,6 +306,12 @@
           <StagingView oncountchange={handleStagingCountChange} />
         {/if}
       {/key}
+    {:else if pendingProvider}
+      <div class="app-status">
+        {scopeError || 'Enter the required scope in the sidebar to continue.'}
+      </div>
+    {:else}
+      <div class="app-status">Select a provider to begin.</div>
     {/if}
   </main>
 </div>

--- a/internal/gui/frontend/src/lib/Modal.svelte
+++ b/internal/gui/frontend/src/lib/Modal.svelte
@@ -66,7 +66,8 @@
   .modal {
     background: #1a1a2e;
     border-radius: 8px;
-    min-width: 400px;
+    /* min(400px, 90vw) so the modal never overflows a 375px viewport. */
+    min-width: min(400px, 90vw);
     max-width: 600px;
     max-height: 80vh;
     display: flex;

--- a/internal/gui/frontend/src/lib/Sidebar.svelte
+++ b/internal/gui/frontend/src/lib/Sidebar.svelte
@@ -6,10 +6,13 @@
   interface Props {
     capabilities?: gui.ProviderCapability[];
     provider?: string;
+    pendingProvider?: string;
     services?: gui.ServiceCapability[];
     hasAnyStaging?: boolean;
     scope?: gui.ScopeSelection | null;
     scopeReady?: boolean;
+    formScope?: gui.ScopeSelection | null;
+    scopeError?: string;
     activeView?: ViewKey;
     stagingCount?: number;
     accountId?: string;
@@ -18,15 +21,19 @@
     onnavigate?: (view: ViewKey) => void;
     onselectprovider?: (provider: string) => void;
     onselectscope?: (sel: gui.ScopeSelection) => void;
+    oncancelscope?: () => void;
   }
 
   let {
     capabilities = [],
     provider = '',
+    pendingProvider = '',
     services = [],
     hasAnyStaging = false,
     scope = null,
     scopeReady = false,
+    formScope = null,
+    scopeError = '',
     activeView = 'param',
     stagingCount = 0,
     accountId = '',
@@ -35,16 +42,37 @@
     onnavigate,
     onselectprovider,
     onselectscope,
+    oncancelscope,
   }: Props = $props();
 
   // Service key → stable nav icon/letter (labels come from capability names).
   const NAV_ICON: Record<string, string> = { param: 'P', secret: 'S' };
 
-  // Google Cloud project form state (prefilled from the backend's current scope).
+  // ---- Scope-form inputs (seeded from the prefill for the pending provider) --
   let projectInput = $state('');
+  let subscriptionInput = $state('');
+  let resourceGroupInput = $state('');
+  let vaultInput = $state('');
+  let storeInput = $state('');
+  let formError = $state('');
+  let firstFieldEl: HTMLInputElement | undefined = $state();
+
   $effect(() => {
-    // Re-seed the project field whenever the provider or prefilled scope changes.
-    projectInput = provider === 'googlecloud' ? (scope?.projectId ?? '') : '';
+    // Re-seed the inputs whenever the pending provider (or its prefill) changes.
+    const s = formScope;
+    projectInput = pendingProvider === 'googlecloud' ? (s?.projectId ?? '') : '';
+    subscriptionInput = pendingProvider === 'azure' ? (s?.subscriptionId ?? '') : '';
+    resourceGroupInput = pendingProvider === 'azure' ? (s?.resourceGroup ?? '') : '';
+    vaultInput = pendingProvider === 'azure' ? (s?.vaultName ?? '') : '';
+    storeInput = pendingProvider === 'azure' ? (s?.storeName ?? '') : '';
+    formError = '';
+  });
+
+  // Focus the first field when a scope form opens (a11y).
+  $effect(() => {
+    if (pendingProvider && firstFieldEl) {
+      firstFieldEl.focus();
+    }
   });
 
   // Move keyboard focus to the active tab after a provider switch, so a clamped
@@ -68,10 +96,21 @@
     onselectprovider?.(value);
   }
 
+  // Escape while a scope form is open cancels the pending selection.
+  function handleWindowKeydown(e: KeyboardEvent) {
+    if (pendingProvider && e.key === 'Escape') {
+      e.preventDefault();
+      oncancelscope?.();
+    }
+  }
+
   function submitProject(e: SubmitEvent) {
     e.preventDefault();
     const projectId = projectInput.trim();
-    if (!projectId) return;
+    if (!projectId) {
+      formError = 'Project ID is required.';
+      return;
+    }
     onselectscope?.({
       provider: 'googlecloud',
       projectId,
@@ -81,7 +120,28 @@
       storeName: '',
     } as gui.ScopeSelection);
   }
+
+  function submitAzure(e: SubmitEvent) {
+    e.preventDefault();
+    const vaultName = vaultInput.trim();
+    const storeName = storeInput.trim();
+    // Mirror the backend rule (#276): at least one service target is required.
+    if (!vaultName && !storeName) {
+      formError = 'Enter a Key Vault name (for secrets) and/or an App Configuration store name (for parameters).';
+      return;
+    }
+    onselectscope?.({
+      provider: 'azure',
+      projectId: '',
+      subscriptionId: subscriptionInput.trim(),
+      resourceGroup: resourceGroupInput.trim(),
+      vaultName,
+      storeName,
+    } as gui.ScopeSelection);
+  }
 </script>
+
+<svelte:window onkeydown={handleWindowKeydown} />
 
 <aside class="sidebar">
   <div class="logo">
@@ -92,20 +152,18 @@
   <!-- Provider selector -->
   <div class="provider-select">
     <label class="provider-label" for="provider-select">Provider</label>
-    <select id="provider-select" class="provider-dropdown" value={provider} onchange={handleProviderChange}>
-      {#if !provider}
+    <select id="provider-select" class="provider-dropdown" value={pendingProvider || provider} onchange={handleProviderChange}>
+      {#if !provider && !pendingProvider}
         <option value="" disabled selected>Select provider…</option>
       {/if}
       {#each capabilities as cap}
-        <option value={cap.provider} disabled={cap.provider === 'azure'}>
-          {cap.displayName}{cap.provider === 'azure' ? ' (coming soon)' : ''}
-        </option>
+        <option value={cap.provider}>{cap.displayName}</option>
       {/each}
     </select>
   </div>
 
-  <!-- Scope form: only shown when the selected provider still needs input -->
-  {#if provider === 'googlecloud' && !scopeReady}
+  <!-- Scope form: shown while a selected provider still needs input -->
+  {#if pendingProvider === 'googlecloud'}
     <form class="scope-form" onsubmit={submitProject}>
       <label class="scope-label" for="gcloud-project">Project ID</label>
       <input
@@ -114,11 +172,35 @@
         type="text"
         placeholder="my-project"
         bind:value={projectInput}
+        bind:this={firstFieldEl}
       />
+      {#if formError || scopeError}
+        <div class="scope-error">{formError || scopeError}</div>
+      {/if}
       <button type="submit" class="scope-submit" disabled={!projectInput.trim()}>Connect</button>
     </form>
-  {:else if provider === 'azure' && !scopeReady}
-    <div class="scope-hint">Azure scope setup ships next.</div>
+  {:else if pendingProvider === 'azure'}
+    <form class="scope-form" onsubmit={submitAzure}>
+      <label class="scope-label" for="azure-subscription">Subscription ID</label>
+      <input
+        id="azure-subscription"
+        class="scope-input"
+        type="text"
+        placeholder="00000000-0000-…"
+        bind:value={subscriptionInput}
+        bind:this={firstFieldEl}
+      />
+      <label class="scope-label" for="azure-resource-group">Resource Group</label>
+      <input id="azure-resource-group" class="scope-input" type="text" placeholder="my-rg" bind:value={resourceGroupInput} />
+      <label class="scope-label" for="azure-vault">Key Vault name</label>
+      <input id="azure-vault" class="scope-input" type="text" placeholder="my-vault (secrets)" bind:value={vaultInput} />
+      <label class="scope-label" for="azure-store">App Configuration store</label>
+      <input id="azure-store" class="scope-input" type="text" placeholder="my-store (params)" bind:value={storeInput} />
+      {#if formError || scopeError}
+        <div class="scope-error">{formError || scopeError}</div>
+      {/if}
+      <button type="submit" class="scope-submit" disabled={!vaultInput.trim() && !storeInput.trim()}>Connect</button>
+    </form>
   {/if}
 
   <!-- Navigation tabs: capability-driven, only once a scope is active -->
@@ -300,10 +382,10 @@
     cursor: not-allowed;
   }
 
-  .scope-hint {
-    padding: 8px 16px;
+  .scope-error {
     font-size: 11px;
-    color: #888;
+    color: #e94560;
+    line-height: 1.4;
   }
 
   .nav {

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -19,6 +19,7 @@ export interface Secret {
   // and Azure return) drives the presence-gated rendering in SecretView.
   arn?: string;
   versionStage?: string[];
+  versionId?: string;
 }
 
 export interface Tag {
@@ -650,7 +651,7 @@ export function createAzureState(overrides: Partial<MockState> = {}): Partial<Mo
     },
     // App Configuration values are untyped/unversioned; Key Vault has no ARN.
     params: [{ name: 'app/config/key', type: 'String', value: 'v' }],
-    secrets: [{ name: 'kv-secret', value: 'v', arn: '', versionStage: [] }],
+    secrets: [{ name: 'kv-secret', value: 'v', arn: '', versionStage: [], versionId: 'a1b2c3d4e5f6' }],
     // Key Vault versions are opaque hex ids with no AWS staging labels.
     secretVersions: {
       'kv-secret': [
@@ -705,6 +706,13 @@ export async function getRecordedCalls(page: Page): Promise<string[]> {
   return page.evaluate(() => ((window as any).__wailsCalls as string[]) ?? []);
 }
 
+/**
+ * Read the exact ScopeSelection payloads passed to SelectScope.
+ */
+export async function getSelectScopeCalls(page: Page): Promise<ScopeSelection[]> {
+  return page.evaluate(() => ((window as any).__selectScopeCalls as ScopeSelection[]) ?? []);
+}
+
 // ============================================================================
 // Main Mock Setup Function
 // ============================================================================
@@ -728,8 +736,15 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
       InitialProvider: async () => state.initialProvider,
       GetCurrentScope: async () => state.currentScope,
       SelectScope: async (sel: any) => {
-        if (state.simulateError?.operation === 'SelectScope') {
-          throw new Error(state.simulateError.message);
+        calls.push('SelectScope');
+        // Record the exact payload so specs can assert it (incl. vault vs store
+        // not being swapped). Rejected calls are still recorded (the attempt).
+        (window as any).__selectScopeCalls = (window as any).__selectScopeCalls ?? [];
+        (window as any).__selectScopeCalls.push(JSON.parse(JSON.stringify(sel)));
+        // Runtime-settable failure so a spec can make a *later* SelectScope fail
+        // (e.g. after AWS is already active) to test "keep previous scope".
+        if (state.simulateError?.operation === 'SelectScope' || (window as any).__forceSelectScopeError) {
+          throw new Error(state.simulateError?.message ?? 'scope selection failed');
         }
         // Mirror the backend validation (internal/gui/app.go) so provider-aware
         // specs exercise the same error paths.
@@ -949,7 +964,7 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
         return {
           name,
           arn: secret?.arn !== undefined ? secret.arn : `arn:aws:secretsmanager:us-east-1:123456789:secret:${name}`,
-          versionId: 'v1',
+          versionId: secret?.versionId ?? 'v1',
           versionStage: secret?.versionStage !== undefined ? secret.versionStage : ['AWSCURRENT'],
           value: secret?.value || 'mock-secret',
           description: '',

--- a/internal/gui/frontend/tests/provider-selection.spec.ts
+++ b/internal/gui/frontend/tests/provider-selection.spec.ts
@@ -95,12 +95,12 @@ test.describe('Provider selection', () => {
   });
 
   test.describe('Azure', () => {
-    test('is greyed-out (disabled) in the provider selector', async ({ page }) => {
+    test('is selectable in the provider selector (un-greyed by #267)', async ({ page }) => {
       await setupWailsMocks(page);
       await page.goto('/');
       await waitForViewLoaded(page);
 
-      await expect(page.locator('#provider-select option[value="azure"]')).toBeDisabled();
+      await expect(page.locator('#provider-select option[value="azure"]')).toBeEnabled();
     });
 
     test('App Configuration (param): no Type dropdown, no version history, no tags', async ({ page }) => {

--- a/internal/gui/frontend/tests/scope-form.spec.ts
+++ b/internal/gui/frontend/tests/scope-form.spec.ts
@@ -1,0 +1,195 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  setupWailsMocks,
+  createAzureState,
+  getSelectScopeCalls,
+  waitForItemList,
+  waitForViewLoaded,
+  navigateTo,
+  type MockState,
+} from './fixtures/wails-mock';
+
+// Select a provider from the sidebar dropdown.
+async function pickProvider(page: Page, value: string) {
+  await page.locator('#provider-select').selectOption(value);
+}
+
+// An Azure environment where subscription/RG are env-derived but no vault/store
+// yet → the app parks in the Azure scope form (prefilled, not auto-applied).
+const azurePartialScope: Partial<MockState> = {
+  initialProvider: 'azure',
+  currentScope: {
+    provider: 'azure',
+    projectId: '',
+    subscriptionId: 'env-sub',
+    resourceGroup: 'env-rg',
+    vaultName: '',
+    storeName: '',
+  },
+  detectResult: { param: 'azure', secret: 'azure', stage: '', paramActive: ['azure'], secretActive: ['azure'], stageActive: [] },
+};
+
+test.describe('Azure scope form', () => {
+  test('renders subscription/RG + vault/store fields for Azure only', async ({ page }) => {
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForItemList(page);
+
+    await pickProvider(page, 'azure');
+    for (const id of ['#azure-subscription', '#azure-resource-group', '#azure-vault', '#azure-store']) {
+      await expect(page.locator(id)).toBeVisible();
+    }
+    await expect(page.locator('#gcloud-project')).toHaveCount(0);
+  });
+
+  test('Google Cloud shows only a project field; AWS shows no scope form', async ({ page }) => {
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForItemList(page);
+
+    await pickProvider(page, 'googlecloud');
+    await expect(page.locator('#gcloud-project')).toBeVisible();
+    await expect(page.locator('#azure-vault')).toHaveCount(0);
+
+    await pickProvider(page, 'aws');
+    // AWS needs no scope → auto-applied, no form.
+    await expect(page.locator('#gcloud-project')).toHaveCount(0);
+    await expect(page.locator('#azure-subscription')).toHaveCount(0);
+  });
+
+  test('submit sends the exact ScopeSelection (vault vs store not swapped, trimmed)', async ({ page }) => {
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForItemList(page);
+
+    await pickProvider(page, 'azure');
+    await page.locator('#azure-subscription').fill('sub-1');
+    await page.locator('#azure-resource-group').fill('rg-1');
+    await page.locator('#azure-vault').fill('  the-vault  '); // whitespace trimmed
+    await page.locator('#azure-store').fill('the-store');
+    await page.getByRole('button', { name: 'Connect' }).click();
+    await waitForItemList(page);
+
+    const calls = await getSelectScopeCalls(page);
+    const last = calls[calls.length - 1];
+    expect(last).toMatchObject({
+      provider: 'azure',
+      subscriptionId: 'sub-1',
+      resourceGroup: 'rg-1',
+      vaultName: 'the-vault', // NOT the store
+      storeName: 'the-store', // NOT the vault
+    });
+  });
+
+  test('Connect is disabled until a vault or store name is given', async ({ page }) => {
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForItemList(page);
+
+    await pickProvider(page, 'azure');
+    const connect = page.getByRole('button', { name: 'Connect' });
+    await page.locator('#azure-subscription').fill('sub-only');
+    await expect(connect).toBeDisabled(); // sub/rg alone is not enough
+    await page.locator('#azure-vault').fill('v');
+    await expect(connect).toBeEnabled();
+    // whitespace-only does not count
+    await page.locator('#azure-vault').fill('   ');
+    await expect(connect).toBeDisabled();
+  });
+
+  test('a rejected SelectScope shows the error and keeps the previous scope browsable', async ({ page }) => {
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForItemList(page);
+    // AWS is active and browsable.
+    await expect(page.locator('.item-name.param').first()).toBeVisible();
+
+    // Make the next SelectScope fail, then try to switch to Azure.
+    await page.evaluate(() => {
+      (window as any).__forceSelectScopeError = true;
+    });
+    await pickProvider(page, 'azure');
+    await page.locator('#azure-vault').fill('v');
+    await page.getByRole('button', { name: 'Connect' }).click();
+
+    // Error surfaced in the form; AWS list still works (previous scope kept).
+    await expect(page.locator('.scope-error')).toBeVisible();
+    await expect(page.locator('.item-name.param').first()).toBeVisible();
+  });
+
+  test('prefills subscription/RG from env-derived GetCurrentScope', async ({ page }) => {
+    await setupWailsMocks(page, azurePartialScope);
+    await page.goto('/');
+    await expect(page.locator('#azure-subscription')).toHaveValue('env-sub');
+    await expect(page.locator('#azure-resource-group')).toHaveValue('env-rg');
+    await expect(page.locator('#azure-vault')).toHaveValue('');
+  });
+
+  test('retains scope when switching provider away and back (localStorage)', async ({ page }) => {
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForItemList(page);
+
+    // Establish an Azure scope.
+    await pickProvider(page, 'azure');
+    await page.locator('#azure-vault').fill('kept-vault');
+    await page.getByRole('button', { name: 'Connect' }).click();
+    await waitForItemList(page);
+    await expect(page.locator('.nav').getByRole('button', { name: /Key Vault/i })).toBeVisible();
+
+    // Away to AWS, then back to Azure → retained (no form, auto-applied).
+    await pickProvider(page, 'aws');
+    await waitForItemList(page);
+    await pickProvider(page, 'azure');
+    await waitForItemList(page);
+    await expect(page.locator('#azure-vault')).toHaveCount(0); // no form: applied from cache
+    await expect(page.locator('.nav').getByRole('button', { name: /Key Vault/i })).toBeVisible();
+  });
+
+  test.describe('a11y', () => {
+    test('fields are labeled and the first field is focused on open', async ({ page }) => {
+      await setupWailsMocks(page);
+      await page.goto('/');
+      await waitForItemList(page);
+      await pickProvider(page, 'azure');
+
+      await expect(page.getByLabel('Subscription ID')).toBeVisible();
+      await expect(page.getByLabel('Key Vault name')).toBeVisible();
+      await expect(page.locator('#azure-subscription')).toBeFocused();
+    });
+
+    test('Enter submits and Escape cancels', async ({ page }) => {
+      await setupWailsMocks(page);
+      await page.goto('/');
+      await waitForItemList(page);
+
+      // Escape cancels → back to the active AWS provider, form gone.
+      await pickProvider(page, 'azure');
+      await expect(page.locator('#azure-subscription')).toBeVisible();
+      await page.keyboard.press('Escape');
+      await expect(page.locator('#azure-subscription')).toHaveCount(0);
+
+      // Enter in a field submits.
+      await pickProvider(page, 'azure');
+      await page.locator('#azure-vault').fill('via-enter');
+      await page.locator('#azure-vault').press('Enter');
+      await waitForItemList(page);
+      const calls = await getSelectScopeCalls(page);
+      expect(calls[calls.length - 1]).toMatchObject({ provider: 'azure', vaultName: 'via-enter' });
+    });
+  });
+
+  test('form is usable at 375px width', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForViewLoaded(page);
+
+    await pickProvider(page, 'azure');
+    await expect(page.locator('#azure-subscription')).toBeVisible();
+    const noOverflow = await page.evaluate(
+      () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+    );
+    expect(noOverflow).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #267. Part of #250.

Azure needs scope inputs no other provider has; #266 shipped it **greyed-out**. This un-greys Azure, adds its scope form, and introduces a pending-selection flow so a rejected/incomplete scope never tears down a working view.

## What

- **Selector**: Azure is now selectable (the `disabled` attribute is removed).
- **Azure scope form** (sidebar): Subscription ID + Resource Group + Key Vault name + App Configuration store, prefilled from `GetCurrentScope()` (env-derived `AZURE_*`). Client validation mirrors #276 (**≥1 of vault/store**, trimmed) with GUI-worded errors; the GCP project form gains the same error surface.
- **Service-tab gating by scope**: a vault-only user sees only **Key Vault**, a store-only user only **App Configuration** (services filtered by which name is set).
- **`pendingProvider` flow**: selecting a provider that still needs scope shows its form **without unmounting the active provider** — so on `SelectScope` rejection the previous scope stays browsable and the error surfaces in the form. A successful apply switches + remounts and clears the form.
- **localStorage persistence** of the last-applied scope per provider: switching away and back re-applies the cached scope (no re-entry).
- **a11y**: labels bound, Enter submits, Escape cancels, first field focused on open.
- **Modal `min-width` → `min(400px, 90vw)`** so forms/modals fit a 375px viewport.

## Tests

New `scope-form.spec.ts`: fields-per-provider, exact `SelectScope` payload (incl. **vault-vs-store not swapped** + whitespace trimming), disabled-until-valid, **rejection keeps the previous scope browsable**, env prefill, away/back persistence, a11y (labels/Enter/Escape/focus), 375px. The mock records `SelectScope` payloads and gains a runtime `__forceSelectScopeError` hook; the #266 "Azure disabled" assertion is flipped to "selectable". **515 chromium specs pass**; `npm run ci` + Naming Convention green. No Go changes.

## Note for review
While entering a new provider's scope, the **previously-active provider stays mounted and browsable** (its tabs/identity remain visible under the form) — this is the intentional "keep previous scope on rejection" behavior. Screenshots below show it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SPyCZL1EWNiYBe17j4ocM
