### PR TITLE
fix(gui): add a "Change scope" control to re-point the active scope

### DIFF
--- a/internal/gui/frontend/src/App.svelte
+++ b/internal/gui/frontend/src/App.svelte
@@ -192,6 +192,16 @@
     scopeError = '';
   }
 
+  // handleChangeScope re-opens the scope form for the ACTIVE provider, prefilled
+  // with its current values, so the user can point it at a different resource.
+  // It deliberately bypasses handleSelectProvider (which would auto-apply the
+  // cached scope) by parking pendingProvider directly — the form's prefill comes
+  // from formPrefill (cache/current scope), and Connect overwrites the cache.
+  function handleChangeScope() {
+    scopeError = '';
+    pendingProvider = provider;
+  }
+
   // applyScope validates+commits the scope server-side, then (AWS only) loads
   // identity and the staging badge. On success it switches the active provider
   // and clears the pending form; on rejection it leaves the previous provider
@@ -280,6 +290,7 @@
     onselectprovider={handleSelectProvider}
     onselectscope={handleSelectScope}
     oncancelscope={handleCancelScope}
+    onchangescope={handleChangeScope}
   />
 
   <main class="main-content">

--- a/internal/gui/frontend/src/lib/Sidebar.svelte
+++ b/internal/gui/frontend/src/lib/Sidebar.svelte
@@ -22,6 +22,7 @@
     onselectprovider?: (provider: string) => void;
     onselectscope?: (sel: gui.ScopeSelection) => void;
     oncancelscope?: () => void;
+    onchangescope?: () => void;
   }
 
   let {
@@ -43,6 +44,7 @@
     onselectprovider,
     onselectscope,
     oncancelscope,
+    onchangescope,
   }: Props = $props();
 
   // Service key → stable nav icon/letter (labels come from capability names).
@@ -221,8 +223,8 @@
     </nav>
   {/if}
 
-  <!-- Identity / scope info -->
-  {#if scopeReady && provider === 'aws' && accountId && region}
+  <!-- Identity / scope info (hidden while a scope form is pending) -->
+  {#if scopeReady && !pendingProvider && provider === 'aws' && accountId && region}
     <div class="aws-info">
       {#if profile}
         <div class="aws-info-row">
@@ -239,14 +241,15 @@
         <span class="aws-info-value" title={region}>{region}</span>
       </div>
     </div>
-  {:else if scopeReady && provider === 'googlecloud' && scope?.projectId}
+  {:else if scopeReady && !pendingProvider && provider === 'googlecloud' && scope?.projectId}
     <div class="aws-info scope-info">
       <div class="aws-info-row">
         <span class="aws-info-label">Project</span>
         <span class="aws-info-value" title={scope.projectId}>{scope.projectId}</span>
       </div>
+      <button type="button" class="scope-change" onclick={() => onchangescope?.()}>Change scope</button>
     </div>
-  {:else if scopeReady && provider === 'azure'}
+  {:else if scopeReady && !pendingProvider && provider === 'azure'}
     <div class="aws-info scope-info">
       {#if scope?.vaultName}
         <div class="aws-info-row">
@@ -260,6 +263,7 @@
           <span class="aws-info-value" title={scope.storeName}>{scope.storeName}</span>
         </div>
       {/if}
+      <button type="button" class="scope-change" onclick={() => onchangescope?.()}>Change scope</button>
     </div>
   {/if}
 </aside>
@@ -363,6 +367,22 @@
     font-size: 11px;
     color: #e94560;
     line-height: 1.4;
+  }
+
+  .scope-change {
+    margin-top: 8px;
+    padding: 4px 8px;
+    background: transparent;
+    color: #8a8aa0;
+    border: 1px solid #2d2d44;
+    border-radius: 6px;
+    font-size: 11px;
+    cursor: pointer;
+  }
+
+  .scope-change:hover {
+    color: #fff;
+    border-color: #3d3d5c;
   }
 
   .nav {

--- a/internal/gui/frontend/tests/scope-form.spec.ts
+++ b/internal/gui/frontend/tests/scope-form.spec.ts
@@ -141,6 +141,32 @@ test.describe('Azure scope form', () => {
     await expect(page.locator('.nav').getByRole('button', { name: /Key Vault/i })).toBeVisible();
   });
 
+  test('Change scope re-opens the prefilled form and re-points to a different resource', async ({ page }) => {
+    // Azure launched with vault+store already applied (no form on start).
+    await setupWailsMocks(page, createAzureState());
+    await page.goto('/');
+    await waitForItemList(page);
+    await expect(page.locator('#azure-vault')).toHaveCount(0); // connected: no form
+
+    // "Change scope" re-opens the form, prefilled with the current values —
+    // without auto-reconnecting the cached scope.
+    await page.getByRole('button', { name: 'Change scope' }).click();
+    await expect(page.locator('#azure-vault')).toHaveValue('my-vault');
+    await expect(page.locator('#azure-store')).toHaveValue('my-store');
+
+    // Re-point to a different vault and reconnect.
+    await page.locator('#azure-vault').fill('other-vault');
+    await page.getByRole('button', { name: 'Connect' }).click();
+    await waitForItemList(page);
+
+    const calls = await getSelectScopeCalls(page);
+    expect(calls[calls.length - 1]).toMatchObject({
+      provider: 'azure',
+      vaultName: 'other-vault', // replaced
+      storeName: 'my-store', // preserved from the prefill
+    });
+  });
+
   test.describe('a11y', () => {
     test('fields are labeled and the first field is focused on open', async ({ page }) => {
       await setupWailsMocks(page);


### PR DESCRIPTION
Closes #291.

## Problem

Once a scope was connected in the GUI, there was **no way to change or clear it**:

- The frontend persists the last-applied scope to `localStorage["suve.scope.<provider>"]` and `buildSelection()` prefers the cache, so switching the Provider dropdown to an already-cached provider **auto-reconnects** it and skips the form.
- Re-selecting the **active** provider in the dropdown doesn't fire `onchange`.
- The scope-info panel only displayed values — no control to edit them.

A wrong/unreachable cached vault/store left the user stuck (only DevTools or wiping the app data dir could recover).

## Fix

Add a **"Change scope"** button to the Google Cloud / Azure scope-info panel. It:

- Re-opens the scope form for the **active** provider, prefilled with the current values.
- Bypasses the auto-apply path (`handleChangeScope` parks `pendingProvider` directly instead of routing through `handleSelectProvider`, which would auto-apply the cache).
- On Connect, the entered values overwrite the cached scope.

The scope-info panel is hidden while a form is pending (`!pendingProvider`), so Change cleanly swaps info → form. AWS has no editable scope form (region comes from the ambient config), so it gets no button.

## Verification

- Frontend biome + svelte-check ✅ 0 errors
- Playwright ✅ **502 passed** (chromium), incl. the new test `Change scope re-opens the prefilled form and re-points to a different resource` (connect → Change → prefilled form → re-point vault → reconnect with the new value, other field preserved)

## Note

Complements #290 (flag-seeded initial scope); together they make the launch-time and run-time scope both explicitly controllable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)