### PR TITLE
fix(param): map ParameterVersionNotFound to provider.ErrNotFound (#318)

### DIFF
--- a/internal/provider/aws/param/param.go
+++ b/internal/provider/aws/param/param.go
@@ -120,8 +120,12 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 		WithDecryption: aws.Bool(true),
 	})
 	if err != nil {
-		var notFound *types.ParameterNotFound
-		if errors.As(err, &notFound) {
+		var (
+			notFound        *types.ParameterNotFound
+			versionNotFound *types.ParameterVersionNotFound
+		)
+
+		if errors.As(err, &notFound) || errors.As(err, &versionNotFound) {
 			return nil, fmt.Errorf("%w: %s", provider.ErrNotFound, name)
 		}
 

--- a/internal/provider/aws/param/param_test.go
+++ b/internal/provider/aws/param/param_test.go
@@ -449,6 +449,24 @@ func TestGet_NotFoundMapsSentinel(t *testing.T) {
 	assert.ErrorIs(t, err, provider.ErrNotFound)
 }
 
+// TestGet_VersionNotFoundMapsSentinel guards #318: requesting a nonexistent
+// version selector raises *types.ParameterVersionNotFound, a distinct SDK type
+// from ParameterNotFound, which must also map to the provider.ErrNotFound
+// sentinel so errors.Is drives staging decisions correctly.
+func TestGet_VersionNotFoundMapsSentinel(t *testing.T) {
+	t.Parallel()
+
+	store := param.New(&mockClient{
+		getParameter: func(*ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+			return nil, &types.ParameterVersionNotFound{Message: aws.String("no such version")}
+		},
+	})
+
+	_, err := store.Get(t.Context(), "/p", provider.NewVersionRef("999"))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, provider.ErrNotFound)
+}
+
 // paginatedHistoryClient returns history across two pages: page 1 (versions 1,2)
 // with a NextToken, page 2 (version 3) without. Exercises the NextToken loop.
 func paginatedHistoryClient() *mockClient {


### PR DESCRIPTION
## Problem

`internal/provider/aws/param/param.go` `Get` mapped only `*types.ParameterNotFound` to `provider.ErrNotFound`. A `GetParameter` call with a `name:version` selector for a nonexistent version raises `*types.ParameterVersionNotFound` — a distinct SDK type — which fell through to the generic error wrap.

This breaks the `provider.Reader` contract, which requires `Get` to return a wrapped `provider.ErrNotFound` when the entry does not exist, and it defeats the `errors.Is(err, provider.ErrNotFound)` checks that drive staging decisions.

## Fix

Handle `*types.ParameterVersionNotFound` in the same error-handling branch as `*types.ParameterNotFound`, wrapping it as `provider.ErrNotFound`. A regression test constructs a mock whose `GetParameter` returns `&types.ParameterVersionNotFound{}` and asserts the error satisfies `errors.Is(err, provider.ErrNotFound)`.

## Verification

- `go build ./...`
- `go test ./internal/provider/aws/param/`
- `go test ./...`
- `golangci-lint run --allow-parallel-runners --build-tags=e2e,production ./internal/provider/aws/param/...`

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD