### PR TITLE
fix(staging): surface unstage failures after a successful apply (#327)

### DIFF
--- a/internal/staging/cli/apply.go
+++ b/internal/staging/cli/apply.go
@@ -146,6 +146,12 @@ func (r *ApplyRunner) Run(ctx context.Context, opts ApplyOptions) error {
 					// Unreachable: when Status is Failed, entry.Error is always non-nil,
 					// so the outer if-branch handles this case.
 				}
+
+				// The cloud apply succeeded but clearing the staged entry failed:
+				// warn so the leftover (which a later apply would re-run) is visible.
+				if entry.UnstageError != nil {
+					output.Warning(r.Stderr, "failed to clear staging for %s: %v", name, entry.UnstageError)
+				}
 			}
 
 			break
@@ -163,6 +169,10 @@ func (r *ApplyRunner) Run(ctx context.Context, opts ApplyOptions) error {
 				output.Failed(r.Stderr, name+" (tags)", tag.Error)
 			} else {
 				output.Success(r.Stdout, "Tagged %s%s", name, FormatTagApplySummary(tag))
+
+				if tag.UnstageError != nil {
+					output.Warning(r.Stderr, "failed to clear staging for %s tags: %v", name, tag.UnstageError)
+				}
 			}
 
 			break

--- a/internal/staging/cli/cli_test.go
+++ b/internal/staging/cli/cli_test.go
@@ -1737,6 +1737,67 @@ func TestEditRunner_WithMetadata(t *testing.T) {
 	})
 }
 
+// TestApplyRunner_UnstageFailureWarns verifies that when the cloud apply
+// succeeds but clearing the staged entry afterwards fails, the service-specific
+// apply surfaces a warning instead of silently ignoring it (#327).
+func TestApplyRunner_UnstageFailureWarns(t *testing.T) {
+	t.Parallel()
+
+	t.Run("entry unstage failure warns", func(t *testing.T) {
+		t.Parallel()
+
+		store := testutil.NewMockStore()
+		_ = store.StageEntry(t.Context(), staging.ServiceParam, "/app/config", staging.Entry{
+			Operation: staging.OperationUpdate,
+			Value:     lo.ToPtr("v"),
+			StagedAt:  time.Now(),
+		})
+		store.UnstageEntryErr = errors.New("disk full")
+
+		var stdout, stderr bytes.Buffer
+
+		r := &cli.ApplyRunner{
+			UseCase: &stagingusecase.ApplyUseCase{
+				Strategy: &fullMockStrategy{service: staging.ServiceParam},
+				Store:    store,
+			},
+			Stdout: &stdout,
+			Stderr: &stderr,
+		}
+
+		require.NoError(t, r.Run(t.Context(), cli.ApplyOptions{}))
+		assert.Contains(t, stdout.String(), "Updated /app/config")
+		assert.Contains(t, stderr.String(), "failed to clear staging for /app/config")
+		assert.Contains(t, stderr.String(), "disk full")
+	})
+
+	t.Run("tag unstage failure warns", func(t *testing.T) {
+		t.Parallel()
+
+		store := testutil.NewMockStore()
+		_ = store.StageTag(t.Context(), staging.ServiceParam, "/app/config", staging.TagEntry{
+			Add:      map[string]string{"env": "prod"},
+			StagedAt: time.Now(),
+		})
+		store.UnstageTagErr = errors.New("disk full")
+
+		var stdout, stderr bytes.Buffer
+
+		r := &cli.ApplyRunner{
+			UseCase: &stagingusecase.ApplyUseCase{
+				Strategy: &fullMockStrategy{service: staging.ServiceParam},
+				Store:    store,
+			},
+			Stdout: &stdout,
+			Stderr: &stderr,
+		}
+
+		require.NoError(t, r.Run(t.Context(), cli.ApplyOptions{}))
+		assert.Contains(t, stdout.String(), "Tagged /app/config")
+		assert.Contains(t, stderr.String(), "failed to clear staging for /app/config tags")
+	})
+}
+
 func TestApplyRunner_WithTags(t *testing.T) {
 	t.Parallel()
 

--- a/internal/usecase/staging/apply.go
+++ b/internal/usecase/staging/apply.go
@@ -32,6 +32,10 @@ type ApplyEntryResult struct {
 	Name   string
 	Status ApplyResultStatus
 	Error  error
+	// UnstageError is set when the cloud apply succeeded but clearing the entry
+	// from the staging store afterwards failed. The entry is still staged, so a
+	// later apply would re-run it; callers must surface this rather than ignore it.
+	UnstageError error
 }
 
 // ApplyTagResult represents the result of applying tag changes.
@@ -40,6 +44,9 @@ type ApplyTagResult struct {
 	AddTags   map[string]string   // Tags that were added/updated
 	RemoveTag maputil.Set[string] // Tag keys that were removed
 	Error     error
+	// UnstageError is set when the cloud tag apply succeeded but clearing the
+	// staged tag afterwards failed (see ApplyEntryResult.UnstageError).
+	UnstageError error
 }
 
 // ApplyOutput holds the result of the apply use case.
@@ -174,8 +181,12 @@ func (u *ApplyUseCase) applyEntries(ctx context.Context, service staging.Service
 			case staging.OperationDelete:
 				resultEntry.Status = ApplyResultDeleted
 			}
-			// Unstage successful operations
-			_ = u.Store.UnstageEntry(ctx, service, name)
+			// Unstage successful operations. A failure here leaves the entry
+			// staged after a successful cloud apply, so record it rather than
+			// discarding it — a silent leftover would be re-applied next time.
+			if err := u.Store.UnstageEntry(ctx, service, name); err != nil {
+				resultEntry.UnstageError = err
+			}
 
 			output.EntrySucceeded++
 		}
@@ -205,8 +216,11 @@ func (u *ApplyUseCase) applyTags(ctx context.Context, service staging.Service, t
 			resultTag.Error = result.Err
 			output.TagFailed++
 		} else {
-			// Unstage successful operations
-			_ = u.Store.UnstageTag(ctx, service, name)
+			// Unstage successful operations (see applyEntries: record rather
+			// than discard a post-apply unstage failure).
+			if err := u.Store.UnstageTag(ctx, service, name); err != nil {
+				resultTag.UnstageError = err
+			}
 
 			output.TagSucceeded++
 		}


### PR DESCRIPTION
## Problem

`ApplyUseCase` discarded post-apply unstage errors (`_ = u.Store.UnstageEntry(...)` / `_ = u.Store.UnstageTag(...)`). If the staging-store write failed *after* a successful cloud apply, the entry stayed staged with **zero indication**; a later `apply` re-ran it — a re-applied create fails "already exists", and a stale delete could remove a resource that was re-created in the meantime. The global `stage apply` already warned; the service-specific path was silent.

## Fix

Record the unstage failure on `ApplyEntryResult`/`ApplyTagResult` (`UnstageError`) and have the service-specific apply presenter warn `failed to clear staging for <name>`, consistent with the global command.

## Tests

Added coverage that an entry/tag unstage failure (via the mock store's `UnstageEntryErr`/`UnstageTagErr`) still reports success for the cloud apply but warns that staging could not be cleared.

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD