### PR TITLE
fix(staging): never auto-unstage a delete because the remote value is empty (#323)

### DIFF
--- a/internal/cli/commands/stage/diff/diff.go
+++ b/internal/cli/commands/stage/diff/diff.go
@@ -297,7 +297,11 @@ func (r *Runner) outputDiff(
 		remoteValue, stagedValue = jsonutil.TryFormatOrWarn2(remoteValue, stagedValue, r.Stderr, name)
 	}
 
-	if remoteValue == stagedValue {
+	// The identical-value auto-unstage never applies to a delete: deleting a
+	// resource is not a no-op just because its current value happens to be the
+	// empty string (legal in Azure App Configuration / Key Vault / Google
+	// Cloud), so an empty-valued delete must not be silently cancelled.
+	if entry.Operation != staging.OperationDelete && remoteValue == stagedValue {
 		// Auto-unstage since there's no difference
 		if err := r.Store.UnstageEntry(ctx, strategy.Service(), name); err != nil {
 			return fmt.Errorf("failed to unstage %s: %w", name, err)

--- a/internal/cli/commands/stage/diff/diff_test.go
+++ b/internal/cli/commands/stage/diff/diff_test.go
@@ -658,6 +658,36 @@ func TestRun_KeptStagedOnTransientFetchError(t *testing.T) {
 	}
 }
 
+// TestRun_DeleteEmptyRemoteNotUnstaged verifies a staged delete of a resource
+// whose remote value is the empty string is not cancelled by the
+// identical-value shortcut (#323).
+func TestRun_DeleteEmptyRemoteNotUnstaged(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, "/app/empty", staging.Entry{
+		Operation: staging.OperationDelete,
+		StagedAt:  time.Now(),
+	}))
+
+	var stdout, stderr bytes.Buffer
+
+	r := &stagediff.Runner{
+		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(storeReturning("", "1")))},
+		ProviderLabel: "AWS",
+		Store:         store,
+		Stdout:        &stdout,
+		Stderr:        &stderr,
+	}
+
+	require.NoError(t, r.Run(t.Context(), stagediff.Options{}))
+	assert.NotContains(t, stderr.String(), "unstaged")
+
+	// The staged deletion must survive `stage diff`.
+	_, err := store.GetEntry(t.Context(), staging.ServiceParam, "/app/empty")
+	require.NoError(t, err)
+}
+
 func TestRun_SecretDeleteAutoUnstageWhenAlreadyDeleted(t *testing.T) {
 	t.Parallel()
 

--- a/internal/usecase/staging/diff.go
+++ b/internal/usecase/staging/diff.go
@@ -189,8 +189,11 @@ func (u *DiffUseCase) processDiffResult(ctx context.Context, name string, entry 
 		stagedValue = ""
 	}
 
-	// Check if identical and auto-unstage
-	if awsValue == stagedValue {
+	// Check if identical and auto-unstage. This never applies to a delete:
+	// deleting a resource is not a no-op just because its current value happens
+	// to be the empty string (legal in Azure App Configuration / Key Vault /
+	// Google Cloud), so an empty-valued delete must not be silently cancelled.
+	if entry.Operation != staging.OperationDelete && awsValue == stagedValue {
 		_ = u.Store.UnstageEntry(ctx, service, name)
 
 		return DiffEntry{

--- a/internal/usecase/staging/diff_test.go
+++ b/internal/usecase/staging/diff_test.go
@@ -222,6 +222,37 @@ func TestDiffUseCase_Execute_AutoUnstage_AlreadyDeleted(t *testing.T) {
 	assert.Contains(t, entry.Warning, "already deleted")
 }
 
+// TestDiffUseCase_Execute_DeleteEmptyRemoteNotUnstaged verifies a staged delete
+// of a resource whose remote value is the empty string is NOT auto-unstaged by
+// the identical-value shortcut (#323).
+func TestDiffUseCase_Execute_DeleteEmptyRemoteNotUnstaged(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, "/app/empty", staging.Entry{
+		Operation: staging.OperationDelete,
+		StagedAt:  time.Now(),
+	}))
+
+	strategy := newMockDiffStrategy()
+	// The remote value is the empty string (legal in App Config / Key Vault /
+	// Google Cloud); the staged-delete value is also "" — but a delete must not
+	// be cancelled just because both are empty.
+	strategy.fetchResults["/app/empty"] = &staging.FetchResult{Value: "", Identifier: "#1"}
+
+	uc := &usecasestaging.DiffUseCase{Strategy: strategy, Store: store}
+
+	output, err := uc.Execute(t.Context(), usecasestaging.DiffInput{})
+	require.NoError(t, err)
+	require.Len(t, output.Entries, 1)
+	assert.NotEqual(t, usecasestaging.DiffEntryAutoUnstaged, output.Entries[0].Type)
+	assert.Equal(t, staging.OperationDelete, output.Entries[0].Operation)
+
+	// The staged deletion must survive `stage diff`.
+	_, err = store.GetEntry(t.Context(), staging.ServiceParam, "/app/empty")
+	require.NoError(t, err)
+}
+
 func TestDiffUseCase_Execute_FilterByName(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
> Supersedes #373 (auto-closed when its stacked base branch merged). Rebased onto `main`.

## Problem

For `OperationDelete` the diff sets `stagedValue = ""` and then applied the identical-value shortcut `remoteValue == stagedValue`. A resource whose current value is the empty string (legal in Azure App Configuration, Key Vault, and Google Cloud) therefore had its **staged deletion silently cancelled** just by running the read-only `stage diff`.

## Fix

Guard the identical-value auto-unstage with `entry.Operation != OperationDelete` in both the `DiffUseCase` and the duplicated global `stage diff` command. Deleting a resource is never a no-op just because its value is empty.

## Tests

Added regression tests (usecase + global command) that a delete of an empty-valued resource survives `stage diff`.

Closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD