### PR TITLE
fix(staging): require --yes for stash drop in non-interactive contexts (#331)

### DIFF
--- a/internal/staging/cli/stash_drop.go
+++ b/internal/staging/cli/stash_drop.go
@@ -16,6 +16,28 @@ import (
 	"github.com/mpyw/suve/internal/staging/store/file"
 )
 
+// errStashDropNeedsYes is returned when `stash drop` runs without --yes in a
+// non-interactive context. Dropping the stash is destructive, so it requires an
+// explicit opt-in rather than proceeding unconfirmed (as it silently did).
+var errStashDropNeedsYes = errors.New(
+	"refusing to drop the stash without confirmation in a non-interactive context; re-run with --yes",
+)
+
+// requireStashDropConfirmation enforces the --yes opt-in when we cannot prompt.
+// Dropping the stash is destructive; without --yes and without a TTY to prompt
+// on (errW), it returns errStashDropNeedsYes instead of proceeding unconfirmed.
+func requireStashDropConfirmation(skipConfirm bool, errW io.Writer) error {
+	if skipConfirm {
+		return nil
+	}
+
+	if !terminal.IsTerminalWriter(errW) {
+		return errStashDropNeedsYes
+	}
+
+	return nil
+}
+
 // GlobalDropRunner executes global stash drop (delete entire file).
 type GlobalDropRunner struct {
 	FileStore *file.Store
@@ -134,9 +156,15 @@ func globalStashDropAction(resolver staging.ScopeResolver) func(context.Context,
 			return errors.New("no stashed changes to drop")
 		}
 
-		// Confirm unless --yes
+		// Confirm unless --yes. In a non-interactive context (no TTY) we cannot
+		// prompt, so require the explicit --yes opt-in rather than dropping
+		// silently.
 		skipConfirm := cmd.Bool(flagYes)
-		if !skipConfirm && terminal.IsTerminalWriter(cmd.Root().ErrWriter) {
+		if err := requireStashDropConfirmation(skipConfirm, cmd.Root().ErrWriter); err != nil {
+			return err
+		}
+
+		if !skipConfirm {
 			// Check if encrypted to decide confirmation message
 			isEncrypted, err := fileStore.IsEncrypted()
 			if err != nil {
@@ -202,9 +230,15 @@ func serviceStashDropAction(service staging.Service, resolver staging.ScopeResol
 			return err
 		}
 
-		// Confirm unless --yes
+		// Confirm unless --yes. In a non-interactive context (no TTY) we cannot
+		// prompt, so require the explicit --yes opt-in rather than dropping
+		// silently.
 		skipConfirm := cmd.Bool(flagYes)
-		if !skipConfirm && terminal.IsTerminalWriter(cmd.Root().ErrWriter) {
+		if err := requireStashDropConfirmation(skipConfirm, cmd.Root().ErrWriter); err != nil {
+			return err
+		}
+
+		if !skipConfirm {
 			// Count items for the message
 			state, err := fileStore.Drain(ctx, "", true)
 			if err != nil {

--- a/internal/staging/cli/stash_drop_internal_test.go
+++ b/internal/staging/cli/stash_drop_internal_test.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRequireStashDropConfirmation covers the #331 guard: in a non-interactive
+// context (a non-TTY writer, e.g. a pipe) `stash drop` must require --yes rather
+// than dropping the stash unconfirmed.
+func TestRequireStashDropConfirmation(t *testing.T) {
+	t.Parallel()
+
+	// A bytes.Buffer has no Fd(), so IsTerminalWriter reports false (non-TTY).
+	nonTTY := &bytes.Buffer{}
+
+	t.Run("non-TTY without --yes is refused", func(t *testing.T) {
+		t.Parallel()
+
+		err := requireStashDropConfirmation(false, nonTTY)
+		require.ErrorIs(t, err, errStashDropNeedsYes)
+	})
+
+	t.Run("--yes bypasses the prompt even without a TTY", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, requireStashDropConfirmation(true, nonTTY))
+	})
+
+	t.Run("error message points to --yes", func(t *testing.T) {
+		t.Parallel()
+
+		err := requireStashDropConfirmation(false, nonTTY)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--yes")
+	})
+}


### PR DESCRIPTION
## Problem

Both the global and service-specific `stage stash drop` actions gated the confirmation on `!skipConfirm && IsTerminalWriter(...)`. So a scripted/piped `suve stage stash drop` (no TTY, no `--yes`) **skipped the prompt entirely** and permanently deleted the stash with no explicit opt-in — unlike other destructive commands, which require `--yes` non-interactively.

## Fix

Extract `requireStashDropConfirmation`: without `--yes` and without a TTY to prompt on, it returns an error telling the user to re-run with `--yes`. Both actions call it before the interactive prompt (which is now only reached when a TTY is present).

## Tests

Unit test for the guard: non-TTY without `--yes` is refused; `--yes` bypasses; the message points to `--yes`.

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD