### PR TITLE
fix(cli): correct `log -p` patch attribution and show the initial creation diff (#336, #337)

### DIFF
--- a/internal/cli/commands/azure/secret/log.go
+++ b/internal/cli/commands/azure/secret/log.go
@@ -129,43 +129,49 @@ func (p *logPresenter) RenderValue(_ io.Writer, _, _ int) {}
 
 func (p *logPresenter) RenderPatch(stdout, stderr io.Writer, i int, parseJSON, reverse bool) {
 	entries := p.result.Entries
+	parentIdx, oldest := genericlog.PatchParent(i, len(entries), reverse)
 
-	var oldIdx, newIdx int
+	newEntry := entries[i]
 
-	if reverse {
-		if i < len(entries)-1 {
-			oldIdx, newIdx = i, i+1
-		} else {
-			oldIdx = -1
+	newValue, newOk := p.values[newEntry.Version]
+	if !newOk {
+		return
+	}
+
+	var oldValue, oldName string
+
+	if oldest {
+		// The oldest version in the window has no parent to diff against. Render
+		// its creation (all-added) diff, but only when it is genuinely the
+		// initial version — otherwise a --number/date-filter window cut would
+		// masquerade as a creation.
+		if !p.result.InitialIncluded {
+			return
+		}
+
+		oldName = p.result.Name
+
+		if parseJSON {
+			newValue = jsonutil.TryFormatOrWarn(newValue, stderr, "")
 		}
 	} else {
-		if i < len(entries)-1 {
-			oldIdx, newIdx = i+1, i
-		} else {
-			oldIdx = -1
+		oldEntry := entries[parentIdx]
+
+		var oldOk bool
+
+		oldValue, oldOk = p.values[oldEntry.Version]
+		if !oldOk {
+			return
+		}
+
+		oldName = fmt.Sprintf("%s#%s", p.result.Name, oldEntry.Version)
+
+		if parseJSON {
+			oldValue, newValue = jsonutil.TryFormatOrWarn2(oldValue, newValue, stderr, "")
 		}
 	}
 
-	if oldIdx < 0 {
-		return
-	}
-
-	oldVersion := entries[oldIdx].Version
-	newVersion := entries[newIdx].Version
-
-	oldValue, oldOk := p.values[oldVersion]
-
-	newValue, newOk := p.values[newVersion]
-	if !oldOk || !newOk {
-		return
-	}
-
-	if parseJSON {
-		oldValue, newValue = jsonutil.TryFormatOrWarn2(oldValue, newValue, stderr, "")
-	}
-
-	oldName := fmt.Sprintf("%s#%s", p.result.Name, oldVersion)
-	newName := fmt.Sprintf("%s#%s", p.result.Name, newVersion)
+	newName := fmt.Sprintf("%s#%s", p.result.Name, newEntry.Version)
 
 	diff := output.Diff(oldName, newName, oldValue, newValue)
 	if diff != "" {

--- a/internal/cli/commands/azure/secret/secret_test.go
+++ b/internal/cli/commands/azure/secret/secret_test.go
@@ -191,3 +191,42 @@ func TestLogPresenter(t *testing.T) {
 	assert.Contains(t, out, "Version new")
 	assert.Contains(t, out, "enabled")
 }
+
+func TestLogPresenter_Patch(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2024, 5, 6, 7, 8, 9, 0, time.UTC)
+
+	store := &providermock.Store{
+		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
+			return []domain.Version{
+				{ID: "2", Label: "enabled", Created: &created},
+				{ID: "1", Label: "enabled", Created: &created},
+			}, nil
+		},
+		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+			return provider.NewVersionRef(spec[1:]), nil
+		},
+		GetFunc: func(_ context.Context, _ string, ref provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{Value: "v" + ref.ID()}, nil
+		},
+	}
+
+	presenter := secret.NewLogPresenter(store, genericlog.Request{Name: "my-secret"})
+	require.NoError(t, presenter.Fetch(t.Context()))
+
+	var buf, errBuf bytes.Buffer
+
+	// i=0 is the newest version (v2): patch against its parent v1.
+	presenter.RenderPatch(&buf, &errBuf, 0, false, false)
+	// i=1 is the oldest/initial version (v1): all-added creation diff.
+	presenter.RenderPatch(&buf, &errBuf, 1, false, false)
+
+	out := buf.String()
+	assert.Contains(t, out, "-v1")
+	assert.Contains(t, out, "+v2")
+	assert.Contains(t, out, "my-secret#1")
+	assert.Contains(t, out, "my-secret#2")
+	// The initial version renders its all-added creation diff (+v1).
+	assert.Contains(t, out, "+v1")
+}

--- a/internal/cli/commands/gcloud/gcloud_test.go
+++ b/internal/cli/commands/gcloud/gcloud_test.go
@@ -250,3 +250,42 @@ func TestLogPresenter(t *testing.T) {
 	assert.Contains(t, out, "Version 2")
 	assert.Contains(t, out, "enabled")
 }
+
+func TestLogPresenter_Patch(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2024, 5, 6, 7, 8, 9, 0, time.UTC)
+
+	store := &providermock.Store{
+		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
+			return []domain.Version{
+				{ID: "2", Label: "enabled", Created: &created},
+				{ID: "1", Label: "enabled", Created: &created},
+			}, nil
+		},
+		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+			return provider.NewVersionRef(spec[1:]), nil
+		},
+		GetFunc: func(_ context.Context, _ string, ref provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{Value: "v" + ref.ID()}, nil
+		},
+	}
+
+	presenter := gcloud.NewLogPresenter(store, genericlog.Request{Name: "my-secret"})
+	require.NoError(t, presenter.Fetch(t.Context()))
+
+	var buf, errBuf bytes.Buffer
+
+	// i=0 is the newest version (v2): patch against its parent v1.
+	presenter.RenderPatch(&buf, &errBuf, 0, false, false)
+	// i=1 is the oldest/initial version (v1): all-added creation diff.
+	presenter.RenderPatch(&buf, &errBuf, 1, false, false)
+
+	out := buf.String()
+	assert.Contains(t, out, "-v1")
+	assert.Contains(t, out, "+v2")
+	assert.Contains(t, out, "my-secret#1")
+	assert.Contains(t, out, "my-secret#2")
+	// The initial version renders its all-added creation diff (+v1).
+	assert.Contains(t, out, "+v1")
+}

--- a/internal/cli/commands/gcloud/log.go
+++ b/internal/cli/commands/gcloud/log.go
@@ -129,43 +129,49 @@ func (p *logPresenter) RenderValue(_ io.Writer, _, _ int) {}
 
 func (p *logPresenter) RenderPatch(stdout, stderr io.Writer, i int, parseJSON, reverse bool) {
 	entries := p.result.Entries
+	parentIdx, oldest := genericlog.PatchParent(i, len(entries), reverse)
 
-	var oldIdx, newIdx int
+	newEntry := entries[i]
 
-	if reverse {
-		if i < len(entries)-1 {
-			oldIdx, newIdx = i, i+1
-		} else {
-			oldIdx = -1
+	newValue, newOk := p.values[newEntry.Version]
+	if !newOk {
+		return
+	}
+
+	var oldValue, oldName string
+
+	if oldest {
+		// The oldest version in the window has no parent to diff against. Render
+		// its creation (all-added) diff, but only when it is genuinely the
+		// initial version — otherwise a --number/date-filter window cut would
+		// masquerade as a creation.
+		if !p.result.InitialIncluded {
+			return
+		}
+
+		oldName = p.result.Name
+
+		if parseJSON {
+			newValue = jsonutil.TryFormatOrWarn(newValue, stderr, "")
 		}
 	} else {
-		if i < len(entries)-1 {
-			oldIdx, newIdx = i+1, i
-		} else {
-			oldIdx = -1
+		oldEntry := entries[parentIdx]
+
+		var oldOk bool
+
+		oldValue, oldOk = p.values[oldEntry.Version]
+		if !oldOk {
+			return
+		}
+
+		oldName = fmt.Sprintf("%s#%s", p.result.Name, oldEntry.Version)
+
+		if parseJSON {
+			oldValue, newValue = jsonutil.TryFormatOrWarn2(oldValue, newValue, stderr, "")
 		}
 	}
 
-	if oldIdx < 0 {
-		return
-	}
-
-	oldVersion := entries[oldIdx].Version
-	newVersion := entries[newIdx].Version
-
-	oldValue, oldOk := p.values[oldVersion]
-
-	newValue, newOk := p.values[newVersion]
-	if !oldOk || !newOk {
-		return
-	}
-
-	if parseJSON {
-		oldValue, newValue = jsonutil.TryFormatOrWarn2(oldValue, newValue, stderr, "")
-	}
-
-	oldName := fmt.Sprintf("%s#%s", p.result.Name, oldVersion)
-	newName := fmt.Sprintf("%s#%s", p.result.Name, newVersion)
+	newName := fmt.Sprintf("%s#%s", p.result.Name, newEntry.Version)
 
 	diff := output.Diff(oldName, newName, oldValue, newValue)
 	if diff != "" {

--- a/internal/cli/commands/generic/log/log.go
+++ b/internal/cli/commands/generic/log/log.go
@@ -108,6 +108,24 @@ func (r *Runner) Run(ctx context.Context) error {
 	return nil
 }
 
+// PatchParent computes, for version i in a fetched window of n versions, the
+// index of its parent (the immediately-older version) and whether i is the
+// oldest version in the window.
+//
+// git log -p attaches each version's own creation patch under its own header —
+// the diff from its parent to itself. In newest-first order the parent is the
+// next entry (i+1); in reverse (oldest-first) order it is the previous entry
+// (i-1). The oldest version in the window has no parent in the list; the caller
+// renders it as an all-added creation diff, but only when it is genuinely the
+// initial version (guarding against a --number / date-filter window cut).
+func PatchParent(i, n int, reverse bool) (parentIdx int, oldest bool) {
+	if reverse {
+		return i - 1, i == 0
+	}
+
+	return i + 1, i == n-1
+}
+
 // Config holds the provider-specific configuration for the log command.
 type Config struct {
 	// Usage is the one-line command usage string.

--- a/internal/cli/commands/generic/log/log_test.go
+++ b/internal/cli/commands/generic/log/log_test.go
@@ -230,7 +230,7 @@ func TestRunParam(t *testing.T) {
 			},
 		},
 		{
-			name: "patch with single version shows no diff",
+			name: "patch with single version shows creation diff",
 			req:  genericlog.Request{Name: "/app/param", MaxResults: 10},
 			opts: genericlog.Options{ShowPatch: true},
 			store: paramLogStore([]paramLogVer{
@@ -238,8 +238,12 @@ func TestRunParam(t *testing.T) {
 			}),
 			check: func(t *testing.T, output string) {
 				t.Helper()
+				// The sole version is the initial one: git log -p renders it as
+				// an all-added creation diff, not a bare header.
 				assert.Contains(t, output, "Version 1")
-				assert.NotContains(t, output, "---")
+				assert.Contains(t, output, "--- /app/param")
+				assert.Contains(t, output, "+++ /app/param#1")
+				assert.Contains(t, output, "+only-value")
 			},
 		},
 		{
@@ -288,6 +292,57 @@ func TestRunParam(t *testing.T) {
 				assert.Contains(t, output, "+new-value")
 				assert.Contains(t, output, "--- /app/param#1")
 				assert.Contains(t, output, "+++ /app/param#2")
+			},
+		},
+		{
+			name: "reverse patch attaches each patch under its own version header",
+			req:  genericlog.Request{Name: "/app/param", MaxResults: 10, Reverse: true},
+			opts: genericlog.Options{ShowPatch: true, Reverse: true},
+			store: paramLogStore([]paramLogVer{
+				{ver: 1, value: "a", modified: lo.ToPtr(now.Add(-2 * time.Hour))},
+				{ver: 2, value: "b", modified: lo.ToPtr(now.Add(-time.Hour))},
+				{ver: 3, value: "c", modified: &now},
+			}),
+			check: func(t *testing.T, output string) {
+				t.Helper()
+
+				// git log -p --reverse: each version's own patch sits under its
+				// own header. v2's patch (#1->#2) must fall between the Version 2
+				// and Version 3 headers, and v3's patch (#2->#3) after Version 3.
+				v2Hdr := strings.Index(output, "Version 2")
+				v3Hdr := strings.Index(output, "Version 3")
+				patch12 := strings.Index(output, "+++ /app/param#2")
+				patch23 := strings.Index(output, "+++ /app/param#3")
+
+				require.NotEqual(t, -1, patch12)
+				require.NotEqual(t, -1, patch23)
+				assert.Greater(t, patch12, v2Hdr, "v1->v2 patch must be under Version 2 header")
+				assert.Less(t, patch12, v3Hdr, "v1->v2 patch must precede Version 3 header")
+				assert.Greater(t, patch23, v3Hdr, "v2->v3 patch must be under Version 3 header")
+
+				// The initial version (v1) renders its all-added creation diff.
+				assert.Contains(t, output, "+++ /app/param#1")
+			},
+		},
+		{
+			name: "patch does not fabricate a creation diff when the window is cut by --number",
+			req:  genericlog.Request{Name: "/app/param", MaxResults: 2},
+			opts: genericlog.Options{ShowPatch: true},
+			store: paramLogStore([]paramLogVer{
+				{ver: 1, value: "a", modified: lo.ToPtr(now.Add(-2 * time.Hour))},
+				{ver: 2, value: "b", modified: lo.ToPtr(now.Add(-time.Hour))},
+				{ver: 3, value: "c", modified: &now},
+			}),
+			check: func(t *testing.T, output string) {
+				t.Helper()
+				// Only versions 3 and 2 are shown; version 1 exists beyond the
+				// window, so the oldest shown version (2) is NOT a creation and
+				// must not get an all-added hunk.
+				assert.Contains(t, output, "Version 3")
+				assert.Contains(t, output, "Version 2")
+				assert.NotContains(t, output, "Version 1")
+				assert.NotContains(t, output, "@@ -0,0")
+				assert.NotContains(t, output, "+++ /app/param#2")
 			},
 		},
 		{
@@ -472,7 +527,7 @@ func TestRunParam(t *testing.T) {
 			},
 		},
 		{
-			name: "patch with identical values shows no diff",
+			name: "patch with identical consecutive values shows no diff between them",
 			req:  genericlog.Request{Name: "/app/param", MaxResults: 10},
 			opts: genericlog.Options{ShowPatch: true},
 			store: paramLogStore([]paramLogVer{
@@ -482,8 +537,11 @@ func TestRunParam(t *testing.T) {
 			check: func(t *testing.T, output string) {
 				t.Helper()
 				assert.Contains(t, output, "Version")
+				// v1 -> v2 is a no-op, so no line is ever removed.
 				assert.NotContains(t, output, "-same-value")
-				assert.NotContains(t, output, "+same-value")
+				// The initial version (v1) still renders its all-added creation
+				// diff exactly once; the v2 patch adds nothing.
+				assert.Equal(t, 1, strings.Count(output, "+same-value"))
 			},
 		},
 	}
@@ -605,7 +663,7 @@ func TestRunSecret(t *testing.T) {
 			},
 		},
 		{
-			name: "patch with single version shows no diff",
+			name: "patch with single version shows creation diff",
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10},
 			opts: genericlog.Options{ShowPatch: true},
 			store: secretLogStore([]domain.Version{
@@ -613,8 +671,11 @@ func TestRunSecret(t *testing.T) {
 			}, map[string]string{"only-version": "only-value"}, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
+				// The sole version is the initial one: rendered as an all-added
+				// creation diff (git log -p style), not a bare header.
 				assert.Contains(t, output, "Version")
-				assert.NotContains(t, output, "---")
+				assert.Contains(t, output, "--- my-secret")
+				assert.Contains(t, output, "+only-value")
 			},
 		},
 		{

--- a/internal/cli/commands/param/log.go
+++ b/internal/cli/commands/param/log.go
@@ -148,33 +148,37 @@ func (p *logPresenter) RenderValue(stdout io.Writer, i, maxValueLength int) {
 
 func (p *logPresenter) RenderPatch(stdout, stderr io.Writer, i int, parseJSON, reverse bool) {
 	entries := p.result.Entries
+	parentIdx, oldest := genericlog.PatchParent(i, len(entries), reverse)
 
-	// For patch mode, we need to compare with the next entry in the list.
-	// The list is ordered by the usecase based on reverse.
-	if i >= len(entries)-1 {
-		return
-	}
-
-	var oldEntry, newEntry param.LogEntry
-
-	if reverse {
-		// In reverse mode (oldest first): current is old, next is new
-		oldEntry = entries[i]
-		newEntry = entries[i+1]
-	} else {
-		// In normal mode (newest first): next is old, current is new
-		oldEntry = entries[i+1]
-		newEntry = entries[i]
-	}
-
-	oldValue := oldEntry.Value
-
+	newEntry := entries[i]
 	newValue := newEntry.Value
-	if parseJSON {
-		oldValue, newValue = jsonutil.TryFormatOrWarn2(oldValue, newValue, stderr, "")
+
+	var oldValue, oldName string
+
+	if oldest {
+		// The oldest version in the window has no parent to diff against. Render
+		// its creation (all-added) diff, but only when it is genuinely the
+		// initial version — otherwise a --number/date-filter window cut would
+		// masquerade as a creation.
+		if !p.result.InitialIncluded {
+			return
+		}
+
+		oldName = p.result.Name
+
+		if parseJSON {
+			newValue = jsonutil.TryFormatOrWarn(newValue, stderr, "")
+		}
+	} else {
+		oldEntry := entries[parentIdx]
+		oldValue = oldEntry.Value
+		oldName = fmt.Sprintf("%s#%d", p.result.Name, oldEntry.Version)
+
+		if parseJSON {
+			oldValue, newValue = jsonutil.TryFormatOrWarn2(oldValue, newValue, stderr, "")
+		}
 	}
 
-	oldName := fmt.Sprintf("%s#%d", p.result.Name, oldEntry.Version)
 	newName := fmt.Sprintf("%s#%d", p.result.Name, newEntry.Version)
 
 	diff := output.Diff(oldName, newName, oldValue, newValue)

--- a/internal/cli/commands/secret/log.go
+++ b/internal/cli/commands/secret/log.go
@@ -140,47 +140,49 @@ func (p *logPresenter) RenderValue(_ io.Writer, _, _ int) {}
 
 func (p *logPresenter) RenderPatch(stdout, stderr io.Writer, i int, parseJSON, reverse bool) {
 	entries := p.result.Entries
+	parentIdx, oldest := genericlog.PatchParent(i, len(entries), reverse)
 
-	// Determine old/new indices based on order
-	var oldIdx, newIdx int
+	newEntry := entries[i]
 
-	if reverse {
-		// In reverse mode: comparing with next version (newer)
-		if i < len(entries)-1 {
-			oldIdx = i
-			newIdx = i + 1
-		} else {
-			oldIdx = -1 // No diff for the last (current) version
+	newValue, newOk := p.secretValues[newEntry.VersionID]
+	if !newOk {
+		return
+	}
+
+	var oldValue, oldName string
+
+	if oldest {
+		// The oldest version in the window has no parent to diff against. Render
+		// its creation (all-added) diff, but only when it is genuinely the
+		// initial version — otherwise a --number/date-filter window cut would
+		// masquerade as a creation.
+		if !p.result.InitialIncluded {
+			return
+		}
+
+		oldName = p.result.Name
+
+		if parseJSON {
+			newValue = jsonutil.TryFormatOrWarn(newValue, stderr, "")
 		}
 	} else {
-		// In normal mode: comparing with previous version (older)
-		if i < len(entries)-1 {
-			oldIdx = i + 1
-			newIdx = i
-		} else {
-			oldIdx = -1 // No diff for the oldest version
+		oldEntry := entries[parentIdx]
+
+		var oldOk bool
+
+		oldValue, oldOk = p.secretValues[oldEntry.VersionID]
+		if !oldOk {
+			return
+		}
+
+		oldName = fmt.Sprintf("%s#%s", p.result.Name, secretversion.TruncateVersionID(oldEntry.VersionID))
+
+		if parseJSON {
+			oldValue, newValue = jsonutil.TryFormatOrWarn2(oldValue, newValue, stderr, "")
 		}
 	}
 
-	if oldIdx < 0 {
-		return
-	}
-
-	oldVersionID := entries[oldIdx].VersionID
-	newVersionID := entries[newIdx].VersionID
-	oldValue, oldOk := p.secretValues[oldVersionID]
-
-	newValue, newOk := p.secretValues[newVersionID]
-	if !oldOk || !newOk {
-		return
-	}
-
-	if parseJSON {
-		oldValue, newValue = jsonutil.TryFormatOrWarn2(oldValue, newValue, stderr, "")
-	}
-
-	oldName := fmt.Sprintf("%s#%s", p.result.Name, secretversion.TruncateVersionID(oldVersionID))
-	newName := fmt.Sprintf("%s#%s", p.result.Name, secretversion.TruncateVersionID(newVersionID))
+	newName := fmt.Sprintf("%s#%s", p.result.Name, secretversion.TruncateVersionID(newEntry.VersionID))
 
 	diff := output.Diff(oldName, newName, oldValue, newValue)
 	if diff != "" {

--- a/internal/usecase/azure/log.go
+++ b/internal/usecase/azure/log.go
@@ -31,6 +31,10 @@ type LogEntry struct {
 type LogOutput struct {
 	Name    string
 	Entries []LogEntry
+	// InitialIncluded reports whether the oldest entry in Entries is the very
+	// first version that ever existed. It is false when the window was cut by
+	// --number or a date filter, so the oldest shown version is not a creation.
+	InitialIncluded bool
 }
 
 // LogUseCase executes log operations.
@@ -54,6 +58,11 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 	if len(versions) == 0 {
 		return &LogOutput{Name: input.Name}, nil
 	}
+
+	// The complete history is newest first, so its last element is the very
+	// first version that ever existed. Remember it before truncation so we can
+	// tell whether the oldest shown version is genuinely the initial one.
+	initialVersion := versions[len(versions)-1].ID
 
 	if input.MaxResults > 0 && len(versions) > int(input.MaxResults) {
 		versions = versions[:input.MaxResults]
@@ -91,7 +100,13 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 		})
 	}
 
-	return &LogOutput{Name: input.Name, Entries: entries}, nil
+	return &LogOutput{
+		Name:    input.Name,
+		Entries: entries,
+		InitialIncluded: slices.ContainsFunc(entries, func(e LogEntry) bool {
+			return e.Version == initialVersion
+		}),
+	}, nil
 }
 
 // getValue fetches the value for a specific version id, tolerating fetch

--- a/internal/usecase/gcloud/log.go
+++ b/internal/usecase/gcloud/log.go
@@ -31,6 +31,10 @@ type LogEntry struct {
 type LogOutput struct {
 	Name    string
 	Entries []LogEntry
+	// InitialIncluded reports whether the oldest entry in Entries is the very
+	// first version that ever existed. It is false when the window was cut by
+	// --number or a date filter, so the oldest shown version is not a creation.
+	InitialIncluded bool
 }
 
 // LogUseCase executes log operations.
@@ -52,6 +56,11 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 	if len(versions) == 0 {
 		return &LogOutput{Name: input.Name}, nil
 	}
+
+	// The complete history is newest first, so its last element is the very
+	// first version that ever existed. Remember it before truncation so we can
+	// tell whether the oldest shown version is genuinely the initial one.
+	initialVersion := versions[len(versions)-1].ID
 
 	if input.MaxResults > 0 && len(versions) > int(input.MaxResults) {
 		versions = versions[:input.MaxResults]
@@ -89,7 +98,13 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 		})
 	}
 
-	return &LogOutput{Name: input.Name, Entries: entries}, nil
+	return &LogOutput{
+		Name:    input.Name,
+		Entries: entries,
+		InitialIncluded: slices.ContainsFunc(entries, func(e LogEntry) bool {
+			return e.Version == initialVersion
+		}),
+	}, nil
 }
 
 // getValue fetches the value for a specific version number, tolerating fetch

--- a/internal/usecase/param/log.go
+++ b/internal/usecase/param/log.go
@@ -33,6 +33,10 @@ type LogEntry struct {
 type LogOutput struct {
 	Name    string
 	Entries []LogEntry
+	// InitialIncluded reports whether the oldest entry in Entries is the very
+	// first version that ever existed. It is false when the window was cut by
+	// --number or a date filter, so the oldest shown version is not a creation.
+	InitialIncluded bool
 }
 
 // LogUseCase executes log operations.
@@ -55,6 +59,11 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 	if len(versions) == 0 {
 		return &LogOutput{Name: input.Name}, nil
 	}
+
+	// The complete history is newest first, so its last element is the very
+	// first version that ever existed. Remember it before truncation so we can
+	// tell whether the oldest shown version is genuinely the initial one.
+	initialVersion := parseVersion(versions[len(versions)-1].ID)
 
 	// History is newest first; MaxResults caps the number of versions shown.
 	if input.MaxResults > 0 && len(versions) > int(input.MaxResults) {
@@ -114,6 +123,9 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 	return &LogOutput{
 		Name:    input.Name,
 		Entries: entries,
+		InitialIncluded: slices.ContainsFunc(entries, func(e LogEntry) bool {
+			return e.Version == initialVersion
+		}),
 	}, nil
 }
 

--- a/internal/usecase/secret/log.go
+++ b/internal/usecase/secret/log.go
@@ -32,6 +32,10 @@ type LogEntry struct {
 type LogOutput struct {
 	Name    string
 	Entries []LogEntry
+	// InitialIncluded reports whether the oldest entry in Entries is the very
+	// first version that ever existed. It is false when the window was cut by
+	// --number or a date filter, so the oldest shown version is not a creation.
+	InitialIncluded bool
 }
 
 // LogUseCase executes log operations.
@@ -54,6 +58,11 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 	if len(versions) == 0 {
 		return &LogOutput{Name: input.Name}, nil
 	}
+
+	// The complete history is newest first, so its last element is the very
+	// first version that ever existed. Remember it before truncation so we can
+	// tell whether the oldest shown version is genuinely the initial one.
+	initialVersion := versions[len(versions)-1].ID
 
 	// History is newest first; MaxResults caps the number of versions shown.
 	if input.MaxResults > 0 && len(versions) > int(input.MaxResults) {
@@ -98,6 +107,9 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 	return &LogOutput{
 		Name:    input.Name,
 		Entries: entries,
+		InitialIncluded: slices.ContainsFunc(entries, func(e LogEntry) bool {
+			return e.VersionID == initialVersion
+		}),
 	}, nil
 }
 


### PR DESCRIPTION
Fixes two related `log -p` defects in every provider's `RenderPatch`.

## #337 — reverse mode off-by-one

In `--reverse -p` mode, entry `i` diffed `entries[i] → entries[i+1]`, so the change that **created version i+1** was printed under **version i's** header. The newest version got no patch at all. `git log -p --reverse` puts each commit's own patch under its own header.

## #336 — initial version's creation diff never shown

Every `RenderPatch` early-returned at the list boundary, so a single-version history showed a bare header with nothing, and the oldest version never got a patch. `git log -p` renders the initial commit as an all-added diff.

## Fix

- New `generic/log.PatchParent(i, n, reverse)` computes each version's parent index (`i+1` newest-first, `i-1` reverse) and whether it is the oldest in the window. All four presenters (param / secret / gcloud / azure-secret) share it, replacing the duplicated index arithmetic.
- The oldest version renders as an all-added creation diff `Diff(name, name#v, "", value)` — but **only when it is genuinely the initial version**. Each usecase now reports `InitialIncluded`, so a `--number` / date-filter window cut is not misrepresented as a creation.

## Tests

- Updated the single-version and identical-values expectations (which previously encoded the buggy behavior) to git-log-p semantics.
- Added regression tests: reverse-mode per-header attribution, and the window-cut guard that must **not** fabricate a creation diff.

`mise test` and `mise lint` both pass.

Closes #336
Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD