### PR TITLE
fix(secret): use the version's own CreatedDate and pick a deterministic stage label

### DIFF
--- a/internal/provider/aws/secret/secret.go
+++ b/internal/provider/aws/secret/secret.go
@@ -255,7 +255,7 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 		Type:  domain.ValueTypeSecret,
 		Version: domain.Version{
 			ID:      aws.ToString(out.VersionId),
-			Label:   firstStage(out.VersionStages),
+			Label:   representativeStage(out.VersionStages),
 			Created: out.CreatedDate,
 		},
 		Modified: out.CreatedDate,
@@ -287,7 +287,7 @@ func (s *Store) History(ctx context.Context, name string) ([]domain.Version, err
 	return lo.Map(list, func(v types.SecretVersionsListEntry, _ int) domain.Version {
 		return domain.Version{
 			ID:      aws.ToString(v.VersionId),
-			Label:   firstStage(v.VersionStages),
+			Label:   representativeStage(v.VersionStages),
 			Created: v.CreatedDate,
 		}
 	}), nil
@@ -494,16 +494,21 @@ func (s *Store) Describe(ctx context.Context, name string) (*domain.Entry, error
 		Extra:       []domain.Field{{Label: "ARN", Value: aws.ToString(desc.ARN)}},
 	}
 
-	// Best-effort: surface the current (AWSCURRENT) version if present.
-	for versionID, stages := range desc.VersionIdsToStages {
-		if slices.Contains(stages, "AWSCURRENT") {
+	// Best-effort: surface the current (AWSCURRENT) version with its OWN
+	// creation time. DescribeSecret's CreatedDate is when the SECRET was
+	// created, not when the AWSCURRENT version was, so an updated secret would
+	// otherwise report a stale version timestamp; ListSecretVersionIds carries
+	// the per-version CreatedDate (#317). A listing failure is tolerated: the
+	// metadata entry is still returned without version details.
+	if versions, listErr := s.listAllVersions(ctx, name); listErr == nil {
+		if cur, found := lo.Find(versions, func(v types.SecretVersionsListEntry) bool {
+			return slices.Contains(v.VersionStages, "AWSCURRENT")
+		}); found {
 			entry.Version = domain.Version{
-				ID:      versionID,
-				Label:   firstStage(stages),
-				Created: desc.CreatedDate,
+				ID:      aws.ToString(cur.VersionId),
+				Label:   representativeStage(cur.VersionStages),
+				Created: cur.CreatedDate,
 			}
-
-			break
 		}
 	}
 
@@ -548,14 +553,27 @@ func (s *Store) Untag(ctx context.Context, name string, keys []string) error {
 	return nil
 }
 
-// firstStage returns the first staging label, or "" when there are none. It
-// keeps the AWS label confined to a provider-neutral, informational Label.
-func firstStage(stages []string) string {
+// representativeStage picks a single, DETERMINISTIC staging label to surface as
+// the version's provider-neutral Label. A version can carry several labels and
+// AWS returns them in an unspecified order, so choosing stages[0] made both the
+// displayed label and any "is this AWSCURRENT?" check non-deterministic (#317).
+//
+// A well-known label wins in fixed priority order (AWSCURRENT > AWSPENDING >
+// AWSPREVIOUS); otherwise the lexicographically smallest custom label is used
+// so the choice is stable. It returns "" when there are no labels.
+func representativeStage(stages []string) string {
 	if len(stages) == 0 {
 		return ""
 	}
 
-	return stages[0]
+	// Well-known AWS staging labels, highest priority first.
+	for _, known := range []string{"AWSCURRENT", "AWSPENDING", "AWSPREVIOUS"} {
+		if slices.Contains(stages, known) {
+			return known
+		}
+	}
+
+	return slices.Min(stages)
 }
 
 // mapTags maps Secrets Manager tags to provider-neutral domain tags.

--- a/internal/provider/aws/secret/secret_test.go
+++ b/internal/provider/aws/secret/secret_test.go
@@ -231,6 +231,67 @@ func TestGet_LatestOmitsVersionID(t *testing.T) {
 	assert.False(t, hadVersionID)
 }
 
+// A version can carry several staging labels in an unspecified order; the
+// representative Label must be chosen deterministically by priority, so
+// AWSCURRENT wins even when it is not the first stage returned (#317).
+func TestGet_LabelPrefersAWSCURRENTRegardlessOfOrder(t *testing.T) {
+	t.Parallel()
+
+	store := secret.New(&mockClient{
+		getValue: func(_ *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+			return &secretsmanager.GetSecretValueOutput{
+				Name:          aws.String("my-secret"),
+				SecretString:  aws.String("v"),
+				VersionId:     aws.String("id-3"),
+				VersionStages: []string{"my-custom-label", "AWSPREVIOUS", "AWSCURRENT"},
+			}, nil
+		},
+		describe: func(_ *secretsmanager.DescribeSecretInput) (*secretsmanager.DescribeSecretOutput, error) {
+			return &secretsmanager.DescribeSecretOutput{}, nil
+		},
+	})
+
+	entry, err := store.Get(t.Context(), "my-secret", provider.NewVersionRef("id-3"))
+	require.NoError(t, err)
+	assert.Equal(t, "AWSCURRENT", entry.Version.Label)
+}
+
+// Priority ordering among the well-known and custom labels: AWSPENDING beats
+// AWSPREVIOUS, and custom-only labels tie-break lexicographically (#317).
+func TestHistory_LabelPriorityOrdering(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	store := secret.New(&mockClient{
+		listVersion: func(_ *secretsmanager.ListSecretVersionIdsInput) (*secretsmanager.ListSecretVersionIdsOutput, error) {
+			return &secretsmanager.ListSecretVersionIdsOutput{
+				Versions: []types.SecretVersionsListEntry{
+					{
+						VersionId:     aws.String("id-2"),
+						CreatedDate:   aws.Time(base.Add(time.Hour)),
+						VersionStages: []string{"AWSPREVIOUS", "AWSPENDING"},
+					},
+					{
+						VersionId:     aws.String("id-1"),
+						CreatedDate:   aws.Time(base),
+						VersionStages: []string{"zeta", "alpha"},
+					},
+				},
+			}, nil
+		},
+	})
+
+	versions, err := store.History(t.Context(), "my-secret")
+	require.NoError(t, err)
+	require.Len(t, versions, 2)
+	// Newest first: id-2 (AWSPENDING preferred over AWSPREVIOUS).
+	assert.Equal(t, "id-2", versions[0].ID)
+	assert.Equal(t, "AWSPENDING", versions[0].Label)
+	// Custom-only labels tie-break lexicographically: "alpha" < "zeta".
+	assert.Equal(t, "id-1", versions[1].ID)
+	assert.Equal(t, "alpha", versions[1].Label)
+}
+
 func TestHistory_NewestFirst(t *testing.T) {
 	t.Parallel()
 
@@ -547,14 +608,28 @@ func TestRestore(t *testing.T) {
 func TestDescribe(t *testing.T) {
 	t.Parallel()
 
+	// The secret was created long before its current version; Describe must
+	// report the VERSION's own CreatedDate, not the secret's (#317).
+	secretCreated := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	currentVersionCreated := time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)
+
 	store := secret.New(&mockClient{
 		describe: func(_ *secretsmanager.DescribeSecretInput) (*secretsmanager.DescribeSecretOutput, error) {
 			return &secretsmanager.DescribeSecretOutput{
 				Name:               aws.String("my-secret"),
 				Description:        aws.String("the desc"),
 				Tags:               []types.Tag{{Key: aws.String("team"), Value: aws.String("sec")}},
+				CreatedDate:        aws.Time(secretCreated),
 				LastChangedDate:    aws.Time(time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)),
 				VersionIdsToStages: map[string][]string{"id-3": {"AWSCURRENT"}},
+			}, nil
+		},
+		listVersion: func(_ *secretsmanager.ListSecretVersionIdsInput) (*secretsmanager.ListSecretVersionIdsOutput, error) {
+			return &secretsmanager.ListSecretVersionIdsOutput{
+				Versions: []types.SecretVersionsListEntry{
+					{VersionId: aws.String("id-1"), CreatedDate: aws.Time(secretCreated), VersionStages: []string{}},
+					{VersionId: aws.String("id-3"), CreatedDate: aws.Time(currentVersionCreated), VersionStages: []string{"AWSCURRENT"}},
+				},
 			}, nil
 		},
 	})
@@ -566,6 +641,11 @@ func TestDescribe(t *testing.T) {
 	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
 	assert.Equal(t, "the desc", entry.Description)
 	assert.Equal(t, "id-3", entry.Version.ID)
+	assert.Equal(t, "AWSCURRENT", entry.Version.Label)
+	// The version's own creation time, not the secret-level CreatedDate.
+	require.NotNil(t, entry.Version.Created)
+	assert.Equal(t, currentVersionCreated, *entry.Version.Created)
+	assert.NotEqual(t, secretCreated, *entry.Version.Created)
 	require.Len(t, entry.Tags, 1)
 	assert.Equal(t, "team", entry.Tags[0].Key)
 }

--- a/internal/usecase/secret/log.go
+++ b/internal/usecase/secret/log.go
@@ -108,8 +108,12 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 			VersionStage: stages(v.Label),
 			Value:        value,
 			CreatedDate:  v.Created,
-			IsCurrent:    v.Label == "AWSCURRENT",
-			Error:        fetchErr,
+			// The adapter picks the version's Label by priority, so AWSCURRENT
+			// always surfaces whenever the version carries it (even alongside a
+			// custom label). This equality is therefore a correct membership
+			// test, not a fragile "first stage" check (#317).
+			IsCurrent: v.Label == "AWSCURRENT",
+			Error:     fetchErr,
 		})
 	}
 


### PR DESCRIPTION
## Summary

Fixes two AWS Secrets Manager version-metadata bugs reported in #317.

### Bug A — `Describe` reported the secret's `CreatedDate` as the version's

`Store.Describe` populated `entry.Version.Created` with `DescribeSecret`'s `CreatedDate`, which is when the **secret** was created — not when the AWSCURRENT version was. Any secret that had been updated showed a stale version timestamp.

**Fix:** `Describe` now finds the AWSCURRENT version via `ListSecretVersionIds` (which carries a per-version `CreatedDate`) and uses that version's own creation time. The extra listing is best-effort: if it fails, the metadata entry is still returned, just without version details.

### Bug B — displayed label / `IsCurrent` picked from unspecified stage order

A version can carry multiple staging labels (e.g. `AWSCURRENT` plus a custom label), and AWS returns them in an unspecified order. The old `firstStage` helper returned `stages[0]`, so:

- the displayed label rendered non-deterministically, and
- `IsCurrent` (`v.Label == "AWSCURRENT"` in `usecase/secret/log.go`) could fail to flag the current version when `AWSCURRENT` was not first.

**Fix:** a new `representativeStage` chooses a single label deterministically — a well-known label wins in fixed priority order (`AWSCURRENT` > `AWSPENDING` > `AWSPREVIOUS`), otherwise the lexicographically smallest custom label. Because `AWSCURRENT` has top priority, it always surfaces as the representative `Label` whenever the version carries it, which makes the existing `IsCurrent` equality a correct membership test rather than a fragile first-element check. `representativeStage` replaces `firstStage` in `Get`, `History`, and `Describe`.

## Tests

- `TestDescribe` now asserts the version's own `CreatedDate` is surfaced and is distinct from the secret-level `CreatedDate`.
- `TestGet_LabelPrefersAWSCURRENTRegardlessOfOrder` — `AWSCURRENT` is chosen even when it is not the first stage.
- `TestHistory_LabelPriorityOrdering` — `AWSPENDING` beats `AWSPREVIOUS`, and custom-only labels tie-break lexicographically.

## Verification

- `go build ./...` — clean
- `go test ./...` — all pass
- `golangci-lint run --allow-parallel-runners --build-tags=e2e,production ./internal/provider/aws/... ./internal/usecase/secret/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)