### PR TITLE
fix(cli): reject unknown --output values instead of silently using text (#349)

### DIFF
--- a/internal/cli/commands/generic/diff/diff.go
+++ b/internal/cli/commands/generic/diff/diff.go
@@ -160,10 +160,15 @@ func Command[S any](cfg Config[S]) *cli.Command {
 				return err
 			}
 
+			outputFormat, err := output.ParseFormat(cmd.String("output"))
+			if err != nil {
+				return err
+			}
+
 			opts := Options{
 				ParseJSON: cmd.Bool("parse-json"),
 				NoPager:   cmd.Bool("no-pager"),
-				Output:    output.ParseFormat(cmd.String("output")),
+				Output:    outputFormat,
 			}
 
 			// JSON output disables pager

--- a/internal/cli/commands/generic/list/list.go
+++ b/internal/cli/commands/generic/list/list.go
@@ -121,9 +121,14 @@ func Command(cfg Config) *cli.Command {
 		Description: cfg.Description,
 		Flags:       cfg.Flags,
 		Action: func(ctx context.Context, cmd *cli.Command) error {
+			outputFormat, err := output.ParseFormat(cmd.String("output"))
+			if err != nil {
+				return err
+			}
+
 			opts := Options{
 				Show:   cmd.Bool("show"),
-				Output: output.ParseFormat(cmd.String("output")),
+				Output: outputFormat,
 			}
 
 			list, err := cfg.NewList(ctx, cmd, opts.Show)

--- a/internal/cli/commands/generic/log/log.go
+++ b/internal/cli/commands/generic/log/log.go
@@ -157,13 +157,18 @@ func Command(cfg Config) *cli.Command {
 				return fmt.Errorf("%s", cfg.UsageError)
 			}
 
+			outputFormat, err := output.ParseFormat(cmd.String("output"))
+			if err != nil {
+				return err
+			}
+
 			opts := Options{
 				ShowPatch: cmd.Bool("patch"),
 				ParseJSON: cmd.Bool("parse-json"),
 				Reverse:   cmd.Bool("reverse"),
 				NoPager:   cmd.Bool("no-pager"),
 				Oneline:   cmd.Bool("oneline"),
-				Output:    output.ParseFormat(cmd.String("output")),
+				Output:    outputFormat,
 				// --max-value-length is declared as an Int32Flag, so it must be
 				// read with cmd.Int32: urfave/cli's cmd.Int does a strict int
 				// type assertion that fails for int32 and silently returns 0,

--- a/internal/cli/commands/generic/show/show.go
+++ b/internal/cli/commands/generic/show/show.go
@@ -129,7 +129,11 @@ func Command[S any](cfg Config[S]) *cli.Command {
 				return err
 			}
 
-			outputFormat := output.ParseFormat(cmd.String("output"))
+			outputFormat, err := output.ParseFormat(cmd.String("output"))
+			if err != nil {
+				return err
+			}
+
 			raw := cmd.Bool("raw")
 
 			// Check mutually exclusive options

--- a/internal/cli/output/output.go
+++ b/internal/cli/output/output.go
@@ -30,14 +30,17 @@ const (
 	FormatJSON Format = "json"
 )
 
-// ParseFormat parses a format string and returns the Format.
-// Returns FormatText for empty string or invalid values.
-func ParseFormat(s string) Format {
+// ParseFormat parses an --output value into a Format. An empty value or "text"
+// is FormatText and "json" is FormatJSON; any other value is a usage error so a
+// typo like "jsonn" fails loudly instead of silently printing text.
+func ParseFormat(s string) (Format, error) {
 	switch s {
-	case "json":
-		return FormatJSON
+	case "", string(FormatText):
+		return FormatText, nil
+	case string(FormatJSON):
+		return FormatJSON, nil
 	default:
-		return FormatText
+		return "", fmt.Errorf("invalid --output value %q: must be %q or %q", s, FormatText, FormatJSON)
 	}
 }
 

--- a/internal/cli/output/output_internal_test.go
+++ b/internal/cli/output/output_internal_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/mpyw/suve/internal/cli/colors"
 )
@@ -279,19 +280,29 @@ func TestParseFormat(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected Format
+		wantErr  bool
 	}{
-		{"json", FormatJSON},
-		{"JSON", FormatText}, // Not case-insensitive
-		{"text", FormatText},
-		{"", FormatText},
-		{"invalid", FormatText},
+		{input: "json", expected: FormatJSON},
+		{input: "text", expected: FormatText},
+		{input: "", expected: FormatText},
+		{input: "JSON", wantErr: true}, // not case-insensitive
+		{input: "invalid", wantErr: true},
+		{input: "jsonn", wantErr: true}, // the #349 typo
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
 			t.Parallel()
 
-			result := ParseFormat(tt.input)
+			result, err := ParseFormat(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "--output")
+
+				return
+			}
+
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, result)
 		})
 	}


### PR DESCRIPTION
## Problem

`ParseFormat` mapped anything other than `"json"` to text, so `suve param show --output=jsonn /x` silently printed text with exit 0 — scripts expecting JSON got unparseable output with no error.

## Fix

`ParseFormat` now returns `(Format, error)`: `""`/`"text"` → text, `"json"` → json, anything else → a usage error naming the valid values. The four callers (`log`, `diff`, `list`, `show`) surface the error.

## Tests

Updated `TestParseFormat` to assert valid values parse and unknown ones (`JSON`, `invalid`, `jsonn`) error.

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD