### PR TITLE
fix(output): decide color per destination writer via a unified colors.Palette (#341)

### DIFF
--- a/internal/cli/colors/colors.go
+++ b/internal/cli/colors/colors.go
@@ -11,9 +11,6 @@ var (
 	// Error formats text in red for error messages.
 	Error = color.New(color.FgRed).SprintFunc()
 
-	// Success formats text in green for success messages.
-	Success = color.New(color.FgGreen).SprintFunc()
-
 	// Info formats text in cyan for informational messages.
 	Info = color.New(color.FgCyan).SprintFunc()
 
@@ -46,7 +43,47 @@ var (
 
 	// OpDelete formats delete operation indicator (D) in red.
 	OpDelete = color.New(color.FgRed).SprintFunc()
+)
 
-	// Failed formats "Failed" text in red.
-	Failed = color.New(color.FgRed).SprintFunc()
+// Style colorizes text for a specific destination writer, independent of the
+// process-global color.NoColor (which fatih/color derives once from os.Stdout).
+// Feedback primitives use it so a message's color tracks the TTY-ness of its own
+// writer rather than that of os.Stdout, keeping stderr correct under redirection
+// like `suve … 2>err.log` or `suve … | cat` (#341).
+type Style struct {
+	attrs []color.Attribute
+}
+
+// Sprint colorizes the operands with the style's attributes when enabled, and
+// returns them unformatted otherwise. A fresh color.Color with a forced
+// per-instance setting is used, so writers to different destinations never race
+// on (or get overridden by) the process-global color.NoColor.
+func (s Style) Sprint(enabled bool, a ...any) string {
+	c := color.New(s.attrs...)
+
+	if enabled {
+		c.EnableColor()
+	} else {
+		c.DisableColor()
+	}
+
+	return c.Sprint(a...)
+}
+
+//nolint:gochecknoglobals // Immutable style definitions initialized at package load
+var (
+	// WarningStyle is yellow, for warning text.
+	WarningStyle = Style{attrs: []color.Attribute{color.FgYellow}}
+
+	// ErrorStyle is red, for error text.
+	ErrorStyle = Style{attrs: []color.Attribute{color.FgRed}}
+
+	// SuccessStyle is green, for success markers.
+	SuccessStyle = Style{attrs: []color.Attribute{color.FgGreen}}
+
+	// InfoStyle is cyan, for informational/hint text.
+	InfoStyle = Style{attrs: []color.Attribute{color.FgCyan}}
+
+	// FieldLabelStyle is cyan, for field labels.
+	FieldLabelStyle = Style{attrs: []color.Attribute{color.FgCyan}}
 )

--- a/internal/cli/colors/colors.go
+++ b/internal/cli/colors/colors.go
@@ -1,67 +1,48 @@
-// Package colors provides pre-configured color functions for CLI output.
+// Package colors provides per-destination colored output for the CLI.
+//
+// Coloring is decided per destination writer rather than from a process-global:
+// fatih/color's package-global NoColor is set once from whether os.Stdout is a
+// TTY, which is wrong for anything written to os.Stderr (or any other writer).
+// Every colored string therefore goes through a Palette bound to the writer it
+// will be written to, so its color tracks that writer's own TTY-ness and stays
+// correct under redirection like `suve … 2>err.log` or `suve … | cat` (#341).
 package colors
 
-import "github.com/fatih/color"
+import (
+	"io"
+	"os"
 
-//nolint:gochecknoglobals // Immutable color definitions initialized at package load
-var (
-	// Warning formats text in yellow for warning messages.
-	Warning = color.New(color.FgYellow).SprintFunc()
+	"github.com/fatih/color"
 
-	// Error formats text in red for error messages.
-	Error = color.New(color.FgRed).SprintFunc()
-
-	// Info formats text in cyan for informational messages.
-	Info = color.New(color.FgCyan).SprintFunc()
-
-	// Version formats version numbers in yellow.
-	Version = color.New(color.FgYellow).SprintFunc()
-
-	// Current formats "(current)" marker in green.
-	Current = color.New(color.FgGreen).SprintFunc()
-
-	// FieldLabel formats field labels (e.g., "Date:", "Value:") in cyan.
-	FieldLabel = color.New(color.FgCyan).SprintFunc()
-
-	// DiffHeader formats diff header lines (---/+++) in cyan.
-	DiffHeader = color.New(color.FgCyan).SprintFunc()
-
-	// DiffHunk formats diff hunk markers (@@) in cyan.
-	DiffHunk = color.New(color.FgCyan).SprintFunc()
-
-	// DiffAdded formats added lines (+) in green.
-	DiffAdded = color.New(color.FgGreen).SprintFunc()
-
-	// DiffRemoved formats removed lines (-) in red.
-	DiffRemoved = color.New(color.FgRed).SprintFunc()
-
-	// OpAdd formats add operation indicator (A) in green.
-	OpAdd = color.New(color.FgGreen).SprintFunc()
-
-	// OpModify formats modify operation indicator (M) in green.
-	OpModify = color.New(color.FgGreen).SprintFunc()
-
-	// OpDelete formats delete operation indicator (D) in red.
-	OpDelete = color.New(color.FgRed).SprintFunc()
+	"github.com/mpyw/suve/internal/cli/terminal"
 )
 
-// Style colorizes text for a specific destination writer, independent of the
-// process-global color.NoColor (which fatih/color derives once from os.Stdout).
-// Feedback primitives use it so a message's color tracks the TTY-ness of its own
-// writer rather than that of os.Stdout, keeping stderr correct under redirection
-// like `suve … 2>err.log` or `suve … | cat` (#341).
-type Style struct {
-	attrs []color.Attribute
+// Palette renders colored text for a single destination writer. Obtain one with
+// For(w) and use its methods to color strings destined for w.
+type Palette struct {
+	enabled bool
 }
 
-// Sprint colorizes the operands with the style's attributes when enabled, and
-// returns them unformatted otherwise. A fresh color.Color with a forced
-// per-instance setting is used, so writers to different destinations never race
-// on (or get overridden by) the process-global color.NoColor.
-func (s Style) Sprint(enabled bool, a ...any) string {
-	c := color.New(s.attrs...)
+// For returns a Palette whose coloring is enabled only when NO_COLOR is unset
+// and w is a terminal. Deciding this per writer (rather than from the
+// os.Stdout-derived process-global) is what keeps each stream's color correct.
+func For(w io.Writer) Palette {
+	return Palette{enabled: os.Getenv("NO_COLOR") == "" && terminal.IsTerminalWriter(w)}
+}
 
-	if enabled {
+// Enabled reports whether this palette emits ANSI color.
+func (p Palette) Enabled() bool {
+	return p.enabled
+}
+
+// sprint colorizes the operands with attrs when the palette is enabled, and
+// returns them unformatted otherwise. A fresh color.Color with a forced
+// per-instance setting is used, so palettes for different destinations never
+// race on (or get overridden by) the process-global color.NoColor.
+func (p Palette) sprint(a []any, attrs ...color.Attribute) string {
+	c := color.New(attrs...)
+
+	if p.enabled {
 		c.EnableColor()
 	} else {
 		c.DisableColor()
@@ -70,20 +51,47 @@ func (s Style) Sprint(enabled bool, a ...any) string {
 	return c.Sprint(a...)
 }
 
-//nolint:gochecknoglobals // Immutable style definitions initialized at package load
-var (
-	// WarningStyle is yellow, for warning text.
-	WarningStyle = Style{attrs: []color.Attribute{color.FgYellow}}
+// Warning formats text in yellow for warning messages.
+func (p Palette) Warning(a ...any) string { return p.sprint(a, color.FgYellow) }
 
-	// ErrorStyle is red, for error text.
-	ErrorStyle = Style{attrs: []color.Attribute{color.FgRed}}
+// Error formats text in red for error messages.
+func (p Palette) Error(a ...any) string { return p.sprint(a, color.FgRed) }
 
-	// SuccessStyle is green, for success markers.
-	SuccessStyle = Style{attrs: []color.Attribute{color.FgGreen}}
+// Success formats text in green for success messages.
+func (p Palette) Success(a ...any) string { return p.sprint(a, color.FgGreen) }
 
-	// InfoStyle is cyan, for informational/hint text.
-	InfoStyle = Style{attrs: []color.Attribute{color.FgCyan}}
+// Info formats text in cyan for informational messages.
+func (p Palette) Info(a ...any) string { return p.sprint(a, color.FgCyan) }
 
-	// FieldLabelStyle is cyan, for field labels.
-	FieldLabelStyle = Style{attrs: []color.Attribute{color.FgCyan}}
-)
+// Failed formats "Failed" text in red.
+func (p Palette) Failed(a ...any) string { return p.sprint(a, color.FgRed) }
+
+// Version formats version numbers in yellow.
+func (p Palette) Version(a ...any) string { return p.sprint(a, color.FgYellow) }
+
+// Current formats the "(current)" marker in green.
+func (p Palette) Current(a ...any) string { return p.sprint(a, color.FgGreen) }
+
+// FieldLabel formats field labels (e.g., "Date:", "Value:") in cyan.
+func (p Palette) FieldLabel(a ...any) string { return p.sprint(a, color.FgCyan) }
+
+// DiffHeader formats diff header lines (---/+++) in cyan.
+func (p Palette) DiffHeader(a ...any) string { return p.sprint(a, color.FgCyan) }
+
+// DiffHunk formats diff hunk markers (@@) in cyan.
+func (p Palette) DiffHunk(a ...any) string { return p.sprint(a, color.FgCyan) }
+
+// DiffAdded formats added lines (+) in green.
+func (p Palette) DiffAdded(a ...any) string { return p.sprint(a, color.FgGreen) }
+
+// DiffRemoved formats removed lines (-) in red.
+func (p Palette) DiffRemoved(a ...any) string { return p.sprint(a, color.FgRed) }
+
+// OpAdd formats the add operation indicator (A) in green.
+func (p Palette) OpAdd(a ...any) string { return p.sprint(a, color.FgGreen) }
+
+// OpModify formats the modify operation indicator (M) in green.
+func (p Palette) OpModify(a ...any) string { return p.sprint(a, color.FgGreen) }
+
+// OpDelete formats the delete operation indicator (D) in red.
+func (p Palette) OpDelete(a ...any) string { return p.sprint(a, color.FgRed) }

--- a/internal/cli/commands/azure/param/update.go
+++ b/internal/cli/commands/azure/param/update.go
@@ -71,7 +71,7 @@ func updateAction(ctx context.Context, cmd *cli.Command) error {
 	if !skipConfirm {
 		currentValue, _ := uc.GetCurrentValue(ctx, name)
 		if currentValue != "" {
-			diff := output.Diff(name+" (current)", name+" (new)", currentValue, newValue)
+			diff := output.Diff(cmd.Root().ErrWriter, name+" (current)", name+" (new)", currentValue, newValue)
 			if diff != "" {
 				output.Println(cmd.Root().ErrWriter, diff)
 			}

--- a/internal/cli/commands/azure/secret/log.go
+++ b/internal/cli/commands/azure/secret/log.go
@@ -98,13 +98,13 @@ func (p *logPresenter) RenderOneline(stdout io.Writer, i, _ int) {
 
 	stateStr := ""
 	if entry.State != "" {
-		stateStr = colors.Current(fmt.Sprintf(" [%s]", entry.State))
+		stateStr = colors.For(stdout).Current(fmt.Sprintf(" [%s]", entry.State))
 	}
 
 	output.Printf(stdout, "%s%s  %s\n",
-		colors.Version(entry.Version),
+		colors.For(stdout).Version(entry.Version),
 		stateStr,
-		colors.FieldLabel(dateStr),
+		colors.For(stdout).FieldLabel(dateStr),
 	)
 }
 
@@ -113,13 +113,13 @@ func (p *logPresenter) RenderHeader(stdout io.Writer, i int) {
 
 	versionLabel := fmt.Sprintf("Version %s", entry.Version)
 	if entry.State != "" {
-		versionLabel += " " + colors.Current(fmt.Sprintf("[%s]", entry.State))
+		versionLabel += " " + colors.For(stdout).Current(fmt.Sprintf("[%s]", entry.State))
 	}
 
-	output.Println(stdout, colors.Version(versionLabel))
+	output.Println(stdout, colors.For(stdout).Version(versionLabel))
 
 	if entry.CreatedDate != nil {
-		output.Printf(stdout, "%s %s\n", colors.FieldLabel("Date:"), timeutil.FormatRFC3339(*entry.CreatedDate))
+		output.Printf(stdout, "%s %s\n", colors.For(stdout).FieldLabel("Date:"), timeutil.FormatRFC3339(*entry.CreatedDate))
 	}
 }
 
@@ -173,7 +173,7 @@ func (p *logPresenter) RenderPatch(stdout, stderr io.Writer, i int, parseJSON, r
 
 	newName := fmt.Sprintf("%s#%s", p.result.Name, newEntry.Version)
 
-	diff := output.Diff(oldName, newName, oldValue, newValue)
+	diff := output.Diff(stdout, oldName, newName, oldValue, newValue)
 	if diff != "" {
 		output.Println(stdout, "")
 		output.Print(stdout, diff)

--- a/internal/cli/commands/azure/secret/update.go
+++ b/internal/cli/commands/azure/secret/update.go
@@ -71,7 +71,7 @@ func updateAction(ctx context.Context, cmd *cli.Command) error {
 	if !skipConfirm {
 		currentValue, _ := uc.GetCurrentValue(ctx, name)
 		if currentValue != "" {
-			diff := output.Diff(name+" (current)", name+" (new)", currentValue, newValue)
+			diff := output.Diff(cmd.Root().ErrWriter, name+" (current)", name+" (new)", currentValue, newValue)
 			if diff != "" {
 				output.Println(cmd.Root().ErrWriter, diff)
 			}

--- a/internal/cli/commands/gcloud/log.go
+++ b/internal/cli/commands/gcloud/log.go
@@ -98,13 +98,13 @@ func (p *logPresenter) RenderOneline(stdout io.Writer, i, _ int) {
 
 	stateStr := ""
 	if entry.State != "" {
-		stateStr = colors.Current(fmt.Sprintf(" [%s]", entry.State))
+		stateStr = colors.For(stdout).Current(fmt.Sprintf(" [%s]", entry.State))
 	}
 
 	output.Printf(stdout, "%s%s  %s\n",
-		colors.Version(entry.Version),
+		colors.For(stdout).Version(entry.Version),
 		stateStr,
-		colors.FieldLabel(dateStr),
+		colors.For(stdout).FieldLabel(dateStr),
 	)
 }
 
@@ -113,13 +113,13 @@ func (p *logPresenter) RenderHeader(stdout io.Writer, i int) {
 
 	versionLabel := fmt.Sprintf("Version %s", entry.Version)
 	if entry.State != "" {
-		versionLabel += " " + colors.Current(fmt.Sprintf("[%s]", entry.State))
+		versionLabel += " " + colors.For(stdout).Current(fmt.Sprintf("[%s]", entry.State))
 	}
 
-	output.Println(stdout, colors.Version(versionLabel))
+	output.Println(stdout, colors.For(stdout).Version(versionLabel))
 
 	if entry.CreatedDate != nil {
-		output.Printf(stdout, "%s %s\n", colors.FieldLabel("Date:"), timeutil.FormatRFC3339(*entry.CreatedDate))
+		output.Printf(stdout, "%s %s\n", colors.For(stdout).FieldLabel("Date:"), timeutil.FormatRFC3339(*entry.CreatedDate))
 	}
 }
 
@@ -173,7 +173,7 @@ func (p *logPresenter) RenderPatch(stdout, stderr io.Writer, i int, parseJSON, r
 
 	newName := fmt.Sprintf("%s#%s", p.result.Name, newEntry.Version)
 
-	diff := output.Diff(oldName, newName, oldValue, newValue)
+	diff := output.Diff(stdout, oldName, newName, oldValue, newValue)
 	if diff != "" {
 		output.Println(stdout, "")
 		output.Print(stdout, diff)

--- a/internal/cli/commands/gcloud/update.go
+++ b/internal/cli/commands/gcloud/update.go
@@ -70,7 +70,7 @@ func updateAction(ctx context.Context, cmd *cli.Command) error {
 	if !skipConfirm {
 		currentValue, _ := uc.GetCurrentValue(ctx, name)
 		if currentValue != "" {
-			diff := output.Diff(name+" (current)", name+" (new)", currentValue, newValue)
+			diff := output.Diff(cmd.Root().ErrWriter, name+" (current)", name+" (new)", currentValue, newValue)
 			if diff != "" {
 				output.Println(cmd.Root().ErrWriter, diff)
 			}

--- a/internal/cli/commands/generic/diff/diff.go
+++ b/internal/cli/commands/generic/diff/diff.go
@@ -97,7 +97,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		return nil
 	}
 
-	diff := output.Diff(oldLabel, newLabel, value1, value2)
+	diff := output.Diff(r.Stdout, oldLabel, newLabel, value1, value2)
 
 	// The raw values differ but --parse-json normalized them to the same form:
 	// there is no textual diff to show, so say so explicitly instead of printing

--- a/internal/cli/commands/param/log.go
+++ b/internal/cli/commands/param/log.go
@@ -107,14 +107,14 @@ func (p *logPresenter) RenderOneline(stdout io.Writer, i, maxValueLength int) {
 
 	currentMark := ""
 	if entry.IsCurrent {
-		currentMark = colors.Current(" (current)")
+		currentMark = colors.For(stdout).Current(" (current)")
 	}
 
 	output.Printf(stdout, "%s%d%s  %s  %s\n",
-		colors.Version(""),
+		colors.For(stdout).Version(""),
 		entry.Version,
 		currentMark,
-		colors.FieldLabel(dateStr),
+		colors.For(stdout).FieldLabel(dateStr),
 		value,
 	)
 }
@@ -124,13 +124,13 @@ func (p *logPresenter) RenderHeader(stdout io.Writer, i int) {
 
 	versionLabel := fmt.Sprintf("Version %d", entry.Version)
 	if entry.IsCurrent {
-		versionLabel += " " + colors.Current("(current)")
+		versionLabel += " " + colors.For(stdout).Current("(current)")
 	}
 
-	output.Println(stdout, colors.Version(versionLabel))
+	output.Println(stdout, colors.For(stdout).Version(versionLabel))
 
 	if entry.LastModified != nil {
-		output.Printf(stdout, "%s %s\n", colors.FieldLabel("Date:"), timeutil.FormatRFC3339(*entry.LastModified))
+		output.Printf(stdout, "%s %s\n", colors.For(stdout).FieldLabel("Date:"), timeutil.FormatRFC3339(*entry.LastModified))
 	}
 }
 
@@ -181,7 +181,7 @@ func (p *logPresenter) RenderPatch(stdout, stderr io.Writer, i int, parseJSON, r
 
 	newName := fmt.Sprintf("%s#%d", p.result.Name, newEntry.Version)
 
-	diff := output.Diff(oldName, newName, oldValue, newValue)
+	diff := output.Diff(stdout, oldName, newName, oldValue, newValue)
 	if diff != "" {
 		output.Println(stdout, "")
 		output.Print(stdout, diff)

--- a/internal/cli/commands/param/update/update.go
+++ b/internal/cli/commands/param/update/update.go
@@ -136,7 +136,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	if !skipConfirm {
 		currentValue, _ := uc.GetCurrentValue(ctx, name)
 		if currentValue != "" {
-			diff := output.Diff(name+" (AWS)", name+" (new)", currentValue, newValue)
+			diff := output.Diff(cmd.Root().ErrWriter, name+" (AWS)", name+" (new)", currentValue, newValue)
 			if diff != "" {
 				output.Println(cmd.Root().ErrWriter, diff)
 			}

--- a/internal/cli/commands/secret/log.go
+++ b/internal/cli/commands/secret/log.go
@@ -108,13 +108,13 @@ func (p *logPresenter) RenderOneline(stdout io.Writer, i, _ int) {
 
 	labelsStr := ""
 	if len(entry.VersionStage) > 0 {
-		labelsStr = colors.Current(fmt.Sprintf(" %v", entry.VersionStage))
+		labelsStr = colors.For(stdout).Current(fmt.Sprintf(" %v", entry.VersionStage))
 	}
 
 	output.Printf(stdout, "%s%s  %s%s\n",
-		colors.Version(secretversion.TruncateVersionID(entry.VersionID)),
+		colors.For(stdout).Version(secretversion.TruncateVersionID(entry.VersionID)),
 		labelsStr,
-		colors.FieldLabel(dateStr),
+		colors.For(stdout).FieldLabel(dateStr),
 		"",
 	)
 }
@@ -124,13 +124,13 @@ func (p *logPresenter) RenderHeader(stdout io.Writer, i int) {
 
 	versionLabel := fmt.Sprintf("Version %s", secretversion.TruncateVersionID(entry.VersionID))
 	if len(entry.VersionStage) > 0 {
-		versionLabel += " " + colors.Current(fmt.Sprintf("%v", entry.VersionStage))
+		versionLabel += " " + colors.For(stdout).Current(fmt.Sprintf("%v", entry.VersionStage))
 	}
 
-	output.Println(stdout, colors.Version(versionLabel))
+	output.Println(stdout, colors.For(stdout).Version(versionLabel))
 
 	if entry.CreatedDate != nil {
-		output.Printf(stdout, "%s %s\n", colors.FieldLabel("Date:"), timeutil.FormatRFC3339(*entry.CreatedDate))
+		output.Printf(stdout, "%s %s\n", colors.For(stdout).FieldLabel("Date:"), timeutil.FormatRFC3339(*entry.CreatedDate))
 	}
 }
 
@@ -184,7 +184,7 @@ func (p *logPresenter) RenderPatch(stdout, stderr io.Writer, i int, parseJSON, r
 
 	newName := fmt.Sprintf("%s#%s", p.result.Name, secretversion.TruncateVersionID(newEntry.VersionID))
 
-	diff := output.Diff(oldName, newName, oldValue, newValue)
+	diff := output.Diff(stdout, oldName, newName, oldValue, newValue)
 	if diff != "" {
 		output.Println(stdout, "")
 		output.Print(stdout, diff)

--- a/internal/cli/commands/secret/update/update.go
+++ b/internal/cli/commands/secret/update/update.go
@@ -82,7 +82,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	if !skipConfirm {
 		currentValue, _ := uc.GetCurrentValue(ctx, name)
 		if currentValue != "" {
-			diff := output.Diff(name+" (AWS)", name+" (new)", currentValue, newValue)
+			diff := output.Diff(cmd.Root().ErrWriter, name+" (AWS)", name+" (new)", currentValue, newValue)
 			if diff != "" {
 				output.Println(cmd.Root().ErrWriter, diff)
 			}

--- a/internal/cli/commands/stage/diff/diff.go
+++ b/internal/cli/commands/stage/diff/diff.go
@@ -320,7 +320,7 @@ func (r *Runner) outputDiff(
 		"%s (staged)",
 	), name)
 
-	diff := output.Diff(label1, label2, displayRemote, displayStaged)
+	diff := output.Diff(r.Stdout, label1, label2, displayRemote, displayStaged)
 
 	// Raw values differ but --parse-json renders no textual diff: the staged
 	// update only reformats JSON. It remains staged (decided on raw above).
@@ -351,7 +351,7 @@ func (r *Runner) outputDiffCreate(opts Options, name string, entry staging.Entry
 	label1 := fmt.Sprintf("%s (not in %s)", name, r.ProviderLabel)
 	label2 := fmt.Sprintf("%s (staged for creation)", name)
 
-	diff := output.Diff(label1, label2, "", stagedValue)
+	diff := output.Diff(r.Stdout, label1, label2, "", stagedValue)
 	output.Print(r.Stdout, diff)
 
 	// Show staged metadata
@@ -362,12 +362,12 @@ func (r *Runner) outputDiffCreate(opts Options, name string, entry staging.Entry
 
 func (r *Runner) outputMetadata(entry staging.Entry) {
 	if desc := lo.FromPtr(entry.Description); desc != "" {
-		output.Printf(r.Stdout, "%s %s\n", colors.FieldLabel("Description:"), desc)
+		output.Printf(r.Stdout, "%s %s\n", colors.For(r.Stdout).FieldLabel("Description:"), desc)
 	}
 }
 
 func (r *Runner) outputTagDiff(ctx context.Context, strategy staging.DiffStrategy, name string, tagEntry staging.TagEntry) {
-	output.Printf(r.Stdout, "%s %s (staged tag changes)\n", colors.Info("Tags:"), name)
+	output.Printf(r.Stdout, "%s %s (staged tag changes)\n", colors.For(r.Stdout).Info("Tags:"), name)
 
 	if len(tagEntry.Add) > 0 {
 		tagPairs := make([]string, 0, len(tagEntry.Add))
@@ -375,7 +375,7 @@ func (r *Runner) outputTagDiff(ctx context.Context, strategy staging.DiffStrateg
 			tagPairs = append(tagPairs, fmt.Sprintf("%s=%s", k, tagEntry.Add[k]))
 		}
 
-		output.Printf(r.Stdout, "  %s %s\n", colors.OpAdd("+"), strings.Join(tagPairs, ", "))
+		output.Printf(r.Stdout, "  %s %s\n", colors.For(r.Stdout).OpAdd("+"), strings.Join(tagPairs, ", "))
 	}
 
 	if tagEntry.Remove.Len() > 0 {
@@ -405,5 +405,5 @@ func (r *Runner) outputRemovedTags(remove maputil.Set[string], currentTags map[s
 		}
 	}
 
-	output.Printf(r.Stdout, "  %s %s\n", colors.OpDelete("-"), strings.Join(tagPairs, ", "))
+	output.Printf(r.Stdout, "  %s %s\n", colors.For(r.Stdout).OpDelete("-"), strings.Join(tagPairs, ", "))
 }

--- a/internal/cli/commands/stage/status/status.go
+++ b/internal/cli/commands/stage/status/status.go
@@ -105,7 +105,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 		}
 
 		output.Printf(r.Stdout, "%s (%d):\n",
-			colors.Warning("Staged "+parser.ServiceName()+" changes"), total)
+			colors.For(r.Stdout).Warning("Staged "+parser.ServiceName()+" changes"), total)
 		printEntries(printer, svcEntries, opts.Verbose, parser.HasDeleteOptions())
 		printTagEntries(r.Stdout, svcTags, opts.Verbose)
 
@@ -153,7 +153,7 @@ func printTagEntries(w io.Writer, tagEntries map[string]staging.TagEntry, verbos
 		}
 
 		summary := strings.Join(parts, ", ")
-		output.Printf(w, "  %s %s [%s]\n", colors.Info("T"), name, summary)
+		output.Printf(w, "  %s %s [%s]\n", colors.For(w).Info("T"), name, summary)
 
 		if verbose {
 			for key, value := range entry.Add {

--- a/internal/cli/confirm/confirm.go
+++ b/internal/cli/confirm/confirm.go
@@ -33,7 +33,7 @@ type Prompter struct {
 // printTargetInfo prints the target information before a prompt, if available.
 func (p *Prompter) printTargetInfo() {
 	if p.Target != "" {
-		output.Printf(p.Stderr, "%s Target: %s\n", colors.Info("i"), p.Target)
+		output.Printf(p.Stderr, "%s Target: %s\n", colors.For(p.Stderr).Info("i"), p.Target)
 
 		return
 	}
@@ -43,9 +43,9 @@ func (p *Prompter) printTargetInfo() {
 	}
 
 	if p.Profile != "" {
-		output.Printf(p.Stderr, "%s Target: %s (%s / %s)\n", colors.Info("i"), p.Profile, p.AccountID, p.Region)
+		output.Printf(p.Stderr, "%s Target: %s (%s / %s)\n", colors.For(p.Stderr).Info("i"), p.Profile, p.AccountID, p.Region)
 	} else {
-		output.Printf(p.Stderr, "%s Target: %s / %s\n", colors.Info("i"), p.AccountID, p.Region)
+		output.Printf(p.Stderr, "%s Target: %s / %s\n", colors.For(p.Stderr).Info("i"), p.AccountID, p.Region)
 	}
 }
 
@@ -71,7 +71,7 @@ func (p *Prompter) Confirm(message string, skipConfirm bool) (bool, error) {
 	}
 
 	p.printTargetInfo()
-	output.Printf(p.Stderr, "%s %s [y/N]: ", colors.Warning("?"), message)
+	output.Printf(p.Stderr, "%s %s [y/N]: ", colors.For(p.Stderr).Warning("?"), message)
 
 	return p.readYesNo()
 }
@@ -90,8 +90,8 @@ func (p *Prompter) ConfirmDelete(target string, skipConfirm bool) (bool, error) 
 	}
 
 	p.printTargetInfo()
-	output.Printf(p.Stderr, "%s This will permanently delete: %s\n", colors.Error("!"), target)
-	output.Printf(p.Stderr, "%s Continue? [y/N]: ", colors.Warning("?"))
+	output.Printf(p.Stderr, "%s This will permanently delete: %s\n", colors.For(p.Stderr).Error("!"), target)
+	output.Printf(p.Stderr, "%s Continue? [y/N]: ", colors.For(p.Stderr).Warning("?"))
 
 	return p.readYesNo()
 }
@@ -115,7 +115,7 @@ const (
 // The first choice (index 0) is the default when user just presses Enter.
 func (p *Prompter) ConfirmChoice(message string, choices []Choice) (ChoiceResult, error) {
 	p.printTargetInfo()
-	output.Printf(p.Stderr, "%s %s\n", colors.Warning("?"), message)
+	output.Printf(p.Stderr, "%s %s\n", colors.For(p.Stderr).Warning("?"), message)
 
 	for i, choice := range choices {
 		if choice.Description != "" {

--- a/internal/cli/output/output.go
+++ b/internal/cli/output/output.go
@@ -13,12 +13,24 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/aymanbagabas/go-udiff"
 
 	"github.com/mpyw/suve/internal/cli/colors"
+	"github.com/mpyw/suve/internal/cli/terminal"
 )
+
+// colorEnabled reports whether ANSI color should be emitted for w: only when
+// NO_COLOR is unset and w itself is a terminal. Deciding per destination writer
+// — rather than from the process-global color.NoColor, which fatih/color derives
+// once from os.Stdout — keeps stderr's coloring correct under redirection such
+// as `suve … 2>err.log` (stderr not a TTY) or `suve … | cat` (stderr a TTY while
+// stdout is piped) (#341).
+func colorEnabled(w io.Writer) bool {
+	return os.Getenv("NO_COLOR") == "" && terminal.IsTerminalWriter(w)
+}
 
 // Format represents the output format.
 type Format string
@@ -56,7 +68,7 @@ func New(w io.Writer) *Writer {
 
 // Field prints a labeled field.
 func (o *Writer) Field(label, value string) {
-	_, _ = fmt.Fprintf(o.w, "%s %s\n", colors.FieldLabel(label+":"), value)
+	_, _ = fmt.Fprintf(o.w, "%s %s\n", colors.FieldLabelStyle.Sprint(colorEnabled(o.w), label+":"), value)
 }
 
 // Separator prints a separator line.
@@ -87,12 +99,13 @@ func (o *Writer) Value(value string) {
 // prefixed) so the exact byte layout of each family stays consistent.
 
 // labeled formats a message and prints it as a single line, coloring the whole
-// "label+message" string with colorize. A label of "" colors the message alone.
+// "label+message" string with style. A label of "" colors the message alone.
+// Color tracks w's own TTY-ness so redirected stderr stays clean (#341).
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
-func labeled(w io.Writer, colorize func(...any) string, label, format string, args ...any) {
+func labeled(w io.Writer, style colors.Style, label, format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
-	_, _ = fmt.Fprintln(w, colorize(label+msg))
+	_, _ = fmt.Fprintln(w, style.Sprint(colorEnabled(w), label+msg))
 }
 
 // prefixed formats a message and prints it as "prefix message" on a single
@@ -110,7 +123,7 @@ func prefixed(w io.Writer, prefix, format string, args ...any) {
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
 func Warning(w io.Writer, format string, args ...any) {
-	labeled(w, colors.Warning, "Warning: ", format, args...)
+	labeled(w, colors.WarningStyle, "Warning: ", format, args...)
 }
 
 // Hint prints a hint message in cyan.
@@ -119,7 +132,7 @@ func Warning(w io.Writer, format string, args ...any) {
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
 func Hint(w io.Writer, format string, args ...any) {
-	labeled(w, colors.Info, "Hint: ", format, args...)
+	labeled(w, colors.InfoStyle, "Hint: ", format, args...)
 }
 
 // Error prints an error message in red.
@@ -128,7 +141,7 @@ func Hint(w io.Writer, format string, args ...any) {
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
 func Error(w io.Writer, format string, args ...any) {
-	labeled(w, colors.Error, "Error: ", format, args...)
+	labeled(w, colors.ErrorStyle, "Error: ", format, args...)
 }
 
 // Info prints an informational message in cyan with no prefix.
@@ -137,7 +150,7 @@ func Error(w io.Writer, format string, args ...any) {
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
 func Info(w io.Writer, format string, args ...any) {
-	labeled(w, colors.Info, "", format, args...)
+	labeled(w, colors.InfoStyle, "", format, args...)
 }
 
 // Warn prints a warning message with a yellow "!" prefix.
@@ -146,7 +159,7 @@ func Info(w io.Writer, format string, args ...any) {
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
 func Warn(w io.Writer, format string, args ...any) {
-	prefixed(w, colors.Warning("!"), format, args...)
+	prefixed(w, colors.WarningStyle.Sprint(colorEnabled(w), "!"), format, args...)
 }
 
 // Success prints a success message with a green checkmark prefix.
@@ -155,14 +168,14 @@ func Warn(w io.Writer, format string, args ...any) {
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
 func Success(w io.Writer, format string, args ...any) {
-	prefixed(w, colors.Success("✓"), format, args...)
+	prefixed(w, colors.SuccessStyle.Sprint(colorEnabled(w), "✓"), format, args...)
 }
 
 // Failed prints a per-item failure message with a red "Failed" prefix,
 // appending the error that caused it.
 // Example: "Failed /app/config: error message".
 func Failed(w io.Writer, name string, err error) {
-	_, _ = fmt.Fprintf(w, "%s %s: %v\n", colors.Failed("Failed"), name, err)
+	_, _ = fmt.Fprintf(w, "%s %s: %v\n", colors.ErrorStyle.Sprint(colorEnabled(w), "Failed"), name, err)
 }
 
 // WriteJSON encodes v as indented JSON (two-space indent) followed by a

--- a/internal/cli/output/output.go
+++ b/internal/cli/output/output.go
@@ -13,24 +13,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/aymanbagabas/go-udiff"
 
 	"github.com/mpyw/suve/internal/cli/colors"
-	"github.com/mpyw/suve/internal/cli/terminal"
 )
-
-// colorEnabled reports whether ANSI color should be emitted for w: only when
-// NO_COLOR is unset and w itself is a terminal. Deciding per destination writer
-// — rather than from the process-global color.NoColor, which fatih/color derives
-// once from os.Stdout — keeps stderr's coloring correct under redirection such
-// as `suve … 2>err.log` (stderr not a TTY) or `suve … | cat` (stderr a TTY while
-// stdout is piped) (#341).
-func colorEnabled(w io.Writer) bool {
-	return os.Getenv("NO_COLOR") == "" && terminal.IsTerminalWriter(w)
-}
 
 // Format represents the output format.
 type Format string
@@ -68,7 +56,7 @@ func New(w io.Writer) *Writer {
 
 // Field prints a labeled field.
 func (o *Writer) Field(label, value string) {
-	_, _ = fmt.Fprintf(o.w, "%s %s\n", colors.FieldLabelStyle.Sprint(colorEnabled(o.w), label+":"), value)
+	_, _ = fmt.Fprintf(o.w, "%s %s\n", colors.For(o.w).FieldLabel(label+":"), value)
 }
 
 // Separator prints a separator line.
@@ -99,13 +87,14 @@ func (o *Writer) Value(value string) {
 // prefixed) so the exact byte layout of each family stays consistent.
 
 // labeled formats a message and prints it as a single line, coloring the whole
-// "label+message" string with style. A label of "" colors the message alone.
-// Color tracks w's own TTY-ness so redirected stderr stays clean (#341).
+// "label+message" string with colorize. A label of "" colors the message alone.
+// colorize comes from the destination writer's palette, so color tracks w's own
+// TTY-ness and redirected stderr stays clean (#341).
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
-func labeled(w io.Writer, style colors.Style, label, format string, args ...any) {
+func labeled(w io.Writer, colorize func(...any) string, label, format string, args ...any) {
 	msg := fmt.Sprintf(format, args...)
-	_, _ = fmt.Fprintln(w, style.Sprint(colorEnabled(w), label+msg))
+	_, _ = fmt.Fprintln(w, colorize(label+msg))
 }
 
 // prefixed formats a message and prints it as "prefix message" on a single
@@ -123,7 +112,7 @@ func prefixed(w io.Writer, prefix, format string, args ...any) {
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
 func Warning(w io.Writer, format string, args ...any) {
-	labeled(w, colors.WarningStyle, "Warning: ", format, args...)
+	labeled(w, colors.For(w).Warning, "Warning: ", format, args...)
 }
 
 // Hint prints a hint message in cyan.
@@ -132,7 +121,7 @@ func Warning(w io.Writer, format string, args ...any) {
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
 func Hint(w io.Writer, format string, args ...any) {
-	labeled(w, colors.InfoStyle, "Hint: ", format, args...)
+	labeled(w, colors.For(w).Info, "Hint: ", format, args...)
 }
 
 // Error prints an error message in red.
@@ -141,7 +130,7 @@ func Hint(w io.Writer, format string, args ...any) {
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
 func Error(w io.Writer, format string, args ...any) {
-	labeled(w, colors.ErrorStyle, "Error: ", format, args...)
+	labeled(w, colors.For(w).Error, "Error: ", format, args...)
 }
 
 // Info prints an informational message in cyan with no prefix.
@@ -150,7 +139,7 @@ func Error(w io.Writer, format string, args ...any) {
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
 func Info(w io.Writer, format string, args ...any) {
-	labeled(w, colors.InfoStyle, "", format, args...)
+	labeled(w, colors.For(w).Info, "", format, args...)
 }
 
 // Warn prints a warning message with a yellow "!" prefix.
@@ -159,7 +148,7 @@ func Info(w io.Writer, format string, args ...any) {
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
 func Warn(w io.Writer, format string, args ...any) {
-	prefixed(w, colors.WarningStyle.Sprint(colorEnabled(w), "!"), format, args...)
+	prefixed(w, colors.For(w).Warning("!"), format, args...)
 }
 
 // Success prints a success message with a green checkmark prefix.
@@ -168,14 +157,14 @@ func Warn(w io.Writer, format string, args ...any) {
 //
 //nolint:goprintffuncname // intentionally named without 'f' suffix for cleaner API
 func Success(w io.Writer, format string, args ...any) {
-	prefixed(w, colors.SuccessStyle.Sprint(colorEnabled(w), "✓"), format, args...)
+	prefixed(w, colors.For(w).Success("✓"), format, args...)
 }
 
 // Failed prints a per-item failure message with a red "Failed" prefix,
 // appending the error that caused it.
 // Example: "Failed /app/config: error message".
 func Failed(w io.Writer, name string, err error) {
-	_, _ = fmt.Fprintf(w, "%s %s: %v\n", colors.ErrorStyle.Sprint(colorEnabled(w), "Failed"), name, err)
+	_, _ = fmt.Fprintf(w, "%s %s: %v\n", colors.For(w).Failed("Failed"), name, err)
 }
 
 // WriteJSON encodes v as indented JSON (two-space indent) followed by a
@@ -188,12 +177,14 @@ func WriteJSON(w io.Writer, v any) error {
 	return enc.Encode(v)
 }
 
-// Diff generates a unified diff between two strings with ANSI colors.
-func Diff(oldName, newName, oldContent, newContent string) string {
+// Diff generates a unified diff between two strings, colored for the terminal
+// it will be printed to. Pass the same writer the result is written to so the
+// diff's color tracks that destination's TTY-ness (#341).
+func Diff(w io.Writer, oldName, newName, oldContent, newContent string) string {
 	edits := udiff.Strings(oldContent, newContent)
 	unified, _ := udiff.ToUnifiedDiff(oldName, newName, oldContent, edits, udiff.DefaultContextLines)
 
-	return colorDiff(unified.String())
+	return colorDiff(colors.For(w), unified.String())
 }
 
 // DiffRaw generates a unified diff between two strings without colors.
@@ -204,8 +195,8 @@ func DiffRaw(oldName, newName, oldContent, newContent string) string {
 	return unified.String()
 }
 
-// colorDiff adds ANSI colors to diff output.
-func colorDiff(diff string) string {
+// colorDiff adds ANSI colors to diff output using the given palette.
+func colorDiff(p colors.Palette, diff string) string {
 	if diff == "" {
 		return ""
 	}
@@ -221,14 +212,14 @@ func colorDiff(diff string) string {
 	for i, line := range lines {
 		switch {
 		case !inHunk && (strings.HasPrefix(line, "---") || strings.HasPrefix(line, "+++")):
-			colored[i] = colors.DiffHeader(line)
+			colored[i] = p.DiffHeader(line)
 		case strings.HasPrefix(line, "@@"):
 			inHunk = true
-			colored[i] = colors.DiffHunk(line)
+			colored[i] = p.DiffHunk(line)
 		case strings.HasPrefix(line, "-"):
-			colored[i] = colors.DiffRemoved(line)
+			colored[i] = p.DiffRemoved(line)
 		case strings.HasPrefix(line, "+"):
-			colored[i] = colors.DiffAdded(line)
+			colored[i] = p.DiffAdded(line)
 		default:
 			colored[i] = line
 		}

--- a/internal/cli/output/output_internal_test.go
+++ b/internal/cli/output/output_internal_test.go
@@ -10,7 +10,16 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/mpyw/suve/internal/cli/colors"
+	"github.com/mpyw/suve/internal/cli/terminal"
 )
+
+// fakeTTY is a bytes.Buffer that also satisfies terminal.Fder, so
+// terminal.IsTerminalWriter can classify it as a terminal when IsTTY is mocked.
+type fakeTTY struct {
+	bytes.Buffer
+}
+
+func (f *fakeTTY) Fd() uintptr { return 1 }
 
 func TestWriter_Field(t *testing.T) {
 	t.Parallel()
@@ -272,6 +281,54 @@ func TestInfo(t *testing.T) {
 	var buf bytes.Buffer
 	Info(&buf, "No changes %s", "staged")
 	assert.Contains(t, buf.String(), "No changes staged")
+}
+
+// TestFeedback_ColorTracksWriterTTY guards #341: a feedback message's color is
+// decided by its own destination writer, not the process-global color.NoColor.
+// A terminal writer receives ANSI even when the global would say otherwise, and
+// a non-terminal writer (a plain bytes.Buffer with no Fd) stays clean.
+func TestFeedback_ColorTracksWriterTTY(t *testing.T) {
+	origIsTTY := terminal.IsTTY
+	origNoColor := color.NoColor
+
+	t.Cleanup(func() {
+		terminal.IsTTY = origIsTTY
+		color.NoColor = origNoColor
+	})
+	t.Setenv("NO_COLOR", "")
+
+	// Force the global off (as `suve … | cat` would) to prove color no longer
+	// depends on it, then treat the mocked fd as a terminal.
+	color.NoColor = true
+	terminal.IsTTY = func(uintptr) bool { return true }
+
+	var tty fakeTTY
+
+	Warning(&tty, "heads up")
+	assert.Contains(t, tty.String(), "\x1b[", "a terminal writer must receive ANSI color")
+	assert.Contains(t, tty.String(), "heads up")
+
+	var buf bytes.Buffer
+
+	Warning(&buf, "heads up")
+	assert.NotContains(t, buf.String(), "\x1b[", "a non-terminal writer must stay plain")
+}
+
+// TestFeedback_NoColorEnvDisables guards #341: NO_COLOR disables coloring even
+// for a terminal writer.
+func TestFeedback_NoColorEnvDisables(t *testing.T) {
+	origIsTTY := terminal.IsTTY
+
+	t.Cleanup(func() { terminal.IsTTY = origIsTTY })
+	t.Setenv("NO_COLOR", "1")
+
+	terminal.IsTTY = func(uintptr) bool { return true }
+
+	var tty fakeTTY
+
+	Error(&tty, "boom")
+	assert.NotContains(t, tty.String(), "\x1b[", "NO_COLOR must suppress ANSI even on a TTY")
+	assert.Contains(t, tty.String(), "Error: boom")
 }
 
 func TestParseFormat(t *testing.T) {

--- a/internal/cli/output/output_internal_test.go
+++ b/internal/cli/output/output_internal_test.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -20,6 +19,22 @@ type fakeTTY struct {
 }
 
 func (f *fakeTTY) Fd() uintptr { return 1 }
+
+// enabledPalette returns a palette with color forced on, for asserting exact
+// ANSI wrapping. It mocks terminal.IsTTY and clears NO_COLOR, so callers must
+// not run in parallel (t.Setenv already enforces this).
+func enabledPalette(t *testing.T) colors.Palette {
+	t.Helper()
+
+	orig := terminal.IsTTY
+
+	t.Cleanup(func() { terminal.IsTTY = orig })
+	t.Setenv("NO_COLOR", "")
+
+	terminal.IsTTY = func(uintptr) bool { return true }
+
+	return colors.For(&fakeTTY{})
+}
 
 func TestWriter_Field(t *testing.T) {
 	t.Parallel()
@@ -148,7 +163,7 @@ func TestDiff(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := Diff(tt.oldName, tt.newName, tt.oldContent, tt.newContent)
+			result := Diff(&bytes.Buffer{}, tt.oldName, tt.newName, tt.oldContent, tt.newContent)
 
 			for _, expected := range tt.contains {
 				assert.Contains(t, result, expected)
@@ -164,7 +179,7 @@ func TestDiff(t *testing.T) {
 func TestDiff_EmptyInputs(t *testing.T) {
 	t.Parallel()
 
-	result := Diff("old", "new", "", "")
+	result := Diff(&bytes.Buffer{}, "old", "new", "", "")
 	assert.Empty(t, result)
 }
 
@@ -173,7 +188,9 @@ func TestColorDiff(t *testing.T) {
 
 	diff := "--- old\n+++ new\n@@ -1 +1 @@\n-removed\n+added\n context"
 
-	result := colorDiff(diff)
+	// A plain (non-terminal) palette leaves the content unwrapped, so the
+	// substrings appear verbatim regardless of ANSI.
+	result := colorDiff(colors.For(&bytes.Buffer{}), diff)
 
 	assert.NotEmpty(t, result)
 	assert.Contains(t, result, "removed")
@@ -183,22 +200,16 @@ func TestColorDiff(t *testing.T) {
 func TestColorDiff_EmptyInput(t *testing.T) {
 	t.Parallel()
 
-	result := colorDiff("")
+	result := colorDiff(colors.For(&bytes.Buffer{}), "")
 	assert.Empty(t, result)
 }
 
-// TestDiff_MatchesDiffRawNewlines guards #338: with color disabled, Diff is
+// TestDiff_MatchesDiffRawNewlines guards #338: for a non-terminal writer Diff is
 // structure-only, so it must equal DiffRaw with no spurious trailing newline.
-//
-//nolint:paralleltest // toggles the process-global color.NoColor
 func TestDiff_MatchesDiffRawNewlines(t *testing.T) {
-	orig := color.NoColor
+	t.Parallel()
 
-	t.Cleanup(func() { color.NoColor = orig })
-
-	color.NoColor = true
-
-	got := Diff("f", "f", "a\nb\n", "a\nc\n")
+	got := Diff(&bytes.Buffer{}, "f", "f", "a\nb\n", "a\nc\n")
 	raw := DiffRaw("f", "f", "a\nb\n", "a\nc\n")
 
 	assert.Equal(t, raw, got)
@@ -207,26 +218,23 @@ func TestDiff_MatchesDiffRawNewlines(t *testing.T) {
 
 // TestColorDiff_InHunkDashLinesNotHeaders guards #339: inside a hunk, a
 // removed/added line whose content starts with -- / ++ must be colored as
-// removed/added, not misclassified as a ---/+++ header.
+// removed/added, not misclassified as a ---/+++ header. Uses a color-enabled
+// palette so headers (cyan) and removed/added (red/green) are distinguishable.
 //
-//nolint:paralleltest // toggles the process-global color.NoColor
+//nolint:paralleltest // enabledPalette mutates terminal.IsTTY and NO_COLOR
 func TestColorDiff_InHunkDashLinesNotHeaders(t *testing.T) {
-	orig := color.NoColor
-
-	t.Cleanup(func() { color.NoColor = orig })
-
-	color.NoColor = false
+	pal := enabledPalette(t)
 
 	diff := "--- old\n+++ new\n@@ -1 +1 @@\n--- removed content\n+++ added content"
 
-	result := colorDiff(diff)
+	result := colorDiff(pal, diff)
 
 	// The in-hunk lines are wrapped exactly as removed/added would wrap them.
-	assert.Contains(t, result, colors.DiffRemoved("--- removed content"))
-	assert.Contains(t, result, colors.DiffAdded("+++ added content"))
+	assert.Contains(t, result, pal.DiffRemoved("--- removed content"))
+	assert.Contains(t, result, pal.DiffAdded("+++ added content"))
 	// And the real file-label headers are still colored as headers.
-	assert.Contains(t, result, colors.DiffHeader("--- old"))
-	assert.Contains(t, result, colors.DiffHeader("+++ new"))
+	assert.Contains(t, result, pal.DiffHeader("--- old"))
+	assert.Contains(t, result, pal.DiffHeader("+++ new"))
 }
 
 func TestWarning(t *testing.T) {
@@ -284,22 +292,15 @@ func TestInfo(t *testing.T) {
 }
 
 // TestFeedback_ColorTracksWriterTTY guards #341: a feedback message's color is
-// decided by its own destination writer, not the process-global color.NoColor.
-// A terminal writer receives ANSI even when the global would say otherwise, and
-// a non-terminal writer (a plain bytes.Buffer with no Fd) stays clean.
+// decided by its own destination writer, not by a process-global. A terminal
+// writer receives ANSI while a non-terminal writer (a plain bytes.Buffer with
+// no Fd) written in the same process stays clean.
 func TestFeedback_ColorTracksWriterTTY(t *testing.T) {
 	origIsTTY := terminal.IsTTY
-	origNoColor := color.NoColor
 
-	t.Cleanup(func() {
-		terminal.IsTTY = origIsTTY
-		color.NoColor = origNoColor
-	})
+	t.Cleanup(func() { terminal.IsTTY = origIsTTY })
 	t.Setenv("NO_COLOR", "")
 
-	// Force the global off (as `suve … | cat` would) to prove color no longer
-	// depends on it, then treat the mocked fd as a terminal.
-	color.NoColor = true
 	terminal.IsTTY = func(uintptr) bool { return true }
 
 	var tty fakeTTY

--- a/internal/cli/passphrase/passphrase.go
+++ b/internal/cli/passphrase/passphrase.go
@@ -107,7 +107,7 @@ func (p *Prompter) ReadFromStdin() (string, error) {
 // confirmPlainText asks user to confirm storing as plain text.
 func (p *Prompter) confirmPlainText() bool {
 	output.Warn(p.Stderr, "Storing secrets as plain text on disk.")
-	output.Printf(p.Stderr, "%s Continue without encryption? [y/N]: ", colors.Warning("?"))
+	output.Printf(p.Stderr, "%s Continue without encryption? [y/N]: ", colors.For(p.Stderr).Warning("?"))
 
 	// Use buffered reader to preserve stream position
 	if p.bufReader == nil {

--- a/internal/staging/cli/diff.go
+++ b/internal/staging/cli/diff.go
@@ -120,7 +120,7 @@ func (r *DiffRunner) OutputDiff(opts DiffOptions, entry stagingusecase.DiffEntry
 		"%s (staged)",
 	), entry.Name)
 
-	diff := output.Diff(label1, label2, awsValue, stagedValue)
+	diff := output.Diff(r.Stdout, label1, label2, awsValue, stagedValue)
 	output.Print(r.Stdout, diff)
 
 	// Show staged metadata
@@ -141,7 +141,7 @@ func (r *DiffRunner) OutputDiffCreate(opts DiffOptions, entry stagingusecase.Dif
 	label1 := fmt.Sprintf("%s (not in AWS)", entry.Name)
 	label2 := fmt.Sprintf("%s (staged for creation)", entry.Name)
 
-	diff := output.Diff(label1, label2, "", stagedValue)
+	diff := output.Diff(r.Stdout, label1, label2, "", stagedValue)
 	output.Print(r.Stdout, diff)
 
 	// Show staged metadata
@@ -151,13 +151,13 @@ func (r *DiffRunner) OutputDiffCreate(opts DiffOptions, entry stagingusecase.Dif
 // OutputMetadata outputs metadata for a diff entry.
 func (r *DiffRunner) OutputMetadata(entry stagingusecase.DiffEntry) {
 	if desc := lo.FromPtr(entry.Description); desc != "" {
-		output.Printf(r.Stdout, "%s %s\n", colors.FieldLabel("Description:"), desc)
+		output.Printf(r.Stdout, "%s %s\n", colors.For(r.Stdout).FieldLabel("Description:"), desc)
 	}
 }
 
 // OutputTagEntry outputs a tag entry.
 func (r *DiffRunner) OutputTagEntry(tagEntry stagingusecase.DiffTagEntry) {
-	output.Printf(r.Stdout, "%s %s (staged tag changes)\n", colors.Info("Tags:"), tagEntry.Name)
+	output.Printf(r.Stdout, "%s %s (staged tag changes)\n", colors.For(r.Stdout).Info("Tags:"), tagEntry.Name)
 
 	if len(tagEntry.Add) > 0 {
 		tagPairs := make([]string, 0, len(tagEntry.Add))
@@ -165,7 +165,7 @@ func (r *DiffRunner) OutputTagEntry(tagEntry stagingusecase.DiffTagEntry) {
 			tagPairs = append(tagPairs, fmt.Sprintf("%s=%s", k, tagEntry.Add[k]))
 		}
 
-		output.Printf(r.Stdout, "  %s %s\n", colors.OpAdd("+"), strings.Join(tagPairs, ", "))
+		output.Printf(r.Stdout, "  %s %s\n", colors.For(r.Stdout).OpAdd("+"), strings.Join(tagPairs, ", "))
 	}
 
 	if len(tagEntry.Remove) > 0 {
@@ -178,6 +178,6 @@ func (r *DiffRunner) OutputTagEntry(tagEntry stagingusecase.DiffTagEntry) {
 			}
 		}
 
-		output.Printf(r.Stdout, "  %s %s\n", colors.OpDelete("-"), strings.Join(tagPairs, ", "))
+		output.Printf(r.Stdout, "  %s %s\n", colors.For(r.Stdout).OpDelete("-"), strings.Join(tagPairs, ", "))
 	}
 }

--- a/internal/staging/cli/status.go
+++ b/internal/staging/cli/status.go
@@ -57,7 +57,7 @@ func (r *StatusRunner) Run(ctx context.Context, opts StatusOptions) error {
 	}
 
 	// For all items, show header and entries
-	output.Printf(r.Stdout, "%s (%d):\n", colors.Warning(fmt.Sprintf("Staged %s changes", result.ServiceName)), totalCount)
+	output.Printf(r.Stdout, "%s (%d):\n", colors.For(r.Stdout).Warning(fmt.Sprintf("Staged %s changes", result.ServiceName)), totalCount)
 
 	printer := &staging.EntryPrinter{Writer: r.Stdout}
 
@@ -96,7 +96,7 @@ func (r *StatusRunner) printTagEntry(e stagingusecase.StatusTagEntry, verbose bo
 	}
 
 	summary := strings.Join(parts, ", ")
-	output.Printf(r.Stdout, "  %s %s [%s]\n", colors.Info("T"), e.Name, summary)
+	output.Printf(r.Stdout, "  %s %s [%s]\n", colors.For(r.Stdout).Info("T"), e.Name, summary)
 
 	if verbose {
 		for key, value := range e.Add {

--- a/internal/staging/printer.go
+++ b/internal/staging/printer.go
@@ -21,15 +21,17 @@ type EntryPrinter struct {
 // If verbose is true, shows detailed information including timestamp and value.
 // If showDeleteOptions is true, shows delete options (Force/RecoveryWindow) for delete operations.
 func (p *EntryPrinter) PrintEntry(name string, entry Entry, verbose, showDeleteOptions bool) {
+	pal := colors.For(p.Writer)
+
 	var opColor string
 
 	switch entry.Operation {
 	case OperationCreate:
-		opColor = colors.OpAdd("A")
+		opColor = pal.OpAdd("A")
 	case OperationUpdate:
-		opColor = colors.OpModify("M")
+		opColor = pal.OpModify("M")
 	case OperationDelete:
-		opColor = colors.OpDelete("D")
+		opColor = pal.OpDelete("D")
 	}
 
 	if !verbose {
@@ -39,7 +41,7 @@ func (p *EntryPrinter) PrintEntry(name string, entry Entry, verbose, showDeleteO
 	}
 
 	output.Printf(p.Writer, "\n%s %s\n", opColor, name)
-	output.Printf(p.Writer, "  %s %s\n", colors.FieldLabel("Staged:"), entry.StagedAt.Format("2006-01-02 15:04:05"))
+	output.Printf(p.Writer, "  %s %s\n", pal.FieldLabel("Staged:"), entry.StagedAt.Format("2006-01-02 15:04:05"))
 
 	switch entry.Operation {
 	case OperationCreate, OperationUpdate:
@@ -49,15 +51,15 @@ func (p *EntryPrinter) PrintEntry(name string, entry Entry, verbose, showDeleteO
 				value = value[:maxValueDisplayLength] + "..."
 			}
 
-			output.Printf(p.Writer, "  %s %s\n", colors.FieldLabel("Value:"), value)
+			output.Printf(p.Writer, "  %s %s\n", pal.FieldLabel("Value:"), value)
 		}
 	case OperationDelete:
 		if showDeleteOptions && entry.DeleteOptions != nil {
 			switch {
 			case entry.DeleteOptions.Force:
-				output.Printf(p.Writer, "  %s force (immediate, no recovery)\n", colors.FieldLabel("Delete:"))
+				output.Printf(p.Writer, "  %s force (immediate, no recovery)\n", pal.FieldLabel("Delete:"))
 			case entry.DeleteOptions.RecoveryWindow > 0:
-				output.Printf(p.Writer, "  %s %d days recovery window\n", colors.FieldLabel("Delete:"), entry.DeleteOptions.RecoveryWindow)
+				output.Printf(p.Writer, "  %s %d days recovery window\n", pal.FieldLabel("Delete:"), entry.DeleteOptions.RecoveryWindow)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Closes #341.

fatih/color's process-global `NoColor` is decided once from whether **os.Stdout** is a TTY. But plenty of colored output goes elsewhere — the feedback primitives (`Warning`/`Hint`/`Error`/`Info`/`Warn`/`Success`/`Failed`/`Field`) and confirm/passphrase prompts write to **stderr**, and the `update` commands' diffs print to stderr too. So:

- `suve … 2>err.log` (stdout a TTY): stderr warnings/hints leaked ANSI into the file.
- `suve … | cat` (stdout piped, stderr still a TTY): stderr lost its color.

## Fix — one per-writer mechanism

Rather than special-casing a few functions and leaving the same latent bug elsewhere, the whole `colors` palette is now **per-writer**:

- `colors.For(w)` returns a `Palette` whose coloring is enabled iff `NO_COLOR` is unset **and** `w` is a terminal. It colorizes via a fresh `color.Color` with a forced per-instance `EnableColor()`/`DisableColor()`, independent of the process-global; different writers never race.
- The global SprintFunc palette (`colors.Warning`, `colors.DiffAdded`, `colors.OpAdd`, …) is **deleted**.
- Every call site routes through the destination writer's palette: `output` feedback + diff, `confirm`/`passphrase` prompts, staging `status`/`diff`/`printer`, and the per-provider `log` presenters.
- `output.Diff(w, …)` now takes the writer it will be printed to.

This also fixes the identical bug in `confirm.go`/`passphrase.go` and the `update`-command diffs, which color to stderr but were deciding from os.Stdout.

## Test

`output_internal_test.go`: `TestFeedback_ColorTracksWriterTTY` (TTY writer gets ANSI, plain buffer stays plain in the same process), `TestFeedback_NoColorEnvDisables` (NO_COLOR suppresses ANSI even on a TTY), and the #339 guard `TestColorDiff_InHunkDashLinesNotHeaders` rewritten against a color-enabled `Palette`.

`go build ./...`, `go test ./...`, and `golangci-lint run --build-tags=e2e,production ./internal/...` all pass (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)