### PR TITLE
fix(param): paginate GetParameterHistory so `~N`/`log` see the full history (#311)

### DIFF
--- a/internal/provider/aws/param/param.go
+++ b/internal/provider/aws/param/param.go
@@ -74,16 +74,12 @@ func (s *Store) Resolve(ctx context.Context, name, spec string) (provider.Versio
 		return provider.NewVersionRef(""), nil
 	}
 
-	// Shift present: walk the history newest-first from the base version.
-	history, err := s.client.GetParameterHistory(ctx, &ssm.GetParameterHistoryInput{
-		Name:           aws.String(name),
-		WithDecryption: aws.Bool(true),
-	})
+	// Shift present: walk the FULL history newest-first from the base version.
+	params, err := s.getFullHistory(ctx, name)
 	if err != nil {
 		return provider.VersionRef{}, fmt.Errorf("failed to get parameter history: %w", err)
 	}
 
-	params := history.Parameters
 	if len(params) == 0 {
 		return provider.VersionRef{}, fmt.Errorf("parameter not found: %s", name)
 	}
@@ -161,15 +157,12 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 
 // History returns the parameter's version history, newest first.
 func (s *Store) History(ctx context.Context, name string) ([]domain.Version, error) {
-	history, err := s.client.GetParameterHistory(ctx, &ssm.GetParameterHistoryInput{
-		Name:           aws.String(name),
-		WithDecryption: aws.Bool(true),
-	})
+	params, err := s.getFullHistory(ctx, name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get parameter history: %w", err)
 	}
 
-	versions := lo.Map(history.Parameters, func(p types.ParameterHistory, _ int) domain.Version {
+	versions := lo.Map(params, func(p types.ParameterHistory, _ int) domain.Version {
 		return domain.Version{
 			ID:      strconv.FormatInt(p.Version, 10),
 			Created: p.LastModifiedDate,
@@ -179,6 +172,39 @@ func (s *Store) History(ctx context.Context, name string) ([]domain.Version, err
 	slices.Reverse(versions) // newest first
 
 	return versions, nil
+}
+
+// getFullHistory returns the parameter's complete version history (oldest
+// first, as AWS returns it), paging through NextToken. GetParameterHistory caps
+// each page at 50 items while SSM retains up to 100 versions, so a single
+// unpaged call would treat page 1 as the whole history — making index 0 look
+// like the latest version and silently mis-resolving ~N / #N~M / log.
+func (s *Store) getFullHistory(ctx context.Context, name string) ([]types.ParameterHistory, error) {
+	var (
+		all   []types.ParameterHistory
+		token *string
+	)
+
+	for {
+		out, err := s.client.GetParameterHistory(ctx, &ssm.GetParameterHistoryInput{
+			Name:           aws.String(name),
+			WithDecryption: aws.Bool(true),
+			NextToken:      token,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		all = append(all, out.Parameters...)
+
+		if aws.ToString(out.NextToken) == "" {
+			break
+		}
+
+		token = out.NextToken
+	}
+
+	return all, nil
 }
 
 // List returns the names of all parameters, paging through DescribeParameters.

--- a/internal/provider/aws/param/param_test.go
+++ b/internal/provider/aws/param/param_test.go
@@ -431,3 +431,57 @@ func TestGet_NotFoundMapsSentinel(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, provider.ErrNotFound)
 }
+
+// paginatedHistoryClient returns history across two pages: page 1 (versions 1,2)
+// with a NextToken, page 2 (version 3) without. Exercises the NextToken loop.
+func paginatedHistoryClient() *mockClient {
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	return &mockClient{
+		getHistory: func(in *ssm.GetParameterHistoryInput) (*ssm.GetParameterHistoryOutput, error) {
+			if aws.ToString(in.NextToken) == "" {
+				return &ssm.GetParameterHistoryOutput{
+					Parameters: []types.ParameterHistory{
+						{Name: aws.String("/my/param"), Version: 1, LastModifiedDate: aws.Time(base)},
+						{Name: aws.String("/my/param"), Version: 2, LastModifiedDate: aws.Time(base.Add(time.Hour))},
+					},
+					NextToken: aws.String("tok"),
+				}, nil
+			}
+
+			return &ssm.GetParameterHistoryOutput{
+				Parameters: []types.ParameterHistory{
+					{Name: aws.String("/my/param"), Version: 3, LastModifiedDate: aws.Time(base.Add(2 * time.Hour))},
+				},
+			}, nil
+		},
+	}
+}
+
+// TestHistory_Paginated guards #311: History must page through NextToken so the
+// newest version (on a later page) is not lost.
+func TestHistory_Paginated(t *testing.T) {
+	t.Parallel()
+
+	versions, err := param.New(paginatedHistoryClient()).History(t.Context(), "/my/param")
+	require.NoError(t, err)
+	require.Len(t, versions, 3)
+	assert.Equal(t, "3", versions[0].ID) // newest first, across pages
+	assert.Equal(t, "1", versions[2].ID)
+}
+
+// TestResolve_ShiftAcrossPages guards #311: ~N must anchor at the true latest
+// (last page), not at page 1's last entry.
+func TestResolve_ShiftAcrossPages(t *testing.T) {
+	t.Parallel()
+
+	// ~1 from the true latest (v3, on page 2) => v2.
+	ref, err := param.New(paginatedHistoryClient()).Resolve(t.Context(), "/my/param", "~1")
+	require.NoError(t, err)
+	assert.Equal(t, "2", ref.ID())
+
+	// #3 exists only on page 2; #3~2 => v1.
+	ref, err = param.New(paginatedHistoryClient()).Resolve(t.Context(), "/my/param", "#3~2")
+	require.NoError(t, err)
+	assert.Equal(t, "1", ref.ID())
+}


### PR DESCRIPTION
## Problem

`Resolve` and `History` each issued a **single** `GetParameterHistory` call with no `NextToken` loop. The API returns at most **50 items per page** (oldest first) while SSM retains up to 100 versions, so `slices.Reverse` treated page 1 as the whole history — index 0 became version 50, not the real latest.

For a parameter at version 80:
- `suve param show /p~1` anchored at v50 and silently returned **v49**;
- `suve param show '/p#55~1'` errored `version 55 not found` even though v55 exists;
- `suve param log /p` listed v50…v1 and marked v50 as `(current)`.

## Fix

Add `getFullHistory` that loops on `NextToken` (exactly like `List` already does for `DescribeParameters`), used by both `Resolve` and `History`.

## Tests

Added a two-page mock: `History` returns all 3 versions newest-first across pages, and `~1` anchors at the true latest (page 2) rather than page 1's last entry (`#3~2` also resolves correctly).

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD