### PR TITLE
feat(cli): add --no-redaction to log full unredacted debug output (v1.4.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,6 +858,7 @@ All timestamps are formatted in RFC3339 format with the local timezone offset ap
 | `TZ` | Timezone for date/time formatting (see above) |
 | `SUVE_NO_UPDATE_CHECK` | Opt out of the update-check notification |
 | `SUVE_DEBUG` | Enable verbose debug logging (same as the global `--debug` flag); any non-empty value except `0`/`false` enables it |
+| `SUVE_NO_REDACTION` | With debug enabled, log full request/response bodies and unmasked headers — **including secret values and credentials** (same as the global `--no-redaction` flag); parsed like `SUVE_DEBUG` |
 
 ### Debugging
 
@@ -898,6 +899,25 @@ never prints request/reply messages; azcore redacts headers outside its own
 allowlist and never logs bodies (error events may include the service's error
 document, the same text normal error output already shows). Debug output goes to
 stderr, so it never contaminates piped stdout.
+
+#### Unredacted output (`--no-redaction`)
+
+When the redacted default hides too much — e.g. you need to see the exact secret
+value a request returned, or the raw payload of a failing call — add
+`--no-redaction` (or set `SUVE_NO_REDACTION=1`) alongside `--debug`:
+
+```bash
+suve secret show my-secret --debug --no-redaction
+```
+
+This switches AWS to the with-body log modes and stops masking headers, and turns
+on azcore body logging for Azure, so **full request/response bodies and
+credentials — including secret values and the signing `Authorization` header —
+are written to stderr**. Use it only for deliberate, local debugging and never
+where the log could be captured or shared; a one-line warning is printed to
+stderr whenever it is active. It has no effect without `--debug` (you'll get a
+hint saying so), and no effect on Google Cloud, whose gRPC interceptor logs no
+message bodies at all.
 
 ### Staging
 

--- a/internal/cli/commands/app.go
+++ b/internal/cli/commands/app.go
@@ -73,7 +73,7 @@ func MakeAppWithDetect(det detect.Result) *cli.Command {
 		Usage:       baseUsage,
 		Description: aliasDescription(det),
 		Version:     Version,
-		Flags:       []cli.Flag{debugFlag()},
+		Flags:       []cli.Flag{debugFlag(), noRedactionFlag()},
 		Before:      enableDebug(det),
 		Commands:    append(flat, commands...),
 		// EnableShellCompletion adds a hidden `completion` command (bash/zsh/fish/pwsh)
@@ -111,12 +111,38 @@ func debugFlag() cli.Flag {
 	}
 }
 
+// noRedactionFlag defines the global --no-redaction switch. Like --debug it is a
+// persistent flag readable in any position, with an env alternative
+// (SUVE_NO_REDACTION) parsed leniently by envNoRedactionEnabled. It only affects
+// debug output: with it set, provider adapters log full request/response bodies
+// and stop masking sensitive headers, so secret values and live credentials
+// appear in the log — hence it is off by default and never implied by --debug.
+func noRedactionFlag() cli.Flag {
+	return &cli.BoolFlag{
+		Name:  "no-redaction",
+		Usage: "With --debug, log full bodies and unmasked headers, INCLUDING secret values and credentials [$SUVE_NO_REDACTION]",
+	}
+}
+
 // envDebugEnabled reports whether SUVE_DEBUG requests debug logging. Bool-ish
 // values are honored (so SUVE_DEBUG=0/false stay off) and any other non-empty
 // value counts as enabled, consistent with SUVE_NO_UPDATE_CHECK's "any
 // non-empty value" semantics.
 func envDebugEnabled() bool {
-	v := os.Getenv("SUVE_DEBUG")
+	return envBoolLenient("SUVE_DEBUG")
+}
+
+// envNoRedactionEnabled reports whether SUVE_NO_REDACTION requests unredacted
+// debug output, using the same lenient parsing as envDebugEnabled.
+func envNoRedactionEnabled() bool {
+	return envBoolLenient("SUVE_NO_REDACTION")
+}
+
+// envBoolLenient reads a bool-ish environment variable: empty is false, a
+// parseable bool (0/1/true/false) is honored, and any other non-empty value
+// counts as true.
+func envBoolLenient(name string) bool {
+	v := os.Getenv(name)
 	if v == "" {
 		return false
 	}
@@ -135,14 +161,34 @@ func envDebugEnabled() bool {
 // output goes to the root ErrWriter so it never contaminates piped STDOUT.
 func enableDebug(det detect.Result) cli.BeforeFunc {
 	return func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-		if !cmd.Bool("debug") && !envDebugEnabled() {
+		debugOn := cmd.Bool("debug") || envDebugEnabled()
+		noRedaction := cmd.Bool("no-redaction") || envNoRedactionEnabled()
+
+		w := lo.CoalesceOrEmpty[io.Writer](cmd.Root().ErrWriter, os.Stderr)
+
+		if !debugOn {
+			// --no-redaction only shapes debug output, so on its own it does
+			// nothing. Say so rather than silently ignoring it, since a user who
+			// expected verbose output would otherwise be left guessing.
+			if noRedaction {
+				output.Hint(w, "--no-redaction has no effect without --debug (or SUVE_DEBUG)")
+			}
+
 			return ctx, nil
 		}
 
 		cfg := debug.Config{
-			Enabled: true,
-			Writer:  lo.CoalesceOrEmpty[io.Writer](cmd.Root().ErrWriter, os.Stderr),
+			Enabled:     true,
+			Writer:      w,
+			NoRedaction: noRedaction,
 		}
+
+		// Print the warning before any debug line so the caller sees, up front,
+		// that this run's log may carry secret values and live credentials.
+		if noRedaction {
+			output.Warning(w, "--no-redaction: debug output will include secret values and live credentials")
+		}
+
 		cfg.Logf("cli: suve version=%s\n", cmd.Root().Version)
 		cfg.Logf("cli: flat aliases: param=%s secret=%s stage=%s%s\n",
 			aliasTarget(det.Param), aliasTarget(det.Secret), aliasTarget(det.Stage), fallbackNote(det))

--- a/internal/cli/commands/debug_internal_test.go
+++ b/internal/cli/commands/debug_internal_test.go
@@ -19,14 +19,14 @@ import (
 const appName = "suve"
 
 // runProbe assembles a minimal app wired exactly like the root (debugFlag +
-// enableDebug Before) with a probe subcommand that records whether debug is
-// enabled on the context its Action receives. It returns that value plus
+// noRedactionFlag + enableDebug Before) with a probe subcommand that records the
+// debug.Config on the context its Action receives. It returns that config plus
 // whatever the Before hook wrote to the app's ErrWriter.
-func runProbe(t *testing.T, det detect.Result, args []string) (bool, string) {
+func runProbe(t *testing.T, det detect.Result, args []string) (debug.Config, string) {
 	t.Helper()
 
 	var (
-		got    bool
+		got    debug.Config
 		stderr bytes.Buffer
 	)
 
@@ -34,13 +34,13 @@ func runProbe(t *testing.T, det detect.Result, args []string) (bool, string) {
 		Name:      appName,
 		Version:   "test",
 		ErrWriter: &stderr,
-		Flags:     []cli.Flag{debugFlag()},
+		Flags:     []cli.Flag{debugFlag(), noRedactionFlag()},
 		Before:    enableDebug(det),
 		Commands: []*cli.Command{
 			{
 				Name: "probe",
 				Action: func(ctx context.Context, _ *cli.Command) error {
-					got = debug.From(ctx).Enabled
+					got = debug.From(ctx)
 
 					return nil
 				},
@@ -54,20 +54,53 @@ func runProbe(t *testing.T, det detect.Result, args []string) (bool, string) {
 }
 
 func TestEnableDebug_off(t *testing.T) {
-	// Not parallel: neutralizes ambient SUVE_DEBUG from the developer's shell
-	// via t.Setenv so the "off" assertion is hermetic.
+	// Not parallel: neutralizes ambient SUVE_DEBUG/SUVE_NO_REDACTION from the
+	// developer's shell via t.Setenv so the "off" assertion is hermetic.
+	t.Setenv("SUVE_DEBUG", "")
+	t.Setenv("SUVE_NO_REDACTION", "")
+
+	cfg, stderr := runProbe(t, detect.Result{}, []string{appName, "probe"})
+	assert.False(t, cfg.Enabled)
+	assert.Empty(t, stderr)
+}
+
+func TestEnableDebug_noRedactionWithDebug(t *testing.T) {
+	t.Parallel()
+
+	cfg, stderr := runProbe(t, detect.Result{}, []string{appName, "--debug", "--no-redaction", "probe"})
+	assert.True(t, cfg.Enabled)
+	assert.True(t, cfg.NoRedaction)
+	// A warning banner precedes any debug output so the risk is visible up front.
+	assert.Contains(t, stderr, "--no-redaction: debug output will include secret values and live credentials")
+}
+
+func TestEnableDebug_noRedactionWithoutDebug(t *testing.T) {
+	// Not parallel: neutralizes ambient SUVE_DEBUG so debug stays off here.
 	t.Setenv("SUVE_DEBUG", "")
 
-	enabled, stderr := runProbe(t, detect.Result{}, []string{appName, "probe"})
-	assert.False(t, enabled)
-	assert.Empty(t, stderr)
+	cfg, stderr := runProbe(t, detect.Result{}, []string{appName, "--no-redaction", "probe"})
+	// Without --debug there is no debug config, and --no-redaction is a no-op
+	// beyond a one-line hint explaining why nothing verbose appeared.
+	assert.False(t, cfg.Enabled)
+	assert.False(t, cfg.NoRedaction)
+	assert.Contains(t, stderr, "--no-redaction has no effect without --debug")
+}
+
+func TestEnableDebug_noRedactionEnv(t *testing.T) {
+	// Not parallel: mutates process environment via t.Setenv.
+	t.Setenv("SUVE_DEBUG", "1")
+	t.Setenv("SUVE_NO_REDACTION", "1")
+
+	cfg, _ := runProbe(t, detect.Result{}, []string{appName, "probe"})
+	assert.True(t, cfg.Enabled)
+	assert.True(t, cfg.NoRedaction)
 }
 
 func TestEnableDebug_flagBeforeSubcommand(t *testing.T) {
 	t.Parallel()
 
-	enabled, stderr := runProbe(t, detect.Result{}, []string{appName, "--debug", "probe"})
-	assert.True(t, enabled)
+	cfg, stderr := runProbe(t, detect.Result{}, []string{appName, "--debug", "probe"})
+	assert.True(t, cfg.Enabled)
 	// The Before hook logs a one-shot summary of pre-API decisions.
 	assert.Contains(t, stderr, "cli: suve version=test")
 	assert.Contains(t, stderr, "flat aliases: param=(none) secret=(none) stage=(none)")
@@ -77,16 +110,16 @@ func TestEnableDebug_flagAfterSubcommand(t *testing.T) {
 	t.Parallel()
 
 	// The flag is persistent (not Local), so it is accepted in either position.
-	enabled, _ := runProbe(t, detect.Result{}, []string{appName, "probe", "--debug"})
-	assert.True(t, enabled)
+	cfg, _ := runProbe(t, detect.Result{}, []string{appName, "probe", "--debug"})
+	assert.True(t, cfg.Enabled)
 }
 
 func TestEnableDebug_env(t *testing.T) {
 	// Not parallel: mutates process environment via t.Setenv.
 	t.Setenv("SUVE_DEBUG", "1")
 
-	enabled, _ := runProbe(t, detect.Result{}, []string{appName, "probe"})
-	assert.True(t, enabled)
+	cfg, _ := runProbe(t, detect.Result{}, []string{appName, "probe"})
+	assert.True(t, cfg.Enabled)
 }
 
 // TestEnableDebug_envLenient covers the lenient SUVE_DEBUG parsing: bool-ish
@@ -110,8 +143,8 @@ func TestEnableDebug_envLenient(t *testing.T) {
 		t.Run(tt.value, func(t *testing.T) {
 			t.Setenv("SUVE_DEBUG", tt.value)
 
-			enabled, _ := runProbe(t, detect.Result{}, []string{appName, "probe"})
-			assert.Equal(t, tt.want, enabled)
+			cfg, _ := runProbe(t, detect.Result{}, []string{appName, "probe"})
+			assert.Equal(t, tt.want, cfg.Enabled)
 		})
 	}
 }

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -26,6 +26,12 @@ type Config struct {
 	// Writer is where debug output should go (typically stderr). Callers that
 	// set Enabled must supply a non-nil Writer.
 	Writer io.Writer
+	// NoRedaction, when true, tells provider adapters to log full request and
+	// response bodies and to stop masking sensitive headers, so the debug output
+	// includes secret values and live credentials. It is opt-in via
+	// --no-redaction and only meaningful when Enabled; the zero value keeps the
+	// safe, redacted default.
+	NoRedaction bool
 }
 
 // With returns a child context carrying cfg.

--- a/internal/infra/client.go
+++ b/internal/infra/client.go
@@ -92,25 +92,38 @@ type debugLogger struct {
 	cfg debug.Config
 }
 
-// Logf implements smithy logging.Logger.
+// Logf implements smithy logging.Logger. Header/body redaction is applied
+// unless --no-redaction is active, in which case the dump is passed through
+// verbatim (secret values and credentials included).
 func (l debugLogger) Logf(classification logging.Classification, format string, v ...any) {
-	l.cfg.Logf("aws sdk %s: %s\n", classification, redactDump(fmt.Sprintf(format, v...)))
+	dump := fmt.Sprintf(format, v...)
+	if !l.cfg.NoRedaction {
+		dump = redactDump(dump)
+	}
+
+	l.cfg.Logf("aws sdk %s: %s\n", classification, dump)
 }
 
 // LoadConfig loads the default AWS configuration. When debug is enabled on the
-// context it turns on SDK request/response/retry logging (metadata only — the
-// bodyless LogRequest/LogResponse modes never print secret values) plus config
-// resolution warnings, and logs a one-line summary of the effective region,
-// profile, and credentials source — the facts a user needs first when a command
-// unexpectedly returns nothing (see #306).
+// context it turns on SDK request/response/retry logging plus config resolution
+// warnings, and logs a one-line summary of the effective region, profile, and
+// credentials source — the facts a user needs first when a command unexpectedly
+// returns nothing (see #306). By default the bodyless LogRequest/LogResponse
+// modes are used (metadata only, no secret values); --no-redaction switches to
+// the WithBody modes so full request/response payloads are logged too.
 func LoadConfig(ctx context.Context) (aws.Config, error) {
 	d := debug.From(ctx)
 	if !d.Enabled {
 		return config.LoadDefaultConfig(ctx)
 	}
 
+	logMode := aws.LogRequest | aws.LogResponse | aws.LogRetries
+	if d.NoRedaction {
+		logMode = aws.LogRequestWithBody | aws.LogResponseWithBody | aws.LogRetries
+	}
+
 	cfg, err := config.LoadDefaultConfig(ctx,
-		config.WithClientLogMode(aws.LogRequest|aws.LogResponse|aws.LogRetries),
+		config.WithClientLogMode(logMode),
 		config.WithLogger(debugLogger{cfg: d}),
 		config.WithLogConfigurationWarnings(true),
 	)

--- a/internal/infra/loadconfig_internal_test.go
+++ b/internal/infra/loadconfig_internal_test.go
@@ -53,10 +53,27 @@ func TestLoadConfig_debug(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, cfg.Logger)
 		assert.NotZero(t, cfg.ClientLogMode)
+		// The default (redacted) mode logs metadata only — bodies are not dumped.
+		assert.False(t, cfg.ClientLogMode.IsRequestWithBody())
+		assert.False(t, cfg.ClientLogMode.IsResponseWithBody())
 
 		// The effective-configuration summary is logged immediately, before any
 		// service call, so the user sees region/profile/credentials up front.
 		assert.Contains(t, buf.String(), `aws: region="us-east-1" profile="default" credentials-source=EnvConfigCredentials`)
+	})
+
+	t.Run("with debug and no redaction", func(t *testing.T) {
+		setAWSTestEnv(t)
+
+		var buf bytes.Buffer
+
+		ctx := debug.With(context.Background(), debug.Config{Enabled: true, Writer: &buf, NoRedaction: true})
+
+		cfg, err := LoadConfig(ctx)
+		require.NoError(t, err)
+		// --no-redaction switches to the WithBody modes so payloads are logged.
+		assert.True(t, cfg.ClientLogMode.IsRequestWithBody())
+		assert.True(t, cfg.ClientLogMode.IsResponseWithBody())
 	})
 }
 
@@ -107,4 +124,23 @@ func TestDebugLogger_redactsCredentials(t *testing.T) {
 	assert.Contains(t, out, "X-Amz-Target: AmazonSSM.DescribeParameters")
 	assert.Contains(t, out, "X-Amz-Date: 20260707T000000Z")
 	assert.Contains(t, out, "POST / HTTP/1.1")
+}
+
+func TestDebugLogger_noRedactionKeepsCredentials(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+
+	l := debugLogger{cfg: debug.Config{Enabled: true, Writer: &buf, NoRedaction: true}}
+	l.Logf(logging.Debug, "Request\n"+
+		"POST / HTTP/1.1\n"+
+		"Authorization: AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE, Signature=deadbeef\n"+
+		"X-Amz-Security-Token: SESSIONTOKENVALUE123\n")
+
+	out := buf.String()
+	// With --no-redaction the dump is passed through verbatim: nothing is masked.
+	assert.NotContains(t, out, "REDACTED")
+	assert.Contains(t, out, "AKIDEXAMPLE")
+	assert.Contains(t, out, "deadbeef")
+	assert.Contains(t, out, "SESSIONTOKENVALUE123")
 }

--- a/internal/provider/azure/azure.go
+++ b/internal/provider/azure/azure.go
@@ -123,8 +123,23 @@ func enableDebugLogging(ctx context.Context) {
 	})
 }
 
+// debugLogOptions returns azcore logging options for a client. When
+// --no-redaction is active on ctx it enables full body logging, so secret
+// values carried in request/response payloads (e.g. a Key Vault secret value)
+// are dumped. Otherwise it returns the zero value, leaving azcore's safe
+// defaults (bodies omitted, sensitive headers masked). azcore has no "log every
+// header" switch, so even under --no-redaction its header allowlist still
+// applies — the un-redacted payload is the body.
+func debugLogOptions(ctx context.Context) policy.LogOptions {
+	if debug.From(ctx).NoRedaction {
+		return policy.LogOptions{IncludeBody: true}
+	}
+
+	return policy.LogOptions{}
+}
+
 // keyVaultStore builds a Key Vault secrets store for the scope's vault.
-func keyVaultStore(_ context.Context, scope provider.Scope) (provider.Store, error) {
+func keyVaultStore(ctx context.Context, scope provider.Scope) (provider.Store, error) {
 	if scope.VaultName == "" {
 		return nil, fmt.Errorf("no Azure Key Vault specified: set --vault-name")
 	}
@@ -139,7 +154,10 @@ func keyVaultStore(_ context.Context, scope provider.Scope) (provider.Store, err
 			},
 		}
 		opts := &azsecrets.ClientOptions{
-			ClientOptions:                        azcore.ClientOptions{Transport: httpClient},
+			ClientOptions: azcore.ClientOptions{
+				Transport: httpClient,
+				Logging:   debugLogOptions(ctx),
+			},
 			DisableChallengeResourceVerification: true,
 		}
 
@@ -158,7 +176,11 @@ func keyVaultStore(_ context.Context, scope provider.Scope) (provider.Store, err
 
 	vaultURL := fmt.Sprintf("https://%s.vault.azure.net", scope.VaultName)
 
-	client, err := azsecrets.NewClient(vaultURL, cred, nil)
+	opts := &azsecrets.ClientOptions{
+		ClientOptions: azcore.ClientOptions{Logging: debugLogOptions(ctx)},
+	}
+
+	client, err := azsecrets.NewClient(vaultURL, cred, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Azure Key Vault client: %w", err)
 	}
@@ -167,7 +189,7 @@ func keyVaultStore(_ context.Context, scope provider.Scope) (provider.Store, err
 }
 
 // appConfigStore builds an App Configuration store for the scope's store.
-func appConfigStore(_ context.Context, scope provider.Scope) (provider.Store, error) {
+func appConfigStore(ctx context.Context, scope provider.Scope) (provider.Store, error) {
 	if scope.StoreName == "" {
 		return nil, fmt.Errorf("no Azure App Configuration store specified: set --store-name")
 	}
@@ -176,7 +198,10 @@ func appConfigStore(_ context.Context, scope provider.Scope) (provider.Store, er
 	// endpoint + DefaultAzureCredential and allows HMAC auth over plain HTTP.
 	if connStr := os.Getenv(AppConfigConnStringEnvVar); connStr != "" {
 		opts := &azappconfig.ClientOptions{
-			ClientOptions: azcore.ClientOptions{InsecureAllowCredentialWithHTTP: true},
+			ClientOptions: azcore.ClientOptions{
+				InsecureAllowCredentialWithHTTP: true,
+				Logging:                         debugLogOptions(ctx),
+			},
 		}
 
 		client, err := azappconfig.NewClientFromConnectionString(connStr, opts)
@@ -194,7 +219,11 @@ func appConfigStore(_ context.Context, scope provider.Scope) (provider.Store, er
 
 	endpoint := fmt.Sprintf("https://%s.azconfig.io", scope.StoreName)
 
-	client, err := azappconfig.NewClient(endpoint, cred, nil)
+	opts := &azappconfig.ClientOptions{
+		ClientOptions: azcore.ClientOptions{Logging: debugLogOptions(ctx)},
+	}
+
+	client, err := azappconfig.NewClient(endpoint, cred, opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Azure App Configuration client: %w", err)
 	}


### PR DESCRIPTION
## Summary

Adds a global **`--no-redaction`** flag (and `SUVE_NO_REDACTION`) that, together with `--debug`, turns off the safeguards that keep secret values out of debug logs. Intended for v1.4.4 (separate from the v1.4.3 bugfix release).

`--debug` today is deliberately redacted — AWS uses bodyless `LogRequest`/`LogResponse` + a header allowlist, and Azure/azcore omits bodies — which is right for diagnosing empty/unexpected output but hides the actual values when you genuinely need them. `--no-redaction` flips that:

- **AWS**: switch to `LogRequestWithBody | LogResponseWithBody` and skip `redactDump`, so full payloads and all headers (incl. the signing `Authorization` header) are logged.
- **Azure**: set azcore `Logging.IncludeBody = true` on the Key Vault / App Config clients, so response bodies (e.g. a secret value) are dumped. (azcore has no "log every header" switch, so its header allowlist still applies; the un-redacted payload is the body.)
- **Google Cloud**: unaffected — the gRPC interceptor logs only method/resource/target/status/timing, no bodies.

### Safeguards (per design review)
- Off by default and **never implied by `--debug`**.
- Prints a **warning banner** to stderr before any debug line when active: `Warning: --no-redaction: debug output will include secret values and live credentials`.
- Used **without `--debug`**, it does nothing but print a hint: `Hint: --no-redaction has no effect without --debug (or SUVE_DEBUG)`.

## Changes
- `internal/debug`: `Config.NoRedaction`.
- `internal/cli/commands/app.go`: `--no-redaction` flag + `SUVE_NO_REDACTION` (shared lenient env parsing), banner/hint wiring.
- `internal/infra/client.go`: body log modes + conditional `redactDump`.
- `internal/provider/azure/azure.go`: `debugLogOptions(ctx)` threaded into all client builders.
- `README.md`: env-var row + an "Unredacted output" subsection.

## Test
- `infra`: WithBody modes under `NoRedaction`; `debugLogger` passes credentials through unmasked.
- `commands`: `--no-redaction` + `--debug` sets the flag and prints the banner; without `--debug` prints the hint and stays off; `SUVE_NO_REDACTION` env path.

`go build ./...`, `go test ./...`, and both lint steps (default + `production,webkit2_41`) pass (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)