### PR TITLE
feat(azure): App Configuration namespace (--namespace/--ns) core (#381 Phase 1)

### DIFF
--- a/internal/cli/commands/azure/param/command.go
+++ b/internal/cli/commands/azure/param/command.go
@@ -41,12 +41,24 @@ variable.`,
 				Usage:   "Azure App Configuration store name (defaults to $AZURE_APPCONFIG_NAME)",
 				Sources: cli.EnvVars("AZURE_APPCONFIG_NAME"),
 			},
+			&cli.StringFlag{
+				Name:    "namespace",
+				Aliases: []string{"ns"},
+				Usage: "App Configuration namespace to target (the label axis; Azure calls it a " +
+					`"label"). List/read accept a filter ("*"=all, "dev,prod"=OR, "dev*"=prefix); ` +
+					"single-item ops need one namespace. Empty = the default namespace " +
+					"(defaults to $AZURE_APPCONFIG_NAMESPACE)",
+				Sources: cli.EnvVars("AZURE_APPCONFIG_NAMESPACE"),
+			},
 		},
-		// Before stashes the resolved store name in the context. Resolution is
-		// deferred to store construction, so `suve azure param --help` works
-		// without a store.
+		// Before stashes the resolved store name and namespace in the context.
+		// Resolution is deferred to store construction, so `suve azure param
+		// --help` works without a store.
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-			return cliinternal.WithAzureStoreName(ctx, cmd.String("store-name")), nil
+			ctx = cliinternal.WithAzureStoreName(ctx, cmd.String("store-name"))
+			ctx = cliinternal.WithAzureAppConfigNamespace(ctx, cmd.String("namespace"))
+
+			return ctx, nil
 		},
 		Commands: []*cli.Command{
 			ShowCommand(),

--- a/internal/cli/commands/azure/stage.go
+++ b/internal/cli/commands/azure/stage.go
@@ -104,9 +104,20 @@ func appConfigStageGroup() *cli.Command {
 				Usage:   "Azure App Configuration store name (defaults to $AZURE_APPCONFIG_NAME)",
 				Sources: cli.EnvVars("AZURE_APPCONFIG_NAME"),
 			},
+			&cli.StringFlag{
+				Name:    "namespace",
+				Aliases: []string{"ns"},
+				Usage: "App Configuration namespace to stage under (the label axis; Azure calls " +
+					`it a "label"). Staging is per-(store, namespace); a staged op needs one ` +
+					"namespace. Empty = the default namespace (defaults to $AZURE_APPCONFIG_NAMESPACE)",
+				Sources: cli.EnvVars("AZURE_APPCONFIG_NAMESPACE"),
+			},
 		},
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-			return cliinternal.WithAzureStoreName(ctx, cmd.String("store-name")), nil
+			ctx = cliinternal.WithAzureStoreName(ctx, cmd.String("store-name"))
+			ctx = cliinternal.WithAzureAppConfigNamespace(ctx, cmd.String("namespace"))
+
+			return ctx, nil
 		},
 		Commands:        appConfigStageSubcommands(appConfigStageConfig()),
 		CommandNotFound: cliinternal.CommandNotFound,

--- a/internal/cli/commands/internal/client.go
+++ b/internal/cli/commands/internal/client.go
@@ -52,8 +52,9 @@ type azureScopeContextKey struct{}
 // azure command group. Each subgroup (secret/param) sets its vault/store name
 // via its Before hook.
 type azureScopeCtx struct {
-	vaultName string
-	storeName string
+	vaultName          string
+	storeName          string
+	appConfigNamespace string
 }
 
 func azureScopeFromContext(ctx context.Context) azureScopeCtx {
@@ -81,6 +82,24 @@ func WithAzureStoreName(ctx context.Context, storeName string) context.Context {
 	sc.storeName = storeName
 
 	return context.WithValue(ctx, azureScopeContextKey{}, sc)
+}
+
+// WithAzureAppConfigNamespace returns a context carrying the resolved Azure App
+// Configuration namespace (the axis Azure calls a "label"), merged onto any base
+// scope already present. The azure param subgroup's Before hook sets it (from
+// --namespace/--ns or the AZURE_APPCONFIG_NAMESPACE env). Empty is the null
+// (default) namespace and also overrides an env default back to null.
+func WithAzureAppConfigNamespace(ctx context.Context, namespace string) context.Context {
+	sc := azureScopeFromContext(ctx)
+	sc.appConfigNamespace = namespace
+
+	return context.WithValue(ctx, azureScopeContextKey{}, sc)
+}
+
+// AzureAppConfigNamespace returns the Azure App Configuration namespace resolved
+// into ctx by WithAzureAppConfigNamespace (empty = the null/default namespace).
+func AzureAppConfigNamespace(ctx context.Context) string {
+	return azureScopeFromContext(ctx).appConfigNamespace
 }
 
 // storeScope is the provider selector for read/write commands. Only the
@@ -147,6 +166,7 @@ func AzureAppConfigStore(ctx context.Context) (provider.Store, error) {
 	}
 
 	scope := provider.AzureAppConfigScope(sc.storeName)
+	scope.AppConfigNamespace = sc.appConfigNamespace
 
 	return registry.Store(ctx, scope, provider.KindParam)
 }
@@ -265,8 +285,16 @@ func AzureAppConfigStagingScopeResolver(ctx context.Context) (staging.ResolvedSc
 		)
 	}
 
+	scope := provider.AzureAppConfigScope(sc.storeName)
+	scope.AppConfigNamespace = sc.appConfigNamespace
+
+	target := "store " + sc.storeName
+	if sc.appConfigNamespace != "" {
+		target += " (namespace " + sc.appConfigNamespace + ")"
+	}
+
 	return staging.ResolvedScope{
-		Scope:  provider.AzureAppConfigScope(sc.storeName),
-		Target: "store " + sc.storeName,
+		Scope:  scope,
+		Target: target,
 	}, nil
 }

--- a/internal/provider/azure/appconfig/appconfig.go
+++ b/internal/provider/azure/appconfig/appconfig.go
@@ -14,8 +14,10 @@
 //
 // Two further constraints shape the adapter:
 //
-//   - It addresses the default (no) App Configuration label only; the default
-//     label is never exposed as a version.
+//   - The App Configuration label axis is exposed as suve's "namespace" (see
+//     the aznamespace subpackage): List forwards the raw value as a LabelFilter;
+//     single-key ops decode it to one literal label; empty is the null/default
+//     namespace. A label is never exposed as a version.
 //   - The azappconfig high-level SDK cannot round-trip setting tags: its
 //     SetSetting/AddSetting drop tags (and a write would clear existing ones).
 //     Tag/Untag therefore return ErrTagsUnsupported rather than silently losing
@@ -36,6 +38,7 @@ import (
 	"github.com/mpyw/suve/internal/debug"
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/azure/appconfig/aznamespace"
 	"github.com/mpyw/suve/internal/version/azureappconfigversion"
 )
 
@@ -46,31 +49,38 @@ var ErrTagsUnsupported = errors.New(
 	"tag mutation is not supported by Azure App Configuration (the azappconfig SDK cannot write setting tags)",
 )
 
-// Client is the narrow App Configuration surface this adapter needs. Every
-// method uses the default (no) label. The list method returns a drained slice
-// rather than the SDK's pager so tests can mock the interface trivially; the
-// production adapter (see Wrap) confines the pager draining and the concrete
+// Client is the narrow App Configuration surface this adapter needs. Single-key
+// methods take a resolved literal label ("" = the null/default label); the list
+// method takes a LabelFilter. The list method returns a drained slice rather
+// than the SDK's pager so tests can mock the interface trivially; the production
+// adapter (see Wrap) confines the pager draining and the concrete
 // *azappconfig.Client to this package.
 type Client interface {
-	GetSetting(ctx context.Context, key string) (azappconfig.GetSettingResponse, error)
-	SetSetting(ctx context.Context, key, value string) (azappconfig.SetSettingResponse, error)
-	AddSetting(ctx context.Context, key, value string) (azappconfig.AddSettingResponse, error)
-	DeleteSetting(ctx context.Context, key string) (azappconfig.DeleteSettingResponse, error)
-	ListSettings(ctx context.Context) ([]azappconfig.Setting, error)
+	GetSetting(ctx context.Context, key, label string) (azappconfig.GetSettingResponse, error)
+	SetSetting(ctx context.Context, key, value, label string) (azappconfig.SetSettingResponse, error)
+	AddSetting(ctx context.Context, key, value, label string) (azappconfig.AddSettingResponse, error)
+	DeleteSetting(ctx context.Context, key, label string) (azappconfig.DeleteSettingResponse, error)
+	ListSettings(ctx context.Context, filter string) ([]azappconfig.Setting, error)
 }
 
 // Store is the App Configuration implementation of provider.Store. It implements
 // neither Restorer nor Describer.
 type Store struct {
 	client Client
+	// namespace is the raw --namespace value selected for this store (the axis
+	// Azure calls a "label"). It is interpreted per operation: a LabelFilter for
+	// List, a decoded single literal label for single-key ops. Empty is the
+	// null (default) namespace.
+	namespace string
 }
 
 // Compile-time assertion that Store implements the provider contract.
 var _ provider.Store = (*Store)(nil)
 
-// New builds a Store backed by the given client.
-func New(client Client) *Store {
-	return &Store{client: client}
+// New builds a Store backed by the given client, scoped to the given raw
+// namespace value (empty = the null/default namespace).
+func New(client Client, namespace string) *Store {
+	return &Store{client: client, namespace: namespace}
 }
 
 // Resolve validates that the spec carries no version specifier (App
@@ -84,6 +94,12 @@ func (s *Store) Resolve(_ context.Context, _, spec string) (provider.VersionRef,
 		return provider.VersionRef{}, fmt.Errorf("%w", azureappconfigversion.ErrVersioningUnsupported)
 	}
 
+	// Resolve precedes every single-item read; reject a namespace value that
+	// names all/multiple namespaces here so the usage error surfaces early.
+	if _, err := aznamespace.Literal(s.namespace); err != nil {
+		return provider.VersionRef{}, err
+	}
+
 	return provider.NewVersionRef(""), nil
 }
 
@@ -91,7 +107,12 @@ func (s *Store) Resolve(_ context.Context, _, spec string) (provider.VersionRef,
 // is always plaintext; Version is left empty (App Configuration has no
 // versions); the setting's tags become Tags.
 func (s *Store) Get(ctx context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
-	resp, err := s.client.GetSetting(ctx, name)
+	label, err := aznamespace.Literal(s.namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.GetSetting(ctx, name, label)
 	if err != nil {
 		return nil, mapError(err, name, "get setting")
 	}
@@ -112,9 +133,12 @@ func (s *Store) History(_ context.Context, _ string) ([]domain.Version, error) {
 	return nil, fmt.Errorf("%w (no version history)", azureappconfigversion.ErrVersioningUnsupported)
 }
 
-// List returns the distinct key names in the store (across all labels), sorted.
+// List returns the distinct key names visible under the selected namespace
+// filter, sorted. The raw --namespace value is forwarded as an App
+// Configuration LabelFilter (empty -> the null-label filter); its `*`/`,`/`\`
+// grammar is honored natively by the service.
 func (s *Store) List(ctx context.Context) ([]string, error) {
-	settings, err := s.client.ListSettings(ctx)
+	settings, err := s.client.ListSettings(ctx, aznamespace.Filter(s.namespace))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list settings: %w", err)
 	}
@@ -150,7 +174,12 @@ func (s *Store) List(ctx context.Context) ([]string, error) {
 func (s *Store) Create(
 	ctx context.Context, name, value string, _ domain.ValueType, _ string, _ ...provider.WriteOption,
 ) (domain.Version, error) {
-	_, err := s.client.AddSetting(ctx, name, value)
+	label, err := aznamespace.Literal(s.namespace)
+	if err != nil {
+		return domain.Version{}, err
+	}
+
+	_, err = s.client.AddSetting(ctx, name, value, label)
 	if err != nil {
 		if isAlreadyExists(err) {
 			return domain.Version{}, fmt.Errorf("%w: %s", provider.ErrAlreadyExists, name)
@@ -168,7 +197,12 @@ func (s *Store) Create(
 func (s *Store) Put(
 	ctx context.Context, name, value string, _ domain.ValueType, _ string, _ ...provider.WriteOption,
 ) (domain.Version, error) {
-	if _, err := s.client.SetSetting(ctx, name, value); err != nil {
+	label, err := aznamespace.Literal(s.namespace)
+	if err != nil {
+		return domain.Version{}, err
+	}
+
+	if _, err := s.client.SetSetting(ctx, name, value, label); err != nil {
 		return domain.Version{}, fmt.Errorf("failed to set setting: %w", err)
 	}
 
@@ -177,7 +211,12 @@ func (s *Store) Put(
 
 // Delete removes a setting. Provider.DeleteOptions (AWS-specific) are ignored.
 func (s *Store) Delete(ctx context.Context, name string, _ ...provider.DeleteOption) error {
-	if _, err := s.client.DeleteSetting(ctx, name); err != nil {
+	label, err := aznamespace.Literal(s.namespace)
+	if err != nil {
+		return err
+	}
+
+	if _, err := s.client.DeleteSetting(ctx, name, label); err != nil {
 		return mapError(err, name, "delete setting")
 	}
 

--- a/internal/provider/azure/appconfig/appconfig_test.go
+++ b/internal/provider/azure/appconfig/appconfig_test.go
@@ -33,38 +33,44 @@ func serverError() error {
 }
 
 // mockClient is a configurable in-test implementation of appconfig.Client.
+// Single-key methods receive the resolved literal label; ListSettings receives
+// the LabelFilter.
 type mockClient struct {
-	getFunc    func(ctx context.Context, key string) (azappconfig.GetSettingResponse, error)
-	setFunc    func(ctx context.Context, key, value string) (azappconfig.SetSettingResponse, error)
-	addFunc    func(ctx context.Context, key, value string) (azappconfig.AddSettingResponse, error)
-	deleteFunc func(ctx context.Context, key string) (azappconfig.DeleteSettingResponse, error)
-	listFunc   func(ctx context.Context) ([]azappconfig.Setting, error)
+	getFunc    func(ctx context.Context, key, label string) (azappconfig.GetSettingResponse, error)
+	setFunc    func(ctx context.Context, key, value, label string) (azappconfig.SetSettingResponse, error)
+	addFunc    func(ctx context.Context, key, value, label string) (azappconfig.AddSettingResponse, error)
+	deleteFunc func(ctx context.Context, key, label string) (azappconfig.DeleteSettingResponse, error)
+	listFunc   func(ctx context.Context, filter string) ([]azappconfig.Setting, error)
 }
 
-func (m *mockClient) GetSetting(ctx context.Context, key string) (azappconfig.GetSettingResponse, error) {
-	return m.getFunc(ctx, key)
+func (m *mockClient) GetSetting(ctx context.Context, key, label string) (azappconfig.GetSettingResponse, error) {
+	return m.getFunc(ctx, key, label)
 }
 
-func (m *mockClient) SetSetting(ctx context.Context, key, value string) (azappconfig.SetSettingResponse, error) {
-	return m.setFunc(ctx, key, value)
+func (m *mockClient) SetSetting(
+	ctx context.Context, key, value, label string,
+) (azappconfig.SetSettingResponse, error) {
+	return m.setFunc(ctx, key, value, label)
 }
 
-func (m *mockClient) AddSetting(ctx context.Context, key, value string) (azappconfig.AddSettingResponse, error) {
-	return m.addFunc(ctx, key, value)
+func (m *mockClient) AddSetting(
+	ctx context.Context, key, value, label string,
+) (azappconfig.AddSettingResponse, error) {
+	return m.addFunc(ctx, key, value, label)
 }
 
-func (m *mockClient) DeleteSetting(ctx context.Context, key string) (azappconfig.DeleteSettingResponse, error) {
-	return m.deleteFunc(ctx, key)
+func (m *mockClient) DeleteSetting(ctx context.Context, key, label string) (azappconfig.DeleteSettingResponse, error) {
+	return m.deleteFunc(ctx, key, label)
 }
 
-func (m *mockClient) ListSettings(ctx context.Context) ([]azappconfig.Setting, error) {
-	return m.listFunc(ctx)
+func (m *mockClient) ListSettings(ctx context.Context, filter string) ([]azappconfig.Setting, error) {
+	return m.listFunc(ctx, filter)
 }
 
 func TestResolve_BareNameLatest(t *testing.T) {
 	t.Parallel()
 
-	store := appconfig.New(&mockClient{})
+	store := appconfig.New(&mockClient{}, "")
 	ref, err := store.Resolve(t.Context(), "my-key", "")
 	require.NoError(t, err)
 	assert.True(t, ref.IsLatest())
@@ -73,7 +79,7 @@ func TestResolve_BareNameLatest(t *testing.T) {
 func TestResolve_RejectsVersionSpecs(t *testing.T) {
 	t.Parallel()
 
-	store := appconfig.New(&mockClient{})
+	store := appconfig.New(&mockClient{}, "")
 
 	for _, spec := range []string{"#1", "#abc", "~1", ":prod"} {
 		_, err := store.Resolve(t.Context(), "my-key", spec)
@@ -81,11 +87,22 @@ func TestResolve_RejectsVersionSpecs(t *testing.T) {
 	}
 }
 
+func TestResolve_RejectsFilterNamespace(t *testing.T) {
+	t.Parallel()
+
+	for _, ns := range []string{"*", "dev,prod", "dev*"} {
+		store := appconfig.New(&mockClient{}, ns)
+		_, err := store.Resolve(t.Context(), "my-key", "")
+		require.Error(t, err, "ns=%q", ns)
+		assert.Contains(t, err.Error(), "single-item operation needs one")
+	}
+}
+
 func TestGet(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		getFunc: func(_ context.Context, key string) (azappconfig.GetSettingResponse, error) {
+		getFunc: func(_ context.Context, key, _ string) (azappconfig.GetSettingResponse, error) {
 			return azappconfig.GetSettingResponse{Setting: azappconfig.Setting{
 				Key:   lo.ToPtr(key),
 				Value: lo.ToPtr("30"),
@@ -93,7 +110,7 @@ func TestGet(t *testing.T) {
 			}}, nil
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	entry, err := store.Get(t.Context(), "app/timeout", provider.VersionRef{})
 	require.NoError(t, err)
@@ -104,15 +121,75 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, []domain.Tag{{Key: "env", Value: "prod"}}, entry.Tags)
 }
 
+func TestGet_AppliesNamespaceLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		namespace string
+		wantLabel string
+	}{
+		{name: "empty is null label", namespace: "", wantLabel: ""},
+		{name: "literal namespace", namespace: "dev", wantLabel: "dev"},
+		{name: "escaped star decodes to literal", namespace: `\*`, wantLabel: "*"},
+		{name: "escaped comma decodes to literal", namespace: `foo\,bar`, wantLabel: "foo,bar"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotLabel string
+
+			m := &mockClient{
+				getFunc: func(_ context.Context, key, label string) (azappconfig.GetSettingResponse, error) {
+					gotLabel = label
+
+					return azappconfig.GetSettingResponse{Setting: azappconfig.Setting{
+						Key:   lo.ToPtr(key),
+						Value: lo.ToPtr("v"),
+					}}, nil
+				},
+			}
+			store := appconfig.New(m, tt.namespace)
+
+			_, err := store.Get(t.Context(), "app/timeout", provider.VersionRef{})
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantLabel, gotLabel)
+		})
+	}
+}
+
+func TestGet_RejectsFilterNamespace(t *testing.T) {
+	t.Parallel()
+
+	for _, ns := range []string{"*", "dev,prod"} {
+		called := false
+		m := &mockClient{
+			getFunc: func(_ context.Context, _, _ string) (azappconfig.GetSettingResponse, error) {
+				called = true
+
+				return azappconfig.GetSettingResponse{}, nil
+			},
+		}
+		store := appconfig.New(m, ns)
+
+		_, err := store.Get(t.Context(), "app/timeout", provider.VersionRef{})
+		require.Error(t, err, "ns=%q", ns)
+		assert.Contains(t, err.Error(), "single-item operation needs one")
+		assert.False(t, called, "client must not be called when the namespace is a filter")
+	}
+}
+
 func TestGet_NotFound(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		getFunc: func(_ context.Context, _ string) (azappconfig.GetSettingResponse, error) {
+		getFunc: func(_ context.Context, _, _ string) (azappconfig.GetSettingResponse, error) {
 			return azappconfig.GetSettingResponse{}, notFound()
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	_, err := store.Get(t.Context(), "missing", provider.VersionRef{})
 	require.ErrorIs(t, err, provider.ErrNotFound)
@@ -122,14 +199,14 @@ func TestGet_NoTags(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		getFunc: func(_ context.Context, key string) (azappconfig.GetSettingResponse, error) {
+		getFunc: func(_ context.Context, key, _ string) (azappconfig.GetSettingResponse, error) {
 			return azappconfig.GetSettingResponse{Setting: azappconfig.Setting{
 				Key:   lo.ToPtr(key),
 				Value: lo.ToPtr("v"),
 			}}, nil
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	entry, err := store.Get(t.Context(), "app/timeout", provider.VersionRef{})
 	require.NoError(t, err)
@@ -140,11 +217,11 @@ func TestGet_Error(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		getFunc: func(_ context.Context, _ string) (azappconfig.GetSettingResponse, error) {
+		getFunc: func(_ context.Context, _, _ string) (azappconfig.GetSettingResponse, error) {
 			return azappconfig.GetSettingResponse{}, serverError()
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	_, err := store.Get(t.Context(), "app/timeout", provider.VersionRef{})
 	require.Error(t, err)
@@ -155,7 +232,7 @@ func TestGet_Error(t *testing.T) {
 func TestHistory_Unsupported(t *testing.T) {
 	t.Parallel()
 
-	store := appconfig.New(&mockClient{})
+	store := appconfig.New(&mockClient{}, "")
 
 	versions, err := store.History(t.Context(), "my-key")
 	require.Error(t, err)
@@ -167,7 +244,7 @@ func TestList(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		listFunc: func(_ context.Context) ([]azappconfig.Setting, error) {
+		listFunc: func(_ context.Context, _ string) ([]azappconfig.Setting, error) {
 			return []azappconfig.Setting{
 				{Key: lo.ToPtr("beta")},
 				{Key: lo.ToPtr("alpha")},
@@ -175,22 +252,58 @@ func TestList(t *testing.T) {
 			}, nil
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	names, err := store.List(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, []string{"alpha", "beta"}, names)
 }
 
+func TestList_ForwardsFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		namespace  string
+		wantFilter string
+	}{
+		{name: "empty is null-label filter", namespace: "", wantFilter: "\x00"},
+		{name: "wildcard all", namespace: "*", wantFilter: "*"},
+		{name: "OR-list", namespace: "dev,prod", wantFilter: "dev,prod"},
+		{name: "prefix wildcard", namespace: "dev*", wantFilter: "dev*"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotFilter string
+
+			m := &mockClient{
+				listFunc: func(_ context.Context, filter string) ([]azappconfig.Setting, error) {
+					gotFilter = filter
+
+					return nil, nil
+				},
+			}
+			store := appconfig.New(m, tt.namespace)
+
+			_, err := store.List(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFilter, gotFilter)
+		})
+	}
+}
+
 func TestList_Error(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		listFunc: func(_ context.Context) ([]azappconfig.Setting, error) {
+		listFunc: func(_ context.Context, _ string) ([]azappconfig.Setting, error) {
 			return nil, serverError()
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	_, err := store.List(t.Context())
 	require.Error(t, err)
@@ -208,11 +321,11 @@ func TestCreate_AlreadyExists(t *testing.T) {
 			t.Parallel()
 
 			m := &mockClient{
-				addFunc: func(_ context.Context, _, _ string) (azappconfig.AddSettingResponse, error) {
+				addFunc: func(_ context.Context, _, _, _ string) (azappconfig.AddSettingResponse, error) {
 					return azappconfig.AddSettingResponse{}, errFn()
 				},
 			}
-			store := appconfig.New(m)
+			store := appconfig.New(m, "")
 
 			_, err := store.Create(t.Context(), "existing", "v", domain.ValueTypePlaintext, "")
 			require.ErrorIs(t, err, provider.ErrAlreadyExists)
@@ -224,11 +337,11 @@ func TestCreate_Error(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		addFunc: func(_ context.Context, _, _ string) (azappconfig.AddSettingResponse, error) {
+		addFunc: func(_ context.Context, _, _, _ string) (azappconfig.AddSettingResponse, error) {
 			return azappconfig.AddSettingResponse{}, serverError()
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	_, err := store.Create(t.Context(), "new-key", "v", domain.ValueTypePlaintext, "")
 	require.Error(t, err)
@@ -239,43 +352,64 @@ func TestCreate_Error(t *testing.T) {
 func TestCreate_New(t *testing.T) {
 	t.Parallel()
 
-	var added string
+	var added, addedLabel string
 
 	m := &mockClient{
-		addFunc: func(_ context.Context, key, value string) (azappconfig.AddSettingResponse, error) {
-			added = key
+		addFunc: func(_ context.Context, key, value, label string) (azappconfig.AddSettingResponse, error) {
+			added, addedLabel = key, label
 
 			assert.Equal(t, "v", value)
 
 			return azappconfig.AddSettingResponse{}, nil
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "dev")
 
 	version, err := store.Create(t.Context(), "new-key", "v", domain.ValueTypePlaintext, "")
 	require.NoError(t, err)
 	assert.Equal(t, "new-key", added)
+	assert.Equal(t, "dev", addedLabel)
 	assert.Empty(t, version.ID) // unversioned
+}
+
+func TestCreate_RejectsFilterNamespace(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	m := &mockClient{
+		addFunc: func(_ context.Context, _, _, _ string) (azappconfig.AddSettingResponse, error) {
+			called = true
+
+			return azappconfig.AddSettingResponse{}, nil
+		},
+	}
+	store := appconfig.New(m, "dev,prod")
+
+	_, err := store.Create(t.Context(), "new-key", "v", domain.ValueTypePlaintext, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "single-item operation needs one")
+	assert.False(t, called)
 }
 
 func TestPut(t *testing.T) {
 	t.Parallel()
 
-	var setKey, setVal string
+	var setKey, setVal, setLabel string
 
 	m := &mockClient{
-		setFunc: func(_ context.Context, key, value string) (azappconfig.SetSettingResponse, error) {
-			setKey, setVal = key, value
+		setFunc: func(_ context.Context, key, value, label string) (azappconfig.SetSettingResponse, error) {
+			setKey, setVal, setLabel = key, value, label
 
 			return azappconfig.SetSettingResponse{}, nil
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "dev")
 
 	version, err := store.Put(t.Context(), "app/timeout", "60", domain.ValueTypePlaintext, "")
 	require.NoError(t, err)
 	assert.Equal(t, "app/timeout", setKey)
 	assert.Equal(t, "60", setVal)
+	assert.Equal(t, "dev", setLabel)
 	assert.Empty(t, version.ID)
 }
 
@@ -283,44 +417,64 @@ func TestPut_Error(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		setFunc: func(_ context.Context, _, _ string) (azappconfig.SetSettingResponse, error) {
+		setFunc: func(_ context.Context, _, _, _ string) (azappconfig.SetSettingResponse, error) {
 			return azappconfig.SetSettingResponse{}, serverError()
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	_, err := store.Put(t.Context(), "app/timeout", "60", domain.ValueTypePlaintext, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "set setting")
 }
 
+func TestPut_RejectsFilterNamespace(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	m := &mockClient{
+		setFunc: func(_ context.Context, _, _, _ string) (azappconfig.SetSettingResponse, error) {
+			called = true
+
+			return azappconfig.SetSettingResponse{}, nil
+		},
+	}
+	store := appconfig.New(m, "*")
+
+	_, err := store.Put(t.Context(), "app/timeout", "60", domain.ValueTypePlaintext, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "single-item operation needs one")
+	assert.False(t, called)
+}
+
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	var deleted string
+	var deleted, deletedLabel string
 
 	m := &mockClient{
-		deleteFunc: func(_ context.Context, key string) (azappconfig.DeleteSettingResponse, error) {
-			deleted = key
+		deleteFunc: func(_ context.Context, key, label string) (azappconfig.DeleteSettingResponse, error) {
+			deleted, deletedLabel = key, label
 
 			return azappconfig.DeleteSettingResponse{}, nil
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "dev")
 
 	require.NoError(t, store.Delete(t.Context(), "app/timeout"))
 	assert.Equal(t, "app/timeout", deleted)
+	assert.Equal(t, "dev", deletedLabel)
 }
 
 func TestDelete_NotFound(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		deleteFunc: func(_ context.Context, _ string) (azappconfig.DeleteSettingResponse, error) {
+		deleteFunc: func(_ context.Context, _, _ string) (azappconfig.DeleteSettingResponse, error) {
 			return azappconfig.DeleteSettingResponse{}, notFound()
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	err := store.Delete(t.Context(), "missing")
 	require.ErrorIs(t, err, provider.ErrNotFound)
@@ -330,11 +484,11 @@ func TestDelete_Error(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		deleteFunc: func(_ context.Context, _ string) (azappconfig.DeleteSettingResponse, error) {
+		deleteFunc: func(_ context.Context, _, _ string) (azappconfig.DeleteSettingResponse, error) {
 			return azappconfig.DeleteSettingResponse{}, serverError()
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	err := store.Delete(t.Context(), "app/timeout")
 	require.Error(t, err)
@@ -342,10 +496,29 @@ func TestDelete_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "delete setting")
 }
 
+func TestDelete_RejectsFilterNamespace(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	m := &mockClient{
+		deleteFunc: func(_ context.Context, _, _ string) (azappconfig.DeleteSettingResponse, error) {
+			called = true
+
+			return azappconfig.DeleteSettingResponse{}, nil
+		},
+	}
+	store := appconfig.New(m, "a,b")
+
+	err := store.Delete(t.Context(), "app/timeout")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "single-item operation needs one")
+	assert.False(t, called)
+}
+
 func TestTagUntag_Unsupported(t *testing.T) {
 	t.Parallel()
 
-	store := appconfig.New(&mockClient{})
+	store := appconfig.New(&mockClient{}, "")
 
 	// Non-empty mutation is declined with a clear error.
 	require.ErrorIs(t, store.Tag(t.Context(), "k", map[string]string{"env": "prod"}), appconfig.ErrTagsUnsupported)

--- a/internal/provider/azure/appconfig/aznamespace/aznamespace.go
+++ b/internal/provider/azure/appconfig/aznamespace/aznamespace.go
@@ -1,0 +1,79 @@
+// Package aznamespace parses the value of the Azure App Configuration
+// --namespace / --ns flag (env AZURE_APPCONFIG_NAMESPACE).
+//
+// suve calls this axis a "namespace"; Azure App Configuration calls it a
+// "label". Structurally it is a k8s-style namespace — a flat identity partition
+// of the key space, with the null (unlabeled) label as the default namespace —
+// not key=value metadata (which suve unifies as tags). See #381 for the naming
+// rationale.
+//
+// The value has two interpretations depending on context:
+//
+//   - list/read: an App Configuration LabelFilter (see Filter). The filter
+//     grammar (`*` wildcard, `,` OR-list, `\` escape) is honored natively by
+//     the service, so `*`=all, `dev*`=prefix, `dev,prod`=multi all fall out.
+//   - single-item ops (show/set/delete/...): exactly one concrete namespace
+//     (see Literal). `\` escapes are decoded; any unescaped `*` or `,` is a
+//     usage error because those name all/multiple namespaces.
+package aznamespace
+
+import (
+	"fmt"
+	"strings"
+)
+
+// NullLabelFilter is the reserved App Configuration label filter that matches
+// ONLY settings with no label — the null (default) namespace. The service
+// encodes it as label=%00 (#352).
+const NullLabelFilter = "\x00"
+
+// Filter maps a raw --namespace value to an App Configuration LabelFilter for
+// list/read enumeration. An empty value maps to the null-label filter (the
+// default namespace); any other value is forwarded verbatim so the service's
+// native filter grammar (`*` wildcard, `,` OR-list, `\` escape) applies (#381).
+func Filter(raw string) string {
+	if raw == "" {
+		return NullLabelFilter
+	}
+
+	return raw
+}
+
+// Literal decodes a raw --namespace value to the single literal namespace a
+// single-item operation must target. `\` escapes are decoded (`\*` -> `*`,
+// `\,` -> `,`, `\\` -> `\`); an empty value maps to the null (default)
+// namespace (""). If any UNESCAPED `*` or `,` remains, the value names
+// all/multiple namespaces and a usage error is returned (#381).
+func Literal(raw string) (string, error) {
+	var b strings.Builder
+
+	escaped := false
+
+	for _, r := range raw {
+		if escaped {
+			b.WriteRune(r)
+
+			escaped = false
+
+			continue
+		}
+
+		switch r {
+		case '\\':
+			escaped = true
+		case '*', ',':
+			return "", fmt.Errorf(
+				"--namespace %q names all/multiple namespaces; a single-item operation needs one", raw,
+			)
+		default:
+			b.WriteRune(r)
+		}
+	}
+
+	// A trailing backslash escapes nothing; keep it as a literal backslash.
+	if escaped {
+		b.WriteRune('\\')
+	}
+
+	return b.String(), nil
+}

--- a/internal/provider/azure/appconfig/aznamespace/aznamespace_test.go
+++ b/internal/provider/azure/appconfig/aznamespace/aznamespace_test.go
@@ -1,0 +1,86 @@
+package aznamespace_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider/azure/appconfig/aznamespace"
+)
+
+func TestFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "empty maps to null-label filter", raw: "", want: "\x00"},
+		{name: "wildcard all forwarded", raw: "*", want: "*"},
+		{name: "OR-list forwarded", raw: "dev,prod", want: "dev,prod"},
+		{name: "prefix wildcard forwarded", raw: "dev*", want: "dev*"},
+		{name: "literal forwarded", raw: "dev", want: "dev"},
+		{name: "escaped reserved forwarded verbatim", raw: `\*`, want: `\*`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, aznamespace.Filter(tt.raw))
+		})
+	}
+}
+
+func TestLiteral(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "empty maps to null namespace", raw: "", want: ""},
+		{name: "plain literal", raw: "dev", want: "dev"},
+		{name: "escaped star decodes to literal star", raw: `\*`, want: "*"},
+		{name: "escaped comma decodes to literal comma", raw: `foo\,bar`, want: "foo,bar"},
+		{name: "escaped backslash decodes to single backslash", raw: `\\`, want: `\`},
+		{name: "trailing backslash kept literal", raw: `foo\`, want: `foo\`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := aznamespace.Literal(tt.raw)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLiteral_UnescapedFilterCharsError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "wildcard all", raw: "*"},
+		{name: "OR-list", raw: "dev,prod"},
+		{name: "prefix wildcard", raw: "dev*"},
+		{name: "comma after escaped star", raw: `\*,x`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := aznamespace.Literal(tt.raw)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "single-item operation needs one")
+		})
+	}
+}

--- a/internal/provider/azure/appconfig/client.go
+++ b/internal/provider/azure/appconfig/client.go
@@ -7,20 +7,14 @@ import (
 	"github.com/samber/lo"
 )
 
-// nullLabelFilter is the reserved App Configuration label filter that matches
-// ONLY settings with no label. The Get/Set/Add/Delete single-key operations all
-// address the null (default) label, so List must restrict to the same label —
-// otherwise it enumerates every label and surfaces phantom keys that show/stage
-// then cannot fetch. The service encodes this reserved value as label=%00.
-const nullLabelFilter = "\x00"
-
 // apiClient adapts the concrete *azappconfig.Client to the narrow Client
 // interface, draining the SDK's list pager into a slice. It is the only place
 // the concrete SDK client and its pager are referenced.
 //
-// Every operation uses the default (no) App Configuration label: options are
-// left nil so the store addresses the single default-labeled setting per key,
-// which the adapter presents as an unversioned parameter.
+// The label carrying suve's namespace is applied via the high-level SDK options
+// (GetSettingOptions.Label, SetSettingOptions.Label, ...) for single-key ops and
+// SettingSelector.LabelFilter for List. An empty label leaves the options nil so
+// the request is byte-for-byte identical to addressing the null (default) label.
 type apiClient struct {
 	c *azappconfig.Client
 }
@@ -33,33 +27,58 @@ func Wrap(c *azappconfig.Client) Client {
 // Compile-time assertion that apiClient satisfies Client.
 var _ Client = (*apiClient)(nil)
 
-func (a *apiClient) GetSetting(ctx context.Context, key string) (azappconfig.GetSettingResponse, error) {
-	return a.c.GetSetting(ctx, key, nil)
+// An empty label leaves the options pointer nil so the request addresses the
+// null (default) label exactly as it did before the namespace axis existed; a
+// non-empty label is carried via the option's Label field.
+
+func (a *apiClient) GetSetting(ctx context.Context, key, label string) (azappconfig.GetSettingResponse, error) {
+	var opts *azappconfig.GetSettingOptions
+	if label != "" {
+		opts = &azappconfig.GetSettingOptions{Label: lo.ToPtr(label)}
+	}
+
+	return a.c.GetSetting(ctx, key, opts)
 }
 
-func (a *apiClient) SetSetting(ctx context.Context, key, value string) (azappconfig.SetSettingResponse, error) {
-	return a.c.SetSetting(ctx, key, lo.ToPtr(value), nil)
+func (a *apiClient) SetSetting(ctx context.Context, key, value, label string) (azappconfig.SetSettingResponse, error) {
+	var opts *azappconfig.SetSettingOptions
+	if label != "" {
+		opts = &azappconfig.SetSettingOptions{Label: lo.ToPtr(label)}
+	}
+
+	return a.c.SetSetting(ctx, key, lo.ToPtr(value), opts)
 }
 
-func (a *apiClient) AddSetting(ctx context.Context, key, value string) (azappconfig.AddSettingResponse, error) {
-	return a.c.AddSetting(ctx, key, lo.ToPtr(value), nil)
+func (a *apiClient) AddSetting(ctx context.Context, key, value, label string) (azappconfig.AddSettingResponse, error) {
+	var opts *azappconfig.AddSettingOptions
+	if label != "" {
+		opts = &azappconfig.AddSettingOptions{Label: lo.ToPtr(label)}
+	}
+
+	return a.c.AddSetting(ctx, key, lo.ToPtr(value), opts)
 }
 
-func (a *apiClient) DeleteSetting(ctx context.Context, key string) (azappconfig.DeleteSettingResponse, error) {
-	return a.c.DeleteSetting(ctx, key, nil)
+func (a *apiClient) DeleteSetting(ctx context.Context, key, label string) (azappconfig.DeleteSettingResponse, error) {
+	var opts *azappconfig.DeleteSettingOptions
+	if label != "" {
+		opts = &azappconfig.DeleteSettingOptions{Label: lo.ToPtr(label)}
+	}
+
+	return a.c.DeleteSetting(ctx, key, opts)
 }
 
-// listSettingSelector is the selector used to enumerate settings: all keys but
-// ONLY the null (default) label, so List matches what the single-key operations
-// address. A nil LabelFilter (SettingSelector{}) would enumerate every label.
-func listSettingSelector() azappconfig.SettingSelector {
+// listSettingSelector is the selector used to enumerate settings: all keys,
+// restricted by the given LabelFilter. The filter is resolved by the store from
+// the raw --namespace value (empty -> the null-label filter, aznamespace.Filter).
+// A nil LabelFilter (SettingSelector{}) would enumerate every label.
+func listSettingSelector(filter string) azappconfig.SettingSelector {
 	return azappconfig.SettingSelector{
-		LabelFilter: lo.ToPtr(nullLabelFilter),
+		LabelFilter: lo.ToPtr(filter),
 	}
 }
 
-func (a *apiClient) ListSettings(ctx context.Context) ([]azappconfig.Setting, error) {
-	pager := a.c.NewListSettingsPager(listSettingSelector(), nil)
+func (a *apiClient) ListSettings(ctx context.Context, filter string) ([]azappconfig.Setting, error) {
+	pager := a.c.NewListSettingsPager(listSettingSelector(filter), nil)
 
 	var out []azappconfig.Setting
 

--- a/internal/provider/azure/appconfig/client_internal_test.go
+++ b/internal/provider/azure/appconfig/client_internal_test.go
@@ -5,21 +5,37 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider/azure/appconfig/aznamespace"
 )
 
-// TestListSettingSelector_FiltersNullLabel guards the #352 fix: List must
-// restrict to the null (default) label so it matches the single-key operations,
-// rather than enumerating every label (a nil LabelFilter). The reserved value
-// "\x00" is sent as label=%00, which App Configuration matches to label-less
-// key-values.
-func TestListSettingSelector_FiltersNullLabel(t *testing.T) {
+// TestListSettingSelector_ForwardsFilter checks that the selector forwards the
+// given LabelFilter verbatim (never a nil filter, which would enumerate every
+// label) and sets no key filter. The store resolves the raw --namespace value
+// into this filter via aznamespace.Filter.
+func TestListSettingSelector_ForwardsFilter(t *testing.T) {
 	t.Parallel()
 
-	sel := listSettingSelector()
+	for _, filter := range []string{"\x00", "dev", "dev,prod", "dev*", "*"} {
+		sel := listSettingSelector(filter)
 
-	require.NotNil(t, sel.LabelFilter, "List must set a label filter, not enumerate all labels")
+		require.NotNil(t, sel.LabelFilter, "List must set a label filter, not enumerate all labels")
+		assert.Equal(t, filter, *sel.LabelFilter)
+
+		// No key filter: all keys, restricted only by label.
+		assert.Nil(t, sel.KeyFilter)
+	}
+}
+
+// TestListSettingSelector_NullLabelDefault guards the #352 behavior end to end:
+// the empty namespace resolves to the null-label filter ("\x00", sent as
+// label=%00), so List matches only label-less key-values rather than every
+// label.
+func TestListSettingSelector_NullLabelDefault(t *testing.T) {
+	t.Parallel()
+
+	sel := listSettingSelector(aznamespace.Filter(""))
+
+	require.NotNil(t, sel.LabelFilter)
 	assert.Equal(t, "\x00", *sel.LabelFilter)
-
-	// No key filter: all keys, restricted only by label.
-	assert.Nil(t, sel.KeyFilter)
 }

--- a/internal/provider/azure/azure.go
+++ b/internal/provider/azure/azure.go
@@ -209,7 +209,7 @@ func appConfigStore(ctx context.Context, scope provider.Scope) (provider.Store, 
 			return nil, fmt.Errorf("failed to create Azure App Configuration client from connection string: %w", err)
 		}
 
-		return appconfig.New(appconfig.Wrap(client)), nil
+		return appconfig.New(appconfig.Wrap(client), scope.AppConfigNamespace), nil
 	}
 
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -228,7 +228,7 @@ func appConfigStore(ctx context.Context, scope provider.Scope) (provider.Store, 
 		return nil, fmt.Errorf("failed to create Azure App Configuration client: %w", err)
 	}
 
-	return appconfig.New(appconfig.Wrap(client)), nil
+	return appconfig.New(appconfig.Wrap(client), scope.AppConfigNamespace), nil
 }
 
 // Register associates the Azure Factory with provider.ProviderAzure in reg.

--- a/internal/provider/scope.go
+++ b/internal/provider/scope.go
@@ -29,6 +29,11 @@ type Scope struct {
 	VaultName string `json:"vaultName,omitempty"`
 	// StoreName is the Azure App Configuration store name (Azure, param).
 	StoreName string `json:"storeName,omitempty"`
+	// AppConfigNamespace is the Azure App Configuration namespace — the axis
+	// Azure calls a "label" — selected for the store (Azure, param). Empty is
+	// the null (default) namespace. A single resolved namespace only; the
+	// filter grammar (`*`/`,`) never reaches staging (see #381).
+	AppConfigNamespace string `json:"appConfigNamespace,omitempty"`
 }
 
 // Key returns a stable, filesystem-safe key identifying the scope. It is used
@@ -45,6 +50,12 @@ func (s Scope) Key() string {
 		// resource — no subscription/resource-group needed.
 		if s.VaultName != "" {
 			return fmt.Sprintf("azure/keyvault/%s", s.VaultName)
+		}
+
+		// The null (default) namespace keeps the original backward-compatible
+		// path; a named namespace makes staging state per-(store, namespace).
+		if s.AppConfigNamespace != "" {
+			return fmt.Sprintf("azure/appconfig/%s/%s", s.StoreName, s.AppConfigNamespace)
 		}
 
 		return fmt.Sprintf("azure/appconfig/%s", s.StoreName)

--- a/internal/provider/scope_test.go
+++ b/internal/provider/scope_test.go
@@ -38,6 +38,16 @@ func TestScope_Key(t *testing.T) {
 			want:  "azure/appconfig/store1",
 		},
 		{
+			// A named namespace makes staging state per-(store, namespace).
+			name: "azure appconfig with namespace",
+			scope: provider.Scope{
+				Provider:           provider.ProviderAzure,
+				StoreName:          "store1",
+				AppConfigNamespace: "dev",
+			},
+			want: "azure/appconfig/store1/dev",
+		},
+		{
 			name:  "unknown provider",
 			scope: provider.Scope{},
 			want:  "",


### PR DESCRIPTION
## Summary

Adds end-to-end support for Azure App Configuration's `(key, label)` axis, exposed under suve's cross-provider term **namespace** (Azure calls it a *label*). One flag `--namespace` (alias `--ns`) + env `AZURE_APPCONFIG_NAMESPACE` on the `azure param` (and `azure stage param`) commands selects it. This is **#381 Phase 1 (namespaces)** only.

Isolation-by-default (kubectl namespaces model): the default is the **null namespace** (App Config's unlabeled/default settings), and a chosen namespace never surfaces another in `list`/`show`.

## `--namespace` value semantics

| Value | Meaning | Scope |
|---|---|---|
| unset or `""` | the **null namespace** (default; also overrides an env default back to null) | all commands |
| `"*"` | **all** namespaces (wildcard) | list/read only |
| `"dev,prod"` | **dev OR prod** (`,` = OR-list) | list/read only |
| `"dev*"` | prefix wildcard | list/read only |
| `"dev"` | the literal namespace `dev` | all commands |
| `"\*"`, `"foo\,bar"` | a **literal** namespace containing a reserved char (`\` escape) | all commands |

- **List/read** forwards the value to App Config's `LabelFilter`; its `*`/`,`/`\` grammar is honored natively. The single suve override: empty maps to the null-label filter (`\x00`, #352).
- **Single-item ops** (`show`/`set`/`delete`/create/update, plus `Resolve`) decode `\` escapes to one literal label; any **unescaped** `*` or `,` is a usage error (`--namespace %q names all/multiple namespaces; a single-item operation needs one`).

## Naming (everything new is obviously Azure-specific)

- New pure, exhaustively unit-tested parser package **`internal/provider/azure/appconfig/aznamespace`**:
  - `Filter(raw string) string` — raw -> `LabelFilter` (empty -> `"\x00"`).
  - `Literal(raw string) (string, error)` — decode `\`-escapes; error on unescaped `*`/`,`; empty -> `""`.
- `provider.Scope.AppConfigNamespace` (JSON-tagged like `StoreName`).
- Context helpers `WithAzureAppConfigNamespace` / `AzureAppConfigNamespace(ctx)` beside `WithAzureStoreName`.

## Wiring (mirrors the existing `--store-name` / `AZURE_APPCONFIG_NAME` plumbing)

- Flag `--namespace`/`--ns` + `AZURE_APPCONFIG_NAMESPACE` on `azure param` (`internal/cli/commands/azure/param/command.go`) and `azure stage param` (`internal/cli/commands/azure/stage.go`); the flat `param`/`stage` aliases reuse those groups verbatim, so they inherit the flag.
- `Scope.Key()` appends the namespace so staging is per-`(store, namespace)`; the null namespace keeps the EXACT current path `azure/appconfig/<store>`.
- `appConfigStore` captures `scope.AppConfigNamespace` and passes it into the adapter store.
- Adapter (`appconfig.go` + `client.go`): the store holds the raw namespace. `List` -> `aznamespace.Filter`; single-item ops -> `aznamespace.Literal` then the label via the high-level SDK options (`GetSettingOptions.Label`, `SetSettingOptions.Label`, `DeleteSettingOptions.Label`, `AddSettingOptions.Label`). Empty label leaves the options pointer nil, reproducing today's null-label behavior byte-for-byte.

## Tests

- `aznamespace_test.go`: table tests for `Filter` and `Literal` (empty/null, `*`, `dev,prod`, `dev*`, `dev`, `\*`->`*`, `foo\,bar`->`foo,bar`, `\\`->`\`, unescaped `*`/`,` -> error).
- Adapter tests: List forwards the filter (incl. empty -> `\x00`); single-item ops apply the decoded label; a filter value (`*`, `a,b`) on a single-item op errors without calling the client; empty preserves null-label behavior.
- `scope_test.go`: `Key()` includes the namespace when set, unchanged when empty.

## Out of scope (separate epic tasks)

- **GUI** — App Config namespace selection is a separate #410 task.
- **README / terminology docs** — #409.
- **Tag write** — #381 Phase 2 (SDK-blocked); `Tag`/`Untag` keep their existing unsupported errors.
- App Config namespace **e2e** is gated on the emulator fork (#258) honoring labels — tracked separately.

## Verification

- `go build ./...` clean.
- `go test ./...` all green.
- `golangci-lint run --allow-parallel-runners --build-tags=e2e,production ./internal/...` -> 0 issues.
- Nothing under `cmd/` touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)