### PR TITLE
fix(secret): include deprecated versions and paginate ListSecretVersionIds (#312)

### DIFF
--- a/internal/provider/aws/secret/secret.go
+++ b/internal/provider/aws/secret/secret.go
@@ -103,14 +103,11 @@ func (s *Store) Resolve(ctx context.Context, name, spec string) (provider.Versio
 	}
 
 	// Label resolution and/or shift require the full version list.
-	versions, err := s.client.ListSecretVersionIds(ctx, &secretsmanager.ListSecretVersionIdsInput{
-		SecretId: aws.String(name),
-	})
+	list, err := s.listAllVersions(ctx, name)
 	if err != nil {
 		return provider.VersionRef{}, fmt.Errorf("failed to list versions: %w", err)
 	}
 
-	list := versions.Versions
 	if len(list) == 0 {
 		return provider.VersionRef{}, fmt.Errorf("secret not found or has no versions: %s", name)
 	}
@@ -128,6 +125,42 @@ func (s *Store) Resolve(ctx context.Context, name, spec string) (provider.Versio
 	}
 
 	return provider.NewVersionRef(aws.ToString(list[targetIdx].VersionId)), nil
+}
+
+// listAllVersions returns every version of the secret, INCLUDING deprecated
+// (unlabeled) versions, paging through ListSecretVersionIds.
+//
+// Without IncludeDeprecated the API returns only versions that still carry a
+// staging label (typically AWSCURRENT/AWSPREVIOUS/AWSPENDING), hiding retained
+// but unlabeled versions from history and from ~shift resolution even though
+// they remain fetchable by version ID. Pagination is mandatory once deprecated
+// versions are included, as the list can span multiple pages.
+func (s *Store) listAllVersions(ctx context.Context, name string) ([]types.SecretVersionsListEntry, error) {
+	var (
+		all   []types.SecretVersionsListEntry
+		token *string
+	)
+
+	for {
+		out, err := s.client.ListSecretVersionIds(ctx, &secretsmanager.ListSecretVersionIdsInput{
+			SecretId:          aws.String(name),
+			IncludeDeprecated: aws.Bool(true),
+			NextToken:         token,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		all = append(all, out.Versions...)
+
+		if aws.ToString(out.NextToken) == "" {
+			break
+		}
+
+		token = out.NextToken
+	}
+
+	return all, nil
 }
 
 // baseIndex finds the starting index in a newest-first version list for the
@@ -218,16 +251,14 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 	return entry, nil
 }
 
-// History returns the secret's version history, newest first.
+// History returns the secret's version history, newest first, including
+// deprecated (unlabeled) versions.
 func (s *Store) History(ctx context.Context, name string) ([]domain.Version, error) {
-	out, err := s.client.ListSecretVersionIds(ctx, &secretsmanager.ListSecretVersionIdsInput{
-		SecretId: aws.String(name),
-	})
+	list, err := s.listAllVersions(ctx, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list secret versions: %w", err)
 	}
 
-	list := out.Versions
 	sortNewestFirst(list)
 
 	return lo.Map(list, func(v types.SecretVersionsListEntry, _ int) domain.Version {

--- a/internal/provider/aws/secret/secret_test.go
+++ b/internal/provider/aws/secret/secret_test.go
@@ -248,6 +248,81 @@ func TestHistory_NewestFirst(t *testing.T) {
 	assert.Equal(t, "id-1", versions[2].ID)
 }
 
+func TestHistory_IncludeDeprecatedAndPaginates(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	var (
+		gotIncludeDeprecated bool
+		calls                int
+	)
+
+	store := secret.New(&mockClient{
+		listVersion: func(in *secretsmanager.ListSecretVersionIdsInput) (*secretsmanager.ListSecretVersionIdsOutput, error) {
+			gotIncludeDeprecated = aws.ToBool(in.IncludeDeprecated)
+			calls++
+
+			if aws.ToString(in.NextToken) == "" {
+				// Page 1: the labeled versions.
+				return &secretsmanager.ListSecretVersionIdsOutput{
+					Versions: []types.SecretVersionsListEntry{
+						{VersionId: aws.String("id-3"), CreatedDate: aws.Time(base.Add(2 * time.Hour)), VersionStages: []string{"AWSCURRENT"}},
+						{VersionId: aws.String("id-2"), CreatedDate: aws.Time(base.Add(time.Hour)), VersionStages: []string{"AWSPREVIOUS"}},
+					},
+					NextToken: aws.String("tok"),
+				}, nil
+			}
+
+			// Page 2: a deprecated (unlabeled) version, retained but invisible
+			// without IncludeDeprecated.
+			return &secretsmanager.ListSecretVersionIdsOutput{
+				Versions: []types.SecretVersionsListEntry{
+					{VersionId: aws.String("id-1"), CreatedDate: aws.Time(base), VersionStages: []string{}},
+				},
+			}, nil
+		},
+	})
+
+	versions, err := store.History(t.Context(), "my-secret")
+	require.NoError(t, err)
+	assert.True(t, gotIncludeDeprecated, "History must request IncludeDeprecated=true")
+	assert.Equal(t, 2, calls, "History must page through all results")
+	require.Len(t, versions, 3)
+	assert.Equal(t, "id-3", versions[0].ID)
+	assert.Equal(t, "id-1", versions[2].ID, "deprecated version must be included as the oldest")
+}
+
+func TestResolve_ShiftReachesDeprecatedVersion(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	var gotIncludeDeprecated bool
+
+	store := secret.New(&mockClient{
+		listVersion: func(in *secretsmanager.ListSecretVersionIdsInput) (*secretsmanager.ListSecretVersionIdsOutput, error) {
+			gotIncludeDeprecated = aws.ToBool(in.IncludeDeprecated)
+
+			return &secretsmanager.ListSecretVersionIdsOutput{
+				Versions: []types.SecretVersionsListEntry{
+					{VersionId: aws.String("id-3"), CreatedDate: aws.Time(base.Add(2 * time.Hour)), VersionStages: []string{"AWSCURRENT"}},
+					{VersionId: aws.String("id-2"), CreatedDate: aws.Time(base.Add(time.Hour)), VersionStages: []string{}},
+					{VersionId: aws.String("id-1"), CreatedDate: aws.Time(base), VersionStages: []string{}},
+				},
+			}, nil
+		},
+	})
+
+	// AWSCURRENT~2 walks two versions back into a deprecated (unlabeled) one;
+	// this would fail with "version shift out of range" if deprecated versions
+	// were excluded from the listing.
+	ref, err := store.Resolve(t.Context(), "my-secret", ":AWSCURRENT~2")
+	require.NoError(t, err)
+	assert.True(t, gotIncludeDeprecated, "Resolve must request IncludeDeprecated=true")
+	assert.Equal(t, "id-1", ref.ID())
+}
+
 func TestList_Paginated(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

`Resolve` and `History` called `ListSecretVersionIds` without `IncludeDeprecated` (and without a `NextToken` loop). By default the API returns **only versions carrying a staging label** (typically `AWSCURRENT`/`AWSPREVIOUS`/`AWSPENDING`). Deprecated (unlabeled) versions are retained and still fetchable by ID, but were invisible to suve:

- `suve secret log my-secret` showed only 2–3 entries;
- `my-secret~2` / `:AWSCURRENT~2` failed with `version shift out of range: ~2` even though the version existed.

## Fix

Add a shared `listAllVersions` helper that passes `IncludeDeprecated: true` and pages through `NextToken`, used by both `Resolve` and `History`.

## Tests

Not covered by e2e (localstack Community cannot run Secrets Manager). Added unit tests for: the `IncludeDeprecated` flag being set, multi-page pagination in `History`, and a `~2` shift reaching a deprecated (unlabeled) version.

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD