### PR TITLE
fix(cli): use the real terminal width for `log --oneline` under the pager (#346)

### DIFF
--- a/internal/cli/pager/pager.go
+++ b/internal/cli/pager/pager.go
@@ -27,9 +27,12 @@ func WithPagerWriter(stdout io.Writer, noPager bool, fn func(w io.Writer) error)
 		return fn(stdout)
 	}
 
-	// Real TTY - collect output first
-	var buf bytes.Buffer
-	if err := fn(&buf); err != nil {
+	// Real TTY - collect output first. The buffer still reports the real
+	// terminal's Fd (see fdBuffer) so width/TTY detection during rendering
+	// (e.g. log --oneline's auto width) sees the actual terminal instead of the
+	// width-less buffer, which would otherwise fall back to DefaultWidth.
+	buf := &fdBuffer{Buffer: &bytes.Buffer{}, fd: f.Fd()}
+	if err := fn(buf); err != nil {
 		return err
 	}
 
@@ -46,6 +49,20 @@ func WithPagerWriter(stdout io.Writer, noPager bool, fn func(w io.Writer) error)
 
 	return moor.PageFromString(buf.String(), moor.Options{})
 }
+
+// fdBuffer buffers output for paging while still reporting the underlying
+// terminal's file descriptor via Fd(). This lets terminal width/TTY detection
+// see the real terminal even though output is buffered before paging. Color
+// output is gated globally (fatih/color), not by this writer's Fd, so exposing
+// it here does not change colorization.
+type fdBuffer struct {
+	*bytes.Buffer
+
+	fd uintptr
+}
+
+// Fd returns the underlying terminal's file descriptor.
+func (b *fdBuffer) Fd() uintptr { return b.fd }
 
 // fitsInTerminal returns true if the content fits within the terminal height.
 // Returns false if terminal size cannot be determined.

--- a/internal/cli/pager/pager_test.go
+++ b/internal/cli/pager/pager_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/mpyw/suve/internal/cli/pager"
+	"github.com/mpyw/suve/internal/cli/terminal"
 )
 
 func TestWithPagerWriter_NoPagerTrue(t *testing.T) {
@@ -94,4 +95,39 @@ func TestWithPagerWriter_WithFdNonTTY(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "test output", string(output))
+}
+
+type fakeTTYWriter struct {
+	bytes.Buffer
+}
+
+func (f *fakeTTYWriter) Fd() uintptr { return 1 }
+
+// TestWithPagerWriter_WidthSeesRealTerminalUnderPager guards #346: when output
+// is buffered for paging on a real TTY, terminal width detection must see the
+// real terminal, not the width-less buffer (which fell back to DefaultWidth and
+// truncated log --oneline to ~20 chars). Mocks package-global terminal vars, so
+// it is not parallel.
+//
+//nolint:paralleltest // mutates package-global terminal.IsTTY/GetSize
+func TestWithPagerWriter_WidthSeesRealTerminalUnderPager(t *testing.T) {
+	origTTY, origSize := terminal.IsTTY, terminal.GetSize
+
+	t.Cleanup(func() { terminal.IsTTY, terminal.GetSize = origTTY, origSize })
+
+	terminal.IsTTY = func(uintptr) bool { return true }
+	terminal.GetSize = func(int) (int, int, error) { return 123, 40, nil }
+
+	stdout := &fakeTTYWriter{}
+
+	var gotWidth int
+
+	err := pager.WithPagerWriter(stdout, false, func(w io.Writer) error {
+		gotWidth = terminal.GetWidthFromWriter(w)
+		_, werr := io.WriteString(w, "short line\n")
+
+		return werr
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 123, gotWidth, "render width must reflect the real terminal, not the buffer default")
 }


### PR DESCRIPTION
## Problem

On a real TTY the pager buffers all output into a `bytes.Buffer`, and `RenderOneline` called `terminal.GetWidthFromWriter` on that buffer — which has no `Fd()`, so it always returned `DefaultWidth` (50). With the ~30-char metadata overhead, `log --oneline` truncated values to **20 chars regardless of the actual terminal width** (the real width was only used with `--no-pager`).

## Fix

Wrap the pager buffer in an `fdBuffer` that reports the underlying terminal's `Fd()`, so width/TTY detection during rendering sees the real terminal. Color output is gated globally by `fatih/color` (not by this writer's `Fd`), so this does not change colorization.

## Tests

Added a pager test (mocking `terminal.IsTTY`/`GetSize`) asserting that the width seen inside the buffered render reflects the real terminal (123), not `DefaultWidth`.

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD