### PR TITLE
fix(staging): propagate stash/working read errors instead of overwriting (#320)

### DIFF
--- a/internal/usecase/staging/stash_pop.go
+++ b/internal/usecase/staging/stash_pop.go
@@ -10,9 +10,11 @@ import (
 
 // Stash error Op codes shared by StashPopError and StashPushError.
 const (
-	stashOpLoad   = "load"
-	stashOpWrite  = "write"
-	stashOpDelete = "delete"
+	stashOpLoad        = "load"
+	stashOpWrite       = "write"
+	stashOpDelete      = "delete"
+	stashOpReadStash   = "read-stash"
+	stashOpReadWorking = "read-working"
 )
 
 // StashPopInput holds input for the drain use case.
@@ -61,11 +63,14 @@ func (u *StashPopUseCase) Execute(ctx context.Context, input StashPopInput) (*St
 		return nil, ErrNothingToStashPop
 	}
 
-	// Check if the working staging area already has staged changes
-	workingState, err := u.Working.Drain(ctx, "", true) // keep=true to not clear yet
+	// Read the working staging area (keep=true to not clear yet). A missing file
+	// yields an empty state with a nil error, so any error here is a real
+	// failure (wrong key, corrupt/unreadable file): propagate it BEFORE the
+	// WriteState below would replace working files — and deleting any service
+	// whose slice ended up empty — with a partial view.
+	workingState, err := u.Working.Drain(ctx, "", true)
 	if err != nil {
-		// Working might not exist, which is fine - treat as empty
-		workingState = staging.NewEmptyState()
+		return nil, &StashPopError{Op: stashOpReadWorking, Err: err}
 	}
 
 	// Determine final state based on mode and scope
@@ -174,6 +179,8 @@ func (e *StashPopError) Error() string {
 		return "failed to write the working staging area: " + e.Err.Error()
 	case stashOpDelete:
 		return "failed to delete file: " + e.Err.Error()
+	case stashOpReadWorking:
+		return "failed to read the working staging area: " + e.Err.Error()
 	default:
 		return e.Err.Error()
 	}

--- a/internal/usecase/staging/stash_pop_test.go
+++ b/internal/usecase/staging/stash_pop_test.go
@@ -432,35 +432,43 @@ func TestDrainUseCase_ServiceSpecific_MergeWithAgentState(t *testing.T) {
 	})
 }
 
