### PR TITLE
fix(staging): enforce stash `--merge`/`--overwrite` mutual exclusion (#322)

### DIFF
--- a/internal/staging/cli/stash_flags_internal_test.go
+++ b/internal/staging/cli/stash_flags_internal_test.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+)
+
+// TestStashMutuallyExclusiveFlags guards #322: --merge and --overwrite must be
+// mutually exclusive, and each must still be readable (folded into the command)
+// when declared only inside MutuallyExclusiveFlags.
+func TestStashMutuallyExclusiveFlags(t *testing.T) {
+	t.Parallel()
+
+	const cmdName = "s" // arbitrary; avoids repeating a command-name literal
+
+	cases := []struct {
+		name  string
+		flags func() []cli.Flag
+		mux   func() []cli.MutuallyExclusiveFlags
+	}{
+		{"push-flags", stashPushFlags, stashPushMutuallyExclusiveFlags},
+		{"pop-flags", stashPopFlags, stashPopMutuallyExclusiveFlags},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			newCmd := func(gotMerge *bool) *cli.Command {
+				return &cli.Command{
+					Name:                   cmdName,
+					Flags:                  tc.flags(),
+					MutuallyExclusiveFlags: tc.mux(),
+					Writer:                 io.Discard,
+					ErrWriter:              io.Discard,
+					Action: func(_ context.Context, cmd *cli.Command) error {
+						if gotMerge != nil {
+							*gotMerge = cmd.Bool(flagMerge)
+						}
+
+						return nil
+					},
+				}
+			}
+
+			// --merge --overwrite together must be rejected.
+			err := newCmd(nil).Run(context.Background(), []string{cmdName, "--merge", "--overwrite"})
+			require.Error(t, err)
+
+			// Each alone is accepted, and its value is readable via cmd.Bool
+			// (proving the group flags fold into the command's flag set).
+			var gotMerge bool
+
+			require.NoError(t, newCmd(&gotMerge).Run(context.Background(), []string{cmdName, "--merge"}))
+			assert.True(t, gotMerge, "--merge must be readable via cmd.Bool")
+
+			require.NoError(t, newCmd(nil).Run(context.Background(), []string{cmdName, "--overwrite"}))
+		})
+	}
+}

--- a/internal/staging/cli/stash_pop.go
+++ b/internal/staging/cli/stash_pop.go
@@ -81,27 +81,22 @@ func stashPopFlags() []cli.Flag {
 			Usage: usageSkipConfirm,
 		},
 		&cli.BoolFlag{
-			Name:  flagMerge,
-			Usage: "Merge with the existing working staging area (default)",
-		},
-		&cli.BoolFlag{
-			Name:  flagOverwrite,
-			Usage: "Overwrite the working staging area",
-		},
-		&cli.BoolFlag{
 			Name:  flagPassphraseStdin,
 			Usage: usagePassphraseStdin,
 		},
 	}
 }
 
-// stashPopMutuallyExclusiveFlags returns the mutually exclusive flags constraint.
+// stashPopMutuallyExclusiveFlags returns the mutually exclusive --merge /
+// --overwrite constraint. The flags are declared ONLY here (see the push
+// equivalent): a duplicate copy in stashPopFlags would shadow these under
+// urfave/cli v3 and silently disable the exclusivity check.
 func stashPopMutuallyExclusiveFlags() []cli.MutuallyExclusiveFlags {
 	return []cli.MutuallyExclusiveFlags{
 		{
 			Flags: [][]cli.Flag{
-				{&cli.BoolFlag{Name: flagMerge}},
-				{&cli.BoolFlag{Name: flagOverwrite}},
+				{&cli.BoolFlag{Name: flagMerge, Usage: "Merge with the existing working staging area (default)"}},
+				{&cli.BoolFlag{Name: flagOverwrite, Usage: "Overwrite the working staging area"}},
 			},
 		},
 	}

--- a/internal/staging/cli/stash_push.go
+++ b/internal/staging/cli/stash_push.go
@@ -88,27 +88,24 @@ func stashPushFlags() []cli.Flag {
 			Usage: usageSkipConfirm,
 		},
 		&cli.BoolFlag{
-			Name:  flagMerge,
-			Usage: "Merge with existing stash (default)",
-		},
-		&cli.BoolFlag{
-			Name:  flagOverwrite,
-			Usage: "Overwrite existing stash",
-		},
-		&cli.BoolFlag{
 			Name:  flagPassphraseStdin,
 			Usage: usagePassphraseStdin,
 		},
 	}
 }
 
-// stashPushMutuallyExclusiveFlags returns the mutually exclusive flags constraint.
+// stashPushMutuallyExclusiveFlags returns the mutually exclusive --merge /
+// --overwrite constraint. The flags are declared ONLY here (not also in
+// stashPushFlags): urfave/cli v3 binds parsed values to the first flag instance
+// of a name, so a separate copy in Flags would shadow these, leaving the group's
+// instances never IsSet() and the exclusivity check dead. Declaring them solely
+// in the group lets v3 fold them into the command and enforce the constraint.
 func stashPushMutuallyExclusiveFlags() []cli.MutuallyExclusiveFlags {
 	return []cli.MutuallyExclusiveFlags{
 		{
 			Flags: [][]cli.Flag{
-				{&cli.BoolFlag{Name: flagMerge}},
-				{&cli.BoolFlag{Name: flagOverwrite}},
+				{&cli.BoolFlag{Name: flagMerge, Usage: "Merge with existing stash (default)"}},
+				{&cli.BoolFlag{Name: flagOverwrite, Usage: "Overwrite existing stash"}},
 			},
 		},
 	}


### PR DESCRIPTION
## Problem

The `MutuallyExclusiveFlags` groups held **fresh shadow** `BoolFlag` instances while the real `--merge`/`--overwrite` were declared separately in `Flags`. urfave/cli v3 binds parsed values to the first flag instance of a name (the `Flags` copies), so the group's copies were never `IsSet()` and the exclusivity check never fired:

`suve stage stash push --merge --overwrite` passed validation and — since the action checks `overwrite` first — silently **overwrote** the stash the user asked to *merge*. The flags also appeared twice in `--help`.

## Fix

Declare `--merge`/`--overwrite` (with their usage strings) **only** inside `MutuallyExclusiveFlags` for both push and pop. urfave/cli v3 folds group flags into the command, so `cmd.Bool` still reads them and the constraint is enforced.

## Tests

Added a test that `--merge --overwrite` together is rejected, each alone is accepted, and the value is still readable via `cmd.Bool` (proving the fold), for both push and pop flag sets.

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD