### PR TITLE
fix(cli): stop the GUI build from clobbering the --debug Before hook

### DIFF
--- a/cmd/suve/gui.go
+++ b/cmd/suve/gui.go
@@ -68,6 +68,10 @@ func registerGUIFlag() {
 		Name:  "gui",
 		Usage: "Launch GUI mode (picks the active provider, or opens the in-app picker if none is unambiguous)",
 	})
+	// Wrap (do not replace) the root Before: the app already installs one
+	// (enableDebug), and clobbering it silently disables --debug / SUVE_DEBUG in
+	// the GUI build. Chain to it on the non-GUI path, mirroring attachGUIFlag.
+	inner := commands.App.Before
 	commands.App.Before = func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
 		if cmd.Bool("gui") {
 			// Launch with the uniquely-active provider when the environment
@@ -76,6 +80,10 @@ func registerGUIFlag() {
 			// than erroring. No scope flags on the bare form, so the GUI hydrates
 			// any resource fields from env.
 			return launchGUI(ctx, provider.Scope{Provider: gui.InitialProviderFromEnv()})
+		}
+
+		if inner != nil {
+			return inner(ctx, cmd)
 		}
 
 		return ctx, nil


### PR DESCRIPTION
## Summary

Fixes a bug shipped in **v1.4.1**: with the GUI build (the Homebrew `suve` formula), the global `--debug` flag and `SUVE_DEBUG` produce **no output at all** — while the CLI-only build (`suve-cli`) works fine.

Reported symptom: `suve aws secret ls --debug` (any flag position) prints nothing to stderr on the Homebrew v1.4.1 binary.

## Root cause

`registerGUIFlag` (in `cmd/suve/gui.go`, compiled only under `production` / `dev`) added the `--gui` short-circuit by **replacing** `commands.App.Before` outright:

```go
commands.App.Before = func(ctx, cmd) {
    if cmd.Bool("gui") { return launchGUI(...) }
    return ctx, nil   // ← discards the enableDebug hook the app installed
}
```

The app's root `Before` is `enableDebug(det)`, which is what turns `--debug` / `SUVE_DEBUG` into a `debug.Config` on the context. Overwriting it means debug is never enabled in the GUI build. The CLI-only build is unaffected because its `gui_stub.go` `registerGUIFlag` is a no-op — which is why only the Homebrew `suve` (GUI) binary was broken.

Notably, the per-subcommand `attachGUIFlag` in the same file already chains to the inner `Before` (`inner := cmd.Before`); only the root registration forgot to.

## Fix

Wrap, don't replace: capture the existing root `Before` and call through to it on the non-`--gui` path, mirroring `attachGUIFlag`.

## Verification

Built with `-tags dev` (the GUI build path):

- `suve aws secret ls --debug` → full debug trace ✅
- `suve --debug aws secret ls` → full debug trace ✅
- `suve aws secret ls` (no `--debug`) → clean, no debug lines ✅
- `suve --gui` short-circuit still launches the GUI ✅

`mise test` ✅ / `mise lint` ✅ (lint compiles this file under all build tags). `cmd/` and the GUI layer are excluded from `mise test` by design, matching the repo's existing convention for the cgo/wails-dependent code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqbNUiCyUzGQMDfCwxQFz7
