### PR TITLE
fix(staging): don't misclassify a zero Modified timestamp as not-found on delete (#334)

### DIFF
--- a/internal/staging/azure_appconfig_param.go
+++ b/internal/staging/azure_appconfig_param.go
@@ -108,8 +108,11 @@ func (s *AzureAppConfigParamStrategy) ApplyTags(_ context.Context, _ string, _ T
 	return ErrAppConfigTagsUnsupported
 }
 
-// FetchLastModified returns zero time: App Configuration staging uses
-// last-write-wins, so no modified-after conflict is ever reported.
+// FetchLastModified returns a zero time with a nil error: App Configuration
+// staging uses last-write-wins, so no modified-after conflict is ever reported.
+// The nil error means the delete use case treats every setting as existing
+// (never "not found"); apply is idempotent on a missing setting, so this is
+// consistent with the last-write-wins model.
 func (s *AzureAppConfigParamStrategy) FetchLastModified(_ context.Context, _ string) (time.Time, error) {
 	return time.Time{}, nil
 }

--- a/internal/staging/azure_keyvault_secret.go
+++ b/internal/staging/azure_keyvault_secret.go
@@ -114,13 +114,15 @@ func (s *AzureKeyVaultSecretStrategy) ApplyTags(ctx context.Context, name string
 	return nil
 }
 
-// FetchLastModified returns the last modified time of the secret. Returns zero
-// time if the secret doesn't exist.
+// FetchLastModified returns the last modified time of the secret. It returns a
+// *ResourceNotFoundError when the secret does not exist, so callers can tell
+// "missing" apart from "exists but has no modification time" (the latter returns
+// a zero time with a nil error).
 func (s *AzureKeyVaultSecretStrategy) FetchLastModified(ctx context.Context, name string) (time.Time, error) {
 	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
 	if err != nil {
 		if errors.Is(err, provider.ErrNotFound) {
-			return time.Time{}, nil
+			return time.Time{}, &ResourceNotFoundError{Err: err}
 		}
 
 		return time.Time{}, fmt.Errorf("failed to get secret: %w", err)

--- a/internal/staging/azure_keyvault_secret_test.go
+++ b/internal/staging/azure_keyvault_secret_test.go
@@ -165,7 +165,7 @@ func TestAzureKeyVaultSecretStrategy_FetchLastModified(t *testing.T) {
 		assert.Equal(t, mod, got)
 	})
 
-	t.Run("not found yields zero time, no error", func(t *testing.T) {
+	t.Run("not found yields ResourceNotFoundError", func(t *testing.T) {
 		t.Parallel()
 
 		store := &providermock.Store{
@@ -173,9 +173,10 @@ func TestAzureKeyVaultSecretStrategy_FetchLastModified(t *testing.T) {
 				return nil, secretNotFound(name)
 			},
 		}
-		got, err := staging.NewAzureKeyVaultSecretStrategy(store).FetchLastModified(t.Context(), "sec")
-		require.NoError(t, err)
-		assert.True(t, got.IsZero())
+		_, err := staging.NewAzureKeyVaultSecretStrategy(store).FetchLastModified(t.Context(), "sec")
+		notFoundErr := (*staging.ResourceNotFoundError)(nil)
+		require.ErrorAs(t, err, &notFoundErr)
+		require.ErrorIs(t, err, provider.ErrNotFound)
 	})
 
 	t.Run("nil Modified yields zero time", func(t *testing.T) {

--- a/internal/staging/gcloud_secret.go
+++ b/internal/staging/gcloud_secret.go
@@ -123,13 +123,15 @@ func (s *GoogleCloudSecretStrategy) ApplyTags(ctx context.Context, name string, 
 	return nil
 }
 
-// FetchLastModified returns the last modified time of the secret. Returns zero
-// time if the secret doesn't exist.
+// FetchLastModified returns the last modified time of the secret. It returns a
+// *ResourceNotFoundError when the secret does not exist, so callers can tell
+// "missing" apart from "exists but has no modification time" (the latter returns
+// a zero time with a nil error).
 func (s *GoogleCloudSecretStrategy) FetchLastModified(ctx context.Context, name string) (time.Time, error) {
 	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
 	if err != nil {
 		if errors.Is(err, provider.ErrNotFound) {
-			return time.Time{}, nil
+			return time.Time{}, &ResourceNotFoundError{Err: err}
 		}
 
 		return time.Time{}, fmt.Errorf("failed to get secret: %w", err)

--- a/internal/staging/gcloud_secret_test.go
+++ b/internal/staging/gcloud_secret_test.go
@@ -135,7 +135,7 @@ func TestGoogleCloudSecretStrategy_FetchLastModified(t *testing.T) {
 		assert.Equal(t, mod, got)
 	})
 
-	t.Run("not found yields zero time, no error", func(t *testing.T) {
+	t.Run("not found yields ResourceNotFoundError", func(t *testing.T) {
 		t.Parallel()
 
 		store := &providermock.Store{
@@ -143,9 +143,10 @@ func TestGoogleCloudSecretStrategy_FetchLastModified(t *testing.T) {
 				return nil, secretNotFound(name)
 			},
 		}
-		got, err := staging.NewGoogleCloudSecretStrategy(store).FetchLastModified(t.Context(), "sec")
-		require.NoError(t, err)
-		assert.True(t, got.IsZero())
+		_, err := staging.NewGoogleCloudSecretStrategy(store).FetchLastModified(t.Context(), "sec")
+		notFoundErr := (*staging.ResourceNotFoundError)(nil)
+		require.ErrorAs(t, err, &notFoundErr)
+		require.ErrorIs(t, err, provider.ErrNotFound)
 	})
 }
 

--- a/internal/staging/param.go
+++ b/internal/staging/param.go
@@ -129,13 +129,15 @@ func (s *ParamStrategy) ApplyTags(ctx context.Context, name string, tagEntry Tag
 	return nil
 }
 
-// FetchLastModified returns the last modified time of the parameter.
-// Returns zero time if the parameter doesn't exist.
+// FetchLastModified returns the last modified time of the parameter. It returns
+// a *ResourceNotFoundError when the parameter does not exist, so callers can
+// tell "missing" apart from "exists but has no modification time" (the latter
+// returns a zero time with a nil error).
 func (s *ParamStrategy) FetchLastModified(ctx context.Context, name string) (time.Time, error) {
 	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
 	if err != nil {
 		if errors.Is(err, provider.ErrNotFound) {
-			return time.Time{}, nil
+			return time.Time{}, &ResourceNotFoundError{Err: err}
 		}
 
 		return time.Time{}, fmt.Errorf("failed to get parameter: %w", err)

--- a/internal/staging/param_test.go
+++ b/internal/staging/param_test.go
@@ -498,7 +498,7 @@ func TestParamStrategy_FetchLastModified(t *testing.T) {
 		assert.Equal(t, now, result)
 	})
 
-	t.Run("not found - returns zero time", func(t *testing.T) {
+	t.Run("not found - returns ResourceNotFoundError", func(t *testing.T) {
 		t.Parallel()
 
 		mock := &providermock.Store{
@@ -508,9 +508,10 @@ func TestParamStrategy_FetchLastModified(t *testing.T) {
 		}
 
 		s := staging.NewParamStrategy(mock)
-		result, err := s.FetchLastModified(t.Context(), "/app/param")
-		require.NoError(t, err)
-		assert.True(t, result.IsZero())
+		_, err := s.FetchLastModified(t.Context(), "/app/param")
+		notFoundErr := (*staging.ResourceNotFoundError)(nil)
+		require.ErrorAs(t, err, &notFoundErr)
+		require.ErrorIs(t, err, provider.ErrNotFound)
 	})
 
 	t.Run("other error - returns error", func(t *testing.T) {

--- a/internal/staging/secret.go
+++ b/internal/staging/secret.go
@@ -133,13 +133,15 @@ func (s *SecretStrategy) ApplyTags(ctx context.Context, name string, tagEntry Ta
 	return nil
 }
 
-// FetchLastModified returns the last modified time of the secret.
-// Returns zero time if the secret doesn't exist.
+// FetchLastModified returns the last modified time of the secret. It returns a
+// *ResourceNotFoundError when the secret does not exist, so callers can tell
+// "missing" apart from "exists but has no modification time" (the latter returns
+// a zero time with a nil error).
 func (s *SecretStrategy) FetchLastModified(ctx context.Context, name string) (time.Time, error) {
 	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
 	if err != nil {
 		if errors.Is(err, provider.ErrNotFound) {
-			return time.Time{}, nil
+			return time.Time{}, &ResourceNotFoundError{Err: err}
 		}
 
 		return time.Time{}, fmt.Errorf("failed to get secret: %w", err)

--- a/internal/staging/secret_test.go
+++ b/internal/staging/secret_test.go
@@ -534,7 +534,7 @@ func TestSecretStrategy_FetchLastModified(t *testing.T) {
 		assert.Equal(t, now, result)
 	})
 
-	t.Run("not found - returns zero time", func(t *testing.T) {
+	t.Run("not found - returns ResourceNotFoundError", func(t *testing.T) {
 		t.Parallel()
 
 		mock := &providermock.Store{
@@ -544,9 +544,10 @@ func TestSecretStrategy_FetchLastModified(t *testing.T) {
 		}
 
 		s := staging.NewSecretStrategy(mock)
-		result, err := s.FetchLastModified(t.Context(), "my-secret")
-		require.NoError(t, err)
-		assert.True(t, result.IsZero())
+		_, err := s.FetchLastModified(t.Context(), "my-secret")
+		notFoundErr := (*staging.ResourceNotFoundError)(nil)
+		require.ErrorAs(t, err, &notFoundErr)
+		require.ErrorIs(t, err, provider.ErrNotFound)
 	})
 
 	t.Run("other error - returns error", func(t *testing.T) {

--- a/internal/staging/service.go
+++ b/internal/staging/service.go
@@ -72,7 +72,10 @@ type ApplyStrategy interface {
 	ApplyTags(ctx context.Context, name string, tagEntry TagEntry) error
 
 	// FetchLastModified returns the last modified time of the resource in AWS.
-	// Returns zero time if the resource doesn't exist (for create operations).
+	// It returns a *ResourceNotFoundError when the resource does not exist, so
+	// callers can distinguish "missing" from "exists but has no modification
+	// time" (the latter returns a zero time with a nil error). Providers that
+	// disable conflict detection may always return a zero time with a nil error.
 	FetchLastModified(ctx context.Context, name string) (time.Time, error)
 }
 
@@ -132,7 +135,10 @@ type DeleteStrategy interface {
 	ServiceStrategy
 
 	// FetchLastModified returns the last modified time of the resource in AWS.
-	// Used for conflict detection when applying delete operations.
+	// Used for existence and conflict detection when applying delete operations.
+	// It returns a *ResourceNotFoundError when the resource does not exist, so
+	// callers can distinguish "missing" from "exists but has no modification
+	// time" (the latter returns a zero time with a nil error).
 	FetchLastModified(ctx context.Context, name string) (time.Time, error)
 }
 

--- a/internal/usecase/staging/delete.go
+++ b/internal/usecase/staging/delete.go
@@ -46,17 +46,29 @@ func (u *DeleteUseCase) Execute(ctx context.Context, input DeleteInput) (*Delete
 		}
 	}
 
-	// Fetch LastModified for conflict detection (needed for non-CREATE cases)
-	lastModified, err := u.Strategy.FetchLastModified(ctx, input.Name)
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch %s: %w", itemName, err)
-	}
+	// Fetch LastModified to determine existence (and, for existing resources, to
+	// record a conflict-detection base). Existence is inferred from the ERROR,
+	// not from the returned timestamp: a resource that exists but carries no
+	// modification time still yields a zero time and must NOT be misread as
+	// "not found".
+	var (
+		lastModified time.Time
+		currentValue *string
+	)
 
-	// Determine CurrentValue based on AWS existence
-	var currentValue *string
-	if !lastModified.IsZero() {
-		// Resource exists on AWS - set a non-nil value to indicate existence
-		// The actual value doesn't matter for delete, only existence check
+	fetched, err := u.Strategy.FetchLastModified(ctx, input.Name)
+	if err != nil {
+		// ResourceNotFoundError means the resource doesn't exist; leave
+		// currentValue nil so the reducer either errors (nothing to delete) or
+		// unstages a staged CREATE. Any other error is a genuine failure.
+		if notFoundErr := (*staging.ResourceNotFoundError)(nil); !errors.As(err, &notFoundErr) {
+			return nil, fmt.Errorf("failed to fetch %s: %w", itemName, err)
+		}
+	} else {
+		// Resource exists on AWS - a non-nil currentValue signals existence to
+		// the reducer. A zero fetched time here means "exists, modification time
+		// unknown" and is preserved as-is.
+		lastModified = fetched
 		currentValue = new(string)
 	}
 

--- a/internal/usecase/staging/delete_test.go
+++ b/internal/usecase/staging/delete_test.go
@@ -143,7 +143,8 @@ func TestDeleteUseCase_Execute_FetchError(t *testing.T) {
 
 	store := testutil.NewMockStore()
 	strategy := newMockDeleteStrategy(false)
-	strategy.fetchErr = errors.New("not found")
+	// A generic (non not-found) fetch failure must surface as an error.
+	strategy.fetchErr = errors.New("access denied")
 
 	uc := &usecasestaging.DeleteUseCase{
 		Strategy: strategy,
@@ -151,30 +152,60 @@ func TestDeleteUseCase_Execute_FetchError(t *testing.T) {
 	}
 
 	_, err := uc.Execute(t.Context(), usecasestaging.DeleteInput{
-		Name: "/app/not-exists",
+		Name: "/app/config",
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to fetch")
 }
 
-func TestDeleteUseCase_Execute_ZeroLastModified_ResourceNotFound(t *testing.T) {
+func TestDeleteUseCase_Execute_ResourceNotFound(t *testing.T) {
 	t.Parallel()
 
 	store := testutil.NewMockStore()
 	strategy := newMockDeleteStrategy(false)
-	strategy.lastModified = time.Time{} // Zero time means resource doesn't exist
+	// The strategy signals a genuine not-found via *ResourceNotFoundError.
+	strategy.fetchErr = &staging.ResourceNotFoundError{}
 
 	uc := &usecasestaging.DeleteUseCase{
 		Strategy: strategy,
 		Store:    store,
 	}
 
-	// Delete should fail when resource doesn't exist on AWS and not staged
+	// Delete should fail when the resource doesn't exist and is not staged.
 	_, err := uc.Execute(t.Context(), usecasestaging.DeleteInput{
-		Name: "/app/to-delete",
+		Name: "/app/not-exists",
 	})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "resource not found")
+}
+
+func TestDeleteUseCase_Execute_ZeroLastModified_ResourceExists(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	strategy := newMockDeleteStrategy(false)
+	// The resource EXISTS but reports a zero modification time (nil error). This
+	// must NOT be misclassified as "not found" (#334): it can still be staged
+	// for deletion.
+	strategy.lastModified = time.Time{}
+
+	uc := &usecasestaging.DeleteUseCase{
+		Strategy: strategy,
+		Store:    store,
+	}
+
+	output, err := uc.Execute(t.Context(), usecasestaging.DeleteInput{
+		Name: "/app/to-delete",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/app/to-delete", output.Name)
+	assert.False(t, output.Unstaged)
+
+	// Verify it was staged for deletion, with no conflict base (zero Modified).
+	entry, err := store.GetEntry(t.Context(), staging.ServiceParam, "/app/to-delete")
+	require.NoError(t, err)
+	assert.Equal(t, staging.OperationDelete, entry.Operation)
+	assert.Nil(t, entry.BaseModifiedAt)
 }
 
 func TestDeleteUseCase_Execute_ZeroLastModified_StagedCreate(t *testing.T) {
@@ -190,7 +221,7 @@ func TestDeleteUseCase_Execute_ZeroLastModified_StagedCreate(t *testing.T) {
 	}))
 
 	strategy := newMockDeleteStrategy(false)
-	strategy.lastModified = time.Time{} // Zero time means resource doesn't exist on AWS
+	strategy.fetchErr = &staging.ResourceNotFoundError{} // Resource doesn't exist on AWS
 
 	uc := &usecasestaging.DeleteUseCase{
 		Strategy: strategy,

--- a/internal/version/secretversion/spec.go
+++ b/internal/version/secretversion/spec.go
@@ -95,8 +95,12 @@ func ParseDiffArgs(args []string) (*Spec, *Spec, error) {
 	)
 }
 
+// isIDChar reports whether c is valid within a Secrets Manager version id.
+// Version ids are ClientRequestTokens (not just console UUIDs): a token created
+// via the API may contain '_' and '.' as well, so accept them alongside
+// letters, digits and '-'. Excludes the specifier characters '#', ':', '~'.
 func isIDChar(c byte) bool {
-	return internal.IsLetter(c) || internal.IsDigit(c) || c == '-'
+	return internal.IsLetter(c) || internal.IsDigit(c) || c == '-' || c == '_' || c == '.'
 }
 
 func isLabelChar(c byte) bool {

--- a/internal/version/secretversion/spec_test.go
+++ b/internal/version/secretversion/spec_test.go
@@ -65,6 +65,13 @@ func TestParse(t *testing.T) {
 			wantName: "my-secret",
 			wantID:   lo.ToPtr("12345"),
 		},
+		{
+			// ClientRequestToken-style version id with '_' and '.' (#319).
+			name:     "with token ID containing underscore and dot",
+			input:    "my-secret#my_token_0123456789.012345678901234567890",
+			wantName: "my-secret",
+			wantID:   lo.ToPtr("my_token_0123456789.012345678901234567890"),
+		},
 
 		// Label specifier (:LABEL)
 		{


### PR DESCRIPTION
## Problem

`internal/usecase/staging/delete.go` inferred whether a resource existed from `FetchLastModified(...).IsZero()`. A provider entry that **exists** but has a nil/zero `Modified` timestamp was therefore misclassified as "resource not found" and could not be staged for deletion.

## Fix

Existence is now determined from the **error**, not the timestamp:

- The `FetchLastModified` implementations for SSM Parameter Store, Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault now return a `*ResourceNotFoundError` on not-found (mirroring how `FetchCurrentValue`/`FetchCurrent` already discriminate not-found in the same files), instead of `(time.Time{}, nil)`.
- `DeleteUseCase.Execute` treats only a `*ResourceNotFoundError` as not-found (leaving `currentValue` nil so the reducer either errors or unstages a staged CREATE). Any other error is a genuine failure. A `nil` error means the resource **exists** and is staged for deletion even when the returned `Modified` time is zero.
- Conflict detection (`CheckConflicts`) is unaffected: it already treats any fetch error as "assume no conflict".
- Azure App Configuration keeps its documented last-write-wins contract (zero time + nil error), which now means its settings are always treated as existing on delete (apply is idempotent on a missing setting).

## Tests

- Added a use-case test proving a resource that exists with a **zero `Modified`** time can still be staged for deletion (no "not found").
- Added a use-case test proving a genuine not-found (strategy returns `*ResourceNotFoundError`) still reports "resource not found".
- Updated the strategy-level `FetchLastModified` tests to assert the new not-found error contract.

## Verification

- `go build ./...`
- `go test ./...`
- `golangci-lint run --allow-parallel-runners --build-tags=e2e,production ./internal/usecase/staging/... ./internal/staging/...` (0 issues)

Closes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1V1i3K1pj1CRq6iaUQXBD