### PR TITLE
fix(log): apply --since/--until before the -n count cap (#351)

### DIFF
--- a/internal/usecase/azure/azure_test.go
+++ b/internal/usecase/azure/azure_test.go
@@ -3,8 +3,11 @@ package azure_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -63,6 +66,43 @@ func TestLogUseCase_HistoryErrorPropagates(t *testing.T) {
 	_, err := uc.Execute(t.Context(), azure.LogInput{Name: "my-key"})
 	require.Error(t, err)
 	require.ErrorIs(t, err, sentinel)
+}
+
+// TestLogUseCase_FilterBeforeCount asserts date filters run BEFORE the count
+// cap: -n must yield up to N versions that match the filter, not N newest then
+// filtered down to fewer (#351). Only the two oldest versions match --until;
+// the old count-first order would have truncated them all away.
+func TestLogUseCase_FilterBeforeCount(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	versions := []domain.Version{
+		{ID: "newest", Created: &now},
+		{ID: "middle", Created: lo.ToPtr(now.Add(-2 * time.Hour))},
+		{ID: "oldest", Created: lo.ToPtr(now.Add(-3 * time.Hour))},
+	}
+
+	store := &providermock.Store{
+		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
+			return versions, nil
+		},
+		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+			return provider.NewVersionRef(strings.TrimPrefix(spec, "#")), nil
+		},
+		GetFunc: func(_ context.Context, name string, ref provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{Name: name, Value: ref.ID(), Version: domain.Version{ID: ref.ID()}}, nil
+		},
+	}
+
+	uc := &azure.LogUseCase{Reader: store}
+	out, err := uc.Execute(t.Context(), azure.LogInput{
+		Name:       "my-key",
+		MaxResults: 1,
+		Until:      lo.ToPtr(now.Add(-time.Hour)),
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Entries, 1)
+	assert.Equal(t, "middle", out.Entries[0].Version)
 }
 
 func TestDiffUseCase(t *testing.T) {

--- a/internal/usecase/azure/log.go
+++ b/internal/usecase/azure/log.go
@@ -64,18 +64,12 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 	// tell whether the oldest shown version is genuinely the initial one.
 	initialVersion := versions[len(versions)-1].ID
 
-	if input.MaxResults > 0 && len(versions) > int(input.MaxResults) {
-		versions = versions[:input.MaxResults]
-	}
+	// Apply date filters BEFORE the count limit: -n must return up to N versions
+	// that match --since/--until, not N newest-then-filtered to fewer (#351).
+	if input.Since != nil || input.Until != nil {
+		kept := versions[:0]
 
-	if input.Reverse {
-		slices.Reverse(versions)
-	}
-
-	entries := make([]LogEntry, 0, len(versions))
-
-	for _, v := range versions {
-		if input.Since != nil || input.Until != nil {
+		for _, v := range versions {
 			if v.Created == nil {
 				continue
 			}
@@ -87,8 +81,24 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 			if input.Until != nil && v.Created.After(*input.Until) {
 				continue
 			}
+
+			kept = append(kept, v)
 		}
 
+		versions = kept
+	}
+
+	if input.MaxResults > 0 && len(versions) > int(input.MaxResults) {
+		versions = versions[:input.MaxResults]
+	}
+
+	if input.Reverse {
+		slices.Reverse(versions)
+	}
+
+	entries := make([]LogEntry, 0, len(versions))
+
+	for _, v := range versions {
 		value, fetchErr := u.getValue(ctx, input.Name, v.ID)
 
 		entries = append(entries, LogEntry{

--- a/internal/usecase/gcloud/gcloud_test.go
+++ b/internal/usecase/gcloud/gcloud_test.go
@@ -2,8 +2,11 @@ package gcloud_test
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -13,6 +16,43 @@ import (
 	"github.com/mpyw/suve/internal/usecase/gcloud"
 	"github.com/mpyw/suve/internal/version/gcloudversion"
 )
+
+// TestLogUseCase_FilterBeforeCount asserts date filters run BEFORE the count
+// cap: -n must yield up to N versions that match the filter, not N newest then
+// filtered down to fewer (#351). Only the two oldest versions match --until;
+// the old count-first order would have truncated them all away.
+func TestLogUseCase_FilterBeforeCount(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	versions := []domain.Version{
+		{ID: "3", Created: &now},
+		{ID: "2", Created: lo.ToPtr(now.Add(-2 * time.Hour))},
+		{ID: "1", Created: lo.ToPtr(now.Add(-3 * time.Hour))},
+	}
+
+	store := &providermock.Store{
+		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
+			return versions, nil
+		},
+		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+			return provider.NewVersionRef(strings.TrimPrefix(spec, "#")), nil
+		},
+		GetFunc: func(_ context.Context, name string, ref provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{Name: name, Value: ref.ID(), Version: domain.Version{ID: ref.ID()}}, nil
+		},
+	}
+
+	uc := &gcloud.LogUseCase{Reader: store}
+	out, err := uc.Execute(t.Context(), gcloud.LogInput{
+		Name:       "my-secret",
+		MaxResults: 1,
+		Until:      lo.ToPtr(now.Add(-time.Hour)),
+	})
+	require.NoError(t, err)
+	require.Len(t, out.Entries, 1)
+	assert.Equal(t, "2", out.Entries[0].Version)
+}
 
 func TestShowUseCase(t *testing.T) {
 	t.Parallel()

--- a/internal/usecase/gcloud/log.go
+++ b/internal/usecase/gcloud/log.go
@@ -62,18 +62,12 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 	// tell whether the oldest shown version is genuinely the initial one.
 	initialVersion := versions[len(versions)-1].ID
 
-	if input.MaxResults > 0 && len(versions) > int(input.MaxResults) {
-		versions = versions[:input.MaxResults]
-	}
+	// Apply date filters BEFORE the count limit: -n must return up to N versions
+	// that match --since/--until, not N newest-then-filtered to fewer (#351).
+	if input.Since != nil || input.Until != nil {
+		kept := versions[:0]
 
-	if input.Reverse {
-		slices.Reverse(versions)
-	}
-
-	entries := make([]LogEntry, 0, len(versions))
-
-	for _, v := range versions {
-		if input.Since != nil || input.Until != nil {
+		for _, v := range versions {
 			if v.Created == nil {
 				continue
 			}
@@ -85,8 +79,24 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 			if input.Until != nil && v.Created.After(*input.Until) {
 				continue
 			}
+
+			kept = append(kept, v)
 		}
 
+		versions = kept
+	}
+
+	if input.MaxResults > 0 && len(versions) > int(input.MaxResults) {
+		versions = versions[:input.MaxResults]
+	}
+
+	if input.Reverse {
+		slices.Reverse(versions)
+	}
+
+	entries := make([]LogEntry, 0, len(versions))
+
+	for _, v := range versions {
 		value, fetchErr := u.getValue(ctx, input.Name, v.ID)
 
 		entries = append(entries, LogEntry{

--- a/internal/usecase/param/log.go
+++ b/internal/usecase/param/log.go
@@ -65,18 +65,14 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 	// tell whether the oldest shown version is genuinely the initial one.
 	initialVersion := parseVersion(versions[len(versions)-1].ID)
 
-	// History is newest first; MaxResults caps the number of versions shown.
-	if input.MaxResults > 0 && len(versions) > int(input.MaxResults) {
-		versions = versions[:input.MaxResults]
-	}
-
-	// The current version is the highest version number in the working set.
+	// The current version is the highest version number over the full history.
 	maxVersion := lo.MaxBy(versions, func(a, b domain.Version) bool {
 		return parseVersion(a.ID) > parseVersion(b.ID)
 	})
 	maxVersionNum := parseVersion(maxVersion.ID)
 
-	// Apply date filters against each version's creation time.
+	// Apply date filters BEFORE the count limit: -n must return up to N versions
+	// that match --since/--until, not N newest-then-filtered to fewer (#351).
 	filtered := lo.Filter(versions, func(v domain.Version, _ int) bool {
 		if input.Since == nil && input.Until == nil {
 			return true
@@ -97,6 +93,11 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 
 		return true
 	})
+
+	// Then cap the (newest-first) filtered set to MaxResults.
+	if input.MaxResults > 0 && len(filtered) > int(input.MaxResults) {
+		filtered = filtered[:input.MaxResults]
+	}
 
 	entries := make([]LogEntry, 0, len(filtered))
 

--- a/internal/usecase/param/log_test.go
+++ b/internal/usecase/param/log_test.go
@@ -201,6 +201,32 @@ func TestLogUseCase_Execute_DateRangeFilter(t *testing.T) {
 	assert.Equal(t, int64(2), output.Entries[0].Version)
 }
 
+// TestLogUseCase_Execute_FilterBeforeCount asserts date filters run BEFORE the
+// count cap: -n must yield up to N versions that match the filter, not N newest
+// then filtered down to fewer (#351). Here only the two oldest versions match
+// --until, and the old count-first order would have truncated them all away.
+func TestLogUseCase_Execute_FilterBeforeCount(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	store := newLogStore([]logVer{
+		{ver: 1, value: "v1", modified: lo.ToPtr(now.Add(-3 * time.Hour))},
+		{ver: 2, value: "v2", modified: lo.ToPtr(now.Add(-2 * time.Hour))},
+		{ver: 3, value: "v3", modified: lo.ToPtr(now)},
+	})
+
+	uc := &param.LogUseCase{Reader: store}
+
+	until := now.Add(-1 * time.Hour)
+	output, err := uc.Execute(t.Context(), param.LogInput{Name: "/app/config", MaxResults: 1, Until: &until})
+	require.NoError(t, err)
+
+	// Only v1 and v2 predate --until; capping to 1 yields the newest of those (v2),
+	// not an empty result from truncating to v3 first.
+	require.Len(t, output.Entries, 1)
+	assert.Equal(t, int64(2), output.Entries[0].Version)
+}
+
 func TestLogUseCase_Execute_NoLastModifiedDate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/usecase/secret/log.go
+++ b/internal/usecase/secret/log.go
@@ -64,6 +64,30 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 	// tell whether the oldest shown version is genuinely the initial one.
 	initialVersion := versions[len(versions)-1].ID
 
+	// Apply date filters BEFORE the count limit: -n must return up to N versions
+	// that match --since/--until, not N newest-then-filtered to fewer (#351).
+	if input.Since != nil || input.Until != nil {
+		kept := versions[:0]
+
+		for _, v := range versions {
+			if v.Created == nil {
+				continue
+			}
+
+			if input.Since != nil && v.Created.Before(*input.Since) {
+				continue
+			}
+
+			if input.Until != nil && v.Created.After(*input.Until) {
+				continue
+			}
+
+			kept = append(kept, v)
+		}
+
+		versions = kept
+	}
+
 	// History is newest first; MaxResults caps the number of versions shown.
 	if input.MaxResults > 0 && len(versions) > int(input.MaxResults) {
 		versions = versions[:input.MaxResults]
@@ -77,21 +101,6 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 	entries := make([]LogEntry, 0, len(versions))
 
 	for _, v := range versions {
-		// Apply date filters (skip entries without CreatedDate when filters are applied).
-		if input.Since != nil || input.Until != nil {
-			if v.Created == nil {
-				continue
-			}
-
-			if input.Since != nil && v.Created.Before(*input.Since) {
-				continue
-			}
-
-			if input.Until != nil && v.Created.After(*input.Until) {
-				continue
-			}
-		}
-
 		value, fetchErr := u.getValue(ctx, input.Name, v.ID)
 
 		entries = append(entries, LogEntry{

--- a/internal/usecase/secret/log_test.go
+++ b/internal/usecase/secret/log_test.go
@@ -150,6 +150,32 @@ func TestLogUseCase_Execute_SinceUntil(t *testing.T) {
 	assert.Equal(t, "middle", output.Entries[0].VersionID)
 }
 
+// TestLogUseCase_Execute_FilterBeforeCount asserts date filters run BEFORE the
+// count cap: -n must yield up to N versions that match the filter, not N newest
+// then filtered down to fewer (#351). Here only the two oldest versions match
+// --until, and the old count-first order would have truncated them all away.
+func TestLogUseCase_Execute_FilterBeforeCount(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	versions := []domain.Version{
+		{ID: "newest", Created: &now},
+		{ID: "middle", Created: tp(now, -2*time.Hour)},
+		{ID: "oldest", Created: tp(now, -3*time.Hour)},
+	}
+
+	uc := &secret.LogUseCase{Reader: logStore(versions, map[string]string{}, nil)}
+
+	output, err := uc.Execute(t.Context(), secret.LogInput{
+		Name:       "my-secret",
+		MaxResults: 1,
+		Until:      tp(now, -time.Hour),
+	})
+	require.NoError(t, err)
+	require.Len(t, output.Entries, 1)
+	assert.Equal(t, "middle", output.Entries[0].VersionID)
+}
+
 // TestLogUseCase_Execute_PartialFetchError records a per-version fetch failure
 // on the entry rather than aborting the whole listing.
 func TestLogUseCase_Execute_PartialFetchError(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #351.

`log -n N --since/--until` could return **fewer than N** matching versions (or none at all) because the date filter ran *after* the history was already truncated to the newest `MaxResults` versions. When the newest versions fell outside the date window, they consumed the count budget and the actually-matching older versions were discarded.

This reorders every provider's log use case to **filter by date first, then cap to N**:

- `internal/usecase/param/log.go`
- `internal/usecase/secret/log.go`
- `internal/usecase/gcloud/log.go`
- `internal/usecase/azure/log.go`

## Test

Added `TestLogUseCase_*_FilterBeforeCount` to each provider: three versions where only the two oldest match `--until`, with `-n 1`. Before the fix the count-first order truncated to the newest version and the filter then removed it, yielding zero entries; now it correctly returns the newest *matching* version.

- `go build ./...` — clean
- `go test ./internal/usecase/...` — pass
- `golangci-lint run --build-tags=e2e,production ./internal/usecase/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)