### PR TITLE
fix(cli): stop --parse-json from HTML-escaping `&`, `<`, `>` (#343)

### DIFF
--- a/internal/jsonutil/json.go
+++ b/internal/jsonutil/json.go
@@ -5,6 +5,7 @@
 package jsonutil
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 
@@ -14,19 +15,30 @@ import (
 // TryFormat attempts to format a JSON string with indentation.
 // Returns the formatted string and true if successful, or the original string and false if not valid JSON.
 // This is useful for commands that need to know whether formatting was applied.
+//
+// HTML escaping is disabled so that characters like &, <, > survive verbatim
+// instead of being mangled into &, <, > — secret/parameter values
+// are not HTML and are never rendered in a browser context.
 func TryFormat(value string) (string, bool) {
 	var data any
 	if err := json.Unmarshal([]byte(value), &data); err != nil {
 		return value, false
 	}
 
-	formatted, err := json.MarshalIndent(data, "", "  ")
-	if err != nil {
+	var buf bytes.Buffer
+
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	enc.SetIndent("", "  ")
+
+	if err := enc.Encode(data); err != nil {
 		// This should not happen if Unmarshal succeeded, but handle it gracefully
 		return value, false
 	}
 
-	return string(formatted), true
+	// json.Encoder.Encode appends a trailing newline; strip it to match the
+	// previous json.MarshalIndent behavior.
+	return string(bytes.TrimRight(buf.Bytes(), "\n")), true
 }
 
 // TryFormatOrWarn formats JSON or warns and returns original.

--- a/internal/jsonutil/json_test.go
+++ b/internal/jsonutil/json_test.go
@@ -42,6 +42,12 @@ func TestTryFormat(t *testing.T) {
 			wantStr:  "[\n  1,\n  2,\n  3\n]",
 			wantBool: true,
 		},
+		{
+			name:     "does not HTML-escape ampersand, angle brackets",
+			input:    `{"url":"https://x.com/?a=1&b=<2>"}`,
+			wantStr:  "{\n  \"url\": \"https://x.com/?a=1&b=<2>\"\n}",
+			wantBool: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

`jsonutil.TryFormat` used `json.MarshalIndent`, which HTML-escapes by default. A value like `{"url":"https://x.com/?a=1&b=<2>"}` was rendered as `"...&b=<2>"` in `show -j`, `diff -j`, and `log -p -j` output.

Secret/parameter values are not HTML and are never rendered in a browser context, so the escaping is pure corruption.

## Fix

Switch to a `json.Encoder` with `SetEscapeHTML(false)`, trimming the trailing newline it appends so the output shape matches the previous `MarshalIndent` behavior.

## Test

Added a `jsonutil.TryFormat` case asserting `&`, `<`, `>` survive verbatim.

Fixes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD