### PR TITLE
fix(staging): write state/stash files atomically (#325)

### DIFF
--- a/internal/staging/store/file/store.go
+++ b/internal/staging/store/file/store.go
@@ -345,8 +345,50 @@ func (s *Store) writeFile(path string, state *staging.State) error {
 		}
 	}
 
-	if err := os.WriteFile(path, data, 0o600); err != nil { //nolint:mnd // owner-only file permissions
+	if err := writeFileAtomic(path, data); err != nil {
 		return fmt.Errorf("failed to write state file: %w", err)
+	}
+
+	return nil
+}
+
+// writeFileAtomic writes data to path atomically: it writes to a temp file in
+// the same directory, fsyncs it, then renames it over the target. A crash, OOM,
+// or power loss mid-write then leaves either the old file or the complete new
+// one — never a truncated/corrupt file, which would fail decryption on the next
+// read and feed the error-swallowing overwrite paths. The file is owner-only
+// (0600), matching os.CreateTemp's default.
+func writeFileAtomic(path string, data []byte) error {
+	dir := filepath.Dir(path)
+
+	tmp, err := os.CreateTemp(dir, "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp state file: %w", err)
+	}
+
+	tmpName := tmp.Name()
+
+	// Best-effort cleanup of the temp file if we bail out before renaming.
+	defer func() { _ = os.Remove(tmpName) }()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+
+		return fmt.Errorf("failed to write temp state file: %w", err)
+	}
+
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+
+		return fmt.Errorf("failed to sync temp state file: %w", err)
+	}
+
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close temp state file: %w", err)
+	}
+
+	if err := os.Rename(tmpName, path); err != nil {
+		return fmt.Errorf("failed to rename temp state file: %w", err)
 	}
 
 	return nil

--- a/internal/staging/store/file/store_key_internal_test.go
+++ b/internal/staging/store/file/store_key_internal_test.go
@@ -234,3 +234,29 @@ func TestNewWorkingStore_KeychainError_EncryptedStateExists_Fatal(t *testing.T) 
 	assert.Contains(t, err.Error(), "keychain locked")
 	assert.Contains(t, err.Error(), "encrypted state exists")
 }
+
+// TestWriteFileAtomic guards #325: writes go through a temp file + rename, so
+// the target ends up complete, owner-only, and no temp file is left behind.
+func TestWriteFileAtomic(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stage.json")
+
+	require.NoError(t, writeFileAtomic(path, []byte("hello")))
+
+	got, err := os.ReadFile(path) //nolint:gosec // test temp path
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(got))
+
+	// No temp files left behind in the directory.
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "stage.json", entries[0].Name())
+
+	// Owner-only permissions.
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+}


### PR DESCRIPTION
## Problem

`writeFile` used `os.WriteFile`, which truncates in place — no temp file, no fsync, no rename. A crash/OOM/power loss mid-write left a truncated or corrupt `param.json`/`secret.json`/`stash.json`, which then failed decryption on the next read and fed the error-swallowing overwrite paths. Every staged secret lives only in these files.

## Fix

Add `writeFileAtomic`: write to a temp file in the same directory, `fsync` it, then `os.Rename` over the target (owner-only `0600`). A crash now leaves either the old file or the complete new one — never a partial write.

## Tests

Added a test asserting the write produces a complete, `0600` file with no temp leftovers in the directory.

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD