### PR TITLE
fix(azure): list only null-label App Configuration settings (#352)

### DIFF
--- a/internal/provider/azure/appconfig/client.go
+++ b/internal/provider/azure/appconfig/client.go
@@ -7,6 +7,13 @@ import (
 	"github.com/samber/lo"
 )
 
+// nullLabelFilter is the reserved App Configuration label filter that matches
+// ONLY settings with no label. The Get/Set/Add/Delete single-key operations all
+// address the null (default) label, so List must restrict to the same label —
+// otherwise it enumerates every label and surfaces phantom keys that show/stage
+// then cannot fetch. The service encodes this reserved value as label=%00.
+const nullLabelFilter = "\x00"
+
 // apiClient adapts the concrete *azappconfig.Client to the narrow Client
 // interface, draining the SDK's list pager into a slice. It is the only place
 // the concrete SDK client and its pager are referenced.
@@ -43,7 +50,9 @@ func (a *apiClient) DeleteSetting(ctx context.Context, key string) (azappconfig.
 }
 
 func (a *apiClient) ListSettings(ctx context.Context) ([]azappconfig.Setting, error) {
-	pager := a.c.NewListSettingsPager(azappconfig.SettingSelector{}, nil)
+	pager := a.c.NewListSettingsPager(azappconfig.SettingSelector{
+		LabelFilter: lo.ToPtr(nullLabelFilter),
+	}, nil)
 
 	var out []azappconfig.Setting
 

--- a/internal/provider/azure/appconfig/client.go
+++ b/internal/provider/azure/appconfig/client.go
@@ -49,10 +49,17 @@ func (a *apiClient) DeleteSetting(ctx context.Context, key string) (azappconfig.
 	return a.c.DeleteSetting(ctx, key, nil)
 }
 
-func (a *apiClient) ListSettings(ctx context.Context) ([]azappconfig.Setting, error) {
-	pager := a.c.NewListSettingsPager(azappconfig.SettingSelector{
+// listSettingSelector is the selector used to enumerate settings: all keys but
+// ONLY the null (default) label, so List matches what the single-key operations
+// address. A nil LabelFilter (SettingSelector{}) would enumerate every label.
+func listSettingSelector() azappconfig.SettingSelector {
+	return azappconfig.SettingSelector{
 		LabelFilter: lo.ToPtr(nullLabelFilter),
-	}, nil)
+	}
+}
+
+func (a *apiClient) ListSettings(ctx context.Context) ([]azappconfig.Setting, error) {
+	pager := a.c.NewListSettingsPager(listSettingSelector(), nil)
 
 	var out []azappconfig.Setting
 

--- a/internal/provider/azure/appconfig/client_internal_test.go
+++ b/internal/provider/azure/appconfig/client_internal_test.go
@@ -1,0 +1,25 @@
+package appconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestListSettingSelector_FiltersNullLabel guards the #352 fix: List must
+// restrict to the null (default) label so it matches the single-key operations,
+// rather than enumerating every label (a nil LabelFilter). The reserved value
+// "\x00" is sent as label=%00, which App Configuration matches to label-less
+// key-values.
+func TestListSettingSelector_FiltersNullLabel(t *testing.T) {
+	t.Parallel()
+
+	sel := listSettingSelector()
+
+	require.NotNil(t, sel.LabelFilter, "List must set a label filter, not enumerate all labels")
+	assert.Equal(t, "\x00", *sel.LabelFilter)
+
+	// No key filter: all keys, restricted only by label.
+	assert.Nil(t, sel.KeyFilter)
+}


### PR DESCRIPTION
## Problem

`List` used `azappconfig.SettingSelector{}` (nil `LabelFilter` → **every label** returned), while `Get`/`Set`/`Add`/`Delete` pass `Label: nil` and address only the **null (default) label** — as the package doc promises (the same "azappconfig SDK only addresses the default label" family of documented constraints as the tag-write refusal). So a key present only under a non-null label (e.g. `prod`) appeared in `suve azure param list` but returned not-found on `suve azure param show`, and list-then-diff staging workflows saw phantom keys.

## Fix

Restrict `ListSettings` to the reserved null-label filter (`"\x00"`, sent by the SDK as `label=%00`, which App Configuration matches to label-less key-values). This makes `list` consistent with the single-key operations and the documented "default (no) label only" behavior. (Full end-to-end label support would be a separate feature, per the issue.)

Verified `"\x00"` → `label=%00`: the generated client does `reqQP.Set("label", *options.Label)` then `url.Values.Encode()`, which percent-encodes the NUL byte to `%00`.

## Tests

The App Configuration **e2e cannot** cover this — suve only ever writes null-label settings, so it never creates the labeled key that would expose the bug. Instead the selector is extracted into `listSettingSelector()` with a unit guard asserting it filters by the null label (`"\x00"`) and sets no key filter, preventing a regression back to `SettingSelector{}`.

Closes #352

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD