### PR TITLE
fix(release): parse goos/goarch robustly against GOAMD64 (_v1) suffix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -438,14 +438,22 @@ jobs:
           for dir in dist/*/; do
             [[ -d "$dir" ]] || continue
             build_name=$(basename "$dir")
-            # goreleaser dir format is {id}_{goos}_{goarch}. The id itself may
-            # contain underscores (e.g. suve-linux-amd64-webkit2_41), so take the
-            # last two underscore-separated fields rather than fixed positions f2/f3,
-            # otherwise webkit2_41 builds mis-parse to goos=41/goarch=linux and the
-            # archive name loses its arch (amd64/arm64 then collide).
-            goarch="${build_name##*_}"
-            rest="${build_name%_*}"
-            goos="${rest##*_}"
+            # goreleaser dir names are {id}_{goos}_{goarch}[_{goamd64}], where the
+            # id itself may contain underscores (e.g. suve-linux-amd64-webkit2_41)
+            # and amd64 builds carry a trailing microarch suffix (e.g. _v1). Neither
+            # fixed field positions (cut -f2/f3) nor "last two fields" survive both,
+            # so match the known goos/goarch tokens directly. The tokens always
+            # appear underscore-delimited (`_linux_`, `_amd64`), while the id embeds
+            # os/arch with hyphens (`-linux-`, `-amd64-`), so there is no ambiguity.
+            case "$build_name" in
+              *_darwin_*)  goos=darwin ;;
+              *_linux_*)   goos=linux ;;
+              *_windows_*) goos=windows ;;
+            esac
+            case "$build_name" in
+              *_amd64*) goarch=amd64 ;;
+              *_arm64*) goarch=arm64 ;;
+            esac
 
             # Determine archive name based on build type
             if [[ "$build_name" == suve-cli-* ]]; then


### PR DESCRIPTION
## What
Follow-up to #303. The release job failed on:

```
dist/suve-windows-amd64_windows_amd64_v1//suve
```

### Root cause
#303 changed archive-name parsing to "last two underscore-separated fields" to cope with the underscore in `webkit2_41` build ids. But goreleaser appends a **GOAMD64 microarch suffix** (`_v1`) to amd64 build dirs, e.g. `suve-windows-amd64_windows_amd64_v1`. "Last two fields" then parsed `goos=amd64`, `goarch=v1`:

- the `windows` branch was skipped → the code looked for `$dir/suve` instead of `$dir/suve.exe` → `cp` failed (`.../_v1//suve`).
- amd64 archive names would also have been wrong (`..._amd64_v1`).

(The original `cut -f2/f3` handled `_v1` but broke on `webkit2_41`; the two failure modes are mutually exclusive under position-based parsing.)

### Fix
Match the known `goos`/`goarch` tokens directly:

```bash
case "$build_name" in
  *_darwin_*)  goos=darwin ;;
  *_linux_*)   goos=linux ;;
  *_windows_*) goos=windows ;;
esac
case "$build_name" in
  *_amd64*) goarch=amd64 ;;
  *_arm64*) goarch=arm64 ;;
esac
```

Robust to **both** underscores in the id and the trailing `_v1`, because tokens are underscore-delimited (`_linux_`, `_amd64`) while ids embed os/arch with hyphens (`-linux-`, `-amd64-`) → no ambiguity.

## Verification
Validated parsing across all 10 build-id variants (darwin/linux/windows × amd64/arm64, CLI-only, webkit2_41, incl. the `_v1` amd64 suffix) — every archive name resolves correctly and windows routes to the `.exe`/zip branch.