### PR TITLE
fix(secret,azure kv): deterministic version ordering on creation-time ties (#314)

### DIFF
--- a/internal/provider/aws/secret/secret.go
+++ b/internal/provider/aws/secret/secret.go
@@ -206,16 +206,26 @@ func baseIndex(list []types.SecretVersionsListEntry, abs secretversion.AbsoluteS
 
 // sortNewestFirst sorts version entries by creation date, newest first.
 func sortNewestFirst(list []types.SecretVersionsListEntry) {
-	sort.Slice(list, func(i, j int) bool {
-		if list[i].CreatedDate == nil {
+	// Newest CreatedDate first, with a deterministic version-id tie-break.
+	// CreatedDate has millisecond resolution and the API returns versions
+	// unordered, so equal timestamps (e.g. a batched apply) would otherwise sort
+	// randomly under the old non-stable sort.Slice — making ~N and log ordering
+	// non-deterministic.
+	sort.SliceStable(list, func(i, j int) bool {
+		ci, cj := list[i].CreatedDate, list[j].CreatedDate
+
+		switch {
+		case ci == nil && cj == nil:
+			return aws.ToString(list[i].VersionId) > aws.ToString(list[j].VersionId)
+		case ci == nil:
 			return false
-		}
-
-		if list[j].CreatedDate == nil {
+		case cj == nil:
 			return true
+		case ci.Equal(*cj):
+			return aws.ToString(list[i].VersionId) > aws.ToString(list[j].VersionId)
+		default:
+			return ci.After(*cj)
 		}
-
-		return list[i].CreatedDate.After(*list[j].CreatedDate)
 	})
 }
 

--- a/internal/provider/aws/secret/secret_test.go
+++ b/internal/provider/aws/secret/secret_test.go
@@ -661,3 +661,33 @@ func TestDescribe_NotFoundMapsSentinel(t *testing.T) {
 	require.Error(t, err)
 	assert.ErrorIs(t, err, provider.ErrNotFound)
 }
+
+// TestHistory_DeterministicOnEqualTimestamps guards #314: versions with equal
+// CreatedDate must sort deterministically (version-id descending tie-break),
+// independent of the arbitrary API/list order.
+func TestHistory_DeterministicOnEqualTimestamps(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mk := func(order []string) *secret.Store {
+		return secret.New(&mockClient{
+			listVersion: func(_ *secretsmanager.ListSecretVersionIdsInput) (*secretsmanager.ListSecretVersionIdsOutput, error) {
+				vs := make([]types.SecretVersionsListEntry, len(order))
+				for i, id := range order {
+					vs[i] = types.SecretVersionsListEntry{VersionId: aws.String(id), CreatedDate: aws.Time(created)}
+				}
+
+				return &secretsmanager.ListSecretVersionIdsOutput{Versions: vs}, nil
+			},
+		})
+	}
+
+	for _, order := range [][]string{{"aaa", "bbb"}, {"bbb", "aaa"}} {
+		versions, err := mk(order).History(t.Context(), "my-secret")
+		require.NoError(t, err)
+		require.Len(t, versions, 2)
+		assert.Equal(t, "bbb", versions[0].ID, "input %v", order) // id-desc tie-break
+		assert.Equal(t, "aaa", versions[1].ID, "input %v", order)
+	}
+}

--- a/internal/provider/azure/keyvault/keyvault.go
+++ b/internal/provider/azure/keyvault/keyvault.go
@@ -340,14 +340,23 @@ func toSecretVersion(p *azsecrets.SecretProperties) secretVersion {
 // sortNewestFirst sorts versions by creation time, newest first. Versions with
 // no creation time sort last.
 func sortNewestFirst(versions []secretVersion) {
+	// Newest created first, with a deterministic version-id tie-break. Key Vault
+	// timestamps have only 1-second resolution and the list-versions API returns
+	// versions unordered, so two SetSecret calls within the same second would
+	// otherwise keep their arbitrary API order — making ~N and log ordering
+	// non-deterministic.
 	sort.SliceStable(versions, func(i, j int) bool {
 		ci, cj := versions[i].created, versions[j].created
 
 		switch {
+		case ci == nil && cj == nil:
+			return versions[i].id > versions[j].id
 		case ci == nil:
 			return false
 		case cj == nil:
 			return true
+		case ci.Equal(*cj):
+			return versions[i].id > versions[j].id
 		default:
 			return ci.After(*cj)
 		}

--- a/internal/provider/azure/keyvault/keyvault_resolve_test.go
+++ b/internal/provider/azure/keyvault/keyvault_resolve_test.go
@@ -139,31 +139,29 @@ func TestResolve_ShiftListError(t *testing.T) {
 	require.ErrorIs(t, err, provider.ErrNotFound)
 }
 
-// TestResolve_OrderingEqualTimestamps documents the emulator-relevant behavior:
-// Key Vault Created timestamps are second-granular, so two versions written in
-// the same second are indistinguishable by time. The sort is STABLE, so it
-// preserves the input (server) order — newest-first sort keeps the first input
-// element at index 0. This is why a fast create+update in e2e needs a delay.
+// TestResolve_OrderingEqualTimestamps documents the #314 fix: Key Vault Created
+// timestamps are second-granular and the list-versions API returns versions
+// unordered, so two versions written in the same second are indistinguishable
+// by time. A deterministic version-id tie-break (descending) is applied, so the
+// ~N result no longer depends on the arbitrary API/input order.
 func TestResolve_OrderingEqualTimestamps(t *testing.T) {
 	t.Parallel()
 
 	same := at(5, 20)
-	m := &mockClient{
-		listVersFunc: versionsFixture(
-			verPair{"first", same},
-			verPair{"second", same},
-		),
+
+	// Both input orders must yield the same result: with the id-desc tie-break
+	// "second" > "first", so "second" is newest (index 0) and ~1 is "first".
+	for _, order := range [][]verPair{
+		{{"first", same}, {"second", same}},
+		{{"second", same}, {"first", same}},
+	} {
+		m := &mockClient{listVersFunc: versionsFixture(order...)}
+		store := keyvault.New(m)
+
+		prev, err := store.Resolve(t.Context(), "my-secret", "~1")
+		require.NoError(t, err)
+		assert.Equal(t, "first", prev.ID(), "input order %v", order)
 	}
-	store := keyvault.New(m)
-
-	// Stable sort preserves input order for equal timestamps: index 0 is "first".
-	cur, err := store.Resolve(t.Context(), "my-secret", "")
-	require.NoError(t, err)
-	assert.True(t, cur.IsLatest())
-
-	prev, err := store.Resolve(t.Context(), "my-secret", "~1")
-	require.NoError(t, err)
-	assert.Equal(t, "second", prev.ID())
 }
 
 // TestHistory_NilCreatedSortsLast verifies versions with no Created timestamp


### PR DESCRIPTION
## Problem

`~N` resolution and `log` ordering sort by creation timestamp with **no tie-breaker**:

- **Azure Key Vault**: `created` has **1-second** resolution and the list-versions API returns versions unordered, so `sort.SliceStable` preserved the arbitrary API order for ties — two `SetSecret` calls within the same second (scripts, CI, batched `stage apply`) made `~N` non-deterministic and `log` could show them swapped.
- **AWS Secrets Manager**: same shape with millisecond timestamps, and used non-stable `sort.Slice`, so equal `CreatedDate` values ordered randomly.

## Fix

Add a deterministic **version-id tie-break (descending)** and use stable sorting in both providers, so equal-timestamp versions order the same way regardless of the API/list order.

## Tests

Both providers: equal-timestamp versions yield the same order for both input orderings (id-desc tie-break); updated the Key Vault ordering test that previously documented the input-order-dependent behavior.

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD