### PR TITLE
docs(readme): add aqua install method and reorder Installation

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,6 +48,12 @@ linters:
         linters:
           - forbidigo
         text: "fmt\\.Fprint"
+      # Allow fmt.Fprint* in debug/debug.go (Config.Logf is the wrapper providers
+      # use, so the debug write is centralized here just like the output package)
+      - path: "internal/debug/debug\\.go"
+        linters:
+          - forbidigo
+        text: "fmt\\.Fprint"
       # Allow fmt.Fprint* in e2e tests
       - path: "e2e/"
         linters:

--- a/README.md
+++ b/README.md
@@ -829,6 +829,23 @@ All timestamps are formatted in RFC3339 format with the local timezone offset ap
 |----------|-------------|
 | `TZ` | Timezone for date/time formatting (see above) |
 | `SUVE_NO_UPDATE_CHECK` | Opt out of the update-check notification |
+| `SUVE_DEBUG` | Enable verbose debug logging (same as the global `--debug` flag) |
+
+### Debugging
+
+Pass the global `--debug` flag (or set `SUVE_DEBUG=1`) to log each cloud SDK
+request/response to stderr. This is useful when a command produces empty or
+unexpected output and you want to see the actual API calls, target region, and
+HTTP status:
+
+```bash
+suve secret ls --debug          # flag works in any position
+SUVE_DEBUG=1 suve secret ls      # or via environment
+```
+
+Only request/response **metadata** (method, endpoint, region, status, retries)
+is printed — secret values are never logged. Debug output goes to stderr, so it
+never contaminates piped stdout.
 
 ### Staging
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ A **Git-like CLI/GUI** for AWS Parameter Store / Secrets Manager, Google Cloud S
 
 ## Installation
 
+> [!NOTE]
+> On Linux, `suve` requires GTK3 and WebKit2GTK for GUI support. Use the CLI-only version if you only need CLI functionality.
+
 ### Using [mise](https://mise.jdx.dev/) (macOS/Linux/Windows)
 
 suve is installable directly from GitHub Releases via mise's `github` backend — no extra registry required:
@@ -54,6 +57,16 @@ mise use -g "github:mpyw/suve[matching=cli]"
 > "github:mpyw/suve" = { version = "latest", matching_regex = "(darwin|windows|cli_[0-9.]+_linux)" }
 > ```
 
+### Using [aqua](https://aquaproj.github.io/) (macOS/Linux/Windows)
+
+suve is available in the [standard aqua registry](https://github.com/aquaproj/aqua-registry):
+
+```bash
+aqua g -i mpyw/suve
+```
+
+The registry picks the right asset per platform automatically: the self-contained GUI build on macOS/Windows, and the dependency-free CLI-only static build on Linux (supported from v1.3.0).
+
 ### Using [Homebrew](https://brew.sh/) (macOS/Linux)
 
 ```bash
@@ -63,9 +76,6 @@ brew install mpyw/tap/suve
 # CLI-only version (no GUI dependencies, recommended for Linux)
 brew install mpyw/tap/suve-cli
 ```
-
-> [!NOTE]
-> On Linux, `suve` requires GTK3 and WebKit2GTK for GUI support. Use `suve-cli` if you only need CLI functionality.
 
 ### Using [Scoop](https://scoop.sh/) (Windows)
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.43.0
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.70.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.44.0
+	github.com/aws/smithy-go v1.27.3
 	github.com/aymanbagabas/go-udiff v0.4.1
 	github.com/fatih/color v1.19.0
 	github.com/mattn/go-isatty v0.0.22
@@ -53,7 +54,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/signin v1.3.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.32.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.37.0 // indirect
-	github.com/aws/smithy-go v1.27.3 // indirect
 	github.com/bep/debounce v1.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charlievieth/strcase v0.0.5 // indirect

--- a/internal/cli/commands/app.go
+++ b/internal/cli/commands/app.go
@@ -4,6 +4,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/samber/lo"
@@ -16,6 +17,7 @@ import (
 	"github.com/mpyw/suve/internal/cli/commands/secret"
 	"github.com/mpyw/suve/internal/cli/commands/stage"
 	"github.com/mpyw/suve/internal/cli/output"
+	"github.com/mpyw/suve/internal/debug"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/detect"
 )
@@ -68,6 +70,8 @@ func MakeAppWithDetect(det detect.Result) *cli.Command {
 		Usage:       baseUsage,
 		Description: aliasDescription(det),
 		Version:     Version,
+		Flags:       []cli.Flag{debugFlag()},
+		Before:      enableDebug,
 		Commands:    append(flat, commands...),
 		CommandNotFound: func(_ context.Context, cmd *cli.Command, command string) {
 			_ = cli.ShowAppHelp(cmd)
@@ -76,6 +80,35 @@ func MakeAppWithDetect(det detect.Result) *cli.Command {
 			output.Warning(w, "Command not found: %s", command)
 		},
 	}
+}
+
+// debugFlag defines the global --debug switch. It is a persistent flag (v3
+// flags propagate to subcommands unless marked Local), so it works in any
+// position: `suve --debug sm ls` and `suve sm ls --debug` are equivalent. The
+// SUVE_DEBUG environment variable is an alternative source.
+func debugFlag() cli.Flag {
+	return &cli.BoolFlag{
+		Name:    "debug",
+		Usage:   "Log cloud SDK requests/responses to stderr (metadata only, no secret values)",
+		Sources: cli.EnvVars("SUVE_DEBUG"),
+	}
+}
+
+// enableDebug is the root Before hook: when --debug (or SUVE_DEBUG) is set it
+// stores a debug.Config in the context that provider adapters read to turn on
+// their SDK request logging. Debug output goes to the root ErrWriter so it never
+// contaminates piped STDOUT.
+func enableDebug(ctx context.Context, cmd *cli.Command) (context.Context, error) {
+	if !cmd.Bool("debug") {
+		return ctx, nil
+	}
+
+	w := cmd.Root().ErrWriter
+	if w == nil {
+		w = os.Stderr
+	}
+
+	return debug.With(ctx, debug.Config{Enabled: true, Writer: w}), nil
 }
 
 // flatCommand builds the top-level alias command (named "param" or "secret") for

--- a/internal/cli/commands/debug_internal_test.go
+++ b/internal/cli/commands/debug_internal_test.go
@@ -1,0 +1,71 @@
+package commands
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+
+	"github.com/mpyw/suve/internal/debug"
+)
+
+// appName is the CLI binary name used to build probe apps in these tests. It is
+// a constant so the literal is not repeated across each Run invocation.
+const appName = "suve"
+
+// runProbe assembles a minimal app wired exactly like the root (debugFlag +
+// enableDebug Before) with a probe subcommand that records whether debug is
+// enabled on the context its Action receives. It returns that value.
+func runProbe(t *testing.T, args []string) bool {
+	t.Helper()
+
+	var got bool
+
+	app := &cli.Command{
+		Name:   appName,
+		Flags:  []cli.Flag{debugFlag()},
+		Before: enableDebug,
+		Commands: []*cli.Command{
+			{
+				Name: "probe",
+				Action: func(ctx context.Context, _ *cli.Command) error {
+					got = debug.From(ctx).Enabled
+
+					return nil
+				},
+			},
+		},
+	}
+
+	require.NoError(t, app.Run(context.Background(), args))
+
+	return got
+}
+
+func TestEnableDebug_off(t *testing.T) {
+	t.Parallel()
+
+	assert.False(t, runProbe(t, []string{appName, "probe"}))
+}
+
+func TestEnableDebug_flagBeforeSubcommand(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, runProbe(t, []string{appName, "--debug", "probe"}))
+}
+
+func TestEnableDebug_flagAfterSubcommand(t *testing.T) {
+	t.Parallel()
+
+	// The flag is persistent (not Local), so it is accepted in either position.
+	assert.True(t, runProbe(t, []string{appName, "probe", "--debug"}))
+}
+
+func TestEnableDebug_env(t *testing.T) {
+	// Not parallel: mutates process environment via t.Setenv.
+	t.Setenv("SUVE_DEBUG", "1")
+
+	assert.True(t, runProbe(t, []string{appName, "probe"}))
+}

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -1,0 +1,53 @@
+// Package debug carries an opt-in, SDK-neutral debug switch through the request
+// context. The root --debug flag (and the SUVE_DEBUG environment variable) turns
+// it on; provider adapters read it to enable their cloud SDK's request/response
+// logging, writing to the supplied writer (stderr in normal use).
+//
+// Keeping this package free of any cloud SDK is deliberate: both the CLI layer
+// (which sets the switch) and every provider adapter (which acts on it) can
+// depend on it without violating the provider seam that confines each cloud SDK
+// to its own provider package.
+package debug
+
+import (
+	"context"
+	"fmt"
+	"io"
+)
+
+// ctxKey is the unexported context key under which Config is stored.
+type ctxKey struct{}
+
+// Config describes the active debug settings pulled from a context.
+type Config struct {
+	// Enabled reports whether verbose debug logging was requested.
+	Enabled bool
+	// Writer is where debug output should go (typically stderr). Callers that
+	// set Enabled must supply a non-nil Writer.
+	Writer io.Writer
+}
+
+// With returns a child context carrying cfg.
+func With(ctx context.Context, cfg Config) context.Context {
+	return context.WithValue(ctx, ctxKey{}, cfg)
+}
+
+// From returns the Config carried by ctx, or the zero value (disabled) when
+// none is present.
+func From(ctx context.Context) Config {
+	cfg, _ := ctx.Value(ctxKey{}).(Config)
+
+	return cfg
+}
+
+// Logf writes a single formatted debug line to the configured Writer. It is a
+// no-op when debug is disabled or no Writer is set, so callers can invoke it
+// unconditionally. Centralizing the write here keeps provider adapters free of
+// direct fmt.Fprint* usage (see the output package for the same rationale).
+func (c Config) Logf(format string, args ...any) {
+	if !c.Enabled || c.Writer == nil {
+		return
+	}
+
+	_, _ = fmt.Fprintf(c.Writer, format, args...)
+}

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -1,0 +1,31 @@
+package debug_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mpyw/suve/internal/debug"
+)
+
+func TestFrom_absent(t *testing.T) {
+	t.Parallel()
+
+	cfg := debug.From(context.Background())
+	assert.False(t, cfg.Enabled)
+	assert.Nil(t, cfg.Writer)
+}
+
+func TestWith_roundtrip(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	ctx := debug.With(context.Background(), debug.Config{Enabled: true, Writer: &buf})
+
+	cfg := debug.From(ctx)
+	assert.True(t, cfg.Enabled)
+	assert.Same(t, &buf, cfg.Writer)
+}

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -29,3 +29,29 @@ func TestWith_roundtrip(t *testing.T) {
 	assert.True(t, cfg.Enabled)
 	assert.Same(t, &buf, cfg.Writer)
 }
+
+func TestConfig_Logf_enabled(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	cfg := debug.Config{Enabled: true, Writer: &buf}
+	cfg.Logf("hello %s\n", "world")
+
+	assert.Equal(t, "hello world\n", buf.String())
+}
+
+func TestConfig_Logf_noop(t *testing.T) {
+	t.Parallel()
+
+	// Disabled: nothing is written.
+	var buf bytes.Buffer
+
+	(debug.Config{Enabled: false, Writer: &buf}).Logf("nope")
+	assert.Empty(t, buf.String())
+
+	// Enabled but no writer: must not panic.
+	assert.NotPanics(t, func() {
+		(debug.Config{Enabled: true}).Logf("nope")
+	})
+}

--- a/internal/infra/client.go
+++ b/internal/infra/client.go
@@ -13,17 +13,29 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/smithy-go/logging"
 	"github.com/samber/lo"
 	"gopkg.in/ini.v1"
 
+	"github.com/mpyw/suve/internal/debug"
 	"github.com/mpyw/suve/internal/maputil"
 )
 
 // arnAccountIDRegex extracts AWS account ID (12 digits) from ARN strings.
 var arnAccountIDRegex = regexp.MustCompile(`:(\d{12}):`)
 
-// LoadConfig loads the default AWS configuration.
+// LoadConfig loads the default AWS configuration. When debug is enabled on the
+// context it turns on SDK request/response/retry logging (metadata only — the
+// bodyless LogRequest/LogResponse modes never print secret values) directed at
+// the debug writer.
 func LoadConfig(ctx context.Context) (aws.Config, error) {
+	if d := debug.From(ctx); d.Enabled {
+		return config.LoadDefaultConfig(ctx,
+			config.WithClientLogMode(aws.LogRequest|aws.LogResponse|aws.LogRetries),
+			config.WithLogger(logging.NewStandardLogger(d.Writer)),
+		)
+	}
+
 	return config.LoadDefaultConfig(ctx)
 }
 

--- a/internal/infra/loadconfig_internal_test.go
+++ b/internal/infra/loadconfig_internal_test.go
@@ -1,0 +1,46 @@
+package infra
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/debug"
+)
+
+// setAWSTestEnv points the SDK at static test credentials so LoadConfig resolves
+// offline (LoadDefaultConfig makes no network calls).
+func setAWSTestEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_ACCESS_KEY_ID", "test")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+}
+
+// TestLoadConfig_debug exercises both branches of LoadConfig.
+//
+//nolint:paralleltest // subtests use t.Setenv (via setAWSTestEnv), so they cannot run in parallel
+func TestLoadConfig_debug(t *testing.T) {
+	t.Run("without debug", func(t *testing.T) {
+		setAWSTestEnv(t)
+
+		cfg, err := LoadConfig(context.Background())
+		require.NoError(t, err)
+		// No client log mode is enabled unless debug is requested.
+		assert.Zero(t, cfg.ClientLogMode)
+	})
+
+	t.Run("with debug", func(t *testing.T) {
+		setAWSTestEnv(t)
+
+		ctx := debug.With(context.Background(), debug.Config{Enabled: true, Writer: &bytes.Buffer{}})
+
+		cfg, err := LoadConfig(ctx)
+		require.NoError(t, err)
+		assert.NotNil(t, cfg.Logger)
+		assert.NotZero(t, cfg.ClientLogMode)
+	})
+}

--- a/internal/provider/azure/azure.go
+++ b/internal/provider/azure/azure.go
@@ -17,14 +17,17 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	azlog "github.com/Azure/azure-sdk-for-go/sdk/azcore/log"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
 
+	"github.com/mpyw/suve/internal/debug"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/azure/appconfig"
 	"github.com/mpyw/suve/internal/provider/azure/keyvault"
@@ -70,6 +73,8 @@ var _ provider.Factory = Factory{}
 // store (requires scope.StoreName). A missing required field yields a clear
 // error; an unknown kind yields provider.ErrUnsupportedKind.
 func (Factory) Store(ctx context.Context, scope provider.Scope, kind provider.Kind) (provider.Store, error) {
+	enableDebugLogging(ctx)
+
 	switch kind {
 	case provider.KindSecret:
 		return keyVaultStore(ctx, scope)
@@ -78,6 +83,31 @@ func (Factory) Store(ctx context.Context, scope provider.Scope, kind provider.Ki
 	default:
 		return nil, fmt.Errorf("%w: %s", provider.ErrUnsupportedKind, kind)
 	}
+}
+
+// debugLogOnce guards the process-global azcore logger so it is configured at
+// most once per process.
+//
+//nolint:gochecknoglobals // azcore's logger is inherently process-global state
+var debugLogOnce sync.Once
+
+// enableDebugLogging turns on azcore request/response logging to the debug
+// writer the first time it is called with debug active on ctx. azcore's logger
+// is process-global and must be set before clients issue requests; the default
+// (IncludeBody off) logs headers and status only, so secret values are never
+// printed.
+func enableDebugLogging(ctx context.Context) {
+	d := debug.From(ctx)
+	if !d.Enabled {
+		return
+	}
+
+	debugLogOnce.Do(func() {
+		azlog.SetEvents(azlog.EventRequest, azlog.EventResponse, azlog.EventResponseError, azlog.EventRetryPolicy)
+		azlog.SetListener(func(cls azlog.Event, msg string) {
+			d.Logf("[suve debug] azure %s: %s\n", cls, msg)
+		})
+	})
 }
 
 // keyVaultStore builds a Key Vault secrets store for the scope's vault.

--- a/internal/provider/azure/azure_internal_test.go
+++ b/internal/provider/azure/azure_internal_test.go
@@ -1,0 +1,26 @@
+package azure
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mpyw/suve/internal/debug"
+)
+
+// TestEnableDebugLogging covers both branches. The azcore logger is
+// process-global and guarded by a sync.Once, so this test only asserts the call
+// is safe (no panic) with and without debug active.
+//
+//nolint:paralleltest // configures the process-global azcore logger
+func TestEnableDebugLogging(t *testing.T) {
+	assert.NotPanics(t, func() {
+		enableDebugLogging(context.Background())
+	})
+
+	assert.NotPanics(t, func() {
+		enableDebugLogging(debug.With(context.Background(), debug.Config{Enabled: true, Writer: &bytes.Buffer{}}))
+	})
+}

--- a/internal/provider/gcloud/gcloud.go
+++ b/internal/provider/gcloud/gcloud.go
@@ -10,12 +10,14 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	secretmanager "cloud.google.com/go/secretmanager/apiv1"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
+	"github.com/mpyw/suve/internal/debug"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/gcloud/secret"
 )
@@ -27,12 +29,53 @@ import (
 // Never set this in production.
 const EmulatorEnvVar = "SUVE_GCLOUD_SECRETMANAGER_ENDPOINT"
 
+// grpcStatus renders a unary call's outcome for a debug line without printing
+// the reply message (an AccessSecretVersion reply carries the secret payload).
+func grpcStatus(err error) string {
+	if err != nil {
+		return fmt.Sprintf("failed: %v", err)
+	}
+
+	return "ok"
+}
+
+// debugUnaryInterceptor logs each unary gRPC call's method, target, duration and
+// status via cfg. It deliberately never logs the request or reply messages, so
+// only metadata is printed.
+func debugUnaryInterceptor(cfg debug.Config) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context, method string, req, reply any,
+		cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
+	) error {
+		start := time.Now()
+		err := invoker(ctx, method, req, reply, cc, opts...)
+		cfg.Logf("[suve debug] gRPC %s (%s) %s in %s\n", method, cc.Target(), grpcStatus(err), time.Since(start))
+
+		return err
+	}
+}
+
+// debugDialOptions returns gRPC dial options that enable request logging when
+// debug is active on ctx, or nil otherwise. They apply only to the normal
+// (self-dialed) client; the emulator seam supplies its own pre-dialed
+// connection, for which dial options are ignored.
+func debugDialOptions(ctx context.Context) []option.ClientOption {
+	d := debug.From(ctx)
+	if !d.Enabled {
+		return nil
+	}
+
+	return []option.ClientOption{
+		option.WithGRPCDialOption(grpc.WithChainUnaryInterceptor(debugUnaryInterceptor(d))),
+	}
+}
+
 // newSecretManagerClient builds the Secret Manager client, honoring the
 // emulator seam (EmulatorEnvVar) when set.
 func newSecretManagerClient(ctx context.Context) (*secretmanager.Client, error) {
 	endpoint := os.Getenv(EmulatorEnvVar)
 	if endpoint == "" {
-		return secretmanager.NewClient(ctx)
+		return secretmanager.NewClient(ctx, debugDialOptions(ctx)...)
 	}
 
 	// Emulator: dial plaintext gRPC and skip authentication entirely.

--- a/internal/provider/gcloud/gcloud_internal_test.go
+++ b/internal/provider/gcloud/gcloud_internal_test.go
@@ -1,0 +1,72 @@
+package gcloud
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/mpyw/suve/internal/debug"
+)
+
+func TestGRPCStatus(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "ok", grpcStatus(nil))
+	assert.Equal(t, "failed: boom", grpcStatus(errors.New("boom")))
+}
+
+func TestDebugDialOptions_disabled(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, debugDialOptions(context.Background()))
+}
+
+func TestDebugDialOptions_enabled(t *testing.T) {
+	t.Parallel()
+
+	ctx := debug.With(context.Background(), debug.Config{Enabled: true, Writer: &bytes.Buffer{}})
+	assert.Len(t, debugDialOptions(ctx), 1)
+}
+
+func TestDebugUnaryInterceptor(t *testing.T) {
+	t.Parallel()
+
+	// A lazily-created client connection: grpc.NewClient does not dial, so this
+	// works offline and only exists to give the interceptor a real cc.Target().
+	cc, err := grpc.NewClient("passthrough:///unit-test", grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cc.Close() })
+
+	tests := []struct {
+		name       string
+		invokerErr error
+		wantSubstr string
+	}{
+		{name: "ok", invokerErr: nil, wantSubstr: "ok in"},
+		{name: "error", invokerErr: errors.New("boom"), wantSubstr: "failed: boom"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+
+			interceptor := debugUnaryInterceptor(debug.Config{Enabled: true, Writer: &buf})
+			invoker := func(context.Context, string, any, any, *grpc.ClientConn, ...grpc.CallOption) error {
+				return tt.invokerErr
+			}
+			err := interceptor(context.Background(), "/pkg.Svc/Method", nil, nil, cc, invoker)
+
+			assert.Equal(t, tt.invokerErr, err)
+			assert.Contains(t, buf.String(), "gRPC /pkg.Svc/Method")
+			assert.Contains(t, buf.String(), tt.wantSubstr)
+		})
+	}
+}


### PR DESCRIPTION
Now that `mpyw/suve` is in the [standard aqua registry](https://github.com/aquaproj/aqua-registry), document aqua as an install method.

- **Installation order:** mise → aqua → Homebrew → Scoop.
- **New aqua section** (`aqua g -i mpyw/suve`), noting the registry auto-selects the GUI build on macOS/Windows and the CLI-only static build on Linux (supported from v1.3.0).
- **Moved** the Linux GTK3/WebKit2GTK note to the top of Installation (slightly reworded) so it applies to all methods, not just Homebrew.