### PR TITLE
fix(staging): drop command name from ParseName version-specifier error (#333)

### DIFF
--- a/internal/staging/azure_keyvault_secret.go
+++ b/internal/staging/azure_keyvault_secret.go
@@ -177,7 +177,7 @@ func (s *AzureKeyVaultSecretStrategy) ParseName(input string) (string, error) {
 	}
 
 	if spec.Absolute.ID != nil || spec.Shift > 0 {
-		return "", fmt.Errorf("stage diff requires a secret name without version specifier")
+		return "", fmt.Errorf("secret name must not contain a version specifier")
 	}
 
 	return spec.Name, nil

--- a/internal/staging/gcloud_secret.go
+++ b/internal/staging/gcloud_secret.go
@@ -186,7 +186,7 @@ func (s *GoogleCloudSecretStrategy) ParseName(input string) (string, error) {
 	}
 
 	if spec.Absolute.Version != nil || spec.Shift > 0 {
-		return "", fmt.Errorf("stage diff requires a secret name without version specifier")
+		return "", fmt.Errorf("secret name must not contain a version specifier")
 	}
 
 	return spec.Name, nil

--- a/internal/staging/param.go
+++ b/internal/staging/param.go
@@ -193,7 +193,7 @@ func (s *ParamStrategy) ParseName(input string) (string, error) {
 	}
 
 	if spec.Absolute.Version != nil || spec.Shift > 0 {
-		return "", fmt.Errorf("stage diff requires a parameter name without version specifier")
+		return "", fmt.Errorf("parameter name must not contain a version specifier")
 	}
 
 	return spec.Name, nil

--- a/internal/staging/param_test.go
+++ b/internal/staging/param_test.go
@@ -278,7 +278,7 @@ func TestParamStrategy_ParseName(t *testing.T) {
 
 		_, err := s.ParseName("/app/param#5")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "without version specifier")
+		assert.Contains(t, err.Error(), "must not contain a version specifier")
 	})
 
 	t.Run("name with shift", func(t *testing.T) {
@@ -286,7 +286,7 @@ func TestParamStrategy_ParseName(t *testing.T) {
 
 		_, err := s.ParseName("/app/param~1")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "without version specifier")
+		assert.Contains(t, err.Error(), "must not contain a version specifier")
 	})
 
 	t.Run("name is valid even without slash prefix", func(t *testing.T) {

--- a/internal/staging/secret.go
+++ b/internal/staging/secret.go
@@ -197,7 +197,7 @@ func (s *SecretStrategy) ParseName(input string) (string, error) {
 	}
 
 	if spec.Absolute.ID != nil || spec.Absolute.Label != nil || spec.Shift > 0 {
-		return "", fmt.Errorf("stage diff requires a secret name without version specifier")
+		return "", fmt.Errorf("secret name must not contain a version specifier")
 	}
 
 	return spec.Name, nil

--- a/internal/staging/secret_test.go
+++ b/internal/staging/secret_test.go
@@ -287,7 +287,7 @@ func TestSecretStrategy_ParseName(t *testing.T) {
 
 		_, err := s.ParseName("my-secret#abc123")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "without version specifier")
+		assert.Contains(t, err.Error(), "must not contain a version specifier")
 	})
 
 	t.Run("name with label", func(t *testing.T) {
@@ -295,7 +295,7 @@ func TestSecretStrategy_ParseName(t *testing.T) {
 
 		_, err := s.ParseName("my-secret:AWSCURRENT")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "without version specifier")
+		assert.Contains(t, err.Error(), "must not contain a version specifier")
 	})
 
 	t.Run("name with shift", func(t *testing.T) {
@@ -303,7 +303,7 @@ func TestSecretStrategy_ParseName(t *testing.T) {
 
 		_, err := s.ParseName("my-secret~1")
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "without version specifier")
+		assert.Contains(t, err.Error(), "must not contain a version specifier")
 	})
 
 	t.Run("parse error - empty version ID", func(t *testing.T) {


### PR DESCRIPTION
## Problem

All four staging strategies' `ParseName` hardcoded an error message that names the `stage diff` command, e.g. `"stage diff requires a parameter name without version specifier"`. But `ParseName` is also called by `stage add`, `stage tag`, and `stage untag`, so `suve stage param add /my/param#3` wrongly reported `stage diff requires ...`.

## Fix

Changed the error message in each strategy's `ParseName` to a command-neutral form:

- `parameter name must not contain a version specifier`
- `secret name must not contain a version specifier` (Secrets Manager, Google Cloud, Azure Key Vault)

Updated the affected test assertions in `internal/staging/param_test.go` and `internal/staging/secret_test.go`.

## Verification

- `go build ./...`
- `go test ./...`
- `golangci-lint run --allow-parallel-runners --build-tags=e2e,production ./internal/staging/... ./internal/cli/commands/stage/...`

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD