### PR TITLE
fix(cli): exit non-zero on unknown commands (#347)

### DIFF
--- a/internal/cli/commands/app.go
+++ b/internal/cli/commands/app.go
@@ -15,6 +15,7 @@ import (
 	awscmd "github.com/mpyw/suve/internal/cli/commands/aws"
 	"github.com/mpyw/suve/internal/cli/commands/azure"
 	"github.com/mpyw/suve/internal/cli/commands/gcloud"
+	cliinternal "github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/commands/param"
 	"github.com/mpyw/suve/internal/cli/commands/secret"
 	"github.com/mpyw/suve/internal/cli/commands/stage"
@@ -88,6 +89,11 @@ func MakeAppWithDetect(det detect.Result) *cli.Command {
 			w := lo.CoalesceOrEmpty(cmd.Root().ErrWriter, cmd.Root().Writer)
 			output.Println(w, "")
 			output.Warning(w, "Command not found: %s", command)
+
+			// urfave/cli's CommandNotFound is void, so Run returns nil; exit
+			// non-zero (via the overridable cli.OsExiter) so an unknown command
+			// fails instead of silently succeeding with status 0.
+			cli.OsExiter(cliinternal.CommandNotFoundExitCode)
 		},
 	}
 }

--- a/internal/cli/commands/app_test.go
+++ b/internal/cli/commands/app_test.go
@@ -113,3 +113,52 @@ func TestMakeApp_shellCompletion(t *testing.T) {
 func contains(ss []string, s string) bool {
 	return slices.Contains(ss, s)
 }
+
+// TestApp_UnknownCommand_ExitsNonZero verifies an unknown command produces a
+// non-zero exit (#347): urfave/cli's void CommandNotFound hook makes Run return
+// nil, so the handler must exit explicitly. It mutates the process-wide
+// cli.OsExiter, so it is not parallel.
+//
+//nolint:paralleltest // mutates the process-wide cli.OsExiter
+func TestApp_UnknownCommand_ExitsNonZero(t *testing.T) {
+	origExiter := cli.OsExiter
+
+	t.Cleanup(func() { cli.OsExiter = origExiter })
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"top-level", []string{"suve", "definitely-not-a-command"}},
+		{"subcommand", []string{"suve", "secret", "definitely-not-a-command"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				called  bool
+				gotCode int
+			)
+
+			cli.OsExiter = func(code int) { called, gotCode = true, code }
+
+			app := commands.MakeAppWithDetect(detect.Result{
+				Param:  provider.ProviderAWS,
+				Secret: provider.ProviderAWS,
+				Stage:  provider.ProviderAWS,
+			})
+
+			var out, errb bytes.Buffer
+
+			app.Writer = &out
+			app.ErrWriter = &errb
+
+			// urfave/cli returns nil after the void CommandNotFound hook runs.
+			err := app.Run(t.Context(), tc.args)
+			require.NoError(t, err)
+
+			assert.True(t, called, "an unknown command must exit")
+			assert.NotZero(t, gotCode, "exit code must be non-zero")
+		})
+	}
+}

--- a/internal/cli/commands/internal/command.go
+++ b/internal/cli/commands/internal/command.go
@@ -10,11 +10,21 @@ import (
 	"github.com/mpyw/suve/internal/cli/output"
 )
 
+// CommandNotFoundExitCode is the process exit code produced for an unknown
+// command. urfave/cli's CommandNotFound hook is a void func, so Command.Run
+// returns nil after it runs and the process would otherwise exit 0 — making
+// scripts/CI treat typos as success. The handlers exit non-zero explicitly.
+const CommandNotFoundExitCode = 1
+
 // CommandNotFound is a shared handler for unknown subcommands.
-// It displays the command help and an error message.
+// It displays the command help and an error message, then exits non-zero.
 func CommandNotFound(_ context.Context, cmd *cli.Command, command string) {
 	_ = cli.ShowSubcommandHelp(cmd)
 	w := lo.CoalesceOrEmpty(cmd.Root().ErrWriter, cmd.Root().Writer)
 	output.Println(w, "")
 	output.Warning(w, "Unknown command: %s", command)
+
+	// urfave/cli's CommandNotFound is void, so Run returns nil; exit non-zero
+	// here (via the overridable cli.OsExiter) so an unknown command fails.
+	cli.OsExiter(CommandNotFoundExitCode)
 }

--- a/internal/cli/commands/internal/command_test.go
+++ b/internal/cli/commands/internal/command_test.go
@@ -11,11 +11,22 @@ import (
 	cliinternal "github.com/mpyw/suve/internal/cli/commands/internal"
 )
 
+// TestCommandNotFound mutates the process-wide cli.OsExiter, so it is not
+// parallel; it saves and restores the original.
+//
+//nolint:paralleltest // mutates the process-wide cli.OsExiter
 func TestCommandNotFound(t *testing.T) {
-	t.Parallel()
+	origExiter := cli.OsExiter
 
-	t.Run("outputs unknown command message", func(t *testing.T) {
-		t.Parallel()
+	t.Cleanup(func() { cli.OsExiter = origExiter })
+
+	t.Run("outputs unknown command message and exits non-zero", func(t *testing.T) {
+		var (
+			called  bool
+			gotCode int
+		)
+
+		cli.OsExiter = func(code int) { called, gotCode = true, code }
 
 		stdout := &bytes.Buffer{}
 		stderr := &bytes.Buffer{}
@@ -34,10 +45,15 @@ func TestCommandNotFound(t *testing.T) {
 		// Should output the unknown command message to stderr (via output.Printf which uses ErrWriter)
 		output := stdout.String() + stderr.String()
 		assert.Contains(t, output, "Unknown command: unknown-cmd")
+
+		// And it must exit non-zero so scripts/CI do not treat a typo as success.
+		assert.True(t, called, "CommandNotFound must exit")
+		assert.Equal(t, cliinternal.CommandNotFoundExitCode, gotCode)
+		assert.NotZero(t, gotCode)
 	})
 
 	t.Run("shows help when ErrWriter is nil", func(t *testing.T) {
-		t.Parallel()
+		cli.OsExiter = func(int) {} // swallow the exit
 
 		stdout := &bytes.Buffer{}
 

--- a/internal/cli/commands/stage/status/status_test.go
+++ b/internal/cli/commands/stage/status/status_test.go
@@ -238,8 +238,9 @@ func TestCommand_Validation(t *testing.T) {
 
 	app.Writer = &buf
 
-	// Test that the command exists and works
-	err := app.Run(t.Context(), []string{"suve", "status", "--help"})
+	// Test that the command exists and works. `status` is a subcommand of
+	// `stage`, not a top-level command, so it must be invoked as `stage status`.
+	err := app.Run(t.Context(), []string{"suve", "stage", "status", "--help"})
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "staged changes")
 }


### PR DESCRIPTION
## Problem

urfave/cli v3's `CommandNotFound` hook is a **void** func, so `Command.Run` returns `nil` after it runs and the process exited **0** — scripts/CI treated typos (`suve not-a-command`, `suve secret not-a-command`) as success.

## Fix

Both the root handler (`app.go`) and the shared subcommand handler (`internal.CommandNotFound`) now call `cli.OsExiter` with a non-zero code after printing help. `cli.OsExiter` is urfave's overridable exit hook, so tests capture the code instead of terminating the process.

Also fixed a `stage/status` test that only "passed" because `suve status` (a non-existent top-level command) fell through to `CommandNotFound` and printed app help containing "staged changes"; it now invokes the real `stage status`.

## Tests

Added coverage that both a top-level and a subcommand typo exit non-zero (via a stubbed `cli.OsExiter`), and updated the internal `CommandNotFound` unit test to assert the exit.

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD