### PR TITLE
refactor(azure)!: drop subscription/resource-group from scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,11 +180,81 @@ cd gui && wails build -tags production,webkit2_41 -skipbindings
 
 </details>
 
-> [!TIP]
-> **Using with [aws-vault](https://github.com/99designs/aws-vault)**: Wrap commands with `aws-vault exec` for temporary credentials:
-> ```bash
-> aws-vault exec my-profile -- suve param show /my/param
-> ```
+## Authentication
+
+suve talks to each cloud's **data plane** using that cloud's own SDK credential chain — the same one the native CLI (`aws` / `gcloud` / `az`) uses. There is nothing suve-specific to configure: sign in the normal way, then point suve at the resource with an environment variable (or the equivalent flag).
+
+<table>
+<thead>
+<tr><th>Provider</th><th>Sign in (identity)</th><th>Point at the resource</th></tr>
+</thead>
+<tbody>
+<tr>
+<td><b>AWS</b></td>
+<td>
+
+```bash
+aws sso login \
+  --profile prod
+```
+
+</td>
+<td>
+
+```bash
+export AWS_PROFILE=prod
+export AWS_REGION=us-east-1
+```
+
+</td>
+</tr>
+<tr>
+<td><b>Google<br>Cloud</b></td>
+<td>
+
+```bash
+gcloud auth \
+  application-default \
+  login
+```
+
+</td>
+<td>
+
+```bash
+export GOOGLE_CLOUD_PROJECT=my-project
+```
+
+</td>
+</tr>
+<tr>
+<td><b>Azure</b></td>
+<td>
+
+```bash
+az login
+```
+
+</td>
+<td>
+
+```bash
+# secret
+export AZURE_KEYVAULT_NAME=my-vault
+# param
+export AZURE_APPCONFIG_NAME=my-store
+```
+
+</td>
+</tr>
+</tbody>
+</table>
+
+> [!NOTE]
+> - Every value has a flag equivalent: `--profile`/`--region`, `--project`, `--vault-name`/`--store-name`.
+> - **AWS** — the standard [credential chain](https://docs.aws.amazon.com/sdkref/latest/guide/standardized-credentials.html): SSO, static keys, `~/.aws/credentials`, or an IAM role. With [aws-vault](https://github.com/99designs/aws-vault): `aws-vault exec prod -- suve param show /my/param`.
+> - **Google Cloud** — [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials); or a service-account key via `GOOGLE_APPLICATION_CREDENTIALS`.
+> - **Azure** — the [DefaultAzureCredential](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication) chain; or a service principal via `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` / `AZURE_TENANT_ID`. `az login` sets no environment variables — it caches credentials under `~/.azure`, which suve reuses. The Key Vault / App Configuration name is a globally-unique endpoint, so **no subscription or resource group is needed**.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ Uses integer version numbers (with the `latest` alias) and has no staging labels
 
 ### Azure Key Vault
 
-Secrets are versioned by opaque IDs and have no staging labels. Select the vault with `--vault-name` or the `AZURE_KEYVAULT_NAME` environment variable. The shared `azure` base flags are `--subscription` / `AZURE_SUBSCRIPTION_ID` and `--resource-group` / `AZURE_RESOURCE_GROUP`. Authentication uses the [DefaultAzureCredential](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication) chain (environment, managed identity, Azure CLI, ...). See [docs/azure.md](docs/azure.md) for details.
+Secrets are versioned by opaque IDs and have no staging labels. Select the vault with `--vault-name` or the `AZURE_KEYVAULT_NAME` environment variable — the vault name is a globally-unique endpoint, so no subscription or resource group is needed. Authentication uses the [DefaultAzureCredential](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication) chain (environment, managed identity, Azure CLI, ...). See [docs/azure.md](docs/azure.md) for details.
 
 | Command | Options | Description |
 |---------|---------|-------------|
@@ -673,7 +673,7 @@ Secrets are versioned by opaque IDs and have no staging labels. Select the vault
 
 ### Azure App Configuration
 
-Unversioned key-value store. Version specifiers (`#VERSION`, `~SHIFT`, `:LABEL`) are rejected, `log` reports that history is unsupported, and `tag` / `untag` are unsupported (SDK limitation). Select the store with `--store-name` or the `AZURE_APPCONFIG_NAME` environment variable, plus the shared `azure` base flags described above. See [docs/azure.md](docs/azure.md) for details.
+Unversioned key-value store. Version specifiers (`#VERSION`, `~SHIFT`, `:LABEL`) are rejected, `log` reports that history is unsupported, and `tag` / `untag` are unsupported (SDK limitation). Select the store with `--store-name` or the `AZURE_APPCONFIG_NAME` environment variable — the store name is a globally-unique endpoint, so no subscription or resource group is needed. See [docs/azure.md](docs/azure.md) for details.
 
 | Command | Options | Description |
 |---------|---------|-------------|
@@ -765,10 +765,10 @@ All timestamps are formatted in RFC3339 format with the local timezone offset ap
 
 | Variable | Description |
 |----------|-------------|
-| `AZURE_SUBSCRIPTION_ID` | Subscription (or use `--subscription`) |
-| `AZURE_RESOURCE_GROUP` | Resource group (or use `--resource-group`) |
 | `AZURE_KEYVAULT_NAME` | Key Vault name for `azure secret` (or use `--vault-name`) |
 | `AZURE_APPCONFIG_NAME` | App Configuration store for `azure param` (or use `--store-name`) |
+
+Authentication uses the DefaultAzureCredential chain (`az login`, environment, managed identity, ...). The Key Vault / App Configuration name is a globally-unique endpoint, so no subscription or resource group is needed.
 
 ## AWS Configuration
 

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -23,8 +23,6 @@ Unlike `aws stage`, there is no cross-service `azure stage status`/`apply` aggre
 
 | Setting | Flag | Environment variable |
 |---------|------|----------------------|
-| Subscription | `--subscription` | `AZURE_SUBSCRIPTION_ID` |
-| Resource group | `--resource-group` | `AZURE_RESOURCE_GROUP` |
 | Key Vault name (secret) | `--vault-name` | `AZURE_KEYVAULT_NAME` |
 | App Config store (param) | `--store-name` | `AZURE_APPCONFIG_NAME` |
 
@@ -34,15 +32,15 @@ Authentication uses the **DefaultAzureCredential** chain (environment, managed i
 az login
 ```
 
-The subscription and resource group can be supplied per-invocation or globally via environment variables:
+The target resource is addressed by its **globally-unique name** — the Key Vault
+or App Configuration store — which is all suve needs; no subscription or resource
+group is required. Supply the name per-invocation or via an environment variable:
 
 ```bash
 # Via flags
-suve azure --subscription <sub-id> --resource-group my-rg secret list --vault-name my-vault
+suve azure secret list --vault-name my-vault
 
 # Via environment variables
-export AZURE_SUBSCRIPTION_ID=<sub-id>
-export AZURE_RESOURCE_GROUP=my-rg
 export AZURE_KEYVAULT_NAME=my-vault
 suve azure secret list
 ```

--- a/docs/provider-selection.md
+++ b/docs/provider-selection.md
@@ -39,10 +39,11 @@ Each command group resolves its store through this shared registry:
      identity is resolved separately, only where staging state must be keyed.
    - **Google Cloud** — the project id from `--project` or `GOOGLE_CLOUD_PROJECT`
      (`provider.GoogleCloudScope(project)`).
-   - **Azure** — subscription / resource group (`--subscription` /
-     `--resource-group` or `AZURE_*` env) plus the Key Vault name
-     (`--vault-name`) or App Configuration store name (`--store-name`)
-     (`provider.AzureKeyVaultScope(...)` / `provider.AzureAppConfigScope(...)`).
+   - **Azure** — the Key Vault name (`--vault-name` / `AZURE_KEYVAULT_NAME`) or
+     App Configuration store name (`--store-name` / `AZURE_APPCONFIG_NAME`); each
+     is a globally-unique name that fully identifies the resource, so no
+     subscription/resource group is needed
+     (`provider.AzureKeyVaultScope(vault)` / `provider.AzureAppConfigScope(store)`).
 2. It asks the registry for the store it needs:
    `registry.Store(ctx, scope, provider.KindParam)` (or `KindSecret`).
 

--- a/e2e/azure_stage_test.go
+++ b/e2e/azure_stage_test.go
@@ -65,9 +65,9 @@ func TestAzureKeyVaultStage_Workflow(t *testing.T) {
 	_, err = runAzureSecret(t, "create", deleteName, "to-be-deleted")
 	require.NoError(t, err)
 
-	// The Key Vault staging scope is keyed by (subscription, resource-group,
-	// vault); the emulator setup pins the vault name and leaves sub/rg empty.
-	store, err := file.NewStore(provider.AzureKeyVaultScope("", "", "suve-e2e"))
+	// The Key Vault staging scope is keyed by the globally-unique vault name
+	// alone; the emulator setup pins it to "suve-e2e".
+	store, err := file.NewStore(provider.AzureKeyVaultScope("suve-e2e"))
 	require.NoError(t, err)
 
 	now := time.Now()
@@ -149,7 +149,7 @@ func TestAzureAppConfigStage_Workflow(t *testing.T) {
 	_, err := runAzureParam(t, "create", updateName, "original")
 	require.NoError(t, err)
 
-	store, err := file.NewStore(provider.AzureAppConfigScope("", "", "suve-e2e"))
+	store, err := file.NewStore(provider.AzureAppConfigScope("suve-e2e"))
 	require.NoError(t, err)
 
 	now := time.Now()

--- a/internal/cli/commands/app_test.go
+++ b/internal/cli/commands/app_test.go
@@ -72,8 +72,8 @@ func TestMakeAppWithDetect_flatCommandsAreRunnable(t *testing.T) {
 	err := app.Run(t.Context(), []string{"suve", "secret", "--help"})
 	require.NoError(t, err)
 
-	// A flat Azure param alias should carry the base --subscription flag folded
-	// in on top of --store-name.
+	// A flat Azure param alias should behave like `azure param`: it carries the
+	// --store-name flag from the group. `--help` must succeed.
 	app = commands.MakeAppWithDetect(detect.Result{Param: provider.ProviderAzure})
 	err = app.Run(t.Context(), []string{"suve", "param", "--help"})
 	require.NoError(t, err)

--- a/internal/cli/commands/azure/command.go
+++ b/internal/cli/commands/azure/command.go
@@ -8,14 +8,12 @@
 //   - App Configuration (param): UNVERSIONED — the abstraction's acid test.
 //
 // Both groups reuse the same generic command scaffolding as the AWS/GoogleCloud commands
-// via Azure-specific presenters and use cases. The top-level azure command owns
-// the shared --subscription / --resource-group flags; each subgroup owns its
-// address flag (--vault-name / --store-name).
+// via Azure-specific presenters and use cases. Each subgroup owns its address
+// flag (--vault-name / --store-name); the target resource's globally-unique name
+// is all that is needed to reach it.
 package azure
 
 import (
-	"context"
-
 	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/cli/commands/azure/param"
@@ -40,16 +38,11 @@ App Configuration has no version history: version specifiers (#VERSION, ~SHIFT,
 :LABEL) are rejected with a clear error, and "log" reports that history is
 unsupported.
 
-Set the subscription and resource group with --subscription/--resource-group or
-the AZURE_SUBSCRIPTION_ID/AZURE_RESOURCE_GROUP environment variables.
 Authentication uses the DefaultAzureCredential chain (environment, managed
-identity, Azure CLI, ...).`,
-		Flags: baseFlags(),
-		// Before resolves the shared subscription/resource-group once and stashes
-		// them in the context so the generic command presenters (which do not
-		// receive *cli.Command) can resolve a store. Resolution is deferred to
-		// store construction, so `suve azure --help` still works without them.
-		Before: withBase,
+identity, Azure CLI via 'az login', ...). The target resource is addressed by
+its globally-unique name (--vault-name / AZURE_KEYVAULT_NAME for Key Vault,
+--store-name / AZURE_APPCONFIG_NAME for App Configuration); no subscription or
+resource group is required.`,
 		Commands: []*cli.Command{
 			secret.Command(),
 			param.Command(),
@@ -60,71 +53,23 @@ identity, Azure CLI, ...).`,
 }
 
 // FlatSecretCommand returns the Azure Key Vault (secret) command as a standalone
-// top-level command named `name`. Because there is no parent azure group to
-// carry them, it folds in the shared --subscription / --resource-group flags and
-// base Before hook on top of the secret group's own --vault-name flag/hook. Used
-// for the flat `suve secret` alias when Azure is the uniquely active secret
-// provider.
+// top-level command named `name`. The secret group already owns its --vault-name
+// flag and Before hook, so it is self-contained. Used for the flat `suve secret`
+// alias when Azure is the uniquely active secret provider.
 func FlatSecretCommand(name string) *cli.Command {
 	c := secret.Command()
 	c.Name = name
 
-	return foldBase(c)
+	return c
 }
 
 // FlatParamCommand returns the Azure App Configuration (param) command as a
-// standalone top-level command named `name`, folding in the base
-// subscription/resource-group flags and hook on top of the param group's own
-// --store-name flag/hook. Used for the flat `suve param` alias when Azure is the
-// uniquely active param provider.
+// standalone top-level command named `name`. The param group already owns its
+// --store-name flag and Before hook, so it is self-contained. Used for the flat
+// `suve param` alias when Azure is the uniquely active param provider.
 func FlatParamCommand(name string) *cli.Command {
 	c := param.Command()
 	c.Name = name
-
-	return foldBase(c)
-}
-
-// baseFlags returns the shared Azure scope flags (a fresh slice per call).
-func baseFlags() []cli.Flag {
-	return []cli.Flag{
-		&cli.StringFlag{
-			Name:    "subscription",
-			Usage:   "Azure subscription id (defaults to $AZURE_SUBSCRIPTION_ID)",
-			Sources: cli.EnvVars("AZURE_SUBSCRIPTION_ID"),
-			// Persistent (default): readable by every azure subcommand.
-		},
-		&cli.StringFlag{
-			Name:    "resource-group",
-			Usage:   "Azure resource group (defaults to $AZURE_RESOURCE_GROUP)",
-			Sources: cli.EnvVars("AZURE_RESOURCE_GROUP"),
-		},
-	}
-}
-
-// withBase stashes the resolved subscription/resource-group into the context.
-func withBase(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-	return cliinternal.WithAzureBase(ctx, cmd.String("subscription"), cmd.String("resource-group")), nil
-}
-
-// foldBase prepends the base scope flags to c and wraps its Before so the base
-// subscription/resource-group are resolved before the command's own hook. It
-// turns a subgroup command (which normally relies on the azure parent) into a
-// self-contained top-level command.
-func foldBase(c *cli.Command) *cli.Command {
-	inner := c.Before
-	c.Flags = append(baseFlags(), c.Flags...)
-	c.Before = func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-		ctx, err := withBase(ctx, cmd)
-		if err != nil {
-			return ctx, err
-		}
-
-		if inner != nil {
-			return inner(ctx, cmd)
-		}
-
-		return ctx, nil
-	}
 
 	return c
 }

--- a/internal/cli/commands/azure/param/command.go
+++ b/internal/cli/commands/azure/param/command.go
@@ -39,8 +39,7 @@ variable.`,
 				Sources: cli.EnvVars("AZURE_APPCONFIG_NAME"),
 			},
 		},
-		// Before merges the resolved store name onto the base scope (subscription
-		// / resource group) set by the parent azure command. Resolution is
+		// Before stashes the resolved store name in the context. Resolution is
 		// deferred to store construction, so `suve azure param --help` works
 		// without a store.
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {

--- a/internal/cli/commands/azure/secret/command.go
+++ b/internal/cli/commands/azure/secret/command.go
@@ -36,8 +36,7 @@ AZURE_KEYVAULT_NAME environment variable.`,
 				Sources: cli.EnvVars("AZURE_KEYVAULT_NAME"),
 			},
 		},
-		// Before merges the resolved vault name onto the base scope (subscription
-		// / resource group) set by the parent azure command. Resolution is
+		// Before stashes the resolved vault name in the context. Resolution is
 		// deferred to store construction, so `suve azure secret --help` works
 		// without a vault.
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {

--- a/internal/cli/commands/azure/stage.go
+++ b/internal/cli/commands/azure/stage.go
@@ -138,12 +138,13 @@ func StageCommand() *cli.Command {
 }
 
 // FlatStageCommand returns the Azure stage command as a standalone top-level
-// command named `name` (e.g. "stage"), folding in the base subscription /
-// resource-group flags and hook. Used for the flat `suve stage` alias when
-// Azure is the uniquely active staging provider.
+// command named `name` (e.g. "stage"). The secret/param staging subgroups own
+// their --vault-name / --store-name flags and hooks, so it is self-contained.
+// Used for the flat `suve stage` alias when Azure is the uniquely active staging
+// provider.
 func FlatStageCommand(name string) *cli.Command {
 	c := StageCommand()
 	c.Name = name
 
-	return foldBase(c)
+	return c
 }

--- a/internal/cli/commands/internal/client.go
+++ b/internal/cli/commands/internal/client.go
@@ -49,31 +49,17 @@ func gcloudProjectFromContext(ctx context.Context) string {
 type azureScopeContextKey struct{}
 
 // azureScopeCtx holds the Azure scope fields resolved from flags/env by the
-// azure command group. It is assembled across two Before hooks: the top-level
-// azure command sets subscription/resource-group; each subgroup (secret/param)
-// sets its vault/store name.
+// azure command group. Each subgroup (secret/param) sets its vault/store name
+// via its Before hook.
 type azureScopeCtx struct {
-	subscription  string
-	resourceGroup string
-	vaultName     string
-	storeName     string
+	vaultName string
+	storeName string
 }
 
 func azureScopeFromContext(ctx context.Context) azureScopeCtx {
 	sc, _ := ctx.Value(azureScopeContextKey{}).(azureScopeCtx)
 
 	return sc
-}
-
-// WithAzureBase returns a context carrying the resolved Azure subscription id and
-// resource group. The azure command group's Before hook sets it once (from
-// --subscription/--resource-group or their env fallbacks).
-func WithAzureBase(ctx context.Context, subscription, resourceGroup string) context.Context {
-	sc := azureScopeFromContext(ctx)
-	sc.subscription = subscription
-	sc.resourceGroup = resourceGroup
-
-	return context.WithValue(ctx, azureScopeContextKey{}, sc)
 }
 
 // WithAzureVaultName returns a context carrying the resolved Azure Key Vault
@@ -134,8 +120,8 @@ func GoogleCloudSecretStore(ctx context.Context) (provider.Store, error) {
 }
 
 // AzureKeyVaultStore resolves a provider.Store for the Azure Key Vault (secret)
-// service. The scope fields are read from the context (see WithAzureBase /
-// WithAzureVaultName); it returns a clear error when no vault name was resolved.
+// service. The vault name is read from the context (see WithAzureVaultName); it
+// returns a clear error when no vault name was resolved.
 func AzureKeyVaultStore(ctx context.Context) (provider.Store, error) {
 	sc := azureScopeFromContext(ctx)
 	if sc.vaultName == "" {
@@ -144,15 +130,14 @@ func AzureKeyVaultStore(ctx context.Context) (provider.Store, error) {
 		)
 	}
 
-	scope := provider.AzureKeyVaultScope(sc.subscription, sc.resourceGroup, sc.vaultName)
+	scope := provider.AzureKeyVaultScope(sc.vaultName)
 
 	return registry.Store(ctx, scope, provider.KindSecret)
 }
 
 // AzureAppConfigStore resolves a provider.Store for the Azure App Configuration
-// (param) service. The scope fields are read from the context (see
-// WithAzureBase / WithAzureStoreName); it returns a clear error when no store
-// name was resolved.
+// (param) service. The store name is read from the context (see
+// WithAzureStoreName); it returns a clear error when no store name was resolved.
 func AzureAppConfigStore(ctx context.Context) (provider.Store, error) {
 	sc := azureScopeFromContext(ctx)
 	if sc.storeName == "" {
@@ -161,7 +146,7 @@ func AzureAppConfigStore(ctx context.Context) (provider.Store, error) {
 		)
 	}
 
-	scope := provider.AzureAppConfigScope(sc.subscription, sc.resourceGroup, sc.storeName)
+	scope := provider.AzureAppConfigScope(sc.storeName)
 
 	return registry.Store(ctx, scope, provider.KindParam)
 }
@@ -253,8 +238,8 @@ func AzureAppConfigParamStrategyFactory(ctx context.Context) (staging.FullStrate
 }
 
 // AzureKeyVaultStagingScopeResolver resolves the Azure Key Vault staging scope
-// from the subscription / resource group / vault stashed in the context (see
-// WithAzureBase / WithAzureVaultName). It performs no network calls.
+// from the vault name stashed in the context (see WithAzureVaultName). It
+// performs no network calls.
 func AzureKeyVaultStagingScopeResolver(ctx context.Context) (staging.ResolvedScope, error) {
 	sc := azureScopeFromContext(ctx)
 	if sc.vaultName == "" {
@@ -264,14 +249,14 @@ func AzureKeyVaultStagingScopeResolver(ctx context.Context) (staging.ResolvedSco
 	}
 
 	return staging.ResolvedScope{
-		Scope:  provider.AzureKeyVaultScope(sc.subscription, sc.resourceGroup, sc.vaultName),
+		Scope:  provider.AzureKeyVaultScope(sc.vaultName),
 		Target: "vault " + sc.vaultName,
 	}, nil
 }
 
 // AzureAppConfigStagingScopeResolver resolves the Azure App Configuration
-// staging scope from the subscription / resource group / store stashed in the
-// context (see WithAzureBase / WithAzureStoreName). It performs no network calls.
+// staging scope from the store name stashed in the context (see
+// WithAzureStoreName). It performs no network calls.
 func AzureAppConfigStagingScopeResolver(ctx context.Context) (staging.ResolvedScope, error) {
 	sc := azureScopeFromContext(ctx)
 	if sc.storeName == "" {
@@ -281,7 +266,7 @@ func AzureAppConfigStagingScopeResolver(ctx context.Context) (staging.ResolvedSc
 	}
 
 	return staging.ResolvedScope{
-		Scope:  provider.AzureAppConfigScope(sc.subscription, sc.resourceGroup, sc.storeName),
+		Scope:  provider.AzureAppConfigScope(sc.storeName),
 		Target: "store " + sc.storeName,
 	}, nil
 }

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -97,8 +97,7 @@ type App struct {
 
 // NewApp creates a new App with the given initial provider. The initial
 // read/write scope is derived from that provider using the ambient environment
-// (project / subscription / resource-group / vault / store); an empty provider
-// defaults to AWS.
+// (project / vault / store); an empty provider defaults to AWS.
 func NewApp(initial provider.Provider) *App {
 	return &App{
 		initialProvider: initial,
@@ -113,11 +112,9 @@ func initialScope(p provider.Provider) provider.Scope {
 		return provider.GoogleCloudScope(os.Getenv("GOOGLE_CLOUD_PROJECT"))
 	case provider.ProviderAzure:
 		return provider.Scope{
-			Provider:       provider.ProviderAzure,
-			SubscriptionID: os.Getenv("AZURE_SUBSCRIPTION_ID"),
-			ResourceGroup:  os.Getenv("AZURE_RESOURCE_GROUP"),
-			VaultName:      os.Getenv("AZURE_KEYVAULT_NAME"),
-			StoreName:      os.Getenv("AZURE_APPCONFIG_NAME"),
+			Provider:  provider.ProviderAzure,
+			VaultName: os.Getenv("AZURE_KEYVAULT_NAME"),
+			StoreName: os.Getenv("AZURE_APPCONFIG_NAME"),
 		}
 	case provider.ProviderAWS:
 		return provider.Scope{Provider: provider.ProviderAWS}
@@ -141,15 +138,13 @@ func (a *App) Startup(ctx context.Context) {
 // operations. Only the fields relevant to the chosen provider are read:
 //   - aws: (none; the ambient AWS config supplies the region)
 //   - googlecloud: ProjectID
-//   - azure: SubscriptionID + ResourceGroup, plus VaultName (Key Vault secret)
-//     and/or StoreName (App Configuration param)
+//   - azure: VaultName (Key Vault secret) and/or StoreName (App Configuration
+//     param)
 type ScopeSelection struct {
-	Provider       string `json:"provider"`
-	ProjectID      string `json:"projectId"`
-	SubscriptionID string `json:"subscriptionId"`
-	ResourceGroup  string `json:"resourceGroup"`
-	VaultName      string `json:"vaultName"`
-	StoreName      string `json:"storeName"`
+	Provider  string `json:"provider"`
+	ProjectID string `json:"projectId"`
+	VaultName string `json:"vaultName"`
+	StoreName string `json:"storeName"`
 }
 
 // SelectScope sets the current read/write provider scope. It performs no
@@ -188,11 +183,9 @@ func scopeFromSelection(sel ScopeSelection) (provider.Scope, error) {
 		}
 
 		return provider.Scope{
-			Provider:       provider.ProviderAzure,
-			SubscriptionID: sel.SubscriptionID,
-			ResourceGroup:  sel.ResourceGroup,
-			VaultName:      sel.VaultName,
-			StoreName:      sel.StoreName,
+			Provider:  provider.ProviderAzure,
+			VaultName: sel.VaultName,
+			StoreName: sel.StoreName,
 		}, nil
 	default:
 		return provider.Scope{}, fmt.Errorf("%w: %q", errInvalidProvider, sel.Provider)
@@ -220,20 +213,18 @@ func (a *App) GetCurrentScope() *ScopeSelection {
 // stay empty.
 func selectionFromScope(s provider.Scope) *ScopeSelection {
 	return &ScopeSelection{
-		Provider:       string(s.Provider),
-		ProjectID:      s.ProjectID,
-		SubscriptionID: s.SubscriptionID,
-		ResourceGroup:  s.ResourceGroup,
-		VaultName:      s.VaultName,
-		StoreName:      s.StoreName,
+		Provider:  string(s.Provider),
+		ProjectID: s.ProjectID,
+		VaultName: s.VaultName,
+		StoreName: s.StoreName,
 	}
 }
 
 // stagingScope resolves the provider.Scope that keys on-disk staging state for
 // the active provider. It mirrors the CLI's ScopeResolvers: AWS is keyed by the
 // STS caller identity (account/region), while Google Cloud and Azure are keyed
-// purely from the already-selected scope (project / subscription+group+vault or
-// store) with no network call. Deriving the staging store AND the apply/diff
+// purely from the already-selected scope (project / vault or store) with no
+// network call. Deriving the staging store AND the apply/diff
 // strategy from this one scope keeps them structurally in sync — the invariant
 // that replaces #276's interim non-AWS guard.
 func (a *App) stagingScope() (provider.Scope, error) {

--- a/internal/gui/frontend/src/App.svelte
+++ b/internal/gui/frontend/src/App.svelte
@@ -65,7 +65,7 @@
   // scope can land in the new one.
   const scopeKey = $derived(
     scope
-      ? [provider, scope.projectId, scope.subscriptionId, scope.resourceGroup, scope.vaultName, scope.storeName].join('|')
+      ? [provider, scope.projectId, scope.vaultName, scope.storeName].join('|')
       : provider,
   );
 
@@ -123,8 +123,6 @@
     return {
       provider: p,
       projectId: p === 'googlecloud' ? (src?.projectId ?? '') : '',
-      subscriptionId: p === 'azure' ? (src?.subscriptionId ?? '') : '',
-      resourceGroup: p === 'azure' ? (src?.resourceGroup ?? '') : '',
       vaultName: p === 'azure' ? (src?.vaultName ?? '') : '',
       storeName: p === 'azure' ? (src?.storeName ?? '') : '',
     } as gui.ScopeSelection;

--- a/internal/gui/frontend/src/lib/Sidebar.svelte
+++ b/internal/gui/frontend/src/lib/Sidebar.svelte
@@ -50,8 +50,6 @@
 
   // ---- Scope-form inputs (seeded from the prefill for the pending provider) --
   let projectInput = $state('');
-  let subscriptionInput = $state('');
-  let resourceGroupInput = $state('');
   let vaultInput = $state('');
   let storeInput = $state('');
   let formError = $state('');
@@ -61,8 +59,6 @@
     // Re-seed the inputs whenever the pending provider (or its prefill) changes.
     const s = formScope;
     projectInput = pendingProvider === 'googlecloud' ? (s?.projectId ?? '') : '';
-    subscriptionInput = pendingProvider === 'azure' ? (s?.subscriptionId ?? '') : '';
-    resourceGroupInput = pendingProvider === 'azure' ? (s?.resourceGroup ?? '') : '';
     vaultInput = pendingProvider === 'azure' ? (s?.vaultName ?? '') : '';
     storeInput = pendingProvider === 'azure' ? (s?.storeName ?? '') : '';
     formError = '';
@@ -114,8 +110,6 @@
     onselectscope?.({
       provider: 'googlecloud',
       projectId,
-      subscriptionId: '',
-      resourceGroup: '',
       vaultName: '',
       storeName: '',
     } as gui.ScopeSelection);
@@ -133,8 +127,6 @@
     onselectscope?.({
       provider: 'azure',
       projectId: '',
-      subscriptionId: subscriptionInput.trim(),
-      resourceGroup: resourceGroupInput.trim(),
       vaultName,
       storeName,
     } as gui.ScopeSelection);
@@ -181,19 +173,15 @@
     </form>
   {:else if pendingProvider === 'azure'}
     <form class="scope-form" onsubmit={submitAzure}>
-      <label class="scope-label" for="azure-subscription">Subscription ID</label>
+      <label class="scope-label" for="azure-vault">Key Vault name</label>
       <input
-        id="azure-subscription"
+        id="azure-vault"
         class="scope-input"
         type="text"
-        placeholder="00000000-0000-…"
-        bind:value={subscriptionInput}
+        placeholder="my-vault (secrets)"
+        bind:value={vaultInput}
         bind:this={firstFieldEl}
       />
-      <label class="scope-label" for="azure-resource-group">Resource Group</label>
-      <input id="azure-resource-group" class="scope-input" type="text" placeholder="my-rg" bind:value={resourceGroupInput} />
-      <label class="scope-label" for="azure-vault">Key Vault name</label>
-      <input id="azure-vault" class="scope-input" type="text" placeholder="my-vault (secrets)" bind:value={vaultInput} />
       <label class="scope-label" for="azure-store">App Configuration store</label>
       <input id="azure-store" class="scope-input" type="text" placeholder="my-store (params)" bind:value={storeInput} />
       {#if formError || scopeError}
@@ -260,18 +248,6 @@
     </div>
   {:else if scopeReady && provider === 'azure'}
     <div class="aws-info scope-info">
-      {#if scope?.subscriptionId}
-        <div class="aws-info-row">
-          <span class="aws-info-label">Subscription</span>
-          <span class="aws-info-value" title={scope.subscriptionId}>{scope.subscriptionId}</span>
-        </div>
-      {/if}
-      {#if scope?.resourceGroup}
-        <div class="aws-info-row">
-          <span class="aws-info-label">Resource Group</span>
-          <span class="aws-info-value" title={scope.resourceGroup}>{scope.resourceGroup}</span>
-        </div>
-      {/if}
       {#if scope?.vaultName}
         <div class="aws-info-row">
           <span class="aws-info-label">Key Vault</span>
@@ -355,6 +331,7 @@
     letter-spacing: 0.05em;
     color: #666;
   }
+
 
   .scope-input {
     width: 100%;

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -77,8 +77,6 @@ export interface AWSIdentity {
 export interface ScopeSelection {
   provider: string;
   projectId: string;
-  subscriptionId: string;
-  resourceGroup: string;
   vaultName: string;
   storeName: string;
 }
@@ -209,8 +207,6 @@ export function createStagedTags(
 export const awsScopeSelection: ScopeSelection = {
   provider: 'aws',
   projectId: '',
-  subscriptionId: '',
-  resourceGroup: '',
   vaultName: '',
   storeName: '',
 };
@@ -255,7 +251,7 @@ export const defaultCapabilities: ProviderCapability[] = [
   {
     provider: 'azure',
     displayName: 'Azure',
-    scopeFields: ['subscription', 'resourceGroup'],
+    scopeFields: [],
     services: [
       { service: 'param', displayName: 'App Configuration', hasVersionHistory: false, hasVersionSpecifiers: false, hasTags: false, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false },
       { service: 'secret', displayName: 'Key Vault', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false },
@@ -592,7 +588,7 @@ export function createNoAWSIdentityState(): Partial<MockState> {
 // ---- Provider-selection states (multi-cloud) ------------------------------
 
 function emptyScope(provider: string): ScopeSelection {
-  return { provider, projectId: '', subscriptionId: '', resourceGroup: '', vaultName: '', storeName: '' };
+  return { provider, projectId: '', vaultName: '', storeName: '' };
 }
 
 /**
@@ -635,8 +631,6 @@ export function createAzureState(overrides: Partial<MockState> = {}): Partial<Mo
     initialProvider: 'azure',
     currentScope: {
       ...emptyScope('azure'),
-      subscriptionId: '00000000-0000-0000-0000-000000000000',
-      resourceGroup: 'rg',
       vaultName: 'my-vault',
       storeName: 'my-store',
     },
@@ -788,8 +782,6 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
         state.currentScope = {
           provider: p,
           projectId: p === 'googlecloud' ? (sel.projectId || '') : '',
-          subscriptionId: p === 'azure' ? (sel.subscriptionId || '') : '',
-          resourceGroup: p === 'azure' ? (sel.resourceGroup || '') : '',
           vaultName: p === 'azure' ? (sel.vaultName || '') : '',
           storeName: p === 'azure' ? (sel.storeName || '') : '',
         };

--- a/internal/gui/frontend/tests/scope-form.spec.ts
+++ b/internal/gui/frontend/tests/scope-form.spec.ts
@@ -14,15 +14,13 @@ async function pickProvider(page: Page, value: string) {
   await page.locator('#provider-select').selectOption(value);
 }
 
-// An Azure environment where subscription/RG are env-derived but no vault/store
-// yet → the app parks in the Azure scope form (prefilled, not auto-applied).
+// An Azure environment with no vault/store env-derived yet → the app parks in
+// the Azure scope form (empty, not auto-applied).
 const azurePartialScope: Partial<MockState> = {
   initialProvider: 'azure',
   currentScope: {
     provider: 'azure',
     projectId: '',
-    subscriptionId: 'env-sub',
-    resourceGroup: 'env-rg',
     vaultName: '',
     storeName: '',
   },
@@ -30,15 +28,18 @@ const azurePartialScope: Partial<MockState> = {
 };
 
 test.describe('Azure scope form', () => {
-  test('renders subscription/RG + vault/store fields for Azure only', async ({ page }) => {
+  test('renders vault/store fields for Azure only (no subscription/RG)', async ({ page }) => {
     await setupWailsMocks(page);
     await page.goto('/');
     await waitForItemList(page);
 
     await pickProvider(page, 'azure');
-    for (const id of ['#azure-subscription', '#azure-resource-group', '#azure-vault', '#azure-store']) {
+    for (const id of ['#azure-vault', '#azure-store']) {
       await expect(page.locator(id)).toBeVisible();
     }
+    // Subscription / resource group are no longer collected (unused).
+    await expect(page.locator('#azure-subscription')).toHaveCount(0);
+    await expect(page.locator('#azure-resource-group')).toHaveCount(0);
     await expect(page.locator('#gcloud-project')).toHaveCount(0);
   });
 
@@ -54,7 +55,7 @@ test.describe('Azure scope form', () => {
     await pickProvider(page, 'aws');
     // AWS needs no scope → auto-applied, no form.
     await expect(page.locator('#gcloud-project')).toHaveCount(0);
-    await expect(page.locator('#azure-subscription')).toHaveCount(0);
+    await expect(page.locator('#azure-vault')).toHaveCount(0);
   });
 
   test('submit sends the exact ScopeSelection (vault vs store not swapped, trimmed)', async ({ page }) => {
@@ -63,8 +64,6 @@ test.describe('Azure scope form', () => {
     await waitForItemList(page);
 
     await pickProvider(page, 'azure');
-    await page.locator('#azure-subscription').fill('sub-1');
-    await page.locator('#azure-resource-group').fill('rg-1');
     await page.locator('#azure-vault').fill('  the-vault  '); // whitespace trimmed
     await page.locator('#azure-store').fill('the-store');
     await page.getByRole('button', { name: 'Connect' }).click();
@@ -74,8 +73,6 @@ test.describe('Azure scope form', () => {
     const last = calls[calls.length - 1];
     expect(last).toMatchObject({
       provider: 'azure',
-      subscriptionId: 'sub-1',
-      resourceGroup: 'rg-1',
       vaultName: 'the-vault', // NOT the store
       storeName: 'the-store', // NOT the vault
     });
@@ -88,8 +85,7 @@ test.describe('Azure scope form', () => {
 
     await pickProvider(page, 'azure');
     const connect = page.getByRole('button', { name: 'Connect' });
-    await page.locator('#azure-subscription').fill('sub-only');
-    await expect(connect).toBeDisabled(); // sub/rg alone is not enough
+    await expect(connect).toBeDisabled(); // nothing entered yet
     await page.locator('#azure-vault').fill('v');
     await expect(connect).toBeEnabled();
     // whitespace-only does not count
@@ -117,12 +113,11 @@ test.describe('Azure scope form', () => {
     await expect(page.locator('.item-name.param').first()).toBeVisible();
   });
 
-  test('prefills subscription/RG from env-derived GetCurrentScope', async ({ page }) => {
+  test('parks in an empty Azure form when env supplies no vault/store', async ({ page }) => {
     await setupWailsMocks(page, azurePartialScope);
     await page.goto('/');
-    await expect(page.locator('#azure-subscription')).toHaveValue('env-sub');
-    await expect(page.locator('#azure-resource-group')).toHaveValue('env-rg');
     await expect(page.locator('#azure-vault')).toHaveValue('');
+    await expect(page.locator('#azure-store')).toHaveValue('');
   });
 
   test('retains scope when switching provider away and back (localStorage)', async ({ page }) => {
@@ -153,9 +148,10 @@ test.describe('Azure scope form', () => {
       await waitForItemList(page);
       await pickProvider(page, 'azure');
 
-      await expect(page.getByLabel('Subscription ID')).toBeVisible();
       await expect(page.getByLabel('Key Vault name')).toBeVisible();
-      await expect(page.locator('#azure-subscription')).toBeFocused();
+      await expect(page.getByLabel('App Configuration store')).toBeVisible();
+      // The Key Vault field leads the form and takes initial focus.
+      await expect(page.locator('#azure-vault')).toBeFocused();
     });
 
     test('Enter submits and Escape cancels', async ({ page }) => {
@@ -165,9 +161,9 @@ test.describe('Azure scope form', () => {
 
       // Escape cancels → back to the active AWS provider, form gone.
       await pickProvider(page, 'azure');
-      await expect(page.locator('#azure-subscription')).toBeVisible();
+      await expect(page.locator('#azure-vault')).toBeVisible();
       await page.keyboard.press('Escape');
-      await expect(page.locator('#azure-subscription')).toHaveCount(0);
+      await expect(page.locator('#azure-vault')).toHaveCount(0);
 
       // Enter in a field submits.
       await pickProvider(page, 'azure');
@@ -186,7 +182,7 @@ test.describe('Azure scope form', () => {
     await waitForViewLoaded(page);
 
     await pickProvider(page, 'azure');
-    await expect(page.locator('#azure-subscription')).toBeVisible();
+    await expect(page.locator('#azure-vault')).toBeVisible();
     const noOverflow = await page.evaluate(
       () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
     );

--- a/internal/gui/frontend/tests/viewport.spec.ts
+++ b/internal/gui/frontend/tests/viewport.spec.ts
@@ -95,14 +95,14 @@ test.describe('Viewport - Provider selector', () => {
     expect(noOverflow).toBe(true);
   });
 
-  test('long Azure scope values (UUID) do not overflow the sidebar', async ({ page }) => {
+  test('Azure scope values do not overflow the sidebar', async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 667 });
     await setupWailsMocks(page, createAzureState());
     await page.goto('/');
     await waitForItemList(page);
 
-    // Sidebar shows a 36-char subscription UUID + "App Configuration" label,
-    // all ellipsized rather than widening the layout.
+    // Sidebar shows the Key Vault / App Configuration names, ellipsized rather
+    // than widening the layout.
     const noOverflow = await page.evaluate(
       () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
     );

--- a/internal/gui/frontend/tests/wails-mock-providers.spec.ts
+++ b/internal/gui/frontend/tests/wails-mock-providers.spec.ts
@@ -50,7 +50,7 @@ test.describe('wails-mock provider bindings', () => {
         errors.push(e.message);
       }
       try {
-        await app.SelectScope({ provider: 'azure', subscriptionId: 's', resourceGroup: 'r' });
+        await app.SelectScope({ provider: 'azure' });
       } catch (e: any) {
         errors.push(e.message);
       }
@@ -78,11 +78,11 @@ test.describe('wails-mock provider bindings', () => {
       const app = (window as any).go.gui.App;
 
       // Key Vault (secret) only — App Configuration (param) absent.
-      await app.SelectScope({ provider: 'azure', subscriptionId: 's', resourceGroup: 'r', vaultName: 'v' });
+      await app.SelectScope({ provider: 'azure', vaultName: 'v' });
       const vaultOnly = await app.GetCurrentScope();
 
       // App Configuration (param) only — Key Vault (secret) absent.
-      await app.SelectScope({ provider: 'azure', subscriptionId: 's', resourceGroup: 'r', storeName: 'c' });
+      await app.SelectScope({ provider: 'azure', storeName: 'c' });
       const storeOnly = await app.GetCurrentScope();
 
       return { vaultOnly, storeOnly };

--- a/internal/gui/frontend/wailsjs/go/models.ts
+++ b/internal/gui/frontend/wailsjs/go/models.ts
@@ -257,11 +257,11 @@ export namespace gui {
 	    hasStaging: boolean;
 	    hasForceDelete: boolean;
 	    hasRecoveryWindow: boolean;
-
+	
 	    static createFrom(source: any = {}) {
 	        return new ServiceCapability(source);
 	    }
-
+	
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.service = source["service"];
@@ -314,8 +314,6 @@ export namespace gui {
 	export class ScopeSelection {
 	    provider: string;
 	    projectId: string;
-	    subscriptionId: string;
-	    resourceGroup: string;
 	    vaultName: string;
 	    storeName: string;
 	
@@ -327,8 +325,6 @@ export namespace gui {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.provider = source["provider"];
 	        this.projectId = source["projectId"];
-	        this.subscriptionId = source["subscriptionId"];
-	        this.resourceGroup = source["resourceGroup"];
 	        this.vaultName = source["vaultName"];
 	        this.storeName = source["storeName"];
 	    }

--- a/internal/gui/providers.go
+++ b/internal/gui/providers.go
@@ -126,10 +126,10 @@ type ProviderCapability struct {
 	Provider string `json:"provider"`
 	// DisplayName is the provider label (e.g. "Google Cloud").
 	DisplayName string `json:"displayName"`
-	// ScopeFields lists the scope inputs the frontend must collect for this
-	// provider (e.g. ["project"] for Google Cloud; ["subscription",
-	// "resourceGroup"] for Azure — per-service vault/store are added by the
-	// service's own view). Empty for AWS (ambient config).
+	// ScopeFields lists the provider-level scope inputs the frontend must collect
+	// (e.g. ["project"] for Google Cloud). Empty for AWS (ambient config) and for
+	// Azure, whose per-service vault/store names are collected by the service's
+	// own view.
 	ScopeFields []string `json:"scopeFields"`
 	// Services are the param/secret services this provider offers, in stable
 	// display order.
@@ -174,7 +174,7 @@ func (a *App) Capabilities() []ProviderCapability {
 		{
 			Provider:    string(provider.ProviderAzure),
 			DisplayName: "Azure",
-			ScopeFields: []string{"subscription", "resourceGroup"},
+			ScopeFields: []string{},
 			Services: []ServiceCapability{
 				// App Configuration is unversioned and cannot write tags.
 				{

--- a/internal/gui/scope_internal_test.go
+++ b/internal/gui/scope_internal_test.go
@@ -37,28 +37,28 @@ func TestApp_SelectScope(t *testing.T) {
 		},
 		{
 			name: "azure with vault only",
-			sel:  ScopeSelection{Provider: "azure", SubscriptionID: "sub", ResourceGroup: "rg", VaultName: "vault"},
+			sel:  ScopeSelection{Provider: "azure", VaultName: "vault"},
 			wantScope: provider.Scope{
-				Provider: provider.ProviderAzure, SubscriptionID: "sub", ResourceGroup: "rg", VaultName: "vault",
+				Provider: provider.ProviderAzure, VaultName: "vault",
 			},
 		},
 		{
 			name: "azure with store only",
-			sel:  ScopeSelection{Provider: "azure", SubscriptionID: "sub", ResourceGroup: "rg", StoreName: "store"},
+			sel:  ScopeSelection{Provider: "azure", StoreName: "store"},
 			wantScope: provider.Scope{
-				Provider: provider.ProviderAzure, SubscriptionID: "sub", ResourceGroup: "rg", StoreName: "store",
+				Provider: provider.ProviderAzure, StoreName: "store",
 			},
 		},
 		{
 			name: "azure with both vault and store",
-			sel:  ScopeSelection{Provider: "azure", SubscriptionID: "sub", ResourceGroup: "rg", VaultName: "vault", StoreName: "store"},
+			sel:  ScopeSelection{Provider: "azure", VaultName: "vault", StoreName: "store"},
 			wantScope: provider.Scope{
-				Provider: provider.ProviderAzure, SubscriptionID: "sub", ResourceGroup: "rg", VaultName: "vault", StoreName: "store",
+				Provider: provider.ProviderAzure, VaultName: "vault", StoreName: "store",
 			},
 		},
 		{
 			name:    "azure missing both vault and store",
-			sel:     ScopeSelection{Provider: "azure", SubscriptionID: "sub", ResourceGroup: "rg"},
+			sel:     ScopeSelection{Provider: "azure"},
 			wantErr: errAzureScopeRequired,
 		},
 		{
@@ -100,19 +100,19 @@ func TestApp_GetCurrentScope_RoundTrip(t *testing.T) {
 		{name: "googlecloud", sel: ScopeSelection{Provider: "googlecloud", ProjectID: "proj"}},
 		{
 			name: "azure key vault + app config",
-			sel:  ScopeSelection{Provider: "azure", SubscriptionID: "sub", ResourceGroup: "rg", VaultName: "vault", StoreName: "store"},
+			sel:  ScopeSelection{Provider: "azure", VaultName: "vault", StoreName: "store"},
 		},
 		{
 			// Only one Azure service configured: Key Vault (secret) available,
 			// App Configuration (param) absent. The readback must preserve the
 			// empty storeName so #267 can render the half-filled form.
 			name: "azure key vault only",
-			sel:  ScopeSelection{Provider: "azure", SubscriptionID: "sub", ResourceGroup: "rg", VaultName: "vault"},
+			sel:  ScopeSelection{Provider: "azure", VaultName: "vault"},
 		},
 		{
 			// Mirror case: only App Configuration (param) available, no vault.
 			name: "azure app config only",
-			sel:  ScopeSelection{Provider: "azure", SubscriptionID: "sub", ResourceGroup: "rg", StoreName: "store"},
+			sel:  ScopeSelection{Provider: "azure", StoreName: "store"},
 		},
 	}
 
@@ -147,8 +147,6 @@ func TestApp_GetCurrentScope_EnvDerivedInitialScope(t *testing.T) {
 }
 
 func TestApp_GetCurrentScope_EnvDerivedAzure(t *testing.T) {
-	t.Setenv("AZURE_SUBSCRIPTION_ID", "env-sub")
-	t.Setenv("AZURE_RESOURCE_GROUP", "env-rg")
 	t.Setenv("AZURE_KEYVAULT_NAME", "env-vault")
 	t.Setenv("AZURE_APPCONFIG_NAME", "env-store")
 
@@ -157,8 +155,6 @@ func TestApp_GetCurrentScope_EnvDerivedAzure(t *testing.T) {
 	got := app.GetCurrentScope()
 	require.NotNil(t, got)
 	assert.Equal(t, string(provider.ProviderAzure), got.Provider)
-	assert.Equal(t, "env-sub", got.SubscriptionID)
-	assert.Equal(t, "env-rg", got.ResourceGroup)
 	assert.Equal(t, "env-vault", got.VaultName)
 	assert.Equal(t, "env-store", got.StoreName)
 }
@@ -168,8 +164,6 @@ func TestApp_GetCurrentScope_EnvDerivedAzure(t *testing.T) {
 // Configuration (param) stays absent. AZURE_APPCONFIG_NAME is pinned empty so
 // the case is hermetic regardless of the ambient environment.
 func TestApp_GetCurrentScope_EnvDerivedAzure_VaultOnly(t *testing.T) {
-	t.Setenv("AZURE_SUBSCRIPTION_ID", "env-sub")
-	t.Setenv("AZURE_RESOURCE_GROUP", "env-rg")
 	t.Setenv("AZURE_KEYVAULT_NAME", "env-vault")
 	t.Setenv("AZURE_APPCONFIG_NAME", "")
 
@@ -185,8 +179,6 @@ func TestApp_GetCurrentScope_EnvDerivedAzure_VaultOnly(t *testing.T) {
 // TestApp_GetCurrentScope_EnvDerivedAzure_StoreOnly is the mirror: only App
 // Configuration (param) is configured; Key Vault stays absent.
 func TestApp_GetCurrentScope_EnvDerivedAzure_StoreOnly(t *testing.T) {
-	t.Setenv("AZURE_SUBSCRIPTION_ID", "env-sub")
-	t.Setenv("AZURE_RESOURCE_GROUP", "env-rg")
 	t.Setenv("AZURE_KEYVAULT_NAME", "")
 	t.Setenv("AZURE_APPCONFIG_NAME", "env-store")
 

--- a/internal/gui/staging_multiprovider_internal_test.go
+++ b/internal/gui/staging_multiprovider_internal_test.go
@@ -26,8 +26,8 @@ func TestApp_stagingScope_NoSTSForResolvableScopes(t *testing.T) {
 		scope provider.Scope
 	}{
 		{"google cloud", provider.GoogleCloudScope("proj")},
-		{"azure key vault", provider.AzureKeyVaultScope("sub", "rg", "vault")},
-		{"azure app config", provider.AzureAppConfigScope("sub", "rg", "store")},
+		{"azure key vault", provider.AzureKeyVaultScope("vault")},
+		{"azure app config", provider.AzureAppConfigScope("store")},
 		{"aws with account+region", provider.AWSScope("123456789012", "us-east-1")},
 	}
 

--- a/internal/provider/scope.go
+++ b/internal/provider/scope.go
@@ -7,8 +7,9 @@ import "fmt"
 //
 //   - AWS: AccountID + Region (shared for param and secret).
 //   - GoogleCloud: ProjectID (Secret Manager only).
-//   - Azure: SubscriptionID + ResourceGroup, plus VaultName (Key Vault, secret)
-//     or StoreName (App Configuration, param).
+//   - Azure: VaultName (Key Vault, secret) or StoreName (App Configuration,
+//     param) — each a globally-unique name that fully identifies the resource,
+//     so no subscription/resource-group is needed.
 //
 // Scope is used both to select a provider factory (Provider field) and to key
 // on-disk staging storage (see Key).
@@ -24,10 +25,6 @@ type Scope struct {
 	// ProjectID is the Google Cloud project id (GoogleCloud).
 	ProjectID string `json:"projectId,omitempty"`
 
-	// SubscriptionID is the Azure subscription id (Azure).
-	SubscriptionID string `json:"subscriptionId,omitempty"`
-	// ResourceGroup is the Azure resource group (Azure).
-	ResourceGroup string `json:"resourceGroup,omitempty"`
 	// VaultName is the Azure Key Vault name (Azure, secret).
 	VaultName string `json:"vaultName,omitempty"`
 	// StoreName is the Azure App Configuration store name (Azure, param).
@@ -43,11 +40,14 @@ func (s Scope) Key() string {
 	case ProviderGoogleCloud:
 		return fmt.Sprintf("googlecloud/%s", s.ProjectID)
 	case ProviderAzure:
+		// Key Vault and App Configuration names are globally unique DNS labels
+		// (*.vault.azure.net / *.azconfig.io), so the name alone identifies the
+		// resource — no subscription/resource-group needed.
 		if s.VaultName != "" {
-			return fmt.Sprintf("azure/%s/%s/keyvault/%s", s.SubscriptionID, s.ResourceGroup, s.VaultName)
+			return fmt.Sprintf("azure/keyvault/%s", s.VaultName)
 		}
 
-		return fmt.Sprintf("azure/%s/%s/appconfig/%s", s.SubscriptionID, s.ResourceGroup, s.StoreName)
+		return fmt.Sprintf("azure/appconfig/%s", s.StoreName)
 	default:
 		return ""
 	}
@@ -107,22 +107,20 @@ func GoogleCloudScope(projectID string) Scope {
 }
 
 // AzureKeyVaultScope creates a Scope for an Azure Key Vault (secret store).
-func AzureKeyVaultScope(subscriptionID, resourceGroup, vaultName string) Scope {
+// The vault name is globally unique, so it fully identifies the resource.
+func AzureKeyVaultScope(vaultName string) Scope {
 	return Scope{
-		Provider:       ProviderAzure,
-		SubscriptionID: subscriptionID,
-		ResourceGroup:  resourceGroup,
-		VaultName:      vaultName,
+		Provider:  ProviderAzure,
+		VaultName: vaultName,
 	}
 }
 
 // AzureAppConfigScope creates a Scope for an Azure App Configuration store
-// (param store).
-func AzureAppConfigScope(subscriptionID, resourceGroup, storeName string) Scope {
+// (param store). The store name is globally unique, so it fully identifies the
+// resource.
+func AzureAppConfigScope(storeName string) Scope {
 	return Scope{
-		Provider:       ProviderAzure,
-		SubscriptionID: subscriptionID,
-		ResourceGroup:  resourceGroup,
-		StoreName:      storeName,
+		Provider:  ProviderAzure,
+		StoreName: storeName,
 	}
 }

--- a/internal/provider/scope_test.go
+++ b/internal/provider/scope_test.go
@@ -27,14 +27,15 @@ func TestScope_Key(t *testing.T) {
 			want:  "googlecloud/my-project",
 		},
 		{
+			// Vault names are globally unique, so the name alone keys the scope.
 			name:  "azure keyvault",
-			scope: provider.AzureKeyVaultScope("sub1", "rg1", "vault1"),
-			want:  "azure/sub1/rg1/keyvault/vault1",
+			scope: provider.AzureKeyVaultScope("vault1"),
+			want:  "azure/keyvault/vault1",
 		},
 		{
 			name:  "azure appconfig",
-			scope: provider.AzureAppConfigScope("sub1", "rg1", "store1"),
-			want:  "azure/sub1/rg1/appconfig/store1",
+			scope: provider.AzureAppConfigScope("store1"),
+			want:  "azure/appconfig/store1",
 		},
 		{
 			name:  "unknown provider",
@@ -75,13 +76,13 @@ func TestScope_SupportsService(t *testing.T) {
 		},
 		{
 			name:       "azure keyvault secret only",
-			scope:      provider.AzureKeyVaultScope("sub1", "rg1", "vault1"),
+			scope:      provider.AzureKeyVaultScope("vault1"),
 			wantParam:  false,
 			wantSecret: true,
 		},
 		{
 			name:       "azure appconfig param only",
-			scope:      provider.AzureAppConfigScope("sub1", "rg1", "store1"),
+			scope:      provider.AzureAppConfigScope("store1"),
 			wantParam:  true,
 			wantSecret: false,
 		},
@@ -123,7 +124,7 @@ func TestScope_SupportedKinds(t *testing.T) {
 		},
 		{
 			name:  "azure appconfig param only",
-			scope: provider.AzureAppConfigScope("sub1", "rg1", "store1"),
+			scope: provider.AzureAppConfigScope("store1"),
 			want:  []provider.Kind{provider.KindParam},
 		},
 		{
@@ -154,13 +155,11 @@ func TestScope_Constructors(t *testing.T) {
 	assert.Equal(t, provider.ProviderGoogleCloud, gcloud.Provider)
 	assert.Equal(t, "proj", gcloud.ProjectID)
 
-	kv := provider.AzureKeyVaultScope("sub", "rg", "vault")
+	kv := provider.AzureKeyVaultScope("vault")
 	assert.Equal(t, provider.ProviderAzure, kv.Provider)
-	assert.Equal(t, "sub", kv.SubscriptionID)
-	assert.Equal(t, "rg", kv.ResourceGroup)
 	assert.Equal(t, "vault", kv.VaultName)
 
-	ac := provider.AzureAppConfigScope("sub", "rg", "store")
+	ac := provider.AzureAppConfigScope("store")
 	assert.Equal(t, provider.ProviderAzure, ac.Provider)
 	assert.Equal(t, "store", ac.StoreName)
 }

--- a/mise-tasks/bash
+++ b/mise-tasks/bash
@@ -76,8 +76,6 @@ if $want_appconfig; then
   env_kv+=(
     "SUVE_AZURE_APPCONFIG_CONNECTION_STRING=Endpoint=http://127.0.0.1:${appconfig_port};Id=abcd;Secret=c2VjcmV0"
     "AZURE_APPCONFIG_NAME=suve-dev"
-    "AZURE_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000"
-    "AZURE_RESOURCE_GROUP=suve-dev"
   )
 fi
 
@@ -88,8 +86,6 @@ if $want_keyvault; then
   env_kv+=(
     "SUVE_AZURE_KEYVAULT_ENDPOINT=https://127.0.0.1:${keyvault_port}"
     "AZURE_KEYVAULT_NAME=suve-dev"
-    "AZURE_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000"
-    "AZURE_RESOURCE_GROUP=suve-dev"
   )
 fi
 


### PR DESCRIPTION
## Summary

Azure Key Vault and App Configuration names are **globally-unique DNS labels** (`*.vault.azure.net` / `*.azconfig.io`), so the name alone fully identifies the resource. `SubscriptionID` / `ResourceGroup` were never used for authentication or data-plane access — they only keyed on-disk staging state, where they added **no** disambiguation and, being optional, could silently fragment a single resource's staged state across present/absent values (`azure/<sub>/<rg>/keyvault/foo` vs `azure//​/keyvault/foo`).

This removes them end to end. The staging key is now name-only:

```
azure/keyvault/<vault>
azure/appconfig/<store>
```

## Changes

- **Core** (`provider.Scope`): drop `SubscriptionID`/`ResourceGroup`; `AzureKeyVaultScope(vault)` / `AzureAppConfigScope(store)` take just the name; `Key()` is name-based.
- **CLI**: remove the `azure` group's `--subscription`/`--resource-group` flags, `baseFlags`/`withBase`/`foldBase`, and `WithAzureBase`. Flat `param`/`secret`/`stage` aliases are self-contained via their own `--vault-name`/`--store-name`.
- **GUI**: drop the fields from `ScopeSelection`, the sidebar form inputs / prefill / info display, the env-derived initial scope, and the capability `ScopeFields`; regenerate wails bindings.
- **Docs**: README, `docs/azure.md`, `docs/provider-selection.md` updated. Also adds a new **Authentication** section covering AWS / Google Cloud / Azure at parity (sign-in + point-at-the-resource), clarifying that `az login` caches under `~/.azure` and needs only the globally-unique name.
- **Dev shell / tests**: `mise-tasks/bash` and all unit / Playwright / e2e tests updated.

## ⚠️ Breaking change

- The `--subscription` / `--resource-group` flags are **removed** (they had no effect; passing them now errors).
- `AZURE_SUBSCRIPTION_ID` / `AZURE_RESOURCE_GROUP` are **no longer read**.
- Existing on-disk Azure **staging state re-keys by name only** — staged changes saved under the old `azure/<sub>/<rg>/…` path won't be seen at the new `azure/keyvault/<vault>` path (re-stage if needed).

## Verification

- `mise test` ✅ · `mise lint` ✅ 0 issues · frontend biome + svelte-check ✅ 0 errors
- Playwright ✅ **501 passed**
- **Azure Key Vault e2e** ✅ and **Azure App Configuration e2e** ✅ — full read/write **and** the staging `apply` workflow, against the emulators (0 skipped; the name-only scope key is exercised end to end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)