### PR TITLE
fix(cli): compute diff `identical` on raw values, clarify identical message (#344, #335)

### DIFF
--- a/internal/cli/commands/generic/diff/diff.go
+++ b/internal/cli/commands/generic/diff/diff.go
@@ -57,15 +57,20 @@ func (r *Runner) Run(ctx context.Context) error {
 		return err
 	}
 
-	value1 := r.Presenter.OldValue()
-	value2 := r.Presenter.NewValue()
+	rawValue1 := r.Presenter.OldValue()
+	rawValue2 := r.Presenter.NewValue()
 
-	// Format as JSON if enabled
+	// The identical decision is made on the RAW stored values, so a --parse-json
+	// reformat (whitespace, key order, number spelling) never masks a real
+	// stored difference (previously the compare ran AFTER formatting).
+	identical := rawValue1 == rawValue2
+
+	// Format as JSON if enabled — for rendering only.
+	value1, value2 := rawValue1, rawValue2
 	if r.Options.ParseJSON {
 		value1, value2 = jsonutil.TryFormatOrWarn2(value1, value2, r.Stderr, "")
 	}
 
-	identical := value1 == value2
 	oldLabel, newLabel := r.Presenter.Labels()
 
 	// JSON output mode
@@ -79,13 +84,30 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 
 	if identical {
-		output.Warning(r.Stderr, "comparing identical versions")
-		r.Presenter.Hints(r.Stderr)
+		// The values are byte-identical. Distinguish self-comparison from two
+		// distinct versions that merely happen to hold the same content, and
+		// only offer the self-comparison hints in the former case.
+		if oldLabel == newLabel {
+			output.Warning(r.Stderr, "comparing identical versions")
+			r.Presenter.Hints(r.Stderr)
+		} else {
+			output.Warning(r.Stderr, "versions differ but content is identical")
+		}
 
 		return nil
 	}
 
 	diff := output.Diff(oldLabel, newLabel, value1, value2)
+
+	// The raw values differ but --parse-json normalized them to the same form:
+	// there is no textual diff to show, so say so explicitly instead of printing
+	// nothing (and never claim the versions are identical).
+	if diff == "" {
+		output.Warning(r.Stderr, "values differ only in JSON formatting")
+
+		return nil
+	}
+
 	output.Print(r.Stdout, diff)
 
 	return nil

--- a/internal/cli/commands/generic/diff/diff_test.go
+++ b/internal/cli/commands/generic/diff/diff_test.go
@@ -16,6 +16,7 @@ import (
 	cmdparam "github.com/mpyw/suve/internal/cli/commands/param"
 	cmdsecret "github.com/mpyw/suve/internal/cli/commands/secret"
 	"github.com/mpyw/suve/internal/cli/diffargs"
+	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/providermock"
@@ -538,6 +539,72 @@ func TestParamIdenticalWarning(t *testing.T) {
 	assert.Contains(t, stderr, "comparing identical versions")
 	assert.Contains(t, stderr, "Hint:")
 	assert.Contains(t, stderr, "/app/param~1")
+}
+
+// TestDiff_DistinctVersionsSameContent verifies that comparing two DISTINCT
+// versions whose values happen to match reports the content as identical (not
+// "comparing identical versions") and omits the self-comparison hint (#335).
+func TestDiff_DistinctVersionsSameContent(t *testing.T) {
+	t.Parallel()
+
+	store := paramDiffStore(map[string]*domain.Entry{
+		"1": {Name: "/app/param", Value: "same-value", Version: domain.Version{ID: "1"}},
+		"3": {Name: "/app/param", Value: "same-value", Version: domain.Version{ID: "3"}},
+	})
+
+	spec1 := &paramversion.Spec{Name: "/app/param", Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))}}
+	spec3 := &paramversion.Spec{Name: "/app/param", Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))}}
+
+	stdout, stderr, err := run(t, cmdparam.NewDiffPresenter(store, spec1, spec3), genericdiff.Options{})
+	require.NoError(t, err)
+
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "versions differ but content is identical")
+	assert.NotContains(t, stderr, "comparing identical versions")
+	// The self-comparison hint ("use ~1") does not apply to two distinct specs.
+	assert.NotContains(t, stderr, "Hint:")
+}
+
+// TestDiff_FormattingOnlyDifference verifies that with --parse-json, two values
+// that differ only in JSON formatting (key order / whitespace) are reported as
+// formatting-only rather than being masked as identical (#344).
+func TestDiff_FormattingOnlyDifference(t *testing.T) {
+	t.Parallel()
+
+	store := paramDiffStore(map[string]*domain.Entry{
+		"1": {Name: "/app/param", Value: `{"a":1,"b":2}`, Version: domain.Version{ID: "1"}},
+		"3": {Name: "/app/param", Value: `{"b":2,"a":1}`, Version: domain.Version{ID: "3"}},
+	})
+
+	spec1 := &paramversion.Spec{Name: "/app/param", Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))}}
+	spec3 := &paramversion.Spec{Name: "/app/param", Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))}}
+
+	stdout, stderr, err := run(t, cmdparam.NewDiffPresenter(store, spec1, spec3), genericdiff.Options{ParseJSON: true})
+	require.NoError(t, err)
+
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "values differ only in JSON formatting")
+	assert.NotContains(t, stderr, "identical")
+}
+
+// TestDiff_JSONOutputIdenticalOnRawValues verifies --output=json reports
+// identical based on the raw stored values, so a formatting-only difference is
+// not masked as identical:true (#344).
+func TestDiff_JSONOutputIdenticalOnRawValues(t *testing.T) {
+	t.Parallel()
+
+	store := paramDiffStore(map[string]*domain.Entry{
+		"1": {Name: "/app/param", Value: `{"a":1,"b":2}`, Version: domain.Version{ID: "1"}},
+		"3": {Name: "/app/param", Value: `{"b":2,"a":1}`, Version: domain.Version{ID: "3"}},
+	})
+
+	spec1 := &paramversion.Spec{Name: "/app/param", Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))}}
+	spec3 := &paramversion.Spec{Name: "/app/param", Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))}}
+
+	stdout, _, err := run(t, cmdparam.NewDiffPresenter(store, spec1, spec3),
+		genericdiff.Options{ParseJSON: true, Output: output.FormatJSON})
+	require.NoError(t, err)
+	assert.Contains(t, stdout, `"identical": false`)
 }
 
 // secretDiffStore builds a mock reader keyed by the resolved spec suffix


### PR DESCRIPTION
Two related generic-`diff` defects.

## #344 — identical computed after JSON normalization

`--parse-json` reformatted both values **before** `identical := v1 == v2`, so values differing only in JSON formatting (whitespace, key order, number spelling) were declared identical: text mode printed only the warning (no diff), and `--output=json` reported `identical: true` — masking a real stored difference.

## #335 — "identical versions" for distinct versions with equal content

The check compared the two values but reported the **versions** as identical, so `diff /x#1 /x#3` (same value) printed "comparing identical versions" plus a self-comparison hint.

## Fix

- `identical` is now computed on the **raw** stored values (used for both the render decision and the JSON `identical` field).
- Raw values differ but `--parse-json` yields no textual diff → `values differ only in JSON formatting`.
- Byte-identical values → distinguish self-comparison (`comparing identical versions` + hint) from distinct versions (`versions differ but content is identical`, no hint).

## Tests

Existing self-comparison tests unchanged; added distinct-version, formatting-only, and `--output=json`-on-raw cases.

Closes #344
Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD