### PR TITLE
fix(staging): only auto-unstage on ErrNotFound, not any diff fetch error (#321)

### DIFF
--- a/internal/cli/commands/stage/diff/diff.go
+++ b/internal/cli/commands/stage/diff/diff.go
@@ -3,6 +3,7 @@ package diff
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -16,6 +17,7 @@ import (
 	"github.com/mpyw/suve/internal/jsonutil"
 	"github.com/mpyw/suve/internal/maputil"
 	"github.com/mpyw/suve/internal/parallel"
+	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/staging"
 	stgcli "github.com/mpyw/suve/internal/staging/cli"
 	"github.com/mpyw/suve/internal/staging/store"
@@ -205,15 +207,26 @@ func (r *Runner) diffEntries(
 		result := results[name]
 
 		if result.Err != nil {
-			// Handle fetch error based on operation type
+			// Only a genuine "not found" justifies auto-unstaging a staged
+			// delete or update. Any other fetch error (expired credentials,
+			// throttling, a network blip) must NOT discard staged work on a
+			// read-only `stage diff`: surface it and leave the entry staged.
+			notFound := errors.Is(result.Err, provider.ErrNotFound)
+
 			switch entry.Operation {
 			case staging.OperationDelete:
-				// Item doesn't exist remotely anymore - deletion already applied
-				if err := r.Store.UnstageEntry(ctx, strategy.Service(), name); err != nil {
-					return fmt.Errorf("failed to unstage %s: %w", name, err)
+				if notFound {
+					// Item doesn't exist remotely anymore - deletion already applied.
+					if err := r.Store.UnstageEntry(ctx, strategy.Service(), name); err != nil {
+						return fmt.Errorf("failed to unstage %s: %w", name, err)
+					}
+
+					output.Warning(r.Stderr, "unstaged %s: already deleted in %s", name, r.ProviderLabel)
+
+					continue
 				}
 
-				output.Warning(r.Stderr, "unstaged %s: already deleted in %s", name, r.ProviderLabel)
+				output.Warning(r.Stderr, "could not diff %s (kept staged): %v", name, result.Err)
 
 				continue
 
@@ -232,12 +245,18 @@ func (r *Runner) diffEntries(
 				continue
 
 			case staging.OperationUpdate:
-				// Item doesn't exist remotely anymore - staged update is invalid
-				if err := r.Store.UnstageEntry(ctx, strategy.Service(), name); err != nil {
-					return fmt.Errorf("failed to unstage %s: %w", name, err)
+				if notFound {
+					// Item doesn't exist remotely anymore - staged update is invalid.
+					if err := r.Store.UnstageEntry(ctx, strategy.Service(), name); err != nil {
+						return fmt.Errorf("failed to unstage %s: %w", name, err)
+					}
+
+					output.Warning(r.Stderr, "unstaged %s: item no longer exists in %s", name, r.ProviderLabel)
+
+					continue
 				}
 
-				output.Warning(r.Stderr, "unstaged %s: item no longer exists in %s", name, r.ProviderLabel)
+				output.Warning(r.Stderr, "could not diff %s (kept staged): %v", name, result.Err)
 
 				continue
 			}

--- a/internal/cli/commands/stage/diff/diff_test.go
+++ b/internal/cli/commands/stage/diff/diff_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -32,9 +33,20 @@ func storeReturning(value, versionID string) *providermock.Store {
 	}
 }
 
-// storeGetError builds a provider.Store mock whose Get fails, simulating a
-// resource that no longer exists in the provider.
+// storeGetError builds a provider.Store mock whose Get fails with a genuine
+// provider.ErrNotFound, simulating a resource that no longer exists.
 func storeGetError(msg string) *providermock.Store {
+	return &providermock.Store{
+		GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) {
+			return nil, fmt.Errorf("%w: %s", provider.ErrNotFound, msg)
+		},
+	}
+}
+
+// storeGetTransientError builds a provider.Store mock whose Get fails with a
+// non-not-found error (e.g. throttling, expired credentials, a network blip),
+// which must NOT trigger auto-unstaging of staged work.
+func storeGetTransientError(msg string) *providermock.Store {
 	return &providermock.Store{
 		GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) {
 			return nil, errors.New(msg)
@@ -603,6 +615,47 @@ func TestRun_DeleteAutoUnstageWhenAlreadyDeleted(t *testing.T) {
 	// Verify unstaged
 	_, err = store.GetEntry(t.Context(), staging.ServiceParam, "/app/config")
 	assert.ErrorIs(t, err, staging.ErrNotStaged)
+}
+
+// TestRun_KeptStagedOnTransientFetchError verifies that a non-not-found fetch
+// error (throttling, expired credentials, a network blip) on a read-only
+// `stage diff` does NOT discard staged deletes/updates (#321).
+func TestRun_KeptStagedOnTransientFetchError(t *testing.T) {
+	t.Parallel()
+
+	for _, op := range []staging.Operation{staging.OperationDelete, staging.OperationUpdate} {
+		t.Run(string(op), func(t *testing.T) {
+			t.Parallel()
+
+			store := testutil.NewMockStore()
+
+			entry := staging.Entry{Operation: op, StagedAt: time.Now()}
+			if op == staging.OperationUpdate {
+				entry.Value = lo.ToPtr("new-value")
+			}
+
+			require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, "/app/config", entry))
+
+			var stdout, stderr bytes.Buffer
+
+			r := &stagediff.Runner{
+				Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(storeGetTransientError("throttled")))},
+				ProviderLabel: "AWS",
+				Store:         store,
+				Stdout:        &stdout,
+				Stderr:        &stderr,
+			}
+
+			require.NoError(t, r.Run(t.Context(), stagediff.Options{}))
+
+			// Surfaced as a warning, but NOT unstaged.
+			assert.Contains(t, stderr.String(), "throttled")
+			assert.NotContains(t, stderr.String(), "unstaged")
+
+			_, err := store.GetEntry(t.Context(), staging.ServiceParam, "/app/config")
+			require.NoError(t, err, "entry must remain staged after a transient fetch error")
+		})
+	}
 }
 
 func TestRun_SecretDeleteAutoUnstageWhenAlreadyDeleted(t *testing.T) {

--- a/internal/staging/cli/cli_test.go
+++ b/internal/staging/cli/cli_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/cli"
 	"github.com/mpyw/suve/internal/staging/store/testutil"
@@ -511,9 +513,12 @@ func TestDiffRunner_Run(t *testing.T) {
 
 		r := &cli.DiffRunner{
 			UseCase: &stagingusecase.DiffUseCase{
-				// FetchCurrent returns error because item was deleted from AWS
-				Strategy: &fullMockStrategy{service: staging.ServiceParam, fetchCurrentErr: errors.New("parameter not found")},
-				Store:    store,
+				// FetchCurrent returns a not-found because the item was deleted from AWS
+				Strategy: &fullMockStrategy{
+					service:         staging.ServiceParam,
+					fetchCurrentErr: fmt.Errorf("%w: parameter not found", provider.ErrNotFound),
+				},
+				Store: store,
 			},
 			Stdout: &stdout,
 			Stderr: &stderr,
@@ -670,9 +675,12 @@ func TestDiffRunner_Run(t *testing.T) {
 
 		r := &cli.DiffRunner{
 			UseCase: &stagingusecase.DiffUseCase{
-				// FetchCurrent returns error because item doesn't exist in AWS anymore
-				Strategy: &fullMockStrategy{service: staging.ServiceParam, fetchCurrentErr: errors.New("parameter not found")},
-				Store:    store,
+				// FetchCurrent returns a not-found because the item no longer exists in AWS
+				Strategy: &fullMockStrategy{
+					service:         staging.ServiceParam,
+					fetchCurrentErr: fmt.Errorf("%w: parameter not found", provider.ErrNotFound),
+				},
+				Store: store,
 			},
 			Stdout: &stdout,
 			Stderr: &stderr,

--- a/internal/usecase/staging/diff.go
+++ b/internal/usecase/staging/diff.go
@@ -7,6 +7,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/mpyw/suve/internal/parallel"
+	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store"
 )
@@ -213,14 +214,22 @@ func (u *DiffUseCase) processDiffResult(ctx context.Context, name string, entry 
 func (u *DiffUseCase) handleFetchError(ctx context.Context, name string, entry staging.Entry, err error) DiffEntry {
 	service := u.Strategy.Service()
 
+	// Only a genuine "not found" justifies auto-unstaging a staged delete or
+	// update. Any other fetch error (expired credentials, throttling, a network
+	// blip) must NOT discard staged work on a read-only `stage diff`: surface it
+	// as a warning and leave the staged entry untouched.
+	notFound := errors.Is(err, provider.ErrNotFound)
+
 	switch entry.Operation {
 	case staging.OperationDelete:
-		_ = u.Store.UnstageEntry(ctx, service, name)
+		if notFound {
+			_ = u.Store.UnstageEntry(ctx, service, name)
 
-		return DiffEntry{
-			Name:    name,
-			Type:    DiffEntryAutoUnstaged,
-			Warning: "already deleted in AWS",
+			return DiffEntry{
+				Name:    name,
+				Type:    DiffEntryAutoUnstaged,
+				Warning: "already deleted in AWS",
+			}
 		}
 
 	case staging.OperationCreate:
@@ -233,12 +242,14 @@ func (u *DiffUseCase) handleFetchError(ctx context.Context, name string, entry s
 		}
 
 	case staging.OperationUpdate:
-		_ = u.Store.UnstageEntry(ctx, service, name)
+		if notFound {
+			_ = u.Store.UnstageEntry(ctx, service, name)
 
-		return DiffEntry{
-			Name:    name,
-			Type:    DiffEntryAutoUnstaged,
-			Warning: "item no longer exists in AWS",
+			return DiffEntry{
+				Name:    name,
+				Type:    DiffEntryAutoUnstaged,
+				Warning: "item no longer exists in AWS",
+			}
 		}
 	}
 

--- a/internal/usecase/staging/diff_test.go
+++ b/internal/usecase/staging/diff_test.go
@@ -3,6 +3,7 @@ package staging_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store/testutil"
 	usecasestaging "github.com/mpyw/suve/internal/usecase/staging"
@@ -204,7 +206,7 @@ func TestDiffUseCase_Execute_AutoUnstage_AlreadyDeleted(t *testing.T) {
 	}))
 
 	strategy := newMockDiffStrategy()
-	strategy.fetchErrors["/app/gone"] = errors.New("not found")
+	strategy.fetchErrors["/app/gone"] = fmt.Errorf("%w: not found", provider.ErrNotFound)
 
 	uc := &usecasestaging.DiffUseCase{
 		Strategy: strategy,
@@ -274,7 +276,7 @@ func TestDiffUseCase_Execute_AutoUnstage_UpdateNoLongerExists(t *testing.T) {
 	}))
 
 	strategy := newMockDiffStrategy()
-	strategy.fetchErrors["/app/gone"] = errors.New("not found")
+	strategy.fetchErrors["/app/gone"] = fmt.Errorf("%w: not found", provider.ErrNotFound)
 
 	uc := &usecasestaging.DiffUseCase{
 		Strategy: strategy,
@@ -292,6 +294,41 @@ func TestDiffUseCase_Execute_AutoUnstage_UpdateNoLongerExists(t *testing.T) {
 	// Verify auto-unstaged
 	_, err = store.GetEntry(t.Context(), staging.ServiceParam, "/app/gone")
 	assert.ErrorIs(t, err, staging.ErrNotStaged)
+}
+
+// TestDiffUseCase_Execute_KeepStagedOnTransientError verifies a non-not-found
+// fetch error does NOT auto-unstage a staged delete/update (#321).
+func TestDiffUseCase_Execute_KeepStagedOnTransientError(t *testing.T) {
+	t.Parallel()
+
+	for _, op := range []staging.Operation{staging.OperationDelete, staging.OperationUpdate} {
+		t.Run(string(op), func(t *testing.T) {
+			t.Parallel()
+
+			store := testutil.NewMockStore()
+
+			entry := staging.Entry{Operation: op, StagedAt: time.Now()}
+			if op == staging.OperationUpdate {
+				entry.Value = lo.ToPtr("v")
+			}
+
+			require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, "/app/x", entry))
+
+			strategy := newMockDiffStrategy()
+			strategy.fetchErrors["/app/x"] = errors.New("throttled")
+
+			uc := &usecasestaging.DiffUseCase{Strategy: strategy, Store: store}
+
+			output, err := uc.Execute(t.Context(), usecasestaging.DiffInput{})
+			require.NoError(t, err)
+			require.Len(t, output.Entries, 1)
+			assert.Equal(t, usecasestaging.DiffEntryWarning, output.Entries[0].Type)
+
+			// Must remain staged.
+			_, err = store.GetEntry(t.Context(), staging.ServiceParam, "/app/x")
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestDiffUseCase_Execute_ListError(t *testing.T) {


### PR DESCRIPTION
## Problem

`stage diff`'s fetch-error handling switched on the staged **operation** without inspecting the **error**: `OperationDelete` → `UnstageEntry` ("already deleted"), `OperationUpdate` → `UnstageEntry` ("no longer exists"). So expired credentials, throttling, or a network blip during the **read-only** `stage diff` silently unstaged every staged update/delete and discarded their draft values.

## Fix

Discriminate with `errors.Is(err, provider.ErrNotFound)` in both the `DiffUseCase` and the duplicated global `stage diff` command: auto-unstage only on a genuine not-found; surface any other error as a warning and leave the entry staged. `FetchCurrent` already propagates the `provider.ErrNotFound`-wrapped error, so no strategy change is needed — and a provider that fails to wrap it merely keeps the entry staged (the safe default).

## Tests

The tests injected a generic `errors.New("not found")` (the very gap the issue notes). Updated them to a `provider.ErrNotFound`-wrapped error and added regression tests (usecase + global command) that a **transient** error keeps deletes/updates staged.

Closes #321

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD