### PR TITLE
fix(maputil): marshal Set JSON in deterministic sorted order (#354)

### DIFF
--- a/internal/maputil/set.go
+++ b/internal/maputil/set.go
@@ -1,6 +1,10 @@
 package maputil
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+)
 
 // Set is a generic set type that serializes to/from JSON arrays.
 type Set[T comparable] map[T]struct{}
@@ -49,7 +53,16 @@ func (s Set[T]) Values() []T {
 
 // MarshalJSON implements json.Marshaler.
 func (s Set[T]) MarshalJSON() ([]byte, error) {
-	return json.Marshal(s.Values())
+	values := s.Values()
+
+	// Deterministic order so staged-state files (which embed a Set in
+	// TagEntry.Remove) don't churn byte-for-byte across otherwise-identical
+	// writes. T is only comparable, not ordered, so sort by string form.
+	sort.Slice(values, func(i, j int) bool {
+		return fmt.Sprint(values[i]) < fmt.Sprint(values[j])
+	})
+
+	return json.Marshal(values)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.

--- a/internal/maputil/set_test.go
+++ b/internal/maputil/set_test.go
@@ -216,16 +216,20 @@ func TestSet_MarshalJSON(t *testing.T) {
 		assert.Equal(t, `["a"]`, string(data))
 	})
 
-	t.Run("multiple values", func(t *testing.T) {
+	t.Run("multiple values are sorted deterministically", func(t *testing.T) {
 		t.Parallel()
 
-		s := maputil.NewSet("a", "b")
-		data, err := json.Marshal(s)
-		require.NoError(t, err)
-		// Order is not guaranteed, so unmarshal and check
-		var values []string
-		require.NoError(t, json.Unmarshal(data, &values))
-		assert.ElementsMatch(t, []string{"a", "b"}, values)
+		// Regardless of insertion order, the JSON is byte-identical and sorted
+		// (#354) so staged-state files don't churn.
+		assertJSON := func(s maputil.Set[string]) {
+			data, err := json.Marshal(s)
+			require.NoError(t, err)
+			assert.Equal(t, `["a","b","c"]`, string(data))
+		}
+
+		assertJSON(maputil.NewSet("a", "b", "c"))
+		assertJSON(maputil.NewSet("c", "b", "a"))
+		assertJSON(maputil.NewSet("b", "a", "c"))
 	})
 
 	t.Run("int set", func(t *testing.T) {


### PR DESCRIPTION
## Problem

`Set.MarshalJSON` serialized `Values()` in map-iteration order. A `Set` embedded in staged state (`TagEntry.Remove`) therefore made `param.json`/`stash.json` change byte content across otherwise-identical writes — hurting reproducibility and file-level diffing.

## Fix

Sort the values before marshaling (by string form, since `T` is only `comparable`).

## Tests

Added a determinism check: the same set built in three insertion orders marshals to the identical sorted `["a","b","c"]`.

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD