### PR TITLE
fix(version): reject overflowing `~N` shifts and guard negative target index (#315)

### DIFF
--- a/internal/provider/aws/param/param.go
+++ b/internal/provider/aws/param/param.go
@@ -104,7 +104,7 @@ func (s *Store) Resolve(ctx context.Context, name, spec string) (provider.Versio
 	}
 
 	targetIdx := baseIdx + parsed.Shift
-	if targetIdx >= len(params) {
+	if targetIdx < 0 || targetIdx >= len(params) {
 		return provider.VersionRef{}, fmt.Errorf("version shift out of range: ~%d", parsed.Shift)
 	}
 

--- a/internal/provider/aws/param/param_test.go
+++ b/internal/provider/aws/param/param_test.go
@@ -142,6 +142,23 @@ func TestResolve_VersionThenShift(t *testing.T) {
 	assert.Equal(t, "1", ref.ID())
 }
 
+// TestResolve_HugeShiftDoesNotPanic guards #315: a shift that overflows int when
+// added to the base index must return an "out of range" error, not panic on a
+// negative slice index (baseIdx + MaxInt wraps negative).
+func TestResolve_HugeShiftDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	store := param.New(&mockClient{
+		getHistory: func(_ *ssm.GetParameterHistoryInput) (*ssm.GetParameterHistoryOutput, error) {
+			return &ssm.GetParameterHistoryOutput{Parameters: historyOldestFirst()}, nil
+		},
+	})
+
+	_, err := store.Resolve(t.Context(), "/my/param", "#2~9223372036854775807")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of range")
+}
+
 func TestResolve_ShiftOutOfRange(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/aws/secret/secret.go
+++ b/internal/provider/aws/secret/secret.go
@@ -120,7 +120,7 @@ func (s *Store) Resolve(ctx context.Context, name, spec string) (provider.Versio
 	}
 
 	targetIdx := baseIdx + parsed.Shift
-	if targetIdx >= len(list) {
+	if targetIdx < 0 || targetIdx >= len(list) {
 		return provider.VersionRef{}, fmt.Errorf("version shift out of range: ~%d", parsed.Shift)
 	}
 

--- a/internal/provider/azure/keyvault/keyvault.go
+++ b/internal/provider/azure/keyvault/keyvault.go
@@ -122,7 +122,7 @@ func (s *Store) Resolve(ctx context.Context, name, spec string) (provider.Versio
 	}
 
 	targetIdx := baseIdx + parsed.Shift
-	if targetIdx >= len(versions) {
+	if targetIdx < 0 || targetIdx >= len(versions) {
 		return provider.VersionRef{}, fmt.Errorf("version shift out of range: ~%d", parsed.Shift)
 	}
 

--- a/internal/provider/gcloud/secret/secret.go
+++ b/internal/provider/gcloud/secret/secret.go
@@ -146,7 +146,7 @@ func (s *Store) Resolve(ctx context.Context, name, spec string) (provider.Versio
 	}
 
 	targetIdx := baseIdx + parsed.Shift
-	if targetIdx >= len(versions) {
+	if targetIdx < 0 || targetIdx >= len(versions) {
 		return provider.VersionRef{}, fmt.Errorf("version shift out of range: ~%d", parsed.Shift)
 	}
 

--- a/internal/version/parse_test.go
+++ b/internal/version/parse_test.go
@@ -2,6 +2,7 @@ package version_test
 
 import (
 	"errors"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -211,6 +212,26 @@ func TestParse(t *testing.T) {
 		spec, err := version.Parse("/my/param~1~2", parser)
 		require.NoError(t, err)
 		assert.Equal(t, 3, spec.Shift) // ~1~2 = 3
+	})
+
+	t.Run("cumulative shift overflow is rejected", func(t *testing.T) {
+		t.Parallel()
+
+		// Previously total wrapped negative -> HasShift() false -> silently
+		// resolved to latest. It must now error instead (#315).
+		_, err := version.Parse("/my/param~9223372036854775807~9223372036854775807", parser)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "out of range")
+	})
+
+	t.Run("single max shift parses without overflow", func(t *testing.T) {
+		t.Parallel()
+
+		// A single MaxInt shift is representable; it is the resolver's bounds
+		// check (targetIdx < 0 || >= len) that rejects it, not the parser.
+		spec, err := version.Parse("/my/param~9223372036854775807", parser)
+		require.NoError(t, err)
+		assert.Equal(t, math.MaxInt, spec.Shift)
 	})
 
 	t.Run("ambiguous tilde", func(t *testing.T) {

--- a/internal/version/shift.go
+++ b/internal/version/shift.go
@@ -2,6 +2,7 @@ package version
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 
 	"github.com/mpyw/suve/internal/version/internal"
@@ -33,12 +34,24 @@ func parseShift(s string) (int, error) {
 		}
 
 		if numStart == i {
-			// Bare ~ means ~1
+			// Bare ~ means ~1.
+			if total == math.MaxInt {
+				return 0, errShiftOutOfRange
+			}
+
 			total++
 		} else {
 			n, err := strconv.Atoi(s[numStart:i])
 			if err != nil {
 				return 0, fmt.Errorf("shift number too large: %s", s[numStart:i])
+			}
+
+			// Overflow-checked cumulative sum: n is non-negative (digits only),
+			// so an unchecked `total += n` could wrap to a negative total, which
+			// HasShift() then reads as "no shift" and silently resolves to latest
+			// (e.g. `~MAX~MAX`). Reject instead.
+			if n > math.MaxInt-total {
+				return 0, errShiftOutOfRange
 			}
 
 			total += n
@@ -47,6 +60,10 @@ func parseShift(s string) (int, error) {
 
 	return total, nil
 }
+
+// errShiftOutOfRange is returned when a ~N shift (or a cumulative ~N~M sum)
+// exceeds what an int can hold.
+var errShiftOutOfRange = fmt.Errorf("shift out of range")
 
 // isShiftStart returns true if position i in string s looks like the start of a shift.
 func isShiftStart(s string, i int) bool {


### PR DESCRIPTION
Two integer-overflow holes in `~N` handling.

## 1. Panic

`parseShift` accepted `Shift` up to `MaxInt`, and the only resolver bound was `targetIdx >= len`. With `baseIdx >= 1`, `baseIdx + MaxInt` wrapped **negative**, passed the check, and panicked on a negative slice index — e.g. `suve param show '/p#2~9223372036854775807'`. Added `targetIdx < 0` to the bounds check in all four providers (AWS param/secret, gcloud secret, Azure Key Vault).

## 2. Silent wrong value

Cumulative shifts were summed unchecked, so `~9223...807~9223...807` wrapped to a negative total, `HasShift()` read it as "no shift", and it silently resolved to **latest**. `parseShift` now uses overflow-checked addition and rejects the sum with `shift out of range`.

A single `MaxInt` shift still parses (it is representable); the resolver's bounds check turns it into a clean out-of-range error instead of a panic.

## Tests

Parser: cumulative overflow rejected; single-max parses. Provider: `#2~MAX` returns out-of-range instead of panicking.

Closes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD