### PR TITLE
fix(staging): apply confirmation should read cmd.Root().Reader, not os.Stdin (#332)

### DIFF
--- a/internal/cli/commands/stage/apply/apply.go
+++ b/internal/cli/commands/stage/apply/apply.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/urfave/cli/v3"
@@ -112,7 +111,7 @@ func runAction(ctx context.Context, cmd *cli.Command, cfg stgcli.GlobalConfig) e
 
 	// Confirm apply.
 	prompter := &confirm.Prompter{
-		Stdin:  os.Stdin,
+		Stdin:  cmd.Root().Reader,
 		Stdout: cmd.Root().Writer,
 		Stderr: cmd.Root().ErrWriter,
 		Target: resolved.Target,

--- a/internal/staging/cli/cli_test.go
+++ b/internal/staging/cli/cli_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mpyw/suve/internal/cli/confirm"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/cli"
@@ -1985,6 +1987,78 @@ func TestApplyRunner_RunInteractive_TagOnly(t *testing.T) {
 
 		assert.False(t, conf.called, "empty store must short-circuit before confirmation")
 		assert.Contains(t, stdout.String(), "No param changes staged")
+	})
+}
+
+// TestApplyRunner_RunInteractive_ReadsPrompterStdin verifies that the
+// interactive apply flow reads its yes/no confirmation from the Prompter's
+// Stdin reader (which the command wires to cmd.Root().Reader, #332) rather than
+// from the process's os.Stdin. It feeds a bytes reader as Prompter.Stdin and
+// asserts that declining aborts the apply and confirming performs it.
+func TestApplyRunner_RunInteractive_ReadsPrompterStdin(t *testing.T) {
+	t.Parallel()
+
+	newRunner := func(store *testutil.MockStore, stdin io.Reader, out, errOut *bytes.Buffer) *cli.ApplyRunner {
+		return &cli.ApplyRunner{
+			UseCase: &stagingusecase.ApplyUseCase{
+				Strategy: &fullMockStrategy{service: staging.ServiceParam},
+				Store:    store,
+			},
+			Store:  store,
+			Parser: &fullMockStrategy{service: staging.ServiceParam},
+			Confirmer: &confirm.Prompter{
+				Stdin:  stdin,
+				Stdout: out,
+				Stderr: errOut,
+			},
+			SkipConfirm: false,
+			Stdout:      out,
+			Stderr:      errOut,
+		}
+	}
+
+	t.Run("declines when reader says no", func(t *testing.T) {
+		t.Parallel()
+
+		store := testutil.NewMockStore()
+		_ = store.StageTag(t.Context(), staging.ServiceParam, "/app/config", staging.TagEntry{
+			Add:      map[string]string{"env": "prod"},
+			StagedAt: time.Now(),
+		})
+
+		var stdout, stderr bytes.Buffer
+
+		err := newRunner(store, bytes.NewBufferString("n\n"), &stdout, &stderr).
+			RunInteractive(t.Context(), cli.ApplyOptions{})
+		require.NoError(t, err)
+
+		// Declined: no apply happened, so the tag remains staged.
+		assert.NotContains(t, stdout.String(), "Tagged")
+
+		_, err = store.GetTag(t.Context(), staging.ServiceParam, "/app/config")
+		require.NoError(t, err)
+	})
+
+	t.Run("applies when reader says yes", func(t *testing.T) {
+		t.Parallel()
+
+		store := testutil.NewMockStore()
+		_ = store.StageTag(t.Context(), staging.ServiceParam, "/app/config", staging.TagEntry{
+			Add:      map[string]string{"env": "prod"},
+			StagedAt: time.Now(),
+		})
+
+		var stdout, stderr bytes.Buffer
+
+		err := newRunner(store, bytes.NewBufferString("y\n"), &stdout, &stderr).
+			RunInteractive(t.Context(), cli.ApplyOptions{})
+		require.NoError(t, err)
+
+		// Confirmed: apply happened and the tag was unstaged.
+		assert.Contains(t, stdout.String(), "Tagged")
+
+		_, err = store.GetTag(t.Context(), staging.ServiceParam, "/app/config")
+		assert.Equal(t, staging.ErrNotStaged, err)
 	})
 }
 

--- a/internal/staging/cli/command.go
+++ b/internal/staging/cli/command.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/urfave/cli/v3"
 
@@ -299,7 +298,7 @@ func NewApplyCommand(cfg CommandConfig) *cli.Command {
 			}
 
 			prompter := &confirm.Prompter{
-				Stdin:  os.Stdin,
+				Stdin:  cmd.Root().Reader,
 				Stdout: cmd.Root().Writer,
 				Stderr: cmd.Root().ErrWriter,
 				Target: resolved.Target,


### PR DESCRIPTION
## The bug

Both the global `stage apply` and the service-specific apply confirmation prompts constructed their `confirm.Prompter` with `Stdin: os.Stdin`, while every other prompt in the codebase (e.g. stash push/pop) reads from `cmd.Root().Reader`. Reading the real `os.Stdin` here:

- blocks / EOF-errors in non-TTY runs without `--yes`
- can consume piped data intended for the command
- breaks testability (no seam to inject input)

## The fix

- `internal/cli/commands/stage/apply/apply.go`: `Stdin: os.Stdin` -> `Stdin: cmd.Root().Reader`
- `internal/staging/cli/command.go`: same change for the service-specific apply prompt
- Dropped the now-unused `os` imports in both files
- Added a behavior test that feeds a `bytes.Reader` as the Prompter's `Stdin` (as `cmd.Root().Reader` does) and asserts declining aborts the apply while confirming performs it

Only the apply-confirmation prompt constructions were changed; unrelated `os.Stdin` usages (editor stdin, passphrase stdin) were intentionally left untouched.

## Verification

- `go build ./...` - passes
- `go test ./...` - passes
- `golangci-lint run --allow-parallel-runners --build-tags=e2e,production ./internal/cli/commands/stage/... ./internal/staging/cli/...` - 0 issues

Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD