### PR TITLE
fix(release): make GitHub Release archives usable by mise/ubi; document mise install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -438,8 +438,14 @@ jobs:
           for dir in dist/*/; do
             [[ -d "$dir" ]] || continue
             build_name=$(basename "$dir")
-            goos=$(echo "$build_name" | cut -d'_' -f2)
-            goarch=$(echo "$build_name" | cut -d'_' -f3)
+            # goreleaser dir format is {id}_{goos}_{goarch}. The id itself may
+            # contain underscores (e.g. suve-linux-amd64-webkit2_41), so take the
+            # last two underscore-separated fields rather than fixed positions f2/f3,
+            # otherwise webkit2_41 builds mis-parse to goos=41/goarch=linux and the
+            # archive name loses its arch (amd64/arm64 then collide).
+            goarch="${build_name##*_}"
+            rest="${build_name%_*}"
+            goos="${rest##*_}"
 
             # Determine archive name based on build type
             if [[ "$build_name" == suve-cli-* ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -468,10 +468,17 @@ jobs:
 
             if [[ "$goos" == "windows" ]]; then
               cp "$dir/${src_binary}.exe" "$staging/${dst_binary}.exe"
+              # Restore the executable bit: upload/download-artifact does not
+              # preserve POSIX permissions, so the binary arrives here as 0644.
+              # Without this, tarball/zip consumers that extract-and-run (mise/ubi
+              # github backend) get "Permission denied".
+              chmod +x "$staging/${dst_binary}.exe"
               cp README.md LICENSE "$staging/"
               (cd "$staging" && zip -r "../releases/${archive_name}" .)
             else
               cp "$dir/${src_binary}" "$staging/${dst_binary}"
+              # Restore the executable bit (see note above).
+              chmod +x "$staging/${dst_binary}"
               cp README.md LICENSE "$staging/"
               tar -czvf "releases/${archive_name}" -C "$staging" .
             fi

--- a/README.md
+++ b/README.md
@@ -35,6 +35,25 @@ A **Git-like CLI/GUI** for AWS Parameter Store / Secrets Manager, Google Cloud S
 
 ## Installation
 
+### Using [mise](https://mise.jdx.dev/) (macOS/Linux/Windows)
+
+suve is installable directly from GitHub Releases via mise's `github` backend — no extra registry required:
+
+```bash
+# Full version (CLI + GUI)
+mise use -g "github:mpyw/suve"
+
+# CLI-only version (no GUI dependencies, recommended for Linux. Not available on macOS/Windows)
+mise use -g "github:mpyw/suve[matching=cli]"
+```
+
+> [!TIP]
+> Committing to a shared `mise.toml` used across OSes? Use a single cross-platform rule instead:
+> ```toml
+> [tools]
+> "github:mpyw/suve" = { version = "latest", matching_regex = "(darwin|windows|cli_[0-9.]+_linux)" }
+> ```
+
 ### Using [Homebrew](https://brew.sh/) (macOS/Linux)
 
 ```bash


### PR DESCRIPTION
## What

Makes suve installable via mise's `github` backend straight from GitHub Releases, and fixes two release-archive bugs found while verifying it.

### 1. Restore executable bit on release archives (`3660d67`)
`upload-artifact`/`download-artifact` does not preserve POSIX permissions, so the built binary reached the release job as `0644`. Every tarball/zip therefore shipped a **non-executable** binary.

- **Impact:** extract-and-run consumers (mise/ubi `github` backend) fail with `Permission denied`. Homebrew was unaffected because `bin.install` sets `+x` itself.
- **Fix:** `chmod +x` the staged binary before archiving, on all platforms.

### 2. Fix `webkit2_41` archive naming collision (`aa6717b`)
The naming loop parsed `goos`/`goarch` with `cut -d'_' -f2/f3`, assuming an underscore-free goreleaser id. The webkit2_41 ids (e.g. `suve-linux-amd64-webkit2_41`) contain an underscore, so parsing yielded `goos=41`/`goarch=linux` and produced the archless name `suve_{v}_41_linux_webkit2_41.tar.gz` — **identical for amd64 and arm64**, so one arch clobbered the other and the release-notes links 404'd.

- **Fix:** derive `goos`/`goarch` from the last two underscore-separated fields (robust to underscores in the id). Now emits the intended `suve_{v}_linux_{arch}_webkit2_41.tar.gz`.

### 3. Document mise install (`d990ea2`)
New mise section (first under Installation): install via the `github` backend, no extra registry required. macOS/Windows get the self-contained GUI build; Linux pins the CLI-only static build with `[matching=cli]` so it runs on headless servers/CI.

```bash
# macOS / Windows — self-contained GUI build
mise use -g "github:mpyw/suve"
# Linux — CLI-only static build (no GTK3/WebKit2GTK, headless-safe)
mise use -g "github:mpyw/suve[matching=cli]"
```

## Verification
Verified locally against the `v1.3.2` release assets:

- **macOS (arm64):** `mise use github:mpyw/suve` picks `suve_*_darwin_arm64.tar.gz`, attestation verified, `suve --version` runs.
- **Linux (arm64, Docker):** GUI binary is dynamically linked against `libwebkit2gtk-4.0.so.37` and cannot even `--version` on bare/headless systems; the CLI-only build is statically linked and runs anywhere.
- `mise ... [matching=cli]` correctly selects `suve-cli_*_linux_*`; after restoring `+x` it runs on a bare container with no WebKit.
- webkit2_41 naming validated across all 10 build-id variants — no collisions.

> [!NOTE]
> The fixes take effect on the **next** release; existing v1.3.2 assets remain `0644`.