### PR TITLE
fix(staging): apply tag-only staged changes in service-specific apply (#329)

### DIFF
--- a/internal/staging/cli/apply.go
+++ b/internal/staging/cli/apply.go
@@ -48,22 +48,34 @@ type ApplyOptions struct {
 func (r *ApplyRunner) RunInteractive(ctx context.Context, opts ApplyOptions) error {
 	service := r.Parser.Service()
 
-	// Get entries to show what will be applied
+	// Get entries and staged tag changes to show what will be applied. Tag-only
+	// changes (a staged tag with no staged entry) are valid applies, so both
+	// must feed the has-changes check, name validation, and confirmation count.
 	entries, err := r.Store.ListEntries(ctx, service)
 	if err != nil {
 		return err
 	}
 
+	tags, err := r.Store.ListTags(ctx, service)
+	if err != nil {
+		return err
+	}
+
 	serviceEntries := entries[service]
-	if len(serviceEntries) == 0 {
+	serviceTags := tags[service]
+
+	if len(serviceEntries) == 0 && len(serviceTags) == 0 {
 		output.Info(r.Stdout, "No %s changes staged.", r.Parser.ServiceName())
 
 		return nil
 	}
 
-	// Validate the target name if specified
+	// Validate the target name if specified: staged as an entry OR a tag change.
 	if opts.Name != "" {
-		if _, ok := serviceEntries[opts.Name]; !ok {
+		_, entryStaged := serviceEntries[opts.Name]
+		_, tagStaged := serviceTags[opts.Name]
+
+		if !entryStaged && !tagStaged {
 			return fmt.Errorf("%s is not staged", opts.Name)
 		}
 	}
@@ -73,7 +85,8 @@ func (r *ApplyRunner) RunInteractive(ctx context.Context, opts ApplyOptions) err
 	if opts.Name != "" {
 		message = fmt.Sprintf("Apply staged changes for %s to AWS?", opts.Name)
 	} else {
-		message = fmt.Sprintf("Apply %d staged %s change(s) to AWS?", len(serviceEntries), r.Parser.ServiceName())
+		total := len(serviceEntries) + len(serviceTags)
+		message = fmt.Sprintf("Apply %d staged %s change(s) to AWS?", total, r.Parser.ServiceName())
 	}
 
 	confirmed, err := r.Confirmer.Confirm(message, r.SkipConfirm)

--- a/internal/staging/cli/cli_test.go
+++ b/internal/staging/cli/cli_test.go
@@ -1830,6 +1830,95 @@ func TestApplyRunner_WithTags(t *testing.T) {
 	})
 }
 
+// stubConfirmer is a Confirmer that returns a fixed reply and records whether
+// it was asked (so tests can assert the apply flow reached confirmation rather
+// than short-circuiting on "no changes staged").
+type stubConfirmer struct {
+	reply   bool
+	called  bool
+	message string
+}
+
+func (c *stubConfirmer) Confirm(message string, _ bool) (bool, error) {
+	c.called = true
+	c.message = message
+
+	return c.reply, nil
+}
+
+// TestApplyRunner_RunInteractive_TagOnly covers the service-specific interactive
+// apply flow for tag-only staged changes (#329): a staged tag with no staged
+// entry must not be reported as "No changes staged", must be counted, and must
+// be a valid name-filtered target.
+func TestApplyRunner_RunInteractive_TagOnly(t *testing.T) {
+	t.Parallel()
+
+	newRunner := func(store *testutil.MockStore, conf *stubConfirmer, out, errOut *bytes.Buffer) *cli.ApplyRunner {
+		return &cli.ApplyRunner{
+			UseCase: &stagingusecase.ApplyUseCase{
+				Strategy: &fullMockStrategy{service: staging.ServiceParam},
+				Store:    store,
+			},
+			Store:     store,
+			Parser:    &fullMockStrategy{service: staging.ServiceParam},
+			Confirmer: conf,
+			Stdout:    out,
+			Stderr:    errOut,
+		}
+	}
+
+	t.Run("tag-only staged is applied, not reported as no changes", func(t *testing.T) {
+		t.Parallel()
+
+		store := testutil.NewMockStore()
+		_ = store.StageTag(t.Context(), staging.ServiceParam, "/app/config", staging.TagEntry{
+			Add:      map[string]string{"env": "prod"},
+			StagedAt: time.Now(),
+		})
+
+		var stdout, stderr bytes.Buffer
+
+		conf := &stubConfirmer{reply: true}
+		require.NoError(t, newRunner(store, conf, &stdout, &stderr).RunInteractive(t.Context(), cli.ApplyOptions{}))
+
+		assert.True(t, conf.called, "expected confirmation to be asked")
+		assert.Contains(t, conf.message, "1 staged")
+		assert.NotContains(t, stdout.String(), "No param changes staged")
+		assert.Contains(t, stdout.String(), "Tagged")
+	})
+
+	t.Run("name-filtered apply accepts a tag-only name", func(t *testing.T) {
+		t.Parallel()
+
+		store := testutil.NewMockStore()
+		_ = store.StageTag(t.Context(), staging.ServiceParam, "/app/config", staging.TagEntry{
+			Add:      map[string]string{"env": "prod"},
+			StagedAt: time.Now(),
+		})
+
+		var stdout, stderr bytes.Buffer
+
+		conf := &stubConfirmer{reply: true}
+		err := newRunner(store, conf, &stdout, &stderr).RunInteractive(t.Context(), cli.ApplyOptions{Name: "/app/config"})
+		require.NoError(t, err)
+		assert.True(t, conf.called)
+	})
+
+	t.Run("empty store still reports no changes", func(t *testing.T) {
+		t.Parallel()
+
+		store := testutil.NewMockStore()
+
+		var stdout, stderr bytes.Buffer
+
+		conf := &stubConfirmer{reply: true}
+		require.NoError(t, newRunner(store, conf, &stdout, &stderr).RunInteractive(t.Context(), cli.ApplyOptions{}))
+
+		assert.False(t, conf.called, "empty store must short-circuit before confirmation")
+		assert.Contains(t, stdout.String(), "No param changes staged")
+	})
+}
+
 // =============================================================================
 // StatusRunner Tag Tests
 // =============================================================================


### PR DESCRIPTION
## Problem

`ApplyRunner.RunInteractive` (the `stage <service> apply` flow) checked only `ListEntries`. With a staged **tag** but no staged **entry**:

- `suve stage param apply` printed `No parameter changes staged.` and returned without applying;
- a name-filtered apply rejected a tag-only name as `not staged`;
- the confirmation count omitted tags.

`ApplyUseCase` itself supports tag-only applies, and the global `suve stage apply` counts tags correctly — only the service-specific path was broken.

## Fix

Fetch `ListTags` alongside `ListEntries` and use both in the has-changes short-circuit, the target-name validation, and the confirmation count (`entries + tags`), matching the global apply path.

## Tests

Added `RunInteractive` coverage: tag-only apply proceeds (and is counted), a tag-only name is a valid `--name` target, and an empty store still short-circuits before confirmation.

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD