### PR TITLE
docs: reflect the now-complete multi-cloud GUI (drop AWS-only/planned notes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,21 +476,19 @@ where ~SHIFT = ~ | ~N  (repeatable, cumulative)
 
 ### Feature support
 
-| Backend | Command | Versioning | Labels / Tags | Staging | GUI² | Auth |
+| Backend | Command | Versioning | Labels / Tags | Staging | GUI | Auth |
 |---------|---------|------------|---------------|---------|------|------|
 | [AWS Parameter Store](docs/aws.md) | `aws param` | ✅ numeric | ✅ tags | ✅ | ✅ | shared config/env/role |
 | [AWS Secrets Manager](docs/aws.md) | `aws secret` | ✅ UUID + staging labels | ✅ tags | ✅ | ✅ | shared config/env/role |
-| [Google Cloud Secret Manager](docs/gcloud.md) | `gcloud secret` | ✅ integer (`latest`) | ✅ labels | ✅ | 🔜 [#250](https://github.com/mpyw/suve/issues/250) | Application Default Credentials |
-| [Azure Key Vault](docs/azure.md) | `azure secret` | ✅ opaque id | ✅ tags | ✅ | 🔜 [#250](https://github.com/mpyw/suve/issues/250) | DefaultAzureCredential |
-| [Azure App Configuration](docs/azure.md) | `azure param` | ❌ unversioned | ❌ unsupported¹ | ✅³ | 🔜 [#250](https://github.com/mpyw/suve/issues/250) | DefaultAzureCredential |
+| [Google Cloud Secret Manager](docs/gcloud.md) | `gcloud secret` | ✅ integer (`latest`) | ✅ labels | ✅ | ✅ | Application Default Credentials |
+| [Azure Key Vault](docs/azure.md) | `azure secret` | ✅ opaque id | ✅ tags | ✅ | ✅ | DefaultAzureCredential |
+| [Azure App Configuration](docs/azure.md) | `azure param` | ❌ unversioned | ❌ unsupported¹ | ✅² | ✅ | DefaultAzureCredential |
 
 Read/write operations (`show`, `log`, `diff`, `list`, `create`, `update`, `delete`, `tag`, `untag`) are available on every backend, with these caveats: `restore` is AWS Secrets Manager only; on Azure App Configuration `log` reports history unsupported and `tag`/`untag` return an unsupported error; version specifiers (`#VERSION`, `~SHIFT`, `:LABEL`) are rejected on App Configuration. Only AWS Secrets Manager has staging labels (`:AWSCURRENT` etc.).
 
 ¹ The `azappconfig` SDK cannot write setting tags without clearing them, so tag writes are refused.
 
-² The bundled GUI (`suve --gui`) is AWS-only today; multi-cloud GUI support is planned ([#250](https://github.com/mpyw/suve/issues/250)). The CLI supports all backends.
-
-³ App Configuration is unversioned, so staging uses **last-write-wins** (no modified-after conflict check) and `tag`/`untag` are unavailable (tags aren't writable).
+² App Configuration is unversioned, so staging uses **last-write-wins** (no modified-after conflict check) and `tag`/`untag` are unavailable (tags aren't writable).
 
 ### Provider selection
 

--- a/internal/gui/capabilities_internal_test.go
+++ b/internal/gui/capabilities_internal_test.go
@@ -35,8 +35,8 @@ func findService(t *testing.T, caps []ProviderCapability, prov, service string) 
 
 // TestApp_Capabilities_StagingAndDeleteFlags pins the staging/delete capability
 // values that drive control visibility, so a stray edit to providers.go is
-// caught. Staging is AWS-only until #270; force-delete/recovery-window are AWS
-// Secrets Manager only.
+// caught. Staging is available for every provider service;
+// force-delete/recovery-window are AWS Secrets Manager only.
 func TestApp_Capabilities_StagingAndDeleteFlags(t *testing.T) {
 	t.Parallel()
 
@@ -50,7 +50,7 @@ func TestApp_Capabilities_StagingAndDeleteFlags(t *testing.T) {
 		hasRecoveryWindow bool
 		hasRestore        bool
 	}{
-		// Staging is now available for every provider service (#270); force-delete
+		// Staging is now available for every provider service; force-delete
 		// and recovery-window stay AWS Secrets Manager only.
 		{string(provider.ProviderAWS), "param", true, false, false, false},
 		{string(provider.ProviderAWS), "secret", true, true, true, true},

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -628,8 +628,7 @@ export function createGoogleCloudState(overrides: Partial<MockState> = {}): Part
 
 /**
  * Launched into Azure with vault + store present (as env/CLI would supply),
- * so both Key Vault (secret) and App Configuration (param) mount. The selector
- * option stays disabled ("greyed") until #267 adds the scope form.
+ * so both Key Vault (secret) and App Configuration (param) mount.
  */
 export function createAzureState(overrides: Partial<MockState> = {}): Partial<MockState> {
   return {

--- a/internal/gui/providers.go
+++ b/internal/gui/providers.go
@@ -106,8 +106,8 @@ type ServiceCapability struct {
 	// Manager only).
 	HasRestore bool `json:"hasRestore"`
 	// HasStaging is true when the GUI's staging workflow applies to this
-	// service. It is AWS-only until scope-keyed multi-provider staging lands
-	// (#270); the frontend hides the staging tab/banner/checkbox when false.
+	// service (every provider service today); the frontend hides the staging
+	// tab/banner/checkbox when false.
 	HasStaging bool `json:"hasStaging"`
 	// HasForceDelete is true when an immediate (no-recovery-window) delete is
 	// offered (AWS Secrets Manager only). The frontend hides the force-delete


### PR DESCRIPTION
The GUI reached multi-cloud parity (read/write/staging across AWS, Google Cloud, and Azure), so the leftover "AWS-only / planned" status is stale. Investigated repo-wide (README, `docs/`, `CLAUDE.md`, `gui/CLAUDE.md`, Go/Svelte/TS comments).

- **README feature-support matrix**: the GUI column is now ✅ for every backend (was a "coming soon" marker for Google Cloud / Azure); dropped the "the bundled GUI is AWS-only; multi-cloud planned" footnote and renumbered the App Configuration staging footnote.
- **`providers.go` + `capabilities_internal_test.go`**: the `HasStaging` comment no longer says staging is AWS-only — it applies to every provider service now.
- **`wails-mock.ts`**: dropped the stale "Azure selector stays disabled" note (Azure is selectable).

`docs/`, top `CLAUDE.md`, and `gui/CLAUDE.md` had no stale GUI-status claims. Comment/doc only — no behavior change; `go build` + capabilities test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019SPyCZL1EWNiYBe17j4ocM