### PR TITLE
fix(gui): show the value for unversioned providers (Azure App Configuration)

### DIFF
--- a/internal/gui/frontend/src/lib/ParamView.svelte
+++ b/internal/gui/frontend/src/lib/ParamView.svelte
@@ -179,15 +179,21 @@
     detailLoading = true;
     showValue = withValue;
     stagingStatus = null;
-    try {
-      const [detail, log] = await Promise.all([ParamShow(name), ParamLog(name, 10)]);
-      paramDetail = detail;
-      paramLog = log?.entries || [];
-    } catch (e) {
-      error = parseError(e);
-    } finally {
-      detailLoading = false;
+    error = '';
+    // History is best-effort and unsupported by some providers (Azure App
+    // Configuration): fetch it only when supported, and use allSettled so a
+    // failed ParamLog never blanks out the value shown by ParamShow.
+    const [detailResult, logResult] = await Promise.allSettled([
+      ParamShow(name),
+      historyEnabled ? ParamLog(name, 10) : Promise.resolve(null),
+    ]);
+    if (detailResult.status === 'fulfilled') {
+      paramDetail = detailResult.value;
+    } else {
+      error = parseError(detailResult.reason);
     }
+    paramLog = logResult.status === 'fulfilled' ? (logResult.value?.entries ?? []) : [];
+    detailLoading = false;
 
     // Staging status is decoupled from the detail fetch: only for
     // staging-capable providers, and a failure just means no banner — it must

--- a/internal/gui/frontend/src/lib/SecretView.svelte
+++ b/internal/gui/frontend/src/lib/SecretView.svelte
@@ -180,15 +180,20 @@
     detailLoading = true;
     showValue = withValue;
     stagingStatus = null;
-    try {
-      const [detail, log] = await Promise.all([SecretShow(name), SecretLog(name, 10)]);
-      secretDetail = detail;
-      secretLog = log?.entries || [];
-    } catch (e) {
-      error = parseError(e);
-    } finally {
-      detailLoading = false;
+    error = '';
+    // History is best-effort: fetch it only when supported, and use allSettled
+    // so a failed SecretLog never blanks out the value shown by SecretShow.
+    const [detailResult, logResult] = await Promise.allSettled([
+      SecretShow(name),
+      historyEnabled ? SecretLog(name, 10) : Promise.resolve(null),
+    ]);
+    if (detailResult.status === 'fulfilled') {
+      secretDetail = detailResult.value;
+    } else {
+      error = parseError(detailResult.reason);
     }
+    secretLog = logResult.status === 'fulfilled' ? (logResult.value?.entries ?? []) : [];
+    detailLoading = false;
 
     // Decoupled staging status: only for staging-capable providers; a failure
     // just means no banner and never breaks the detail pane.

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -877,6 +877,12 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
       ParamTypeOptions: async () =>
         state.currentScope.provider === 'aws' ? ['String', 'SecureString', 'StringList'] : [],
       ParamLog: async (name: string, _limit?: number) => {
+        // Azure App Configuration is unversioned — mirror the backend, which
+        // returns ErrVersioningUnsupported from History (the value must still
+        // be viewable; only history is unavailable).
+        if (state.currentScope?.provider === 'azure') {
+          throw new Error('the Azure App Configuration store does not support versions (no version history)');
+        }
         const versions = state.paramVersions[name] || [
           { version: 1, value: 'current', type: 'String', isCurrent: true, lastModified: new Date().toISOString() },
         ];

--- a/internal/gui/frontend/tests/provider-selection.spec.ts
+++ b/internal/gui/frontend/tests/provider-selection.spec.ts
@@ -121,6 +121,20 @@ test.describe('Provider selection', () => {
       await expect(page.locator('#param-type')).toHaveCount(0);
     });
 
+    test('App Configuration detail shows the value even though history is unsupported', async ({ page }) => {
+      // Regression: ParamLog fails on App Config (no history). The detail (value)
+      // must still render and no history-error banner must appear — the value
+      // fetch must not be coupled to the failing history fetch.
+      await setupWailsMocks(page, createAzureState());
+      await page.goto('/');
+      await waitForItemList(page);
+
+      await clickItemByName(page, 'app/config/key');
+      await expect(page.locator('.detail-panel')).toBeVisible();
+      await expect(page.locator('.value-display')).toBeVisible();
+      await expect(page.locator('.error-banner')).toHaveCount(0);
+    });
+
     test('Key Vault (secret): version history yes, Restore no', async ({ page }) => {
       await setupWailsMocks(page, createAzureState());
       await page.goto('/');


### PR DESCRIPTION
## Bug
Clicking any **Azure App Configuration** setting showed an **empty detail pane + a red "the Azure App Configuration store does not support versions (no version history)" banner** — the current value was never visible.

## Cause
`selectParam` (and `selectSecret`) fetched the detail (`ParamShow`) and history (`ParamLog`) in a single `Promise.all`. App Configuration is unversioned, so `ParamLog` rejects (`ErrVersioningUnsupported`) → the whole `Promise.all` rejects → `paramDetail` is never assigned → empty pane + error banner.

## Fix
Fetch the two independently with `Promise.allSettled`, and request history only when the provider supports it (`capability.hasVersionHistory`). A failed/absent history fetch no longer blanks the value or raises a banner. The history section was already capability-gated, so nothing new renders. Applied to both `ParamView` and `SecretView`.

## Tests
- The mock's `ParamLog` now rejects under an Azure scope (mirroring the backend), so the bug is reproducible in Playwright.
- New regression test: App Configuration detail renders `.value-display` with **no `.error-banner`**.
- 501 chromium specs pass; svelte-check clean.

See the attached screenshot — App Config now shows *Current Value* + *Last Modified* with no banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SPyCZL1EWNiYBe17j4ocM
