### PR TITLE
fix(secret): validate --recovery-window and reject --force combo before prompting (#350)

### DIFF
--- a/internal/cli/commands/secret/delete/delete.go
+++ b/internal/cli/commands/secret/delete/delete.go
@@ -19,10 +19,33 @@ import (
 	"github.com/mpyw/suve/internal/usecase/secret"
 )
 
-// defaultRecoveryWindow is the AWS Secrets Manager default recovery window in
-// days, used to compute the displayed scheduled deletion date when no explicit
-// window is given.
-const defaultRecoveryWindow = 30
+// Recovery-window bounds enforced by AWS Secrets Manager, mirrored here so an
+// invalid value is rejected before the confirmation prompt rather than by AWS
+// after it.
+const (
+	minRecoveryWindow = 7
+	maxRecoveryWindow = 30
+	// defaultRecoveryWindow is the AWS Secrets Manager default recovery window
+	// in days, used to compute the displayed scheduled deletion date when no
+	// explicit window is given.
+	defaultRecoveryWindow = maxRecoveryWindow
+)
+
+// validateDeleteFlags checks the --force / --recovery-window combination before
+// any confirmation prompt or deletion is attempted. recoveryWindow must be the
+// value the user explicitly supplied (0 when the flag was left at its default),
+// so that --force alone is not mistaken for a combined invocation.
+func validateDeleteFlags(force bool, recoveryWindow int) error {
+	if force && recoveryWindow > 0 {
+		return fmt.Errorf("--force and --recovery-window cannot be combined")
+	}
+
+	if recoveryWindow > 0 && (recoveryWindow < minRecoveryWindow || recoveryWindow > maxRecoveryWindow) {
+		return fmt.Errorf("--recovery-window must be between %d and %d days", minRecoveryWindow, maxRecoveryWindow)
+	}
+
+	return nil
+}
 
 // Runner executes the delete command.
 type Runner struct {
@@ -71,7 +94,7 @@ EXAMPLES:
 			&cli.IntFlag{
 				Name:  "recovery-window",
 				Usage: "Number of days before permanent deletion (7-30)",
-				Value: 30, //nolint:mnd // AWS Secrets Manager default recovery window
+				Value: defaultRecoveryWindow,
 			},
 			&cli.BoolFlag{
 				Name:  "yes",
@@ -89,6 +112,19 @@ func action(ctx context.Context, cmd *cli.Command) error {
 
 	name := cmd.Args().First()
 	skipConfirm := cmd.Bool("yes")
+	force := cmd.Bool("force")
+	recoveryWindow := cmd.Int("recovery-window")
+
+	// Only the explicitly-supplied window participates in flag validation; the
+	// flag default must not be mistaken for a user-supplied value.
+	givenWindow := 0
+	if cmd.IsSet("recovery-window") {
+		givenWindow = recoveryWindow
+	}
+
+	if err := validateDeleteFlags(force, givenWindow); err != nil {
+		return err
+	}
 
 	store, err := internal.SecretStore(ctx)
 	if err != nil {
@@ -143,8 +179,8 @@ func action(ctx context.Context, cmd *cli.Command) error {
 
 	return r.Run(ctx, Options{
 		Name:           name,
-		Force:          cmd.Bool("force"),
-		RecoveryWindow: cmd.Int("recovery-window"),
+		Force:          force,
+		RecoveryWindow: recoveryWindow,
 	})
 }
 

--- a/internal/cli/commands/secret/delete/delete_test.go
+++ b/internal/cli/commands/secret/delete/delete_test.go
@@ -28,6 +28,24 @@ func TestCommand_Validation(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "usage:")
 	})
+
+	t.Run("recovery window out of range is rejected before prompt", func(t *testing.T) {
+		t.Parallel()
+
+		app := apptest.AWSApp()
+		err := app.Run(t.Context(), []string{"suve", "secret", "delete", "--recovery-window", "3", "my-secret"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--recovery-window must be between 7 and 30 days")
+	})
+
+	t.Run("force combined with recovery window is rejected before prompt", func(t *testing.T) {
+		t.Parallel()
+
+		app := apptest.AWSApp()
+		err := app.Run(t.Context(), []string{"suve", "secret", "delete", "--force", "--recovery-window", "7", "my-secret"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--force and --recovery-window cannot be combined")
+	})
 }
 
 func TestRun(t *testing.T) {

--- a/internal/cli/commands/secret/delete/export_test.go
+++ b/internal/cli/commands/secret/delete/export_test.go
@@ -1,0 +1,6 @@
+package delete
+
+// ValidateDeleteFlags exposes the unexported validateDeleteFlags for testing.
+//
+//nolint:gochecknoglobals // test-only export hook
+var ValidateDeleteFlags = validateDeleteFlags

--- a/internal/cli/commands/secret/delete/validate_test.go
+++ b/internal/cli/commands/secret/delete/validate_test.go
@@ -1,0 +1,77 @@
+package delete_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/cli/commands/secret/delete"
+)
+
+func TestValidateDeleteFlags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		force          bool
+		recoveryWindow int
+		wantErr        string
+	}{
+		{
+			name:           "no flags",
+			force:          false,
+			recoveryWindow: 0,
+		},
+		{
+			name:           "window in range lower bound",
+			force:          false,
+			recoveryWindow: 7,
+		},
+		{
+			name:           "window in range upper bound",
+			force:          false,
+			recoveryWindow: 30,
+		},
+		{
+			name:           "force alone",
+			force:          true,
+			recoveryWindow: 0,
+		},
+		{
+			name:           "window below range",
+			force:          false,
+			recoveryWindow: 6,
+			wantErr:        "--recovery-window must be between 7 and 30 days",
+		},
+		{
+			name:           "window above range",
+			force:          false,
+			recoveryWindow: 31,
+			wantErr:        "--recovery-window must be between 7 and 30 days",
+		},
+		{
+			name:           "force combined with window",
+			force:          true,
+			recoveryWindow: 7,
+			wantErr:        "--force and --recovery-window cannot be combined",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := delete.ValidateDeleteFlags(tt.force, tt.recoveryWindow)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

The immediate `secret delete` command (`internal/cli/commands/secret/delete/delete.go`) had no client-side 7-30 range validation for `--recovery-window` (only the staging path validated it). An out-of-range value was therefore only rejected by AWS **after** the interactive confirmation prompt.

Additionally, `--force --recovery-window 7` was accepted and the recovery window silently ignored, because the switch in `Run` checked `--force` first.

## Fix

Extracted a pure `validateDeleteFlags(force bool, recoveryWindow int) error` helper and call it **before** the confirmation prompt / deletion:

1. An explicitly-set `--recovery-window` outside 7-30 returns `--recovery-window must be between 7 and 30 days` (mirrors the bound used by the staging path in `internal/usecase/staging/delete.go`).
2. `--force` combined with an explicitly-set `--recovery-window` returns `--force and --recovery-window cannot be combined` (contradictory).

The flag's default value (30) is not treated as user-supplied (via `cmd.IsSet`), so `--force` alone continues to work. The `7`/`30` bounds are named constants (`minRecoveryWindow`/`maxRecoveryWindow`).

## Tests

- Unit tests for `validateDeleteFlags`: in-range ok (lower/upper bound), out-of-range errors, force+window errors, force alone ok, no-flags ok.
- Command-level tests asserting both errors are returned before the prompt.

## Verify

- `go build ./...`
- `go test ./...`
- `golangci-lint run --allow-parallel-runners --build-tags=e2e,production ./internal/cli/commands/secret/...` -> 0 issues

Closes #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD