### PR TITLE
fix(staging): let global stash push prompt when the stash is encrypted (#328)

### DIFF
--- a/internal/staging/cli/stash_push.go
+++ b/internal/staging/cli/stash_push.go
@@ -114,6 +114,36 @@ func stashPushMutuallyExclusiveFlags() []cli.MutuallyExclusiveFlags {
 	}
 }
 
+// stashPeeker is the minimal stash-store surface stashExistsMessage needs.
+// *file.Store satisfies it.
+type stashPeeker interface {
+	IsEncrypted() (bool, error)
+	Drain(ctx context.Context, service staging.Service, keep bool) (*staging.State, error)
+}
+
+// stashExistsMessage builds the "stash already exists" line shown before the
+// merge/overwrite prompt. It never attempts to decrypt: an ENCRYPTED stash is
+// reported without an item count because the pre-check store carries no
+// passphrase, and decrypting here would abort the push before the passphrase is
+// ever requested (#328).
+func stashExistsMessage(ctx context.Context, s stashPeeker) (string, error) {
+	encrypted, err := s.IsEncrypted()
+	if err != nil {
+		return "", fmt.Errorf("failed to check stash file: %w", err)
+	}
+
+	if encrypted {
+		return "Stash file already exists (encrypted).", nil
+	}
+
+	state, err := s.Drain(ctx, "", true)
+	if err != nil {
+		return "", fmt.Errorf("failed to read stash file: %w", err)
+	}
+
+	return fmt.Sprintf("Stash file already exists with %d item(s).", state.TotalCount()), nil
+}
+
 // stashPushAction creates the action function for stash push commands.
 func stashPushAction(service staging.Service, resolver staging.ScopeResolver) func(context.Context, *cli.Command) error {
 	return func(ctx context.Context, cmd *cli.Command) error {
@@ -159,13 +189,11 @@ func stashPushAction(service staging.Service, resolver staging.ScopeResolver) fu
 			// Only prompt for global push when file exists and TTY available
 			// Service-specific push defaults to merge (preserves other services)
 			if exists && service == "" && terminal.IsTerminalWriter(cmd.Root().ErrWriter) {
-				// Count existing items for the prompt message
-				existingState, err := basicStashStore.Drain(ctx, "", true)
+				// Announce the existing stash before prompting merge/overwrite.
+				existsMsg, err := stashExistsMessage(ctx, basicStashStore)
 				if err != nil {
-					return fmt.Errorf("failed to read stash file: %w", err)
+					return err
 				}
-
-				itemCount := existingState.TotalCount()
 
 				confirmPrompter := &confirm.Prompter{
 					Stdin:  cmd.Root().Reader,
@@ -173,7 +201,7 @@ func stashPushAction(service staging.Service, resolver staging.ScopeResolver) fu
 					Stderr: cmd.Root().ErrWriter,
 				}
 
-				output.Warning(cmd.Root().ErrWriter, "Stash file already exists with %d item(s).", itemCount)
+				output.Warning(cmd.Root().ErrWriter, "%s", existsMsg)
 
 				choice, err := confirmPrompter.ConfirmChoice("How do you want to proceed?", []confirm.Choice{
 					{Label: "Merge", Description: "combine with existing stash"},

--- a/internal/staging/cli/stash_push_internal_test.go
+++ b/internal/staging/cli/stash_push_internal_test.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/staging"
+)
+
+// peekStub is a stashPeeker double for stashExistsMessage.
+type peekStub struct {
+	encrypted   bool
+	encErr      error
+	state       *staging.State
+	drainErr    error
+	drainCalled bool
+}
+
+func (p *peekStub) IsEncrypted() (bool, error) { return p.encrypted, p.encErr }
+
+func (p *peekStub) Drain(_ context.Context, _ staging.Service, _ bool) (*staging.State, error) {
+	p.drainCalled = true
+
+	return p.state, p.drainErr
+}
+
+func TestStashExistsMessage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("encrypted stash is announced without decrypting (regression #328)", func(t *testing.T) {
+		t.Parallel()
+
+		// Drain would fail on this passphrase-less store; it must NOT be called.
+		p := &peekStub{encrypted: true, drainErr: errors.New("decryption failed")}
+
+		msg, err := stashExistsMessage(t.Context(), p)
+		require.NoError(t, err)
+		assert.Contains(t, msg, "encrypted")
+		assert.False(t, p.drainCalled, "must not attempt to decrypt an encrypted stash for the pre-count")
+	})
+
+	t.Run("plaintext stash is counted", func(t *testing.T) {
+		t.Parallel()
+
+		state := staging.NewEmptyState()
+		state.Entries[staging.ServiceParam]["/a"] = staging.Entry{Operation: staging.OperationCreate}
+		state.Entries[staging.ServiceParam]["/b"] = staging.Entry{Operation: staging.OperationCreate}
+
+		p := &peekStub{encrypted: false, state: state}
+
+		msg, err := stashExistsMessage(t.Context(), p)
+		require.NoError(t, err)
+		assert.True(t, p.drainCalled)
+		assert.Contains(t, msg, "2 item(s)")
+	})
+
+	t.Run("IsEncrypted error is surfaced", func(t *testing.T) {
+		t.Parallel()
+
+		p := &peekStub{encErr: errors.New("stat failed")}
+
+		_, err := stashExistsMessage(t.Context(), p)
+		require.Error(t, err)
+		assert.False(t, p.drainCalled)
+	})
+}


### PR DESCRIPTION
## Problem

The interactive merge/overwrite prompt for `suve stage stash push` pre-counted stashed items via `Drain` on a stash store constructed **without a passphrase**. For an encrypted stash, that read hit `crypt.ErrDecryptionFailed`, so a plain `suve stage stash push` (no flags, TTY) **always failed** with `failed to read stash file: decryption failed …` instead of prompting — leaving `--merge` (which walks straight into the swallow-and-overwrite data-loss path when the passphrase differs) as the only workaround.

## Fix

The item count is cosmetic. Extract the pre-prompt line into `stashExistsMessage`, which detects encryption first and reports an encrypted stash **without a count** (never decrypting) rather than aborting. The push then prompts merge/overwrite normally and asks for the passphrase downstream.

## Tests

The TTY-gated action path isn't unit-testable with buffers, so the count/message logic is a small testable helper: added `TestStashExistsMessage` covering encrypted (announced, never decrypted), plaintext (counted), and `IsEncrypted` error cases.

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD