### PR TITLE
feat(cli): add shell completion command

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,24 @@ cd gui && wails build -tags production,webkit2_41 -skipbindings
 
 </details>
 
+## Shell Completion
+
+suve can generate completion scripts for **bash**, **zsh**, **fish**, and **PowerShell**. Source the output to enable completion for commands, subcommands, and flags.
+
+```bash
+# bash — add to ~/.bashrc
+source <(suve completion bash)
+
+# zsh — add to ~/.zshrc
+source <(suve completion zsh)
+
+# fish
+suve completion fish > ~/.config/fish/completions/suve.fish
+
+# PowerShell — add to $PROFILE
+suve completion pwsh | Out-String | Invoke-Expression
+```
+
 ## Authentication
 
 suve talks to each cloud's **data plane** using that cloud's own SDK credential chain — the same one the native CLI (`aws` / `gcloud` / `az`) uses. There is nothing suve-specific to configure: sign in the normal way, then point suve at the resource with an environment variable (or the equivalent flag).

--- a/internal/cli/commands/app.go
+++ b/internal/cli/commands/app.go
@@ -69,6 +69,14 @@ func MakeAppWithDetect(det detect.Result) *cli.Command {
 		Description: aliasDescription(det),
 		Version:     Version,
 		Commands:    append(flat, commands...),
+		// EnableShellCompletion adds a hidden `completion` command (bash/zsh/fish/pwsh)
+		// and the `--generate-shell-completion` mechanism the scripts rely on.
+		EnableShellCompletion: true,
+		// Surface the completion command in help so it is discoverable, rather than
+		// leaving it hidden as urfave/cli does by default.
+		ConfigureShellCompletionCommand: func(c *cli.Command) {
+			c.Hidden = false
+		},
 		CommandNotFound: func(_ context.Context, cmd *cli.Command, command string) {
 			_ = cli.ShowAppHelp(cmd)
 			w := lo.CoalesceOrEmpty(cmd.Root().ErrWriter, cmd.Root().Writer)

--- a/internal/cli/commands/app_test.go
+++ b/internal/cli/commands/app_test.go
@@ -1,6 +1,7 @@
 package commands_test
 
 import (
+	"bytes"
 	"slices"
 	"testing"
 
@@ -77,6 +78,36 @@ func TestMakeAppWithDetect_flatCommandsAreRunnable(t *testing.T) {
 	app = commands.MakeAppWithDetect(detect.Result{Param: provider.ProviderAzure})
 	err = app.Run(t.Context(), []string{"suve", "param", "--help"})
 	require.NoError(t, err)
+}
+
+func TestMakeApp_shellCompletion(t *testing.T) {
+	t.Parallel()
+
+	// urfave/cli injects the completion command during setup and hides it by
+	// default; we un-hide it, so it must appear in top-level help.
+	var help bytes.Buffer
+
+	app := commands.MakeAppWithDetect(detect.Result{})
+	app.Writer = &help
+
+	require.NoError(t, app.Run(t.Context(), []string{"suve", "--help"}))
+	assert.Contains(t, help.String(), "completion", "completion command should be discoverable in help")
+
+	// Each supported shell must emit a non-empty script.
+	for _, shell := range []string{"bash", "zsh", "fish", "pwsh"} {
+		t.Run(shell, func(t *testing.T) {
+			t.Parallel()
+
+			var out bytes.Buffer
+
+			app := commands.MakeAppWithDetect(detect.Result{})
+			app.Writer = &out
+
+			err := app.Run(t.Context(), []string{"suve", "completion", shell})
+			require.NoError(t, err)
+			assert.NotEmpty(t, out.String())
+		})
+	}
 }
 
 func contains(ss []string, s string) bool {


### PR DESCRIPTION
## Summary

Implements shell completion for the `suve` CLI, closing #305.

Enables urfave/cli/v3's built-in completion, exposing a `suve completion <bash|zsh|fish|pwsh>` command:

- `EnableShellCompletion: true` — adds the `completion` command and wires up the `--generate-shell-completion` mechanism the generated scripts rely on for dynamic command/subcommand/flag completion.
- `ConfigureShellCompletionCommand` un-hides the command (urfave hides it by default) so it is discoverable in `suve --help`.

## Usage

```bash
# bash — add to ~/.bashrc
source <(suve completion bash)

# zsh — add to ~/.zshrc
source <(suve completion zsh)

# fish
suve completion fish > ~/.config/fish/completions/suve.fish

# PowerShell — add to $PROFILE
suve completion pwsh | Out-String | Invoke-Expression
```

## Testing

- `internal/cli/commands/app_test.go`: asserts the command is discoverable in top-level help and that each of bash/zsh/fish/pwsh emits a non-empty script.
- `mise test` passes; `golangci-lint` clean on the affected package.
- Verified dynamic completion (`suve --generate-shell-completion`) lists subcommands with descriptions at top level and under `aws`.

## Docs

Adds a "Shell Completion" section to the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MbfJBKABGo2jrzmZbLo6LL