### PR TITLE
fix(cli): run $EDITOR via sh -c so space-containing paths work (#355)

### DIFF
--- a/internal/cli/editor/editor.go
+++ b/internal/cli/editor/editor.go
@@ -40,10 +40,11 @@ func Open(ctx context.Context, content string) (string, error) {
 		return "", err
 	}
 
-	// Split editor command to support multi-argument editors like "code --wait"
-	args := strings.Fields(editor)
-	args = append(args, tmpFile.Name())
-	cmd := exec.CommandContext(ctx, args[0], args[1:]...) //nolint:gosec // Editor command from user environment
+	// Invoke the editor through the shell so that quoting and arguments behave
+	// exactly like Git does. The temp-file path is passed as $1 so that $EDITOR,
+	// which may itself contain flags and a space-containing path, is expanded by
+	// the shell (e.g. "code --wait" or "/Applications/Visual Studio Code.app/.../code").
+	cmd := exec.CommandContext(ctx, "sh", "-c", editor+` "$1"`, "sh", tmpFile.Name()) //nolint:gosec // $EDITOR is user-controlled by design
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/cli/editor/editor_test.go
+++ b/internal/cli/editor/editor_test.go
@@ -38,6 +38,34 @@ printf '%s-modified' "$content" > "$1"
 	assert.Equal(t, "original-modified", result)
 }
 
+func TestOpen_EditorPathWithSpaces(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("Skipping on Windows - requires Unix shell")
+	}
+
+	// Place the editor script inside a directory whose name contains a space,
+	// mimicking paths like "/Applications/Visual Studio Code.app/.../code".
+	tmpDir := t.TempDir()
+	spacedDir := filepath.Join(tmpDir, "dir with space")
+	require.NoError(t, os.MkdirAll(spacedDir, 0o750))
+
+	scriptPath := filepath.Join(spacedDir, "test editor.sh")
+	script := `#!/bin/sh
+content=$(cat "$1")
+printf '%s-spaced' "$content" > "$1"
+`
+	//nolint:gosec // G306: executable permission required for test shell script
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
+
+	// $EDITOR is quoted so the shell treats the space-containing path as one word.
+	t.Setenv("EDITOR", `"`+scriptPath+`"`)
+	t.Setenv("VISUAL", "")
+
+	result, err := editor.Open(t.Context(), "original")
+	require.NoError(t, err)
+	assert.Equal(t, "original-spaced", result)
+}
+
 func TestOpen_ReturnsUnmodifiedContent(t *testing.T) {
 	if runtime.GOOS == goosWindows {
 		t.Skip("Skipping on Windows - requires Unix shell")


### PR DESCRIPTION
## Problem

`internal/cli/editor/editor.go` split `$EDITOR` with `strings.Fields(editor)`. This broke editor commands whose path contains spaces (e.g. `/Applications/Visual Studio Code.app/Contents/Resources/app/bin/code`) and ignored shell quoting entirely.

## Fix

Invoke the editor through the shell exactly like Git does, passing the temp-file path as `$1`:

```go
cmd := exec.CommandContext(ctx, "sh", "-c", editor+` "$1"`, "sh", tmpFile.Name())
```

This lets `$EDITOR` carry flags and a space-containing (quoted) path and have them expanded by the shell. Stdin/stdout/stderr wiring and the empty-`$EDITOR` fallback (`vi`/`notepad`) are unchanged.

## Test

Added `TestOpen_EditorPathWithSpaces`, which creates a hermetic editor script under a `t.TempDir()` subdirectory whose name contains a space, points `$EDITOR` at the quoted path, and asserts the content round-trips.

## Scope

Item 2 of the issue (temp-file hardening) is intentionally left out of scope for this PR; only the `$EDITOR` invocation is addressed here.

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD