### PR TITLE
fix(staging): decide stage-diff auto-unstage on raw values, not normalized (#324)

### DIFF
--- a/internal/cli/commands/stage/diff/diff.go
+++ b/internal/cli/commands/stage/diff/diff.go
@@ -292,17 +292,12 @@ func (r *Runner) outputDiff(
 		stagedValue = ""
 	}
 
-	// Format as JSON if enabled
-	if opts.ParseJSON {
-		remoteValue, stagedValue = jsonutil.TryFormatOrWarn2(remoteValue, stagedValue, r.Stderr, name)
-	}
-
-	// The identical-value auto-unstage never applies to a delete: deleting a
-	// resource is not a no-op just because its current value happens to be the
-	// empty string (legal in Azure App Configuration / Key Vault / Google
-	// Cloud), so an empty-valued delete must not be silently cancelled.
+	// The auto-unstage decision is made on the RAW values, never on the
+	// --parse-json-normalized ones: whether staged work survives must not depend
+	// on a display flag, and it must match the service-level DiffUseCase which
+	// compares raw values. It also never applies to a delete (deleting is not a
+	// no-op just because the current value is the empty string).
 	if entry.Operation != staging.OperationDelete && remoteValue == stagedValue {
-		// Auto-unstage since there's no difference
 		if err := r.Store.UnstageEntry(ctx, strategy.Service(), name); err != nil {
 			return fmt.Errorf("failed to unstage %s: %w", name, err)
 		}
@@ -312,6 +307,12 @@ func (r *Runner) outputDiff(
 		return nil
 	}
 
+	// Format for rendering only.
+	displayRemote, displayStaged := remoteValue, stagedValue
+	if opts.ParseJSON {
+		displayRemote, displayStaged = jsonutil.TryFormatOrWarn2(remoteValue, stagedValue, r.Stderr, name)
+	}
+
 	label1 := fmt.Sprintf("%s%s (%s)", name, fr.Identifier, r.ProviderLabel)
 	label2 := fmt.Sprintf(lo.Ternary(
 		entry.Operation == staging.OperationDelete,
@@ -319,7 +320,16 @@ func (r *Runner) outputDiff(
 		"%s (staged)",
 	), name)
 
-	diff := output.Diff(label1, label2, remoteValue, stagedValue)
+	diff := output.Diff(label1, label2, displayRemote, displayStaged)
+
+	// Raw values differ but --parse-json renders no textual diff: the staged
+	// update only reformats JSON. It remains staged (decided on raw above).
+	if diff == "" {
+		output.Warning(r.Stderr, "%s: staged value differs from %s only in JSON formatting", name, r.ProviderLabel)
+
+		return nil
+	}
+
 	output.Print(r.Stdout, diff)
 
 	// Show staged metadata

--- a/internal/cli/commands/stage/diff/diff_test.go
+++ b/internal/cli/commands/stage/diff/diff_test.go
@@ -688,6 +688,39 @@ func TestRun_DeleteEmptyRemoteNotUnstaged(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestRun_ParseJSONReformatOnlyUpdateKeptStaged verifies that a staged update
+// which only reformats JSON (same content, different key order) is NOT unstaged
+// by `stage diff -j`: the auto-unstage decision is made on raw values, so
+// staged work does not depend on a display flag (#324).
+func TestRun_ParseJSONReformatOnlyUpdateKeptStaged(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, "/app/config", staging.Entry{
+		Operation: staging.OperationUpdate,
+		Value:     lo.ToPtr(`{"b":2,"a":1}`),
+		StagedAt:  time.Now(),
+	}))
+
+	var stdout, stderr bytes.Buffer
+
+	r := &stagediff.Runner{
+		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(storeReturning(`{"a":1,"b":2}`, "1")))},
+		ProviderLabel: "AWS",
+		Store:         store,
+		Stdout:        &stdout,
+		Stderr:        &stderr,
+	}
+
+	require.NoError(t, r.Run(t.Context(), stagediff.Options{ParseJSON: true}))
+	assert.NotContains(t, stderr.String(), "unstaged")
+	assert.Contains(t, stderr.String(), "only in JSON formatting")
+
+	// The staged update must survive `stage diff -j`.
+	_, err := store.GetEntry(t.Context(), staging.ServiceParam, "/app/config")
+	require.NoError(t, err)
+}
+
 func TestRun_SecretDeleteAutoUnstageWhenAlreadyDeleted(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Problem

In the global `stage diff` command, `-j/--parse-json` normalized both values via `TryFormatOrWarn2` **before** the `remoteValue == stagedValue` auto-unstage check. A staged update that only reformats JSON (whitespace, key order) was judged "identical to current" and **unstaged** — so whether staged work survived depended on a display flag, and this path diverged from the service-level `DiffUseCase`, which compares raw values.

## Fix

Make the auto-unstage comparison on the **raw** values; format only for rendering. When the raw values differ but `--parse-json` renders no textual diff, report "differs only in JSON formatting" and keep the entry staged instead of printing an empty diff.

## Tests

Added a test that a reformat-only staged update (same content, different key order) survives `stage diff -j`.

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD