### PR TITLE
fix(secret): accept `_` and `.` in version ids so tokens are addressable (#319)

### DIFF
--- a/internal/version/secretversion/spec.go
+++ b/internal/version/secretversion/spec.go
@@ -95,8 +95,12 @@ func ParseDiffArgs(args []string) (*Spec, *Spec, error) {
 	)
 }
 
+// isIDChar reports whether c is valid within a Secrets Manager version id.
+// Version ids are ClientRequestTokens (not just console UUIDs): a token created
+// via the API may contain '_' and '.' as well, so accept them alongside
+// letters, digits and '-'. Excludes the specifier characters '#', ':', '~'.
 func isIDChar(c byte) bool {
-	return internal.IsLetter(c) || internal.IsDigit(c) || c == '-'
+	return internal.IsLetter(c) || internal.IsDigit(c) || c == '-' || c == '_' || c == '.'
 }
 
 func isLabelChar(c byte) bool {

--- a/internal/version/secretversion/spec_test.go
+++ b/internal/version/secretversion/spec_test.go
@@ -65,6 +65,13 @@ func TestParse(t *testing.T) {
 			wantName: "my-secret",
 			wantID:   lo.ToPtr("12345"),
 		},
+		{
+			// ClientRequestToken-style version id with '_' and '.' (#319).
+			name:     "with token ID containing underscore and dot",
+			input:    "my-secret#my_token_0123456789.012345678901234567890",
+			wantName: "my-secret",
+			wantID:   lo.ToPtr("my_token_0123456789.012345678901234567890"),
+		},
 
 		// Label specifier (:LABEL)
 		{


### PR DESCRIPTION
## Problem

`secretversion`'s `isIDChar` accepted only letters/digits/`-`, but Secrets Manager version ids are `ClientRequestToken`s that may legally contain `_` and `.` when created via the API. Such versions:
- could not be addressed via `#id` (`my-secret#my_token_…` failed to parse);
- broke `log`, which re-parses `"#"+versionID` internally, with `unexpected characters: _token…`.

Console/CLI-created UUIDs are unaffected, which is why this is invisible in normal use.

## Fix

Widen `isIDChar` to also accept `_` and `.` (still excluding the specifier characters `#`, `:`, `~`).

## Tests

Added a parse case for a token id containing `_` and `.`.

Closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD