### PR TITLE
fix(cli): preserve numeric precision in `--parse-json` formatting (#342)

### DIFF
--- a/internal/jsonutil/json.go
+++ b/internal/jsonutil/json.go
@@ -7,6 +7,7 @@ package jsonutil
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 
 	"github.com/mpyw/suve/internal/cli/output"
@@ -19,9 +20,24 @@ import (
 // HTML escaping is disabled so that characters like &, <, > survive verbatim
 // instead of being mangled into &, <, > — secret/parameter values
 // are not HTML and are never rendered in a browser context.
+//
+// Numbers are decoded with UseNumber so their exact literal is preserved:
+// decoding into float64 (the default) silently loses integer precision beyond
+// 2^53 and collapses 1.0/1, which would make genuinely different values format
+// identically (and diff as "identical").
 func TryFormat(value string) (string, bool) {
+	dec := json.NewDecoder(bytes.NewReader([]byte(value)))
+	dec.UseNumber()
+
 	var data any
-	if err := json.Unmarshal([]byte(value), &data); err != nil {
+	if err := dec.Decode(&data); err != nil {
+		return value, false
+	}
+
+	// Reject trailing data after the JSON value: json.Decoder stops at the end
+	// of the first value, whereas json.Unmarshal treated trailing content as
+	// invalid. A clean single-value input yields io.EOF here.
+	if _, err := dec.Token(); !errors.Is(err, io.EOF) {
 		return value, false
 	}
 
@@ -32,7 +48,7 @@ func TryFormat(value string) (string, bool) {
 	enc.SetIndent("", "  ")
 
 	if err := enc.Encode(data); err != nil {
-		// This should not happen if Unmarshal succeeded, but handle it gracefully
+		// This should not happen if Decode succeeded, but handle it gracefully
 		return value, false
 	}
 

--- a/internal/jsonutil/json_test.go
+++ b/internal/jsonutil/json_test.go
@@ -48,6 +48,30 @@ func TestTryFormat(t *testing.T) {
 			wantStr:  "{\n  \"url\": \"https://x.com/?a=1&b=<2>\"\n}",
 			wantBool: true,
 		},
+		{
+			name:     "preserves large integers beyond 2^53",
+			input:    `{"id":9007199254740993}`,
+			wantStr:  "{\n  \"id\": 9007199254740993\n}",
+			wantBool: true,
+		},
+		{
+			name:     "preserves the distinction between 1.0 and 1",
+			input:    `{"a":1.0,"b":1}`,
+			wantStr:  "{\n  \"a\": 1.0,\n  \"b\": 1\n}",
+			wantBool: true,
+		},
+		{
+			name:     "preserves high-precision decimals",
+			input:    `{"n":0.1234567890123456789}`,
+			wantStr:  "{\n  \"n\": 0.1234567890123456789\n}",
+			wantBool: true,
+		},
+		{
+			name:     "trailing data after a JSON value is rejected",
+			input:    `{"a":1} garbage`,
+			wantStr:  `{"a":1} garbage`,
+			wantBool: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

`jsonutil.TryFormat` unmarshalled into `any` (numbers → `float64`) and re-marshalled, losing integer precision beyond 2^53 and collapsing `1.0`/`1`. Since the generic diff computes `identical := v1 == v2` **after** formatting, `secret diff --parse-json` printed "comparing identical versions" for genuinely different secrets (`9007199254740993` vs `...992`), and `show --parse-json` / `--raw -j | jq` displayed wrong numbers.

## Fix

Decode with `json.Decoder.UseNumber()` so exact numeric literals are preserved, and reject trailing data after the value (a `json.Decoder` stops at the first value, unlike the previous `json.Unmarshal`).

## Tests

Added `TryFormat` cases: large integer beyond 2^53 preserved, `1.0` vs `1` kept distinct, high-precision decimal preserved, and trailing-garbage rejected.

Closes #342

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD