### PR TITLE
fix(output): correct diff coloring trailing newline and in-hunk dash lines (#338, #339)

### DIFF
--- a/internal/cli/output/output.go
+++ b/internal/cli/output/output.go
@@ -195,27 +195,33 @@ func colorDiff(diff string) string {
 	}
 
 	lines := strings.Split(diff, "\n")
+	colored := make([]string, len(lines))
 
-	var result strings.Builder
+	// The ---/+++ file labels appear only before the first @@ hunk; once inside
+	// a hunk, a removed/added line whose content starts with --/++ must be
+	// colored as removed/added, not misclassified as a header (#339).
+	inHunk := false
 
-	for _, line := range lines {
+	for i, line := range lines {
 		switch {
-		case strings.HasPrefix(line, "---") || strings.HasPrefix(line, "+++"):
-			result.WriteString(colors.DiffHeader(line))
-		case strings.HasPrefix(line, "-"):
-			result.WriteString(colors.DiffRemoved(line))
-		case strings.HasPrefix(line, "+"):
-			result.WriteString(colors.DiffAdded(line))
+		case !inHunk && (strings.HasPrefix(line, "---") || strings.HasPrefix(line, "+++")):
+			colored[i] = colors.DiffHeader(line)
 		case strings.HasPrefix(line, "@@"):
-			result.WriteString(colors.DiffHunk(line))
+			inHunk = true
+			colored[i] = colors.DiffHunk(line)
+		case strings.HasPrefix(line, "-"):
+			colored[i] = colors.DiffRemoved(line)
+		case strings.HasPrefix(line, "+"):
+			colored[i] = colors.DiffAdded(line)
 		default:
-			result.WriteString(line)
+			colored[i] = line
 		}
-
-		result.WriteString("\n")
 	}
 
-	return result.String()
+	// Join rather than append "\n" per element: strings.Split yields a trailing
+	// empty element for a "\n"-terminated diff, so appending per element added a
+	// spurious extra newline vs DiffRaw (#338).
+	return strings.Join(colored, "\n")
 }
 
 // Print writes a message to the writer without a newline.

--- a/internal/cli/output/output_internal_test.go
+++ b/internal/cli/output/output_internal_test.go
@@ -2,9 +2,13 @@ package output
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/mpyw/suve/internal/cli/colors"
 )
 
 func TestWriter_Field(t *testing.T) {
@@ -171,6 +175,48 @@ func TestColorDiff_EmptyInput(t *testing.T) {
 
 	result := colorDiff("")
 	assert.Empty(t, result)
+}
+
+// TestDiff_MatchesDiffRawNewlines guards #338: with color disabled, Diff is
+// structure-only, so it must equal DiffRaw with no spurious trailing newline.
+//
+//nolint:paralleltest // toggles the process-global color.NoColor
+func TestDiff_MatchesDiffRawNewlines(t *testing.T) {
+	orig := color.NoColor
+
+	t.Cleanup(func() { color.NoColor = orig })
+
+	color.NoColor = true
+
+	got := Diff("f", "f", "a\nb\n", "a\nc\n")
+	raw := DiffRaw("f", "f", "a\nb\n", "a\nc\n")
+
+	assert.Equal(t, raw, got)
+	assert.False(t, strings.HasSuffix(got, "\n\n"), "must not doubly-terminate the diff")
+}
+
+// TestColorDiff_InHunkDashLinesNotHeaders guards #339: inside a hunk, a
+// removed/added line whose content starts with -- / ++ must be colored as
+// removed/added, not misclassified as a ---/+++ header.
+//
+//nolint:paralleltest // toggles the process-global color.NoColor
+func TestColorDiff_InHunkDashLinesNotHeaders(t *testing.T) {
+	orig := color.NoColor
+
+	t.Cleanup(func() { color.NoColor = orig })
+
+	color.NoColor = false
+
+	diff := "--- old\n+++ new\n@@ -1 +1 @@\n--- removed content\n+++ added content"
+
+	result := colorDiff(diff)
+
+	// The in-hunk lines are wrapped exactly as removed/added would wrap them.
+	assert.Contains(t, result, colors.DiffRemoved("--- removed content"))
+	assert.Contains(t, result, colors.DiffAdded("+++ added content"))
+	// And the real file-label headers are still colored as headers.
+	assert.Contains(t, result, colors.DiffHeader("--- old"))
+	assert.Contains(t, result, colors.DiffHeader("+++ new"))
 }
 
 func TestWarning(t *testing.T) {


### PR DESCRIPTION
Two `colorDiff` bugs.

## #338 — extra trailing newline

`colorDiff` split on `"\n"` and re-appended `"\n"` for every element **including the trailing empty one**, so `Diff` emitted one more newline than `DiffRaw` — a spurious blank line after every text diff (doubled blank lines between `log -p` entries), a mismatch with the JSON `diff` field, and a +1 pager line count. Join the colored lines instead of appending per element.

## #339 — in-hunk `--`/`++` lines misclassified as headers

The `---`/`+++` header prefixes were checked before `-`/`+`, so a removed line whose content began with `--` rendered as a cyan header. Treat `---`/`+++` as headers only **before the first `@@` hunk**; inside a hunk they are removed/added content.

## Tests

- Diff equals DiffRaw (no doubled trailing newline) with color disabled.
- An in-hunk `--- ...` / `+++ ...` line is colored removed/added, while the real file-label headers stay headers.

Closes #338
Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD