### PR TITLE
fix(cli): skip update check during shell-completion invocations (#348)

### DIFF
--- a/cmd/suve/main.go
+++ b/cmd/suve/main.go
@@ -3,11 +3,18 @@ package main
 import (
 	"context"
 	"os"
+	"slices"
 
 	"github.com/mpyw/suve/internal/cli/commands"
 	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/updatecheck"
 )
+
+// isShellCompletion reports whether args contain the hidden
+// --generate-shell-completion flag that urfave/cli passes on every shell TAB.
+func isShellCompletion(args []string) bool {
+	return slices.Contains(args, "--generate-shell-completion")
+}
 
 func main() {
 	// Register GUI flag (only effective when built with -tags production)
@@ -22,8 +29,14 @@ func main() {
 	// error paths, always to STDERR so it never contaminates piped STDOUT.
 	// It is bounded by a short HTTP timeout and cached for 24h, and returns
 	// "" (silently) on any error or when disabled via SUVE_NO_UPDATE_CHECK.
-	if notice := updatecheck.Notice(ctx, commands.Version); notice != "" {
-		output.Info(os.Stderr, "%s", notice)
+	//
+	// Skip it entirely for shell-completion invocations: those run on every
+	// TAB and their STDERR is not redirected by the shell, so a notice would
+	// garble the prompt and the HTTP timeout could block completion.
+	if !isShellCompletion(os.Args) {
+		if notice := updatecheck.Notice(ctx, commands.Version); notice != "" {
+			output.Info(os.Stderr, "%s", notice)
+		}
 	}
 
 	if runErr != nil {

--- a/cmd/suve/main_test.go
+++ b/cmd/suve/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import "testing"
+
+func TestIsShellCompletion(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		args []string
+		want bool
+	}{
+		"present": {
+			args: []string{"suve", "param", "show", "--generate-shell-completion"},
+			want: true,
+		},
+		"present as only arg after program": {
+			args: []string{"suve", "--generate-shell-completion"},
+			want: true,
+		},
+		"absent": {
+			args: []string{"suve", "param", "show", "/my/param"},
+			want: false,
+		},
+		"empty": {
+			args: nil,
+			want: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isShellCompletion(tt.args); got != tt.want {
+				t.Errorf("isShellCompletion(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## The bug

`cmd/suve/main.go` called `updatecheck.Notice` unconditionally after `App.Run`, including for the hidden `--generate-shell-completion` invocations that urfave/cli issues on every shell TAB. Once per 24h a TAB completion could block up to the HTTP timeout, and the notice was written to STDERR (which zsh's completion does not redirect), garbling the prompt.

## The fix

Skip the update check when the process is a shell-completion invocation, i.e. when `--generate-shell-completion` is present in `os.Args`. Added a small pure helper `isShellCompletion([]string)` (scans args with `slices.Contains`) and guarded the `updatecheck.Notice` call with it.

## Test

Added `cmd/suve/main_test.go` (`package main`) asserting `isShellCompletion` returns true when `--generate-shell-completion` is among the args and false otherwise.

## Verify

- `go build ./...` — pass
- `go test ./...` — pass
- `golangci-lint run --allow-parallel-runners --build-tags=e2e,production ./cmd/...` — no issues in the changed files

Closes #348

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD