### PR TITLE
fix(cli): extract gui subcommand-name consts to satisfy goconst (broken-main Lint)

### DIFF
--- a/cmd/suve/gui.go
+++ b/cmd/suve/gui.go
@@ -89,9 +89,15 @@ func registerGUIFlag() {
 		return ctx, nil
 	}
 
+	// Azure's --vault-name / --store-name live on its secret / param subgroups.
+	const (
+		subcommandSecret = "secret"
+		subcommandParam  = "param"
+	)
+
 	// Per-provider `suve <group> --gui`: launch with that provider pre-selected.
-	// Azure's --vault-name / --store-name live on its secret / param subgroups,
-	// so --gui is attached there too, letting those flags seed the launch scope.
+	// Azure attaches --gui to its secret / param subgroups too, letting those
+	// flags seed the launch scope.
 	for _, group := range commands.App.Commands {
 		p := groupProvider(group.Name)
 		if p == "" {
@@ -102,7 +108,7 @@ func registerGUIFlag() {
 
 		if p == provider.ProviderAzure {
 			for _, sub := range group.Commands {
-				if sub.Name == "secret" || sub.Name == "param" {
+				if sub.Name == subcommandSecret || sub.Name == subcommandParam {
 					attachGUIFlag(sub, p)
 				}
 			}


### PR DESCRIPTION
## Summary

The **production-build Lint** step (`golangci-lint run --build-tags=production,webkit2_41`) compiles `cmd/suve/gui.go` (which is `//go:build production || dev`) into the `main` package alongside `main_test.go`. Between them the string literal `"param"` reaches **3 package-wide occurrences**, tripping `goconst`:

```
cmd/suve/gui.go:105:44: string `param` has 3 occurrences, make it a constant (goconst)
```

This was introduced by #310 and now fails the `Lint` check on **every** PR branched off `main` (it only shows up under the production tag, so the normal lint — which excludes `gui.go` — stayed green).

## Fix

Introduce local `subcommandSecret` / `subcommandParam` consts in `gui.go` and use them at the Azure subgroup check, so the file no longer contributes a raw `"param"` literal and the package-wide count drops below the goconst threshold.

`go build ./...`, `go test ./cmd/...`, and `golangci-lint run --build-tags=production,webkit2_41 ./cmd/...` all pass (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)