### PR TITLE
fix(gui): clear scope via empty Connect + open picker for ambiguous --gui

### DIFF
--- a/cmd/suve/gui.go
+++ b/cmd/suve/gui.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"os"
 	"strings"
 
@@ -14,14 +13,6 @@ import (
 	"github.com/mpyw/suve/internal/cli/commands"
 	"github.com/mpyw/suve/internal/gui"
 	"github.com/mpyw/suve/internal/provider"
-)
-
-// errInvalidGUIProvider is returned when a bare `suve --gui` cannot resolve a
-// single active provider from the environment (0 or 2+ active). The user must
-// choose explicitly with `suve <provider> --gui`.
-var errInvalidGUIProvider = errors.New(
-	"--gui: cannot determine a unique active provider from the environment; " +
-		"launch a specific one with `suve aws --gui`, `suve gcloud --gui`, or `suve azure --gui`",
 )
 
 // launchGUI runs the GUI with the given initial scope and exits. It is the
@@ -75,17 +66,16 @@ func registerGUIFlag() {
 	// Bare `suve --gui`: initial provider resolved from the environment.
 	commands.App.Flags = append(commands.App.Flags, &cli.BoolFlag{
 		Name:  "gui",
-		Usage: "Launch GUI mode (bare form picks the uniquely-active provider)",
+		Usage: "Launch GUI mode (picks the active provider, or opens the in-app picker if none is unambiguous)",
 	})
 	commands.App.Before = func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
 		if cmd.Bool("gui") {
-			initial := gui.InitialProviderFromEnv()
-			if initial == "" {
-				return ctx, errInvalidGUIProvider
-			}
-
-			// Bare form carries no scope flags; the GUI hydrates from env.
-			return launchGUI(ctx, provider.Scope{Provider: initial})
+			// Launch with the uniquely-active provider when the environment
+			// resolves one; otherwise (0 or 2+ active) InitialProviderFromEnv
+			// returns "", and the GUI opens at its in-app provider picker rather
+			// than erroring. No scope flags on the bare form, so the GUI hydrates
+			// any resource fields from env.
+			return launchGUI(ctx, provider.Scope{Provider: gui.InitialProviderFromEnv()})
 		}
 
 		return ctx, nil

--- a/internal/gui/frontend/src/App.svelte
+++ b/internal/gui/frontend/src/App.svelte
@@ -152,6 +152,15 @@
     }
   }
 
+  function clearCachedScope(p: string): void {
+    if (!p || typeof localStorage === 'undefined') return;
+    try {
+      localStorage.removeItem(scopeStorageKey(p));
+    } catch {
+      // best-effort; ignore private-mode failures.
+    }
+  }
+
   function hasRequiredScope(sel: gui.ScopeSelection): boolean {
     switch (sel.provider) {
       case 'aws':
@@ -180,8 +189,16 @@
     }
   }
 
-  // handleSelectScope is invoked when a scope form is submitted.
+  // handleSelectScope is invoked when a scope form is submitted. Submitting with
+  // the fields empty (no required scope) is treated as "disconnect + clear": it
+  // forgets the provider's cached scope and returns to the provider prompt,
+  // rather than erroring. A non-empty submission applies normally.
   async function handleSelectScope(sel: gui.ScopeSelection) {
+    if (!hasRequiredScope(sel)) {
+      clearScope(sel.provider);
+      return;
+    }
+
     await applyScope(sel);
   }
 
@@ -193,13 +210,27 @@
   }
 
   // handleChangeScope re-opens the scope form for the ACTIVE provider, prefilled
-  // with its current values, so the user can point it at a different resource.
-  // It deliberately bypasses handleSelectProvider (which would auto-apply the
-  // cached scope) by parking pendingProvider directly — the form's prefill comes
-  // from formPrefill (cache/current scope), and Connect overwrites the cache.
+  // with its current values. From there you can re-point it (enter new values →
+  // Connect) or disconnect (clear the fields → Connect). It bypasses
+  // handleSelectProvider (which would auto-apply the cached scope) by parking
+  // pendingProvider directly — the prefill comes from formPrefill.
   function handleChangeScope() {
     scopeError = '';
     pendingProvider = provider;
+  }
+
+  // clearScope forgets a provider's cached scope and returns to the "select a
+  // provider" prompt — the escape hatch from a wrong/unreachable cached scope
+  // that would otherwise auto-reconnect on every launch. Reached by submitting
+  // an empty scope form.
+  function clearScope(p: string) {
+    clearCachedScope(p);
+    provider = '';
+    scope = null;
+    scopeReady = false;
+    pendingProvider = '';
+    scopeError = '';
+    resetIdentity();
   }
 
   // applyScope validates+commits the scope server-side, then (AWS only) loads

--- a/internal/gui/frontend/src/lib/Sidebar.svelte
+++ b/internal/gui/frontend/src/lib/Sidebar.svelte
@@ -102,16 +102,14 @@
     }
   }
 
+  // Submitting empty is intentional: the parent treats a no-scope submission as
+  // "disconnect + clear", so Connect stays enabled and there is no required-field
+  // guard here.
   function submitProject(e: SubmitEvent) {
     e.preventDefault();
-    const projectId = projectInput.trim();
-    if (!projectId) {
-      formError = 'Project ID is required.';
-      return;
-    }
     onselectscope?.({
       provider: 'googlecloud',
-      projectId,
+      projectId: projectInput.trim(),
       vaultName: '',
       storeName: '',
     } as gui.ScopeSelection);
@@ -119,18 +117,11 @@
 
   function submitAzure(e: SubmitEvent) {
     e.preventDefault();
-    const vaultName = vaultInput.trim();
-    const storeName = storeInput.trim();
-    // Mirror the backend rule (#276): at least one service target is required.
-    if (!vaultName && !storeName) {
-      formError = 'Enter a Key Vault name (for secrets) and/or an App Configuration store name (for parameters).';
-      return;
-    }
     onselectscope?.({
       provider: 'azure',
       projectId: '',
-      vaultName,
-      storeName,
+      vaultName: vaultInput.trim(),
+      storeName: storeInput.trim(),
     } as gui.ScopeSelection);
   }
 </script>
@@ -171,7 +162,7 @@
       {#if formError || scopeError}
         <div class="scope-error">{formError || scopeError}</div>
       {/if}
-      <button type="submit" class="scope-submit" disabled={!projectInput.trim()}>Connect</button>
+      <button type="submit" class="scope-submit">Connect</button>
     </form>
   {:else if pendingProvider === 'azure'}
     <form class="scope-form" onsubmit={submitAzure}>
@@ -189,7 +180,7 @@
       {#if formError || scopeError}
         <div class="scope-error">{formError || scopeError}</div>
       {/if}
-      <button type="submit" class="scope-submit" disabled={!vaultInput.trim() && !storeInput.trim()}>Connect</button>
+      <button type="submit" class="scope-submit">Connect</button>
     </form>
   {/if}
 

--- a/internal/gui/frontend/tests/scope-form.spec.ts
+++ b/internal/gui/frontend/tests/scope-form.spec.ts
@@ -78,19 +78,26 @@ test.describe('Azure scope form', () => {
     });
   });
 
-  test('Connect is disabled until a vault or store name is given', async ({ page }) => {
-    await setupWailsMocks(page);
+  test('submitting an empty scope form disconnects and clears the cached scope', async ({ page }) => {
+    // Connected to Azure (vault + store), so the scope is cached.
+    await setupWailsMocks(page, createAzureState());
     await page.goto('/');
     await waitForItemList(page);
 
+    // Open the form, clear both fields, and Connect empty → disconnect + clear.
+    await page.getByRole('button', { name: 'Change scope' }).click();
+    await page.locator('#azure-vault').fill('');
+    await page.locator('#azure-store').fill('');
+    await page.getByRole('button', { name: 'Connect' }).click();
+
+    // Back to the provider prompt (no active scope).
+    await expect(page.getByText('Select a provider to begin.')).toBeVisible();
+
+    // Re-selecting Azure shows the EMPTY form — the cached scope was cleared,
+    // so it no longer auto-reconnects.
     await pickProvider(page, 'azure');
-    const connect = page.getByRole('button', { name: 'Connect' });
-    await expect(connect).toBeDisabled(); // nothing entered yet
-    await page.locator('#azure-vault').fill('v');
-    await expect(connect).toBeEnabled();
-    // whitespace-only does not count
-    await page.locator('#azure-vault').fill('   ');
-    await expect(connect).toBeDisabled();
+    await expect(page.locator('#azure-vault')).toHaveValue('');
+    await expect(page.locator('#azure-store')).toHaveValue('');
   });
 
   test('a rejected SelectScope shows the error and keeps the previous scope browsable', async ({ page }) => {


### PR DESCRIPTION
Two related GUI scope-UX fixes.

## 1. Clear/disconnect a scope via an empty Connect

The scope form's **Connect** button was disabled while the fields were empty, so there was no in-app way to clear a cached scope (short of wiping app data). Now:

- **Connect is always enabled.**
- An **empty submission = disconnect + clear**: it forgets the provider's `localStorage` scope and returns to the provider picker, instead of hitting the backend's required-field error.
- A non-empty submission applies as before — so the single **Change scope** button covers both **re-pointing** (enter new values) and **clearing** (blank the fields → Connect).

## 2. Ambiguous bare `--gui` opens the picker instead of erroring

`suve --gui` used to error (`errInvalidGUIProvider`) when the environment didn't resolve a unique active provider (0 or 2+), telling you to relaunch with `suve <provider> --gui`. Now that the GUI has a working provider picker, it just launches with no initial provider so you can choose in-app. `InitialProviderFromEnv()` already returns `""` in that case; it's passed straight through.

## Verification

- Frontend biome + svelte-check ✅ 0 errors
- Playwright ✅ **503 passed** (chromium); the old "Connect disabled until a name is given" test is replaced by "submitting an empty scope form disconnects and clears the cached scope". The picker path (`initialProvider: ''` → "Select a provider to begin.") is already covered in `provider-selection.spec.ts`.
- `mise lint` ✅ 0 issues · production + default builds ✅ · GUI Go tests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)