### PR TITLE
fix(staging): surface hard keychain failures instead of silent plaintext fallback (#330)

### DIFF
--- a/internal/staging/store/file/internal/keyprovider/keyprovider.go
+++ b/internal/staging/store/file/internal/keyprovider/keyprovider.go
@@ -7,8 +7,15 @@
 //     If set but invalid, a clear error is returned (no silent fall-through).
 //  2. Otherwise the OS keychain (get-or-create): fetch the stored key, or
 //     generate 32 random bytes, store them, and use them.
-//  3. Otherwise (keychain unavailable/errors and no env var): plaintext, with
-//     the caller expected to warn the user once.
+//  3. Otherwise (no keyring backend on this platform): plaintext, with the
+//     caller expected to warn the user once.
+//
+// A HARD keychain failure (locked keychain, unreachable dbus, corrupted stored
+// key, failed store) is NOT silently downgraded to plaintext: it is returned as
+// a *KeychainUnavailableError so the caller can surface the real cause instead
+// of letting a nil key later produce a misleading "wrong passphrase" error.
+// Only a platform with no keyring backend at all (keyring.ErrUnsupportedPlatform)
+// takes the plaintext fallback.
 //
 // No passphrase prompt is used for the working store: prompting on every
 // staging operation would defeat the purpose of the keychain. This is an
@@ -51,12 +58,28 @@ var (
 	randReader     = rand.Reader
 )
 
+// KeychainUnavailableError wraps a hard OS-keychain failure — a locked
+// keychain, an unreachable dbus, a corrupted stored key, or a failed store.
+//
+// It is distinct from a platform with no keyring backend at all (which yields
+// the documented plaintext fallback) and from a bad SUVE_STAGING_KEY (a plain
+// configuration error). Callers use errors.As to decide whether a plaintext
+// fallback is still acceptable (no encrypted state yet) or the error must be
+// surfaced (encrypted state exists).
+type KeychainUnavailableError struct{ Err error }
+
+func (e *KeychainUnavailableError) Error() string {
+	return "OS keychain unavailable: " + e.Err.Error()
+}
+
+func (e *KeychainUnavailableError) Unwrap() error { return e.Err }
+
 // Resolve returns the data key for the working staging store.
 //
 // The returned key is 32 bytes when plaintext is false. When plaintext is
 // true, key is nil and the caller should operate without encryption (and warn
-// the user once). err is non-nil only for unrecoverable configuration errors
-// (currently: an invalid SUVE_STAGING_KEY value).
+// the user once). err is non-nil for an invalid SUVE_STAGING_KEY value or for a
+// hard keychain failure (as a *KeychainUnavailableError).
 func Resolve() (key []byte, plaintext bool, err error) {
 	// 1. Environment variable override.
 	if raw, ok := lookupEnvFunc(EnvStagingKey); ok {
@@ -70,12 +93,17 @@ func Resolve() (key []byte, plaintext bool, err error) {
 
 	// 2. OS keychain get-or-create.
 	k, kcErr := getOrCreateKeychainKey()
-	if kcErr == nil {
-		return k, false, nil
-	}
 
-	// 3. Plaintext fallback.
-	return nil, true, nil
+	switch {
+	case kcErr == nil:
+		return k, false, nil
+	case errors.Is(kcErr, keyring.ErrUnsupportedPlatform):
+		// 3. No keyring backend on this platform: documented plaintext fallback.
+		return nil, true, nil
+	default:
+		// Hard keychain failure: surfaced, never silently downgraded.
+		return nil, false, &KeychainUnavailableError{Err: kcErr}
+	}
 }
 
 // decodeEnvKey decodes and validates the env-var key.

--- a/internal/staging/store/file/internal/keyprovider/keyprovider_test.go
+++ b/internal/staging/store/file/internal/keyprovider/keyprovider_test.go
@@ -102,15 +102,16 @@ func TestResolve_Keychain_GetOrCreate(t *testing.T) {
 	})
 }
 
+// TestResolve_UnsupportedPlatform_Plaintext: a platform with no keyring backend
+// takes the documented plaintext fallback.
+//
 //nolint:paralleltest // overrides package-level hook vars.
-func TestResolve_PlaintextFallback(t *testing.T) {
+//nolint:paralleltest // overrides package-level hook vars.
+func TestResolve_UnsupportedPlatform_Plaintext(t *testing.T) {
 	withHooks(t, func() {
 		lookupEnvFunc = func(string) (string, bool) { return "", false }
 		keyringGetFunc = func(string, string) (string, error) {
-			return "", errors.New("keychain unavailable")
-		}
-		keyringSetFunc = func(string, string, string) error {
-			return errors.New("keychain unavailable")
+			return "", keyring.ErrUnsupportedPlatform
 		}
 
 		key, plaintext, err := Resolve()
@@ -120,8 +121,33 @@ func TestResolve_PlaintextFallback(t *testing.T) {
 	})
 }
 
+// TestResolve_HardKeychainError_Surfaced: a hard Get failure (locked keychain,
+// unreachable dbus) is surfaced as a *KeychainUnavailableError, NOT silently
+// downgraded to plaintext.
+//
 //nolint:paralleltest // overrides package-level hook vars.
-func TestResolve_Keychain_SetError_FallsBackToPlaintext(t *testing.T) {
+func TestResolve_HardKeychainError_Surfaced(t *testing.T) {
+	withHooks(t, func() {
+		lookupEnvFunc = func(string) (string, bool) { return "", false }
+		keyringGetFunc = func(string, string) (string, error) {
+			return "", errors.New("keychain locked")
+		}
+
+		key, plaintext, err := Resolve()
+		require.Error(t, err)
+		assert.False(t, plaintext)
+		assert.Nil(t, key)
+
+		var kcErr *KeychainUnavailableError
+		require.ErrorAs(t, err, &kcErr)
+	})
+}
+
+// TestResolve_SetError_Surfaced: a failed store (Get says not-found, Set fails)
+// is a hard error, surfaced rather than silently downgraded.
+//
+//nolint:paralleltest // overrides package-level hook vars.
+func TestResolve_SetError_Surfaced(t *testing.T) {
 	withHooks(t, func() {
 		lookupEnvFunc = func(string) (string, bool) { return "", false }
 		keyringGetFunc = func(string, string) (string, error) {
@@ -131,9 +157,29 @@ func TestResolve_Keychain_SetError_FallsBackToPlaintext(t *testing.T) {
 			return errors.New("cannot write to keychain")
 		}
 
-		key, plaintext, err := Resolve()
-		require.NoError(t, err)
-		assert.True(t, plaintext)
-		assert.Nil(t, key)
+		_, plaintext, err := Resolve()
+		require.Error(t, err)
+		assert.False(t, plaintext)
+
+		var kcErr *KeychainUnavailableError
+		require.ErrorAs(t, err, &kcErr)
+	})
+}
+
+// TestResolve_CorruptStoredKey_Surfaced: a corrupted stored key is a hard error.
+//
+//nolint:paralleltest // overrides package-level hook vars.
+func TestResolve_CorruptStoredKey_Surfaced(t *testing.T) {
+	withHooks(t, func() {
+		lookupEnvFunc = func(string) (string, bool) { return "", false }
+		keyringGetFunc = func(string, string) (string, error) {
+			return "!!not-base64!!", nil
+		}
+
+		_, _, err := Resolve()
+		require.Error(t, err)
+
+		var kcErr *KeychainUnavailableError
+		require.ErrorAs(t, err, &kcErr)
 	})
 }

--- a/internal/staging/store/file/store.go
+++ b/internal/staging/store/file/store.go
@@ -16,6 +16,7 @@ package file
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -121,18 +122,35 @@ func NewWorkingStore(scope provider.Scope) (*Store, error) {
 
 	key, plaintext, err := resolveKeyFunc()
 	if err != nil {
+		// A hard keychain failure (as opposed to a genuinely absent keyring
+		// backend or a bad SUVE_STAGING_KEY) is fatal ONLY when encrypted state
+		// already exists: reading it needs the key, so the real keychain cause
+		// must be surfaced instead of letting a nil key later fail with a
+		// misleading "wrong passphrase" error. With no encrypted state yet, the
+		// tool stays usable via the documented plaintext fallback (e.g. on
+		// headless CI without a keyring), warning the user once.
+		var kcErr *keyprovider.KeychainUnavailableError
+		if errors.As(err, &kcErr) {
+			encrypted, encErr := s.IsEncrypted()
+			if encErr != nil {
+				return nil, fmt.Errorf("failed to check staging state encryption: %w", encErr)
+			}
+
+			if encrypted {
+				return nil, fmt.Errorf(
+					"cannot access the staging encryption key while encrypted state exists: %w", err)
+			}
+
+			warnPlaintextOnce(err)
+
+			return s, nil
+		}
+
 		return nil, fmt.Errorf("failed to resolve staging encryption key: %w", err)
 	}
 
 	if plaintext {
-		plaintextWarnOnce.Do(func() {
-			// Direct stderr write: this low-level store package intentionally
-			// avoids depending on the cli/output package.
-			//nolint:forbidigo // one-time operator warning to stderr.
-			fmt.Fprintln(os.Stderr,
-				"warning: staging state is stored UNENCRYPTED; "+
-					"set SUVE_STAGING_KEY or enable an OS keychain to encrypt")
-		})
+		warnPlaintextOnce(nil)
 
 		return s, nil
 	}
@@ -140,6 +158,24 @@ func NewWorkingStore(scope provider.Scope) (*Store, error) {
 	s.key = key
 
 	return s, nil
+}
+
+// warnPlaintextOnce emits the unencrypted-storage warning once per process. When
+// cause is non-nil (a hard keychain failure that degraded to plaintext), the
+// underlying keychain error is included so the operator can diagnose it.
+func warnPlaintextOnce(cause error) {
+	plaintextWarnOnce.Do(func() {
+		msg := "warning: staging state is stored UNENCRYPTED; " +
+			"set SUVE_STAGING_KEY or enable an OS keychain to encrypt"
+		if cause != nil {
+			msg += "\nwarning: " + cause.Error()
+		}
+
+		// Direct stderr write: this low-level store package intentionally
+		// avoids depending on the cli/output package.
+		//nolint:forbidigo // one-time operator warning to stderr.
+		fmt.Fprintln(os.Stderr, msg)
+	})
 }
 
 // NewStoreWithPath creates a new single-file Store with a custom state file path.

--- a/internal/staging/store/file/store_key_internal_test.go
+++ b/internal/staging/store/file/store_key_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store/file/internal/crypt"
+	"github.com/mpyw/suve/internal/staging/store/file/internal/keyprovider"
 )
 
 func newTestKey() []byte {
@@ -164,4 +165,72 @@ func TestNewWorkingStore_ResolveError(t *testing.T) {
 	require.Error(t, err)
 	assert.Nil(t, s)
 	assert.Contains(t, err.Error(), "failed to resolve staging encryption key")
+}
+
+// TestNewWorkingStore_KeychainError_NoEncryptedState_Plaintext verifies that a
+// hard keychain failure degrades to plaintext when no encrypted state exists
+// yet (so the tool stays usable on e.g. headless CI without a keyring).
+//
+//nolint:paralleltest // overrides package-level resolveKeyFunc.
+func TestNewWorkingStore_KeychainError_NoEncryptedState_Plaintext(t *testing.T) {
+	origResolve := resolveKeyFunc
+	origHome := userHomeDirFunc
+
+	defer func() {
+		resolveKeyFunc = origResolve
+		userHomeDirFunc = origHome
+	}()
+
+	userHomeDirFunc = func() (string, error) { return t.TempDir(), nil }
+	resolveKeyFunc = func() ([]byte, bool, error) {
+		return nil, false, &keyprovider.KeychainUnavailableError{Err: errors.New("dbus down")}
+	}
+
+	s, err := NewWorkingStore(provider.AWSScope("123456789012", "ap-northeast-1"))
+	require.NoError(t, err)
+	assert.Nil(t, s.key)
+}
+
+// TestNewWorkingStore_KeychainError_EncryptedStateExists_Fatal verifies that a
+// hard keychain failure is surfaced (not downgraded) when encrypted state
+// already exists — the real cause must reach the user instead of a later
+// misleading "wrong passphrase" decryption error.
+//
+//nolint:paralleltest // overrides package-level resolveKeyFunc.
+func TestNewWorkingStore_KeychainError_EncryptedStateExists_Fatal(t *testing.T) {
+	origResolve := resolveKeyFunc
+	origHome := userHomeDirFunc
+
+	defer func() {
+		resolveKeyFunc = origResolve
+		userHomeDirFunc = origHome
+	}()
+
+	home := t.TempDir()
+	userHomeDirFunc = func() (string, error) { return home, nil }
+
+	scope := provider.AWSScope("123456789012", "ap-northeast-1")
+
+	// Seed an ENCRYPTED param.json under the scope directory.
+	seed, err := NewStore(scope)
+	require.NoError(t, err)
+
+	seed.key = newTestKey()
+
+	state := staging.NewEmptyState()
+	state.Entries[staging.ServiceParam]["/app/secret"] = staging.Entry{
+		Operation: staging.OperationCreate,
+		Value:     lo.ToPtr("v"),
+	}
+	require.NoError(t, seed.WriteState(t.Context(), "", state))
+
+	resolveKeyFunc = func() ([]byte, bool, error) {
+		return nil, false, &keyprovider.KeychainUnavailableError{Err: errors.New("keychain locked")}
+	}
+
+	s, err := NewWorkingStore(scope)
+	require.Error(t, err)
+	assert.Nil(t, s)
+	assert.Contains(t, err.Error(), "keychain locked")
+	assert.Contains(t, err.Error(), "encrypted state exists")
 }


### PR DESCRIPTION
## Problem

`keyprovider.Resolve` treated **any** keychain failure as "operate in plaintext":

- a locked keychain, unreachable dbus, corrupted stored key, or failed `keyring.Set` silently wrote new secret values **UNENCRYPTED** (one stderr warning only);
- worse, when encrypted state already existed, later reads failed with `decryption failed: wrong passphrase or corrupted data`, hiding the real keychain cause (including the `stored keychain key is corrupted` diagnostic).

The `SUVE_STAGING_KEY` path was strict; the keychain path was not.

## Fix

Distinguish "keychain unavailable by design" from a hard failure:

- **No keyring backend on this platform** (`keyring.ErrUnsupportedPlatform`) → documented plaintext fallback, unchanged.
- **Hard keychain failure** → returned as a new `*KeychainUnavailableError`. `NewWorkingStore`:
  - **surfaces** it when encrypted state already exists (the key is needed to read it — no more misleading "wrong passphrase");
  - degrades to plaintext only when there is no encrypted state to misread, and the one-time warning now **names the keychain cause**. This keeps headless CI without a keyring usable.
- A bad `SUVE_STAGING_KEY` remains an unconditional configuration error.

## Tests

Updated the keyprovider tests (previously asserting silent plaintext on generic/Set errors) to the new distinction, and added store-level tests for both branches (no-encrypted-state → plaintext; encrypted-state-exists → fatal with the real cause).

`mise test` and `mise lint` pass.

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD