### PR TITLE
fix(param): truncate log value previews by runes and sanitize control chars (#340)

### DIFF
--- a/internal/cli/commands/param/log.go
+++ b/internal/cli/commands/param/log.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
+	"unicode"
 
 	"github.com/urfave/cli/v3"
 
@@ -101,9 +103,9 @@ func (p *logPresenter) RenderOneline(stdout io.Writer, i, maxValueLength int) {
 		maxLen = max(termWidth-metadataOverhead, minValueLength)
 	}
 
-	if maxLen > 0 && len(value) > maxLen {
-		value = value[:maxLen] + "..."
-	}
+	// Replace control characters so a multi-line value can't break the
+	// one-line-per-version layout, then truncate by runes (#340).
+	value = truncateRunes(sanitizeControl(value), maxLen)
 
 	currentMark := ""
 	if entry.IsCurrent {
@@ -137,11 +139,11 @@ func (p *logPresenter) RenderHeader(stdout io.Writer, i int) {
 func (p *logPresenter) RenderValue(stdout io.Writer, i, maxValueLength int) {
 	entry := p.result.Entries[i]
 
-	// Show value preview (unlimited unless --max-value-length specified)
-	value := entry.Value
-	if maxValueLength > 0 && len(value) > maxValueLength {
-		value = value[:maxValueLength] + "..."
-	}
+	// Show value preview (unlimited unless --max-value-length specified).
+	// Truncate by runes so multi-byte content is never cut mid-rune (#340).
+	// Newlines are preserved here: normal mode intentionally shows the full
+	// multi-line value under each version's header.
+	value := truncateRunes(entry.Value, maxValueLength)
 
 	output.Printf(stdout, "%s\n", value)
 }
@@ -186,6 +188,35 @@ func (p *logPresenter) RenderPatch(stdout, stderr io.Writer, i int, parseJSON, r
 		output.Println(stdout, "")
 		output.Print(stdout, diff)
 	}
+}
+
+// truncateRunes shortens s to at most maxLen runes, appending "..." only when
+// it actually trims. Counting runes rather than bytes keeps multi-byte
+// characters (e.g. Japanese text, emoji) whole (#340). A maxLen <= 0 disables
+// truncation.
+func truncateRunes(s string, maxLen int) string {
+	if maxLen <= 0 {
+		return s
+	}
+
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+
+	return string(runes[:maxLen]) + "..."
+}
+
+// sanitizeControl replaces every control character (newlines, tabs, etc.) with
+// a visible ␤ so a value cannot break the one-line-per-version layout (#340).
+func sanitizeControl(s string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return '␤'
+		}
+
+		return r
+	}, s)
 }
 
 // LogCommand returns the SSM Parameter Store log command.

--- a/internal/cli/commands/param/log_internal_test.go
+++ b/internal/cli/commands/param/log_internal_test.go
@@ -1,0 +1,51 @@
+package param
+
+import (
+	"testing"
+	"unicode/utf8"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTruncateRunes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		in     string
+		maxLen int
+		want   string
+	}{
+		{name: "no truncation when under limit", in: "hello", maxLen: 10, want: "hello"},
+		{name: "no truncation at exact limit", in: "hello", maxLen: 5, want: "hello"},
+		{name: "ascii truncated with ellipsis", in: "hello world", maxLen: 5, want: "hello..."},
+		{name: "zero maxLen disables truncation", in: "hello", maxLen: 0, want: "hello"},
+		{name: "negative maxLen disables truncation", in: "hello", maxLen: -1, want: "hello"},
+		// Byte slicing would cut a 3-byte rune apart here; rune slicing keeps
+		// the first maxLen characters whole (#340).
+		{name: "multibyte kept whole", in: "日本語テスト", maxLen: 3, want: "日本語..."},
+		{name: "emoji kept whole", in: "🎉🎊🎈🎆", maxLen: 2, want: "🎉🎊..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := truncateRunes(tt.in, tt.maxLen)
+			assert.Equal(t, tt.want, got)
+			assert.True(t, utf8.ValidString(got), "result must be valid UTF-8")
+		})
+	}
+}
+
+func TestSanitizeControl(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "a␤b", sanitizeControl("a\nb"))
+	assert.Equal(t, "a␤b␤c", sanitizeControl("a\nb\tc"))
+	// Each control char maps individually, so CRLF becomes two markers.
+	assert.Equal(t, "a␤␤b", sanitizeControl("a\r\nb"))
+	assert.Equal(t, "plain text", sanitizeControl("plain text"))
+	// Multi-byte, non-control content is left untouched.
+	assert.Equal(t, "日本語", sanitizeControl("日本語"))
+}


### PR DESCRIPTION
## Summary

Closes #340. Two formatting bugs in `suve param log`:

1. **Byte truncation split UTF-8 runes.** `value[:maxLen] + "..."` sliced by bytes, so multi-byte content (Japanese, emoji) was cut mid-rune, producing invalid UTF-8. Affected `--oneline` and normal-mode `--max-value-length`.
2. **Embedded newlines broke the one-line format.** In `--oneline`, the raw value was printed as-is, so a multi-line value spilled across several lines.

## Fix

Two helpers in `param/log.go`: `truncateRunes` (truncates by runes, appends `...` only when trimming) and `sanitizeControl` (control chars → `␤`). `RenderOneline` sanitizes then truncates; `RenderValue` truncates by runes but keeps newlines (normal mode intentionally shows the full multi-line value).

Only the AWS `param` presenter prints/truncates the value; secret/gcloud/azure-secret oneline renderers are unaffected.

## Test

New `log_internal_test.go`: `TestTruncateRunes` (multibyte `日本語テスト`→`日本語...`, emoji, boundaries, disabled; asserts valid UTF-8) and `TestSanitizeControl`. Build/test/lint all pass (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)