### PR TITLE
fix(cli): read `--max-value-length` via cmd.Int32 so truncation works (#345)

### DIFF
--- a/internal/cli/commands/generic/log/log.go
+++ b/internal/cli/commands/generic/log/log.go
@@ -158,13 +158,17 @@ func Command(cfg Config) *cli.Command {
 			}
 
 			opts := Options{
-				ShowPatch:      cmd.Bool("patch"),
-				ParseJSON:      cmd.Bool("parse-json"),
-				Reverse:        cmd.Bool("reverse"),
-				NoPager:        cmd.Bool("no-pager"),
-				Oneline:        cmd.Bool("oneline"),
-				Output:         output.ParseFormat(cmd.String("output")),
-				MaxValueLength: cmd.Int("max-value-length"),
+				ShowPatch: cmd.Bool("patch"),
+				ParseJSON: cmd.Bool("parse-json"),
+				Reverse:   cmd.Bool("reverse"),
+				NoPager:   cmd.Bool("no-pager"),
+				Oneline:   cmd.Bool("oneline"),
+				Output:    output.ParseFormat(cmd.String("output")),
+				// --max-value-length is declared as an Int32Flag, so it must be
+				// read with cmd.Int32: urfave/cli's cmd.Int does a strict int
+				// type assertion that fails for int32 and silently returns 0,
+				// disabling truncation entirely.
+				MaxValueLength: int(cmd.Int32("max-value-length")),
 			}
 
 			req := Request{

--- a/internal/cli/commands/generic/log/log_test.go
+++ b/internal/cli/commands/generic/log/log_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"slices"
 	"strconv"
 	"strings"
@@ -13,6 +14,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
 
 	genericlog "github.com/mpyw/suve/internal/cli/commands/generic/log"
 	"github.com/mpyw/suve/internal/cli/commands/internal/apptest"
@@ -99,6 +101,57 @@ func TestCommand_Validation(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, buf.String(), "Show parameter version history")
 	})
+}
+
+// recordingPresenter captures the maxValueLength the Runner passes to the render
+// methods, so a flag-parsing test can assert the Int32 --max-value-length flag
+// actually reaches Options (it was silently read via cmd.Int, always 0) (#345).
+type recordingPresenter struct {
+	gotMaxValueLength int
+}
+
+func (p *recordingPresenter) Fetch(context.Context) error { return nil }
+func (p *recordingPresenter) Len() int                    { return 1 }
+func (p *recordingPresenter) RenderJSON(io.Writer) error  { return nil }
+func (p *recordingPresenter) RenderOneline(_ io.Writer, _, maxValueLength int) {
+	p.gotMaxValueLength = maxValueLength
+}
+func (p *recordingPresenter) RenderHeader(io.Writer, int) {}
+func (p *recordingPresenter) RenderValue(_ io.Writer, _, maxValueLength int) {
+	p.gotMaxValueLength = maxValueLength
+}
+func (p *recordingPresenter) RenderPatch(io.Writer, io.Writer, int, bool, bool) {}
+
+func TestCommand_MaxValueLengthFlagReachesOptions(t *testing.T) {
+	t.Parallel()
+
+	rec := &recordingPresenter{}
+
+	logCmd := genericlog.Command(genericlog.Config{
+		Usage:      "u",
+		ArgsUsage:  "<name>",
+		UsageError: "usage",
+		Flags: []cli.Flag{
+			&cli.Int32Flag{Name: "max-value-length"},
+			&cli.BoolFlag{Name: "no-pager"},
+		},
+		NewPresenter: func(_ context.Context, _ genericlog.Request) (genericlog.Presenter, error) {
+			return rec, nil
+		},
+	})
+
+	var buf, errBuf bytes.Buffer
+
+	app := &cli.Command{
+		Name:      "suve",
+		Commands:  []*cli.Command{logCmd},
+		Writer:    &buf,
+		ErrWriter: &errBuf,
+	}
+
+	err := app.Run(t.Context(), []string{"suve", "log", "--no-pager", "--max-value-length", "20", "myname"})
+	require.NoError(t, err)
+	assert.Equal(t, 20, rec.gotMaxValueLength, "Int32 --max-value-length must reach Options.MaxValueLength")
 }
 
 // === param log ===


### PR DESCRIPTION
## Problem

The generic log command read `MaxValueLength: cmd.Int("max-value-length")`, but the flag is declared as an `Int32Flag`. urfave/cli's `cmd.Int` does a strict `int` type assertion that fails for `int32` and silently returns `0`, so `suve param log --max-value-length N` never truncated in normal mode and fell back to auto-width in oneline mode.

## Fix

Read it with `cmd.Int32(...)`.

## Tests

Existing unit tests missed this because they build `Options{MaxValueLength: N}` directly, bypassing flag parsing. Added a flag-level test that drives the real flag → `Options` → `Runner` path through a recording presenter and asserts the value arrives as `20`.

Closes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD