### PR TITLE
fix(cli): make Azure App Config keys containing `:` `#` `~` addressable (#353)

### DIFF
--- a/internal/cli/commands/azure/param/param_test.go
+++ b/internal/cli/commands/azure/param/param_test.go
@@ -18,52 +18,61 @@ import (
 	"github.com/mpyw/suve/internal/version/azureappconfigversion"
 )
 
-// TestCommandValidation exercises the acid-test parse rejection: App
-// Configuration is unversioned, so any version specifier fails before any store
-// is resolved (no Azure credentials needed) — and never panics.
+// TestCommandValidation checks argument handling that fails before any store is
+// resolved (no Azure credentials needed) — and never panics. App Configuration
+// keys are unversioned but may legally contain ':' / '#' / '~', so those are
+// treated as ordinary key characters rather than rejected as version specifiers.
 func TestCommandValidation(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name    string
-		args    []string
-		wantErr string
+	// missingKey / usage errors are raised before store resolution.
+	usageTests := []struct {
+		name string
+		args []string
 	}{
 		{
-			name:    "show missing key",
-			args:    []string{"suve", "azure", "param", "show"},
-			wantErr: "usage:",
+			name: "show missing key",
+			args: []string{"suve", "azure", "param", "show"},
 		},
 		{
-			name:    "show rejects version number",
-			args:    []string{"suve", "azure", "param", "show", "my-key#1"},
-			wantErr: "does not support versions",
-		},
-		{
-			name:    "show rejects shift",
-			args:    []string{"suve", "azure", "param", "show", "my-key~1"},
-			wantErr: "does not support versions",
-		},
-		{
-			name:    "show rejects label",
-			args:    []string{"suve", "azure", "param", "show", "my-key:prod"},
-			wantErr: "does not support versions",
-		},
-		{
-			name:    "create missing args",
-			args:    []string{"suve", "azure", "param", "create"},
-			wantErr: "usage:",
+			name: "create missing args",
+			args: []string{"suve", "azure", "param", "create"},
 		},
 	}
 
-	for _, tt := range tests {
+	for _, tt := range usageTests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
 			app := appcli.MakeApp()
 			err := app.Run(t.Context(), tt.args)
 			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.wantErr)
+			assert.Contains(t, err.Error(), "usage:")
+		})
+	}
+
+	// Specifier-like characters are legal key characters: the key is accepted
+	// and the command proceeds to store resolution (which fails only because no
+	// store is configured), never producing a version-related rejection.
+	keyTests := []struct {
+		name string
+		args []string
+	}{
+		{"hash in key accepted", []string{"suve", "azure", "param", "show", "my-key#1"}},
+		{"tilde in key accepted", []string{"suve", "azure", "param", "show", "my-key~1"}},
+		{"colon label-like key accepted", []string{"suve", "azure", "param", "show", "my-key:prod"}},
+		{"ASP.NET colon hierarchy accepted", []string{"suve", "azure", "param", "show", "Logging:LogLevel:Default"}},
+	}
+
+	for _, tt := range keyTests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			app := appcli.MakeApp()
+			err := app.Run(t.Context(), tt.args)
+			require.Error(t, err)
+			assert.NotContains(t, err.Error(), "does not support versions")
+			assert.Contains(t, err.Error(), "store specified")
 		})
 	}
 }

--- a/internal/gui/specparse_internal_test.go
+++ b/internal/gui/specparse_internal_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/mpyw/suve/internal/provider"
-	"github.com/mpyw/suve/internal/version/azureappconfigversion"
 	"github.com/mpyw/suve/internal/version/gcloudversion"
 )
 
@@ -50,15 +49,19 @@ func TestApp_parseParamSpec(t *testing.T) {
 			input: "app/config/timeout", wantName: "app/config/timeout",
 		},
 		{
-			// The key regression: '#' in an App Configuration key must NOT be
-			// split into name+version (as the AWS grammar would); it is rejected
-			// with a clean unsupported-versioning error.
-			name: "azure key containing hash is rejected, not mis-split", provider: provider.ProviderAzure,
-			input: "my-key#3", wantErr: azureappconfigversion.ErrVersioningUnsupported,
+			// The #353 regression: '#' in an App Configuration key must NOT be
+			// split into name+version (as the AWS grammar would); the whole
+			// argument is the key.
+			name: "azure key containing hash is kept whole", provider: provider.ProviderAzure,
+			input: "my-key#3", wantName: "my-key#3",
 		},
 		{
-			name: "azure key with tilde is rejected", provider: provider.ProviderAzure,
-			input: "my-key~1", wantErr: azureappconfigversion.ErrVersioningUnsupported,
+			name: "azure key with tilde is kept whole", provider: provider.ProviderAzure,
+			input: "my-key~1", wantName: "my-key~1",
+		},
+		{
+			name: "azure ASP.NET-style colon key is kept whole", provider: provider.ProviderAzure,
+			input: "Logging:LogLevel:Default", wantName: "Logging:LogLevel:Default",
 		},
 	}
 

--- a/internal/provider/azure/appconfig/appconfig.go
+++ b/internal/provider/azure/appconfig/appconfig.go
@@ -76,9 +76,12 @@ func New(client Client) *Store {
 // Resolve validates that the spec carries no version specifier (App
 // Configuration has none) and returns the latest ref. The parse guard rejects
 // any #/~/: specifier with a clear error before any API call.
-func (s *Store) Resolve(_ context.Context, name, spec string) (provider.VersionRef, error) {
-	if _, err := azureappconfigversion.Parse(name + spec); err != nil {
-		return provider.VersionRef{}, err
+func (s *Store) Resolve(_ context.Context, _, spec string) (provider.VersionRef, error) {
+	// App Configuration is unversioned: the entire argument is the key name, so
+	// the caller passes no version specifier. A non-empty spec means something
+	// tried to version an unversioned store, which is unsupported.
+	if spec != "" {
+		return provider.VersionRef{}, fmt.Errorf("%w", azureappconfigversion.ErrVersioningUnsupported)
 	}
 
 	return provider.NewVersionRef(""), nil

--- a/internal/staging/azure_appconfig_param.go
+++ b/internal/staging/azure_appconfig_param.go
@@ -131,8 +131,8 @@ func (s *AzureAppConfigParamStrategy) FetchCurrentTags(_ context.Context, _ stri
 	return nil, nil //nolint:nilnil // intentional: App Configuration tags are not staged
 }
 
-// ParseName parses and validates a name. Any version specifier is rejected by
-// azureappconfigversion.
+// ParseName parses and validates a name. App Configuration is unversioned, so
+// the entire argument is the key (':' / '#' / '~' are legal key characters).
 func (s *AzureAppConfigParamStrategy) ParseName(input string) (string, error) {
 	spec, err := azureappconfigversion.Parse(input)
 	if err != nil {
@@ -158,7 +158,7 @@ func (s *AzureAppConfigParamStrategy) FetchCurrentValue(ctx context.Context, nam
 }
 
 // ParseSpec parses a name for reset. App Configuration is unversioned, so a
-// version is never present (specifiers are rejected at parse time).
+// version is never present; the entire argument is the key.
 func (s *AzureAppConfigParamStrategy) ParseSpec(input string) (name string, hasVersion bool, err error) {
 	spec, err := azureappconfigversion.Parse(input)
 	if err != nil {
@@ -168,8 +168,8 @@ func (s *AzureAppConfigParamStrategy) ParseSpec(input string) (name string, hasV
 	return spec.Name, false, nil
 }
 
-// FetchVersion fetches the current value. Version specifiers are rejected at
-// parse time, so this only ever resolves the current (unversioned) value.
+// FetchVersion fetches the current value. App Configuration is unversioned and
+// the entire argument is the key, so this only ever resolves the current value.
 func (s *AzureAppConfigParamStrategy) FetchVersion(ctx context.Context, input string) (value string, versionLabel string, err error) {
 	spec, err := azureappconfigversion.Parse(input)
 	if err != nil {

--- a/internal/staging/azure_appconfig_param_test.go
+++ b/internal/staging/azure_appconfig_param_test.go
@@ -265,20 +265,22 @@ func TestAzureAppConfigParamStrategy_ParseAndVersion(t *testing.T) {
 
 	s := staging.NewAzureAppConfigParamStrategy(&providermock.Store{})
 
-	t.Run("ParseName: bare name ok, specifiers rejected", func(t *testing.T) {
+	t.Run("ParseName: whole argument is the key, including specifier-like chars", func(t *testing.T) {
 		t.Parallel()
 
 		name, err := s.ParseName("cfg")
 		require.NoError(t, err)
 		assert.Equal(t, "cfg", name)
 
-		for _, spec := range []string{"cfg#1", "cfg~1", "cfg:lbl"} {
-			_, err := s.ParseName(spec)
-			require.Error(t, err, spec)
+		// ':' / '#' / '~' are legal App Configuration key characters (#353).
+		for _, key := range []string{"cfg#1", "cfg~1", "cfg:lbl", "Logging:LogLevel:Default"} {
+			got, err := s.ParseName(key)
+			require.NoError(t, err, key)
+			assert.Equal(t, key, got)
 		}
 	})
 
-	t.Run("ParseSpec: bare name has no version, specifier errors", func(t *testing.T) {
+	t.Run("ParseSpec: whole argument is the key, never has a version", func(t *testing.T) {
 		t.Parallel()
 
 		name, hasVersion, err := s.ParseSpec("cfg")
@@ -286,8 +288,10 @@ func TestAzureAppConfigParamStrategy_ParseAndVersion(t *testing.T) {
 		assert.Equal(t, "cfg", name)
 		assert.False(t, hasVersion)
 
-		_, _, err = s.ParseSpec("cfg#1")
-		require.Error(t, err)
+		name, hasVersion, err = s.ParseSpec("cfg#1")
+		require.NoError(t, err)
+		assert.Equal(t, "cfg#1", name)
+		assert.False(t, hasVersion)
 	})
 
 	t.Run("FetchVersion resolves current for a bare name", func(t *testing.T) {
@@ -306,11 +310,21 @@ func TestAzureAppConfigParamStrategy_ParseAndVersion(t *testing.T) {
 		assert.Equal(t, "current", label)
 	})
 
-	t.Run("FetchVersion rejects a version specifier", func(t *testing.T) {
+	t.Run("FetchVersion resolves a specifier-like key as the whole key", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, err := s.FetchVersion(t.Context(), "cfg#1")
-		require.Error(t, err)
+		store := &providermock.Store{
+			GetFunc: func(_ context.Context, name string, ref provider.VersionRef) (*domain.Entry, error) {
+				assert.Equal(t, "cfg#1", name)
+				assert.True(t, ref.IsLatest())
+
+				return &domain.Entry{Value: "current"}, nil
+			},
+		}
+		value, label, err := staging.NewAzureAppConfigParamStrategy(store).FetchVersion(t.Context(), "cfg#1")
+		require.NoError(t, err)
+		assert.Equal(t, "current", value)
+		assert.Equal(t, "current", label)
 	})
 
 	t.Run("FetchVersion propagates get error", func(t *testing.T) {

--- a/internal/version/azureappconfigversion/spec.go
+++ b/internal/version/azureappconfigversion/spec.go
@@ -2,21 +2,28 @@
 // Configuration (bare key names only).
 //
 // Azure App Configuration has NO versioning: a key/label pair holds a single
-// current value with no version history. This parser therefore accepts a bare
-// name only; ANY version specifier (#VERSION, ~SHIFT, or :LABEL) is rejected at
-// parse time with ErrVersioningUnsupported, so the mistake produces a clean
-// error before any API call rather than reaching the provider.
+// current value with no version history. It also imposes almost no restriction
+// on key characters — ':' is the standard ASP.NET configuration-hierarchy
+// separator (e.g. "Logging:LogLevel:Default"), and '#', '~' are legal too.
+//
+// Because there are no version specifiers to parse, this parser performs NO
+// specifier splitting at all: the entire argument is taken verbatim as the key
+// name. This is what makes keys containing ':', '#', or '~' addressable — the
+// previous behavior mis-read those characters as (unsupported) version
+// specifiers and rejected the key outright.
 package azureappconfigversion
 
 import (
 	"errors"
+	"strings"
 
-	"github.com/mpyw/suve/internal/cli/diffargs"
 	"github.com/mpyw/suve/internal/version"
 )
 
-// ErrVersioningUnsupported is returned when any version specifier (#VERSION,
-// ~SHIFT, or :LABEL) is used. Azure App Configuration does not support versions.
+// ErrVersioningUnsupported is returned by the provider's History (App
+// Configuration keeps no version history). Version specifiers are no longer
+// rejected at parse time — they are legal key characters — so this is not
+// produced by Parse.
 var ErrVersioningUnsupported = errors.New("the Azure App Configuration store does not support versions")
 
 // AbsoluteSpec is empty: Azure App Configuration has no absolute version
@@ -25,72 +32,53 @@ type AbsoluteSpec struct{}
 
 // Spec represents a parsed Azure App Configuration "version" specification.
 //
-// Grammar: <name>  (bare name only; no specifiers permitted)
+// Grammar: <name>  (the whole argument is the key; nothing is split off)
 //
-// Examples: my-key, /app/config. Any #VERSION, ~SHIFT, or :LABEL is rejected.
+// Examples: my-key, /app/config, Logging:LogLevel:Default, weird#key, a~b.
 type Spec = version.Spec[AbsoluteSpec]
 
-// parser rejects the two absolute specifier prefixes ('#', ':') cleanly: their
-// IsChar never matches, so findNameEnd returns ErrVersioningUnsupported instead
-// of folding the prefix into the name. The '~' shift is handled by the shared
-// framework (it is not a configurable prefix) and is rejected post-parse in
-// Parse via HasShift.
-//
-//nolint:gochecknoglobals // stateless parser configuration
-var parser = version.AbsoluteParser[AbsoluteSpec]{
-	Parsers: []version.SpecifierParser[AbsoluteSpec]{
-		{
-			PrefixChar: '#',
-			IsChar:     func(byte) bool { return false },
-			Error:      ErrVersioningUnsupported,
-			Apply: func(_ string, abs AbsoluteSpec) (AbsoluteSpec, error) {
-				return abs, ErrVersioningUnsupported
-			},
-		},
-		{
-			PrefixChar: ':',
-			IsChar:     func(byte) bool { return false },
-			Error:      ErrVersioningUnsupported,
-			Apply: func(_ string, abs AbsoluteSpec) (AbsoluteSpec, error) {
-				return abs, ErrVersioningUnsupported
-			},
-		},
-	},
-	Zero: func() AbsoluteSpec {
-		return AbsoluteSpec{}
-	},
-}
-
-// Parse parses an Azure App Configuration key specification string. It accepts a
-// bare name only; any version specifier yields ErrVersioningUnsupported.
-//
-// Empty-input and empty-name errors from the shared grammar are surfaced
-// unchanged; every other parse failure (a '#'/':' specifier, or a '~' shift) is
-// normalized to ErrVersioningUnsupported so the caller gets one clear message.
+// Parse parses an Azure App Configuration key specification string. The entire
+// (whitespace-trimmed) input is the key name; no version specifier is split
+// off, so ':' / '#' / '~' are preserved verbatim. Empty input yields
+// version.ErrEmptySpec.
 func Parse(input string) (*Spec, error) {
-	spec, err := version.Parse(input, parser)
-
-	switch {
-	case errors.Is(err, version.ErrEmptySpec), errors.Is(err, version.ErrEmptyName):
-		return nil, err
-	case err != nil:
-		return nil, ErrVersioningUnsupported
-	case spec.HasShift():
-		return nil, ErrVersioningUnsupported
+	name := strings.TrimSpace(input)
+	if name == "" {
+		return nil, version.ErrEmptySpec
 	}
 
-	return spec, nil
+	return &Spec{Name: name}, nil
 }
 
-// ParseDiffArgs parses diff command arguments for Azure App Configuration. Two
-// bare keys may be compared; any version specifier yields
-// ErrVersioningUnsupported.
+// ParseDiffArgs parses diff command arguments for Azure App Configuration.
+//
+// Since keys are unversioned and carry no specifiers, only one or two bare keys
+// are accepted (a single key compares against itself). The generic name+specifier
+// concatenation used by versioned stores does not apply here.
 func ParseDiffArgs(args []string) (*Spec, *Spec, error) {
-	return diffargs.ParseArgs(
-		args,
-		Parse,
-		func(AbsoluteSpec) bool { return false },
-		"",
-		"usage: suve azure param diff <key1> [key2]",
-	)
+	const usage = "usage: suve azure param diff <key1> [key2]"
+
+	switch len(args) {
+	case 1:
+		spec, err := Parse(args[0])
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return spec, &Spec{Name: spec.Name}, nil
+	case 2: //nolint:mnd // two-key comparison
+		spec1, err := Parse(args[0])
+		if err != nil {
+			return nil, nil, err
+		}
+
+		spec2, err := Parse(args[1])
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return spec1, spec2, nil
+	default:
+		return nil, nil, errors.New(usage)
+	}
 }

--- a/internal/version/azureappconfigversion/spec_test.go
+++ b/internal/version/azureappconfigversion/spec_test.go
@@ -29,7 +29,7 @@ func TestParse(t *testing.T) {
 			wantName: "app/config/timeout",
 		},
 		{
-			name:     "name with dots and colons in the middle are fine only if not a specifier",
+			name:     "name with dots",
 			input:    "app.timeout",
 			wantName: "app.timeout",
 		},
@@ -39,78 +39,80 @@ func TestParse(t *testing.T) {
 			wantName: "my-key",
 		},
 
-		// ANY version specifier is rejected (App Configuration is unversioned).
+		// Characters that look like version specifiers are legal key characters
+		// in App Configuration and are preserved verbatim (the #353 regression).
 		{
-			name:    "version number rejected",
-			input:   "my-key#3",
-			wantErr: true,
+			name:     "colon-separated ASP.NET-style key",
+			input:    "Logging:LogLevel:Default",
+			wantName: "Logging:LogLevel:Default",
 		},
 		{
-			name:    "version id rejected",
-			input:   "my-key#abc123",
-			wantErr: true,
+			name:     "hash in key preserved",
+			input:    "my-key#3",
+			wantName: "my-key#3",
 		},
 		{
-			name:    "single shift rejected",
-			input:   "my-key~",
-			wantErr: true,
+			name:     "hash id in key preserved",
+			input:    "my-key#abc123",
+			wantName: "my-key#abc123",
 		},
 		{
-			name:    "numeric shift rejected",
-			input:   "my-key~2",
-			wantErr: true,
+			name:     "trailing tilde preserved",
+			input:    "my-key~",
+			wantName: "my-key~",
 		},
 		{
-			name:    "double tilde rejected",
-			input:   "my-key~~",
-			wantErr: true,
+			name:     "tilde with number preserved",
+			input:    "my-key~2",
+			wantName: "my-key~2",
 		},
 		{
-			name:    "label rejected",
-			input:   "my-key:prod",
-			wantErr: true,
+			name:     "double tilde preserved",
+			input:    "my-key~~",
+			wantName: "my-key~~",
 		},
 		{
-			name:    "hash at end rejected",
-			input:   "my-key#",
-			wantErr: true,
+			name:     "single label-like colon preserved",
+			input:    "my-key:prod",
+			wantName: "my-key:prod",
 		},
 		{
-			name:    "colon at end rejected",
-			input:   "my-key:",
-			wantErr: true,
+			name:     "trailing hash preserved",
+			input:    "my-key#",
+			wantName: "my-key#",
 		},
-
-		// Additional accepted bare names (no version specifier present).
+		{
+			name:     "trailing colon preserved",
+			input:    "my-key:",
+			wantName: "my-key:",
+		},
 		{
 			name:     "name with @ allowed",
 			input:    "user@example.com",
 			wantName: "user@example.com",
 		},
 		{
-			name:     "shift zero collapses to a bare name",
+			name:     "tilde-zero preserved verbatim",
 			input:    "my-key~0",
-			wantName: "my-key",
+			wantName: "my-key~0",
+		},
+		{
+			name:     "cumulative-shift-like key preserved",
+			input:    "my-key~1~2",
+			wantName: "my-key~1~2",
+		},
+		{
+			name:     "hash-and-tilde key preserved",
+			input:    "my-key#abc~1",
+			wantName: "my-key#abc~1",
+		},
+		{
+			name:     "multiple colons preserved",
+			input:    "a:b:c",
+			wantName: "a:b:c",
 		},
 
-		// Additional rejected version specifiers.
-		{
-			name:    "cumulative shift rejected",
-			input:   "my-key~1~2",
-			wantErr: true,
-		},
-		{
-			name:    "version id with shift rejected",
-			input:   "my-key#abc~1",
-			wantErr: true,
-		},
-		{
-			name:    "multiple colons rejected",
-			input:   "a:b:c",
-			wantErr: true,
-		},
-
-		// Empty-input errors are surfaced (not normalized to unsupported).
+		// Empty-input errors are surfaced.
 		{
 			name:    "empty input",
 			input:   "",
@@ -140,26 +142,15 @@ func TestParse(t *testing.T) {
 	}
 }
 
-func TestParse_VersionSpecErrorIsUnsupported(t *testing.T) {
+// TestParse_SpecifierLikeKeysAccepted verifies that keys containing what would
+// be version specifiers in versioned stores are accepted verbatim (#353).
+func TestParse_SpecifierLikeKeysAccepted(t *testing.T) {
 	t.Parallel()
 
-	for _, input := range []string{"my-key#3", "my-key~1", "my-key:prod", "my-key#abc"} {
-		_, err := azureappconfigversion.Parse(input)
-		require.Error(t, err)
-		require.ErrorIs(t, err, azureappconfigversion.ErrVersioningUnsupported, "input=%q", input)
-	}
-}
-
-// TestParse_EmptyErrorsNotNormalized verifies that empty-input and empty-name
-// errors from the shared grammar are surfaced unchanged rather than being
-// collapsed into ErrVersioningUnsupported.
-func TestParse_EmptyErrorsNotNormalized(t *testing.T) {
-	t.Parallel()
-
-	for _, input := range []string{"", "   "} {
-		_, err := azureappconfigversion.Parse(input)
-		require.Error(t, err)
-		require.NotErrorIs(t, err, azureappconfigversion.ErrVersioningUnsupported, "input=%q", input)
+	for _, input := range []string{"my-key#3", "my-key~1", "my-key:prod", "Logging:LogLevel:Default"} {
+		spec, err := azureappconfigversion.Parse(input)
+		require.NoError(t, err, "input=%q", input)
+		assert.Equal(t, input, spec.Name)
 	}
 }
 
@@ -184,18 +175,22 @@ func TestParseDiffArgs(t *testing.T) {
 		assert.Equal(t, "key-b", spec2.Name)
 	})
 
-	t.Run("version spec rejected", func(t *testing.T) {
+	t.Run("single key containing hash compares against itself", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, err := azureappconfigversion.ParseDiffArgs([]string{"my-key#1"})
-		require.Error(t, err)
+		spec1, spec2, err := azureappconfigversion.ParseDiffArgs([]string{"my-key#1"})
+		require.NoError(t, err)
+		assert.Equal(t, "my-key#1", spec1.Name)
+		assert.Equal(t, "my-key#1", spec2.Name)
 	})
 
-	t.Run("name plus specifier-only arg rejected", func(t *testing.T) {
+	t.Run("two keys where the second contains a hash", func(t *testing.T) {
 		t.Parallel()
 
-		_, _, err := azureappconfigversion.ParseDiffArgs([]string{"my-key", "#1"})
-		require.Error(t, err)
+		spec1, spec2, err := azureappconfigversion.ParseDiffArgs([]string{"my-key", "#1"})
+		require.NoError(t, err)
+		assert.Equal(t, "my-key", spec1.Name)
+		assert.Equal(t, "#1", spec2.Name)
 	})
 
 	t.Run("three args rejected", func(t *testing.T) {


### PR DESCRIPTION
## Problem

App Configuration is unversioned and imposes almost no restriction on key characters: `:` is the standard ASP.NET config-hierarchy separator (e.g. `Logging:LogLevel:Default`), and `#`/`~` are legal too. The spec parser treated those characters as (unsupported) version specifiers and rejected the key with a misleading `does not support versions` error — so such keys could be **listed but never shown, staged, or diffed**.

## Fix

Since there are no version specifiers to parse for App Config, stop splitting entirely:

- `azureappconfigversion.Parse` now takes the whole (trimmed) argument as the key name; `:` / `#` / `~` are preserved verbatim.
- `ParseDiffArgs` accepts one or two bare keys (the generic name+specifier concatenation is meaningless for an unversioned store).
- The provider `Resolve` now rejects only a genuinely non-empty version specifier — which the CLI never produces for App Config — instead of re-parsing `name+spec`.

## Tests

Updated the parser / GUI / command / provider / staging tests that previously encoded the rejection to assert the keys are now preserved verbatim, and added ASP.NET-style colon-key cases.

`mise test` and `mise lint` pass.

Closes #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD