### PR TITLE
fix(secret,gcloud): anchor bare `~N` at what the bare name resolves to (#313)

### DIFF
--- a/internal/provider/aws/secret/secret.go
+++ b/internal/provider/aws/secret/secret.go
@@ -164,8 +164,14 @@ func (s *Store) listAllVersions(ctx context.Context, name string) ([]types.Secre
 }
 
 // baseIndex finds the starting index in a newest-first version list for the
-// given absolute spec (version ID or staging label). No absolute spec anchors
-// at the newest version (index 0).
+// given absolute spec (version ID or staging label).
+//
+// With NO absolute spec, a bare `~N` counts back from whatever the bare name
+// resolves to — the AWSCURRENT version (GetSecretValue with no VersionId) — NOT
+// the newest-by-CreatedDate entry. During an in-progress rotation AWSPENDING is
+// the newest-created version, so anchoring at index 0 would make `~1` skip past
+// AWSCURRENT (and leave AWSPREVIOUS unreachable). Anchor at AWSCURRENT instead,
+// falling back to index 0 only if no version carries that label.
 func baseIndex(list []types.SecretVersionsListEntry, abs secretversion.AbsoluteSpec) (int, error) {
 	switch {
 	case abs.ID != nil:
@@ -187,7 +193,14 @@ func baseIndex(list []types.SecretVersionsListEntry, abs secretversion.AbsoluteS
 
 		return idx, nil
 	default:
-		return 0, nil
+		_, idx, found := lo.FindIndexOf(list, func(v types.SecretVersionsListEntry) bool {
+			return slices.Contains(v.VersionStages, "AWSCURRENT")
+		})
+		if !found {
+			return 0, nil
+		}
+
+		return idx, nil
 	}
 }
 

--- a/internal/provider/aws/secret/secret_test.go
+++ b/internal/provider/aws/secret/secret_test.go
@@ -323,6 +323,32 @@ func TestResolve_ShiftReachesDeprecatedVersion(t *testing.T) {
 	assert.Equal(t, "id-1", ref.ID())
 }
 
+func TestResolve_BareShiftAnchorsAtAWSCURRENT(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// During an in-progress rotation AWSPENDING is the newest-CREATED version.
+	store := secret.New(&mockClient{
+		listVersion: func(_ *secretsmanager.ListSecretVersionIdsInput) (*secretsmanager.ListSecretVersionIdsOutput, error) {
+			return &secretsmanager.ListSecretVersionIdsOutput{
+				Versions: []types.SecretVersionsListEntry{
+					{VersionId: aws.String("pending"), CreatedDate: aws.Time(base.Add(3 * time.Hour)), VersionStages: []string{"AWSPENDING"}},
+					{VersionId: aws.String("current"), CreatedDate: aws.Time(base.Add(2 * time.Hour)), VersionStages: []string{"AWSCURRENT"}},
+					{VersionId: aws.String("previous"), CreatedDate: aws.Time(base.Add(time.Hour)), VersionStages: []string{"AWSPREVIOUS"}},
+				},
+			}, nil
+		},
+	})
+
+	// Bare ~1 counts back from AWSCURRENT (what the bare name resolves to), not
+	// from the newest-created version (AWSPENDING), so it reaches AWSPREVIOUS.
+	// With the old index-0 anchor it would have returned AWSCURRENT. (#313)
+	ref, err := store.Resolve(t.Context(), "my-secret", "~1")
+	require.NoError(t, err)
+	assert.Equal(t, "previous", ref.ID())
+}
+
 func TestList_Paginated(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/gcloud/secret/secret.go
+++ b/internal/provider/gcloud/secret/secret.go
@@ -119,14 +119,15 @@ func (s *Store) Resolve(ctx context.Context, name, spec string) (provider.Versio
 		return provider.NewVersionRef(""), nil
 	}
 
-	// A shift requires the enabled version list, newest first.
-	versions, err := s.enabledVersionsNewestFirst(ctx, name)
+	// A shift counts back from `latest`, so it walks the full version list
+	// (any state), newest first — the same anchor the bare name resolves to.
+	versions, err := s.versionsNewestFirst(ctx, name)
 	if err != nil {
 		return provider.VersionRef{}, err
 	}
 
 	if len(versions) == 0 {
-		return provider.VersionRef{}, fmt.Errorf("secret has no enabled versions: %s", name)
+		return provider.VersionRef{}, fmt.Errorf("secret has no versions: %s", name)
 	}
 
 	baseIdx := 0
@@ -138,7 +139,7 @@ func (s *Store) Resolve(ctx context.Context, name, spec string) (provider.Versio
 			return versionNumber(v.GetName()) == want
 		})
 		if !found {
-			return provider.VersionRef{}, fmt.Errorf("version not found or not enabled: %s", want)
+			return provider.VersionRef{}, fmt.Errorf("version not found: %s", want)
 		}
 
 		baseIdx = idx
@@ -152,9 +153,15 @@ func (s *Store) Resolve(ctx context.Context, name, spec string) (provider.Versio
 	return provider.NewVersionRef(versionNumber(versions[targetIdx].GetName())), nil
 }
 
-// enabledVersionsNewestFirst lists the secret's ENABLED versions sorted by
+// versionsNewestFirst lists ALL the secret's versions (any state) sorted by
 // version number, newest (highest) first.
-func (s *Store) enabledVersionsNewestFirst(ctx context.Context, name string) ([]*secretmanagerpb.SecretVersion, error) {
+//
+// This is the same set History shows and the same ordering the `latest` alias
+// anchors at, so a ~shift counts back positionally from whatever the bare name
+// resolves to. Filtering to ENABLED here (as an earlier version did) made a
+// bare `~N` skip disabled/destroyed versions that `latest` still counts,
+// yielding a version further back than "N before the current one".
+func (s *Store) versionsNewestFirst(ctx context.Context, name string) ([]*secretmanagerpb.SecretVersion, error) {
 	versions, err := s.client.ListSecretVersions(ctx, &secretmanagerpb.ListSecretVersionsRequest{
 		Parent: s.secretPath(name),
 	})
@@ -162,13 +169,9 @@ func (s *Store) enabledVersionsNewestFirst(ctx context.Context, name string) ([]
 		return nil, mapError(err, name, "list secret versions")
 	}
 
-	enabled := lo.Filter(versions, func(v *secretmanagerpb.SecretVersion, _ int) bool {
-		return v.GetState() == secretmanagerpb.SecretVersion_ENABLED
-	})
+	sortNewestFirst(versions)
 
-	sortNewestFirst(enabled)
-
-	return enabled, nil
+	return versions, nil
 }
 
 // Get retrieves the secret value at the given ref (latest when ref is latest)

--- a/internal/provider/gcloud/secret/secret_more_test.go
+++ b/internal/provider/gcloud/secret/secret_more_test.go
@@ -30,7 +30,7 @@ func TestResolve_Errors(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("shift on secret with no enabled versions", func(t *testing.T) {
+	t.Run("shift on secret with no versions", func(t *testing.T) {
 		t.Parallel()
 
 		m := &mockClient{
@@ -42,10 +42,10 @@ func TestResolve_Errors(t *testing.T) {
 
 		_, err := store.Resolve(t.Context(), "my-secret", "~1")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no enabled versions")
+		assert.Contains(t, err.Error(), "no versions")
 	})
 
-	t.Run("shift from explicit version that is not enabled", func(t *testing.T) {
+	t.Run("shift from a nonexistent explicit version", func(t *testing.T) {
 		t.Parallel()
 
 		m := &mockClient{
@@ -60,7 +60,7 @@ func TestResolve_Errors(t *testing.T) {
 
 		_, err := store.Resolve(t.Context(), "my-secret", "#9~1")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not found or not enabled")
+		assert.Contains(t, err.Error(), "version not found")
 	})
 
 	t.Run("shift propagates list error", func(t *testing.T) {

--- a/internal/provider/gcloud/secret/secret_test.go
+++ b/internal/provider/gcloud/secret/secret_test.go
@@ -114,7 +114,7 @@ func TestResolve(t *testing.T) {
 		assert.Equal(t, "3", ref.ID())
 	})
 
-	t.Run("shift walks enabled versions newest first", func(t *testing.T) {
+	t.Run("shift counts back from latest through all version states", func(t *testing.T) {
 		t.Parallel()
 
 		m := &mockClient{
@@ -128,8 +128,15 @@ func TestResolve(t *testing.T) {
 		}
 		store := newStore(m)
 
-		// ~1 from latest ENABLED (3) -> next enabled is 1 (2 is disabled, skipped).
+		// latest is version 3; ~1 is the version immediately before it (2) even
+		// though 2 is disabled — a shift counts back positionally from what the
+		// bare name / `latest` resolves to, not through ENABLED-only. (#313)
 		ref, err := store.Resolve(t.Context(), "my-secret", "~1")
+		require.NoError(t, err)
+		assert.Equal(t, "2", ref.ID())
+
+		// ~2 reaches version 1.
+		ref, err = store.Resolve(t.Context(), "my-secret", "~2")
 		require.NoError(t, err)
 		assert.Equal(t, "1", ref.ID())
 	})


### PR DESCRIPTION
> **Stacked on #370 (#312).** Base will retarget to `main` once #370 merges. Review the [last commit](https://github.com/mpyw/suve/pull/371/commits) for this change alone.

## Problem

The unshifted spec and the shift anchor disagreed:

- **AWS Secrets Manager**: bare `my-secret` resolves to AWSCURRENT (`GetSecretValue` with no VersionId), but `my-secret~N` anchored at index 0 of the newest-by-`CreatedDate` list. During an in-progress rotation AWSPENDING is the newest-created version, so `~1` returned the **AWSCURRENT** value (same as the bare name) and AWSPREVIOUS was unreachable via `~1`.
- **Google Cloud**: bare name uses the `latest` alias (any state), but the shift walked **ENABLED-only** versions, so if the newest version was disabled, `sec~1` returned the version *two* behind what `sec` shows.

## Fix

- AWS `baseIndex`: a no-absolute spec now anchors at the **AWSCURRENT** version (falling back to index 0 only if no version is labeled).
- gcloud: the shift now walks the **full** version list (any state), newest first — the same set `History` shows and the same anchor `latest` resolves to.

## Tests

Updated the gcloud tests that encoded the ENABLED-only walk; added regression tests for the AWS rotation case (`~1` → AWSPREVIOUS) and a gcloud `~1`/`~2` counting back through a disabled version.

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD