### PR TITLE
feat(cli): add AWS `secretsmanager` alias to match native CLI names

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,7 +542,7 @@ Explicit command groups (always available) and their bare aliases (exposed per t
 | Backend | Explicit command | Bare alias (conditional) |
 |---------|------------------|--------------------------|
 | [AWS SSM Parameter Store](docs/aws.md) | `aws param` (`ssm`, `ps`) | `param` |
-| [AWS Secrets Manager](docs/aws.md) | `aws secret` (`sm`) | `secret` |
+| [AWS Secrets Manager](docs/aws.md) | `aws secret` (`sm`, `secretsmanager`) | `secret` |
 | AWS Staging | `aws stage` (`stg`) | `stage` |
 | [Google Cloud Secret Manager](docs/gcloud.md) | `gcloud secret` (`secrets`, `sm`) | `secret` |
 | Google Cloud Staging | `gcloud stage` (`stg`) | `stage` |

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -3,7 +3,7 @@
 [<- Back to README](../README.md) | [Google Cloud Commands](gcloud.md) | [Azure Commands](azure.md)
 
 > [!TIP]
-> AWS is invoked as `suve aws param` (`ssm`, `ps`), `suve aws secret` (`sm`), and `suve aws stage` (`stg`).
+> AWS is invoked as `suve aws param` (`ssm`, `ps`), `suve aws secret` (`sm`, `secretsmanager`), and `suve aws stage` (`stg`).
 > You can drop the `aws` prefix — `suve param`, `suve secret`, `suve stage` — when AWS is the only provider active in your environment. The exact rules are in [Provider selection](../README.md#provider-selection).
 
 ## suve aws param show

--- a/internal/cli/commands/secret/command.go
+++ b/internal/cli/commands/secret/command.go
@@ -15,7 +15,7 @@ import (
 func Command() *cli.Command {
 	return &cli.Command{
 		Name:    "secret",
-		Aliases: []string{"sm"},
+		Aliases: []string{"sm", "secretsmanager"},
 		Usage:   "Interact with AWS Secrets Manager",
 		Commands: []*cli.Command{
 			ShowCommand(),

--- a/internal/cli/commands/stage/secret/command.go
+++ b/internal/cli/commands/stage/secret/command.go
@@ -27,7 +27,7 @@ func Config() stgcli.CommandConfig {
 func Command() *cli.Command {
 	return &cli.Command{
 		Name:    "secret",
-		Aliases: []string{"sm"},
+		Aliases: []string{"sm", "secretsmanager"},
 		Usage:   "Staging operations for Secrets Manager",
 		Description: `Stage changes locally before applying to AWS.
 


### PR DESCRIPTION
## Summary

Follow-up to #286. That PR gave Google Cloud / Azure aliases mirroring each cloud's native shorthand (`gcloud secrets`, `az keyvault`, `az appconfig`). This rounds out the symmetry on the AWS side: AWS Secrets Manager's native CLI command is `aws secretsmanager`, so `aws secret` now accepts `secretsmanager` alongside the existing `sm`.

## Result: every service accepts its native CLI name + a short initialism

| Cloud | Native CLI | suve canonical | suve aliases |
|---|---|---|---|
| AWS Parameter Store | `aws ssm` | `aws param` | `ssm`, `ps` |
| AWS Secrets Manager | `aws secretsmanager` | `aws secret` | **`secretsmanager`** (new), `sm` |
| Google Cloud Secret Manager | `gcloud secrets` | `gcloud secret` | `secrets`, `sm` |
| Azure Key Vault | `az keyvault` | `azure secret` | `keyvault`, `kv` |
| Azure App Configuration | `az appconfig` | `azure param` | `appconfig`, `ac`, `appcfg` |

So `suve aws secretsmanager`, `suve gcloud secrets`, `suve az keyvault`, `suve az appconfig` all resolve just like the real CLIs. The alias is added to both `aws secret` and `aws stage secret`.

## Verification

- `mise lint` → 0 issues
- `mise test` → pass
- Verified `suve aws secretsmanager` / `suve aws stage secretsmanager` resolve to the AWS Secrets Manager group locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)