### PR TITLE
fix(gui): always render the scope panel (AWS/GCloud/Azure) + disable Change while editing

### DIFF
--- a/internal/gui/frontend/src/lib/Sidebar.svelte
+++ b/internal/gui/frontend/src/lib/Sidebar.svelte
@@ -224,46 +224,47 @@
   {/if}
 
   <!-- Identity / scope info (hidden while a scope form is pending) -->
-  {#if scopeReady && !pendingProvider && provider === 'aws' && accountId && region}
+  {#if provider === 'aws'}
+    <!-- Gated by provider only, symmetric with Google Cloud / Azure: every row
+         is always rendered, showing "?" when unset (e.g. identity unavailable).
+         AWS has no editable scope form (region/creds come from the ambient AWS
+         config), so there is no Change scope button. -->
     <div class="aws-info">
-      {#if profile}
-        <div class="aws-info-row">
-          <span class="aws-info-label">Profile</span>
-          <span class="aws-info-value aws-info-profile" title={profile}>{profile}</span>
-        </div>
-      {/if}
+      <div class="aws-info-row">
+        <span class="aws-info-label">Profile</span>
+        <span class="aws-info-value aws-info-profile" title={profile || '?'}>{profile || '?'}</span>
+      </div>
       <div class="aws-info-row">
         <span class="aws-info-label">Account</span>
-        <span class="aws-info-value" title={accountId}>{accountId}</span>
+        <span class="aws-info-value" title={accountId || '?'}>{accountId || '?'}</span>
       </div>
       <div class="aws-info-row">
         <span class="aws-info-label">Region</span>
-        <span class="aws-info-value" title={region}>{region}</span>
+        <span class="aws-info-value" title={region || '?'}>{region || '?'}</span>
       </div>
     </div>
-  {:else if scopeReady && !pendingProvider && provider === 'googlecloud' && scope?.projectId}
+  {:else if provider === 'googlecloud'}
+    <!-- Gated by provider only: every row is always rendered ("?" when unset).
+         Change scope is always present and only disabled while a form is pending
+         (so it stays reachable in an errored/partial state). -->
     <div class="aws-info scope-info">
       <div class="aws-info-row">
         <span class="aws-info-label">Project</span>
-        <span class="aws-info-value" title={scope.projectId}>{scope.projectId}</span>
+        <span class="aws-info-value" title={scope?.projectId || '?'}>{scope?.projectId || '?'}</span>
       </div>
-      <button type="button" class="scope-change" onclick={() => onchangescope?.()}>Change scope</button>
+      <button type="button" class="scope-change" disabled={!!pendingProvider} onclick={() => onchangescope?.()}>Change scope</button>
     </div>
-  {:else if scopeReady && !pendingProvider && provider === 'azure'}
+  {:else if provider === 'azure'}
     <div class="aws-info scope-info">
-      {#if scope?.vaultName}
-        <div class="aws-info-row">
-          <span class="aws-info-label">Key Vault</span>
-          <span class="aws-info-value" title={scope.vaultName}>{scope.vaultName}</span>
-        </div>
-      {/if}
-      {#if scope?.storeName}
-        <div class="aws-info-row">
-          <span class="aws-info-label">App Config</span>
-          <span class="aws-info-value" title={scope.storeName}>{scope.storeName}</span>
-        </div>
-      {/if}
-      <button type="button" class="scope-change" onclick={() => onchangescope?.()}>Change scope</button>
+      <div class="aws-info-row">
+        <span class="aws-info-label">Key Vault</span>
+        <span class="aws-info-value" title={scope?.vaultName || '?'}>{scope?.vaultName || '?'}</span>
+      </div>
+      <div class="aws-info-row">
+        <span class="aws-info-label">App Config</span>
+        <span class="aws-info-value" title={scope?.storeName || '?'}>{scope?.storeName || '?'}</span>
+      </div>
+      <button type="button" class="scope-change" disabled={!!pendingProvider} onclick={() => onchangescope?.()}>Change scope</button>
     </div>
   {/if}
 </aside>
@@ -380,9 +381,14 @@
     cursor: pointer;
   }
 
-  .scope-change:hover {
+  .scope-change:hover:not(:disabled) {
     color: #fff;
     border-color: #3d3d5c;
+  }
+
+  .scope-change:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 
   .nav {

--- a/internal/gui/frontend/tests/app.spec.ts
+++ b/internal/gui/frontend/tests/app.spec.ts
@@ -139,61 +139,60 @@ test.describe('AWS Identity Display', () => {
     await expect(awsInfo).toContainText('ap-northeast-1');
   });
 
-  test('should display AWS identity without profile', async ({ page }) => {
+  test('renders "?" for the profile when none is set', async ({ page }) => {
     await setupWailsMocks(page, createAWSIdentityState('987654321098', 'us-east-1', ''));
     await page.goto('/');
 
     const awsInfo = page.locator('.aws-info');
     await expect(awsInfo).toBeVisible();
 
-    // Profile row should not be displayed
-    await expect(awsInfo.locator('.aws-info-profile')).not.toBeVisible();
-
-    // Account and region should still be displayed
+    // Profile is optional; it renders as "?" instead of being hidden.
+    await expect(awsInfo.locator('.aws-info-profile')).toHaveText('?');
+    // Account and region still show their values.
     await expect(awsInfo).toContainText('987654321098');
     await expect(awsInfo).toContainText('us-east-1');
   });
 
-  test('should not display AWS info section when identity is unavailable', async ({ page }) => {
+  test('renders the AWS panel with "?" everywhere when identity is unavailable', async ({ page }) => {
     await setupWailsMocks(page, createNoAWSIdentityState());
     await page.goto('/');
 
-    // Wait for sidebar to be visible
-    await expect(page.locator('.sidebar')).toBeVisible();
-
-    // AWS info section should not be displayed
-    await expect(page.locator('.aws-info')).not.toBeVisible();
+    const awsInfo = page.locator('.aws-info');
+    // Symmetric with Google Cloud / Azure: the panel always renders, with "?"
+    // for every unresolved value rather than being hidden.
+    await expect(awsInfo).toBeVisible();
+    await expect(awsInfo.getByText('?', { exact: true })).toHaveCount(3);
   });
 
-  test('should not display AWS info section when GetAWSIdentity fails', async ({ page }) => {
+  test('renders the AWS panel with "?" when GetAWSIdentity fails', async ({ page }) => {
     await setupWailsMocks(page, {
       simulateError: { operation: 'GetAWSIdentity', message: 'No credentials found' },
     });
     await page.goto('/');
 
-    // Wait for sidebar to be visible
-    await expect(page.locator('.sidebar')).toBeVisible();
-
-    // AWS info section should not be displayed when API fails
-    await expect(page.locator('.aws-info')).not.toBeVisible();
+    const awsInfo = page.locator('.aws-info');
+    await expect(awsInfo).toBeVisible();
+    await expect(awsInfo.getByText('?', { exact: true })).toHaveCount(3);
   });
 
-  test('should not display AWS info section when only accountId is available', async ({ page }) => {
+  test('renders "?" for region when only the account id is available', async ({ page }) => {
     await setupWailsMocks(page, createAWSIdentityState('123456789012', '', ''));
     await page.goto('/');
 
-    await expect(page.locator('.sidebar')).toBeVisible();
-    // Both accountId AND region are required
-    await expect(page.locator('.aws-info')).not.toBeVisible();
+    const awsInfo = page.locator('.aws-info');
+    await expect(awsInfo).toBeVisible();
+    await expect(awsInfo).toContainText('123456789012'); // account shown
+    await expect(awsInfo.getByText('?', { exact: true })).toHaveCount(2); // region + profile
   });
 
-  test('should not display AWS info section when only region is available', async ({ page }) => {
+  test('renders "?" for the account id when only the region is available', async ({ page }) => {
     await setupWailsMocks(page, createAWSIdentityState('', 'ap-northeast-1', ''));
     await page.goto('/');
 
-    await expect(page.locator('.sidebar')).toBeVisible();
-    // Both accountId AND region are required
-    await expect(page.locator('.aws-info')).not.toBeVisible();
+    const awsInfo = page.locator('.aws-info');
+    await expect(awsInfo).toBeVisible();
+    await expect(awsInfo).toContainText('ap-northeast-1'); // region shown
+    await expect(awsInfo.getByText('?', { exact: true })).toHaveCount(2); // account + profile
   });
 });
 

--- a/internal/gui/frontend/tests/scope-form.spec.ts
+++ b/internal/gui/frontend/tests/scope-form.spec.ts
@@ -167,6 +167,30 @@ test.describe('Azure scope form', () => {
     });
   });
 
+  test('scope info always renders every row ("?" when unset); Change scope stays present but disables while editing', async ({ page }) => {
+    // Only a Key Vault is configured — no App Configuration store.
+    await setupWailsMocks(
+      page,
+      createAzureState({ currentScope: { provider: 'azure', projectId: '', vaultName: 'only-vault', storeName: '' } }),
+    );
+    await page.goto('/');
+    const info = page.locator('.scope-info');
+    await expect(info).toBeVisible();
+
+    // Every row renders; the unset App Configuration store shows "?" (not hidden).
+    await expect(info).toContainText('only-vault');
+    await expect(info).toContainText('?');
+
+    // Change scope is present and enabled while connected...
+    const change = page.getByRole('button', { name: 'Change scope' });
+    await expect(change).toBeEnabled();
+
+    // ...and stays present but disabled once a form is pending.
+    await change.click();
+    await expect(page.locator('#azure-vault')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Change scope' })).toBeDisabled();
+  });
+
   test.describe('a11y', () => {
     test('fields are labeled and the first field is focused on open', async ({ page }) => {
       await setupWailsMocks(page);


### PR DESCRIPTION
Follow-up to #291.

## Problem

The scope-info panel and its **Change scope** button were gated on `scopeReady` *and* on each value being present, so empty rows were hidden and the panel/button could disappear in edge states. AWS was asymmetric: its whole panel was hidden whenever identity (STS) was unavailable.

## Change

- Gate the **AWS / Google Cloud / Azure** scope panels by **provider only**.
- **Always render every value row**; show **`?`** when a value is unset:
  - Azure with only a Key Vault → `App Config: ?`
  - AWS with no/failed identity → `Account: ?`, `Region: ?`, `Profile: ?` (panel used to be hidden entirely)
- Keep **Change scope always present** for the editable providers (Google Cloud / Azure); only **disable** it while a scope form is pending, so it stays reachable in an errored/partial state.
- **AWS has no Change button**: region/creds come from the ambient AWS config (env / `~/.aws` / SSO / role) and aren't editable in the GUI, so AWS gets the symmetric always-on panel but nothing to "change" here.

## Note

`applyScope` still commits/persists only on a successful `SelectScope`; a failed re-point keeps the previous scope and leaves the form open with the error (overwrite-on-success is intentional).

## Verification

- Frontend biome + svelte-check ✅ 0 errors
- Playwright ✅ **503 passed** (chromium); the AWS-identity tests were updated from "panel hidden" to "panel shows `?`", plus the Azure `?`/disabled-Change test from before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)