-func TestDrainUseCase_AgentDrainError_TreatedAsEmpty(t *testing.T) {
+// TestDrainUseCase_WorkingDrainError_Propagated: a real working-area read
+// failure (wrong key, corrupt/unreadable file — a missing file returns an empty
+// state with a nil error) must NOT be swallowed and treated as empty, which
+// would replace the working files (deleting any service whose slice ended up
+// empty) with a partial view (#320).
+func TestDrainUseCase_WorkingDrainError_Propagated(t *testing.T) {
 	t.Parallel()
 
 	fileStore := testutil.NewMockStore()
-	agentStore := testutil.NewMockStore()
+	workingStore := testutil.NewMockStore()
 
-	// File has param entries
+	// Stash has param entries.
 	_ = fileStore.StageEntry(t.Context(), staging.ServiceParam, "/app/param", staging.Entry{
 		Operation: staging.OperationUpdate,
 		Value:     lo.ToPtr("file-param"),
 		StagedAt:  time.Now(),
 	})
 
-	// Make agent drain fail (simulates agent not running)
-	agentStore.DrainErr = errors.New("agent not available")
+	// Working-area read fails (wrong key / unreadable file).
+	workingStore.DrainErr = errors.New("decryption failed: wrong passphrase or corrupted data")
 
 	usecase := &stagingusecase.StashPopUseCase{
 		Stash:   fileStore,
-		Working: agentStore,
+		Working: workingStore,
 	}
 
-	// Should succeed because agent drain error is treated as empty state
-	output, err := usecase.Execute(t.Context(), stagingusecase.StashPopInput{})
-	require.NoError(t, err)
-	assert.Equal(t, 1, output.EntryCount)
+	_, err := usecase.Execute(t.Context(), stagingusecase.StashPopInput{})
+	require.Error(t, err)
 
-	// Verify entry is in agent (write should succeed even though drain failed)
-	_, err = agentStore.GetEntry(t.Context(), staging.ServiceParam, "/app/param")
-	require.NoError(t, err)
+	var popErr *stagingusecase.StashPopError
+
+	require.ErrorAs(t, err, &popErr)
+	assert.Contains(t, err.Error(), "working staging area")
+
+	// The working area must not have been written (WriteState never reached).
+	_, getErr := workingStore.GetEntry(t.Context(), staging.ServiceParam, "/app/param")
+	require.ErrorIs(t, getErr, staging.ErrNotStaged)
 }
 
 func TestDrainUseCase_ServiceSpecific_FileDeleteDrainError(t *testing.T) {

--- a/internal/usecase/staging/stash_push.go
+++ b/internal/usecase/staging/stash_push.go
@@ -57,11 +57,14 @@ func (u *StashPushUseCase) Execute(ctx context.Context, input StashPushInput) (*
 
 	switch {
 	case input.Service != "":
-		// Service-specific: always preserve other services from stash
+		// Service-specific: always preserve other services from stash.
+		// A missing stash yields an empty state with a nil error, so any error
+		// here is a real failure (wrong passphrase, corrupt/unreadable file):
+		// propagate it rather than starting fresh, which would silently drop the
+		// existing stash (and the other services it holds) on the WriteState below.
 		stashState, err := u.Stash.Drain(ctx, "", true)
 		if err != nil {
-			// Stash might not exist, which is fine - start fresh
-			stashState = staging.NewEmptyState()
+			return nil, &StashPushError{Op: stashOpReadStash, Err: err}
 		}
 
 		finalState = stashState
@@ -74,11 +77,14 @@ func (u *StashPushUseCase) Execute(ctx context.Context, input StashPushInput) (*
 			finalState.Merge(persistState)
 		}
 	case input.Mode == StashModeMerge:
-		// Global merge: combine stash state with working state
+		// Global merge: combine stash state with working state. A missing stash
+		// yields an empty state with a nil error, so any error here is a real
+		// failure (wrong passphrase, corrupt/unreadable file): propagate it
+		// rather than starting fresh, which would silently overwrite the stash
+		// with only the working data on the WriteState below.
 		stashState, err := u.Stash.Drain(ctx, "", true)
 		if err != nil {
-			// Stash might not exist, which is fine - start fresh
-			stashState = staging.NewEmptyState()
+			return nil, &StashPushError{Op: stashOpReadStash, Err: err}
 		}
 
 		finalState = stashState
@@ -143,6 +149,8 @@ func (e *StashPushError) Error() string {
 	switch e.Op {
 	case stashOpLoad:
 		return "failed to read the working staging area: " + e.Err.Error()
+	case stashOpReadStash:
+		return "failed to read stash file: " + e.Err.Error()
 	case stashOpWrite:
 		return "failed to save state to file: " + e.Err.Error()
 	case "clear":

--- a/internal/usecase/staging/stash_push_test.go
+++ b/internal/usecase/staging/stash_push_test.go
@@ -682,68 +682,58 @@ func TestPersistUseCase_ServiceSpecific_ClearError(t *testing.T) {
 	})
 }
 
-func TestPersistUseCase_FileDrainError_TreatedAsFresh(t *testing.T) {
+// TestPersistUseCase_StashDrainError_Propagated: a real stash-read failure
+// (wrong passphrase, corrupt/unreadable file — a missing file returns an empty
+// state with a nil error) must NOT be swallowed and treated as "start fresh",
+// which would overwrite the existing stash with only the working data (#320).
+func TestPersistUseCase_StashDrainError_Propagated(t *testing.T) {
 	t.Parallel()
 
-	t.Run("merge mode with file drain error starts fresh", func(t *testing.T) {
-		t.Parallel()
+	newCase := func(t *testing.T) (*testutil.MockStore, *stagingusecase.StashPushUseCase) {
+		t.Helper()
 
 		agentStore := testutil.NewMockStore()
 		fileStore := testutil.NewMockStore()
 
-		// Agent has entries
 		_ = agentStore.StageEntry(t.Context(), staging.ServiceParam, "/app/param", staging.Entry{
 			Operation: staging.OperationUpdate,
 			Value:     lo.ToPtr("agent-value"),
 			StagedAt:  time.Now(),
 		})
 
-		// Make file drain fail (simulates file doesn't exist)
-		fileStore.DrainErr = errors.New("file not found")
+		fileStore.DrainErr = errors.New("decryption failed: wrong passphrase or corrupted data")
 
-		usecase := &stagingusecase.StashPushUseCase{
-			Working: agentStore,
-			Stash:   fileStore,
-		}
+		return fileStore, &stagingusecase.StashPushUseCase{Working: agentStore, Stash: fileStore}
+	}
 
-		// Should succeed because file drain error is treated as empty state (start fresh)
-		output, err := usecase.Execute(t.Context(), stagingusecase.StashPushInput{Mode: stagingusecase.StashModeMerge})
-		require.NoError(t, err)
-		assert.Equal(t, 1, output.EntryCount)
+	assertNotOverwritten := func(t *testing.T, fileStore *testutil.MockStore, err error) {
+		t.Helper()
 
-		// Verify entry is in file
-		_, err = fileStore.GetEntry(t.Context(), staging.ServiceParam, "/app/param")
-		require.NoError(t, err)
+		require.Error(t, err)
+
+		var pushErr *stagingusecase.StashPushError
+
+		require.ErrorAs(t, err, &pushErr)
+		assert.Contains(t, err.Error(), "stash file")
+
+		// The stash must not have been overwritten (WriteState never reached).
+		_, getErr := fileStore.GetEntry(t.Context(), staging.ServiceParam, "/app/param")
+		require.ErrorIs(t, getErr, staging.ErrNotStaged)
+	}
+
+	t.Run("merge mode propagates the stash read error", func(t *testing.T) {
+		t.Parallel()
+
+		fileStore, usecase := newCase(t)
+		_, err := usecase.Execute(t.Context(), stagingusecase.StashPushInput{Mode: stagingusecase.StashModeMerge})
+		assertNotOverwritten(t, fileStore, err)
 	})
 
-	t.Run("service-specific push with file drain error starts fresh", func(t *testing.T) {
+	t.Run("service-specific push propagates the stash read error", func(t *testing.T) {
 		t.Parallel()
 
-		agentStore := testutil.NewMockStore()
-		fileStore := testutil.NewMockStore()
-
-		// Agent has entries
-		_ = agentStore.StageEntry(t.Context(), staging.ServiceParam, "/app/param", staging.Entry{
-			Operation: staging.OperationUpdate,
-			Value:     lo.ToPtr("agent-value"),
-			StagedAt:  time.Now(),
-		})
-
-		// Make file drain fail (simulates file doesn't exist)
-		fileStore.DrainErr = errors.New("file not found")
-
-		usecase := &stagingusecase.StashPushUseCase{
-			Working: agentStore,
-			Stash:   fileStore,
-		}
-
-		// Should succeed because file drain error is treated as empty state (start fresh)
-		output, err := usecase.Execute(t.Context(), stagingusecase.StashPushInput{Service: staging.ServiceParam})
-		require.NoError(t, err)
-		assert.Equal(t, 1, output.EntryCount)
-
-		// Verify entry is in file
-		_, err = fileStore.GetEntry(t.Context(), staging.ServiceParam, "/app/param")
-		require.NoError(t, err)
+		fileStore, usecase := newCase(t)
+		_, err := usecase.Execute(t.Context(), stagingusecase.StashPushInput{Service: staging.ServiceParam})
+		assertNotOverwritten(t, fileStore, err)
 	})
 }


### PR DESCRIPTION
## Problem

Both `stash push` and `stash pop` treated **any** `Drain` error as "file doesn't exist, start fresh". But the file store already returns an empty state with a **nil** error for a missing file — so every swallowed error was a *real* failure (wrong passphrase, corrupt JSON, permissions), after which the subsequent `WriteState` destroyed data:

- `stash push --merge` with a wrong passphrase silently dropped the existing stash (and, for a service-specific push, the other services it held), writing only the working data.
- `stash pop` with an unreadable working file replaced the working area with a partial view (`writeFile` deletes a service whose slice is empty).

## Fix

Propagate these reads as `StashPushError{read-stash}` / `StashPopError{read-working}`, aborting **before** any write. A genuinely missing file still returns a nil error from the store, so the "start fresh" behavior is preserved for that case.

## Tests

Replaced the two tests that encoded the false premise (`FileDrainError_TreatedAsFresh` / `AgentDrainError_TreatedAsEmpty`) with tests asserting the error is surfaced and the target is **not** overwritten.

`mise test` and `mise lint` pass.

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD