### PR TITLE
feat(azure): App Configuration namespaces + cross-provider metadata terminology (CLI + GUI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,20 @@ Read/write operations (`show`, `log`, `diff`, `list`, `create`, `update`, `delet
 
 ² App Configuration is unversioned, so staging uses **last-write-wins** (no modified-after conflict check) and `tag`/`untag` are unavailable (tags aren't writable).
 
+### Metadata terminology
+
+suve normalizes every provider's key=value metadata to a single term — **tags** (`suve … tag` / `untag`). Each provider's native word is a documented mapping; suve does **not** add per-provider command or flag aliases.
+
+| Cloud | metadata term (native) | suve term | identity axis (native) |
+|---|---|---|---|
+| AWS SSM / Secrets Manager | tags | **tags** | version |
+| Azure Key Vault | tags | **tags** | version |
+| Azure App Configuration | tags | **tags** | **label** (`(key, label)` — a *separate* concept, surfaced as suve's [namespace](#namespaces)) |
+| Google Cloud Secret Manager | **labels** | **tags** | version |
+
+> [!WARNING]
+> Naming trap: Google Cloud "labels" are key=value **metadata** — suve surfaces them as **tags** (`suve gcloud secret tag …`). Azure App Configuration's "label" is an **identity** dimension (part of a setting's address), which suve exposes as its own **namespace** axis (`--namespace`/`--ns`; see [Namespaces](#namespaces)). These are different concepts that happen to share the vendor word "label".
+
 ### Provider selection
 
 Every backend has an **explicit command group that is always available**, regardless of environment:
@@ -730,6 +744,9 @@ The command **groups** themselves also take aliases: `gcloud` → `gcp` / `googl
 
 Uses integer version numbers (with the `latest` alias) and has no staging labels. Select the project with `--project` or the `GOOGLE_CLOUD_PROJECT` environment variable. Authentication uses [Application Default Credentials (ADC)](https://cloud.google.com/docs/authentication/application-default-credentials). See [docs/gcloud.md](docs/gcloud.md) for details.
 
+> [!NOTE]
+> Google Cloud Secret Manager calls key=value metadata **"labels"**; suve surfaces them under its cross-provider term **tags** (`tag` / `untag`). See [Metadata terminology](#metadata-terminology).
+
 | Command | Options | Description |
 |---------|---------|-------------|
 | [`suve gcloud secret show`](docs/gcloud.md#suve-gcloud-secret-show) | `--raw`<br>`--parse-json` (`-j`)<br>`--no-pager`<br>`--output=<FORMAT>` | Display secret with metadata |
@@ -739,8 +756,8 @@ Uses integer version numbers (with the `latest` alias) and has no staging labels
 | [`suve gcloud secret create`](docs/gcloud.md#suve-gcloud-secret-create) | | Create new secret |
 | [`suve gcloud secret update`](docs/gcloud.md#suve-gcloud-secret-update) | `--yes` | Update existing secret |
 | [`suve gcloud secret delete`](docs/gcloud.md#suve-gcloud-secret-delete) | `--yes` | Delete secret |
-| [`suve gcloud secret tag`](docs/gcloud.md#suve-gcloud-secret-tag) | `<KEY>=<VALUE>...` | Add or update labels |
-| [`suve gcloud secret untag`](docs/gcloud.md#suve-gcloud-secret-untag) | `<KEY>...` | Remove labels |
+| [`suve gcloud secret tag`](docs/gcloud.md#suve-gcloud-secret-tag) | `<KEY>=<VALUE>...` | Add or update tags (Google Cloud "labels") |
+| [`suve gcloud secret untag`](docs/gcloud.md#suve-gcloud-secret-untag) | `<KEY>...` | Remove tags (Google Cloud "labels") |
 
 **Staging commands** (under `suve gcloud stage`; Google Cloud is secret-only, so staging operates on secrets directly):
 
@@ -753,8 +770,8 @@ Uses integer version numbers (with the `latest` alias) and has no staging labels
 | `suve gcloud stage diff` | `--parse-json` (`-j`)<br>`--no-pager` | Show staged vs Google Cloud |
 | `suve gcloud stage apply` | `--yes`<br>`--ignore-conflicts` | Apply staged changes |
 | `suve gcloud stage reset` | `--all` | Unstage changes |
-| `suve gcloud stage tag` | `<KEY>=<VALUE>...` | Stage label additions |
-| `suve gcloud stage untag` | `<KEY>...` | Stage label removals |
+| `suve gcloud stage tag` | `<KEY>=<VALUE>...` | Stage tag additions (Google Cloud "labels") |
+| `suve gcloud stage untag` | `<KEY>...` | Stage tag removals (Google Cloud "labels") |
 | `suve gcloud stage stash` | `push`/`pop`/`show`/`drop` | Save/restore staged changes |
 
 ### Azure Key Vault
@@ -794,11 +811,32 @@ Unversioned key-value store. Version specifiers (`#VERSION`, `~SHIFT`, `:LABEL`)
 
 | Command | Options | Description |
 |---------|---------|-------------|
-| [`suve azure param show`](docs/azure.md#suve-azure-param-show) | `--raw`<br>`--parse-json` (`-j`)<br>`--no-pager`<br>`--output=<FORMAT>` | Display value with metadata |
-| [`suve azure param list`](docs/azure.md#suve-azure-param-list) | `--filter=<REGEX>`<br>`--show`<br>`--output=<FORMAT>` | List keys |
-| [`suve azure param create`](docs/azure.md#suve-azure-param-create) | | Create a new key |
-| [`suve azure param update`](docs/azure.md#suve-azure-param-update) | `--yes` | Update an existing key |
-| [`suve azure param delete`](docs/azure.md#suve-azure-param-delete) | `--yes` | Delete a key |
+| [`suve azure param show`](docs/azure.md#suve-azure-param-show) | `--namespace`/`--ns`<br>`--raw`<br>`--parse-json` (`-j`)<br>`--no-pager`<br>`--output=<FORMAT>` | Display value with metadata |
+| [`suve azure param list`](docs/azure.md#suve-azure-param-list) | `--namespace`/`--ns`<br>`--filter=<REGEX>`<br>`--show`<br>`--output=<FORMAT>` | List keys |
+| [`suve azure param create`](docs/azure.md#suve-azure-param-create) | `--namespace`/`--ns` | Create a new key |
+| [`suve azure param update`](docs/azure.md#suve-azure-param-update) | `--namespace`/`--ns`<br>`--yes` | Update an existing key |
+| [`suve azure param delete`](docs/azure.md#suve-azure-param-delete) | `--namespace`/`--ns`<br>`--yes` | Delete a key |
+
+#### Namespaces
+
+App Configuration addresses a setting by `(key, label)`. This **label axis is an identity dimension** — a flat partition of the key space, like a Kubernetes namespace — not key=value metadata. Because "label" almost everywhere else means metadata (which suve unifies as [tags](#metadata-terminology)), **suve calls this axis a namespace**; Azure App Configuration calls it a "label".
+
+Select the namespace with `--namespace` (alias `--ns`) or the `AZURE_APPCONFIG_NAMESPACE` environment variable (precedence: flag > env > default). The default is the **null namespace** (App Configuration's unlabeled/default settings); a `dev` namespace never surfaces `prod` settings in `list`/`show`.
+
+The value is interpreted by context:
+
+| Value | Meaning | Where |
+|---|---|---|
+| unset or `""` | the **null namespace** (default; `""` also overrides an env default back to null) | all commands |
+| `"*"` | **all** namespaces (wildcard) | list/read only |
+| `"dev,prod"` | **dev OR prod** (`,` = OR-list) | list/read only |
+| `"dev*"` | prefix wildcard | list/read only |
+| `"dev"` | the literal namespace `dev` | all commands |
+| `"\*"`, `"foo\,bar"` | a **literal** namespace containing a reserved char (`\` escapes `*`, `,`, `\`) | all commands |
+
+- **List/read** (`list`, `show`) forward the value to App Configuration's label filter, so `*` (all), `dev*` (prefix), and `dev,prod` (OR-list) work natively; an empty value maps to the null-namespace filter.
+- **Single-item ops** (`show`, `create`, `update`, `delete`, staging) need exactly one namespace: `\` escapes are decoded, and any **unescaped** `*` or `,` is a usage error (it names all/multiple namespaces). This is also how you address a namespace literally named `*` / `,` / `\` — e.g. `--namespace "\*"`.
+- The namespace is a **separate flag/env channel**; the positional argument stays the whole key, so colon keys like `Logging:LogLevel:Default` are unaffected. The filter grammar (`*` `,` `\`) lives only inside the `--namespace` value.
 
 **Staging commands** (under `suve azure stage param`; unversioned → last-write-wins, no `tag`/`untag`):
 
@@ -945,6 +983,7 @@ message bodies at all.
 |----------|-------------|
 | `AZURE_KEYVAULT_NAME` | Key Vault name for `azure secret` (or use `--vault-name`) |
 | `AZURE_APPCONFIG_NAME` | App Configuration store for `azure param` (or use `--store-name`) |
+| `AZURE_APPCONFIG_NAMESPACE` | Default [namespace](#namespaces) for `azure param` — Azure calls this axis a "label" (or use `--namespace`/`--ns`) |
 
 Authentication uses the DefaultAzureCredential chain (`az login`, environment, managed identity, ...). The Key Vault / App Configuration name is a globally-unique endpoint, so no subscription or resource group is needed.
 

--- a/e2e/azure_appconfig_test.go
+++ b/e2e/azure_appconfig_test.go
@@ -125,3 +125,80 @@ func TestAzureAppConfig_FullWorkflow(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// TestAzureAppConfig_Namespace exercises the --namespace / --ns axis (#381
+// Phase 1) end-to-end against the emulator. It doubles as the empirical check
+// that the emulator honors App Configuration labels: (key, label) pairs are
+// stored and filtered independently, so the same key under two namespaces holds
+// two distinct values and a namespace-scoped list hides the others.
+func TestAzureAppConfig_Namespace(t *testing.T) {
+	setupAzureAppConfig(t)
+
+	// A key that exists under BOTH the null (default) namespace and "dev", to
+	// prove label isolation on read; plus a key that exists ONLY under "dev", to
+	// prove list isolation.
+	const (
+		shared  = "suve/e2e/azure/ns/shared"
+		devOnly = "suve/e2e/azure/ns/dev-only"
+	)
+
+	// Best-effort cleanup from a previous run (each (key, namespace) is distinct).
+	_, _ = runAzureParam(t, "delete", "--yes", shared)
+	_, _ = runAzureParam(t, "delete", "--yes", "--namespace", "dev", shared)
+	_, _ = runAzureParam(t, "delete", "--yes", "--namespace", "dev", devOnly)
+
+	t.Cleanup(func() {
+		_, _ = runAzureParam(t, "delete", "--yes", shared)
+		_, _ = runAzureParam(t, "delete", "--yes", "--namespace", "dev", shared)
+		_, _ = runAzureParam(t, "delete", "--yes", "--namespace", "dev", devOnly)
+	})
+
+	t.Run("create-under-namespaces", func(t *testing.T) {
+		_, err := runAzureParam(t, "create", shared, "null-value")
+		require.NoError(t, err)
+
+		_, err = runAzureParam(t, "create", "--namespace", "dev", shared, "dev-value")
+		require.NoError(t, err)
+
+		_, err = runAzureParam(t, "create", "--ns", "dev", devOnly, "dev-only-value")
+		require.NoError(t, err)
+	})
+
+	// The same key resolves to a different value per namespace — proof the
+	// emulator keys on (key, label), not key alone.
+	t.Run("show-is-namespace-scoped", func(t *testing.T) {
+		stdout, err := runAzureParam(t, "show", "--raw", shared)
+		require.NoError(t, err)
+		assert.Equal(t, "null-value", stdout)
+
+		stdout, err = runAzureParam(t, "show", "--raw", "--namespace", "dev", shared)
+		require.NoError(t, err)
+		assert.Equal(t, "dev-value", stdout)
+	})
+
+	// list is scoped: the null list hides dev-only keys; the dev list shows
+	// them; --namespace "*" spans all namespaces.
+	t.Run("list-is-namespace-scoped", func(t *testing.T) {
+		nullList, err := runAzureParam(t, "list")
+		require.NoError(t, err)
+		assert.Contains(t, nullList, shared)
+		assert.NotContains(t, nullList, devOnly)
+
+		devList, err := runAzureParam(t, "list", "--namespace", "dev")
+		require.NoError(t, err)
+		assert.Contains(t, devList, devOnly)
+
+		allList, err := runAzureParam(t, "list", "--namespace", "*")
+		require.NoError(t, err)
+		assert.Contains(t, allList, devOnly)
+	})
+
+	// A filter value (all/multiple) is rejected on a single-item op.
+	t.Run("wildcard-rejected-on-single-item", func(t *testing.T) {
+		_, err := runAzureParam(t, "show", "--raw", "--namespace", "*", shared)
+		require.Error(t, err)
+
+		_, err = runAzureParam(t, "show", "--raw", "--namespace", "dev,prod", shared)
+		require.Error(t, err)
+	})
+}

--- a/internal/cli/commands/azure/param/command.go
+++ b/internal/cli/commands/azure/param/command.go
@@ -41,12 +41,24 @@ variable.`,
 				Usage:   "Azure App Configuration store name (defaults to $AZURE_APPCONFIG_NAME)",
 				Sources: cli.EnvVars("AZURE_APPCONFIG_NAME"),
 			},
+			&cli.StringFlag{
+				Name:    "namespace",
+				Aliases: []string{"ns"},
+				Usage: "App Configuration namespace to target (the label axis; Azure calls it a " +
+					`"label"). List/read accept a filter ("*"=all, "dev,prod"=OR, "dev*"=prefix); ` +
+					"single-item ops need one namespace. Empty = the default namespace " +
+					"(defaults to $AZURE_APPCONFIG_NAMESPACE)",
+				Sources: cli.EnvVars("AZURE_APPCONFIG_NAMESPACE"),
+			},
 		},
-		// Before stashes the resolved store name in the context. Resolution is
-		// deferred to store construction, so `suve azure param --help` works
-		// without a store.
+		// Before stashes the resolved store name and namespace in the context.
+		// Resolution is deferred to store construction, so `suve azure param
+		// --help` works without a store.
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-			return cliinternal.WithAzureStoreName(ctx, cmd.String("store-name")), nil
+			ctx = cliinternal.WithAzureStoreName(ctx, cmd.String("store-name"))
+			ctx = cliinternal.WithAzureAppConfigNamespace(ctx, cmd.String("namespace"))
+
+			return ctx, nil
 		},
 		Commands: []*cli.Command{
 			ShowCommand(),

--- a/internal/cli/commands/azure/stage.go
+++ b/internal/cli/commands/azure/stage.go
@@ -104,9 +104,20 @@ func appConfigStageGroup() *cli.Command {
 				Usage:   "Azure App Configuration store name (defaults to $AZURE_APPCONFIG_NAME)",
 				Sources: cli.EnvVars("AZURE_APPCONFIG_NAME"),
 			},
+			&cli.StringFlag{
+				Name:    "namespace",
+				Aliases: []string{"ns"},
+				Usage: "App Configuration namespace to stage under (the label axis; Azure calls " +
+					`it a "label"). Staging is per-(store, namespace); a staged op needs one ` +
+					"namespace. Empty = the default namespace (defaults to $AZURE_APPCONFIG_NAMESPACE)",
+				Sources: cli.EnvVars("AZURE_APPCONFIG_NAMESPACE"),
+			},
 		},
 		Before: func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-			return cliinternal.WithAzureStoreName(ctx, cmd.String("store-name")), nil
+			ctx = cliinternal.WithAzureStoreName(ctx, cmd.String("store-name"))
+			ctx = cliinternal.WithAzureAppConfigNamespace(ctx, cmd.String("namespace"))
+
+			return ctx, nil
 		},
 		Commands:        appConfigStageSubcommands(appConfigStageConfig()),
 		CommandNotFound: cliinternal.CommandNotFound,

--- a/internal/cli/commands/gcloud/tag.go
+++ b/internal/cli/commands/gcloud/tag.go
@@ -18,16 +18,19 @@ func newTagger(ctx context.Context) (provider.Tagger, error) {
 // TagCommand returns the Google Cloud Secret Manager tag command.
 func TagCommand() *cli.Command {
 	return generictag.TagCommand(generictag.Config{
-		Usage:     "Add or update labels on a secret",
+		Usage:     `Add or update tags on a secret (Google Cloud calls these "labels")`,
 		ArgsUsage: "<name> <key=value>...",
-		Description: `Add or update one or more labels on an existing secret.
+		Description: `Add or update one or more tags on an existing secret.
 
-Labels are key=value pairs. If a label key already exists, its value is updated.
-You can specify multiple labels in a single command.
+Tags are key=value pairs. If a tag key already exists, its value is updated.
+You can specify multiple tags in a single command.
+
+NOTE: Google Cloud Secret Manager natively calls these "labels". suve uses its
+cross-provider term "tags" for this key=value metadata everywhere.
 
 EXAMPLES:
-   suve gcloud secret tag my-api-key env=prod                 Add single label
-   suve gcloud secret tag my-api-key env=prod team=backend    Add multiple labels`,
+   suve gcloud secret tag my-api-key env=prod                 Add single tag
+   suve gcloud secret tag my-api-key env=prod team=backend    Add multiple tags`,
 		Noun:       nounSecret,
 		UsageError: "usage: suve gcloud secret tag <name> <key=value> [key=value]",
 		NewTagger:  newTagger,
@@ -37,15 +40,18 @@ EXAMPLES:
 // UntagCommand returns the Google Cloud Secret Manager untag command.
 func UntagCommand() *cli.Command {
 	return generictag.UntagCommand(generictag.Config{
-		Usage:     "Remove labels from a secret",
+		Usage:     `Remove tags from a secret (Google Cloud calls these "labels")`,
 		ArgsUsage: "<name> <key>...",
-		Description: `Remove one or more labels from an existing secret.
+		Description: `Remove one or more tags from an existing secret.
 
-Specify the label keys to remove. Non-existent keys are silently ignored.
+Specify the tag keys to remove. Non-existent keys are silently ignored.
+
+NOTE: Google Cloud Secret Manager natively calls these "labels". suve uses its
+cross-provider term "tags" for this key=value metadata everywhere.
 
 EXAMPLES:
-   suve gcloud secret untag my-api-key deprecated             Remove single label
-   suve gcloud secret untag my-api-key env team               Remove multiple labels`,
+   suve gcloud secret untag my-api-key deprecated             Remove single tag
+   suve gcloud secret untag my-api-key env team               Remove multiple tags`,
 		Noun:       nounSecret,
 		UsageError: "usage: suve gcloud secret untag <name> <key> [key]",
 		NewTagger:  newTagger,

--- a/internal/cli/commands/internal/client.go
+++ b/internal/cli/commands/internal/client.go
@@ -52,8 +52,9 @@ type azureScopeContextKey struct{}
 // azure command group. Each subgroup (secret/param) sets its vault/store name
 // via its Before hook.
 type azureScopeCtx struct {
-	vaultName string
-	storeName string
+	vaultName          string
+	storeName          string
+	appConfigNamespace string
 }
 
 func azureScopeFromContext(ctx context.Context) azureScopeCtx {
@@ -81,6 +82,24 @@ func WithAzureStoreName(ctx context.Context, storeName string) context.Context {
 	sc.storeName = storeName
 
 	return context.WithValue(ctx, azureScopeContextKey{}, sc)
+}
+
+// WithAzureAppConfigNamespace returns a context carrying the resolved Azure App
+// Configuration namespace (the axis Azure calls a "label"), merged onto any base
+// scope already present. The azure param subgroup's Before hook sets it (from
+// --namespace/--ns or the AZURE_APPCONFIG_NAMESPACE env). Empty is the null
+// (default) namespace and also overrides an env default back to null.
+func WithAzureAppConfigNamespace(ctx context.Context, namespace string) context.Context {
+	sc := azureScopeFromContext(ctx)
+	sc.appConfigNamespace = namespace
+
+	return context.WithValue(ctx, azureScopeContextKey{}, sc)
+}
+
+// AzureAppConfigNamespace returns the Azure App Configuration namespace resolved
+// into ctx by WithAzureAppConfigNamespace (empty = the null/default namespace).
+func AzureAppConfigNamespace(ctx context.Context) string {
+	return azureScopeFromContext(ctx).appConfigNamespace
 }
 
 // storeScope is the provider selector for read/write commands. Only the
@@ -147,6 +166,7 @@ func AzureAppConfigStore(ctx context.Context) (provider.Store, error) {
 	}
 
 	scope := provider.AzureAppConfigScope(sc.storeName)
+	scope.AppConfigNamespace = sc.appConfigNamespace
 
 	return registry.Store(ctx, scope, provider.KindParam)
 }
@@ -265,8 +285,16 @@ func AzureAppConfigStagingScopeResolver(ctx context.Context) (staging.ResolvedSc
 		)
 	}
 
+	scope := provider.AzureAppConfigScope(sc.storeName)
+	scope.AppConfigNamespace = sc.appConfigNamespace
+
+	target := "store " + sc.storeName
+	if sc.appConfigNamespace != "" {
+		target += " (namespace " + sc.appConfigNamespace + ")"
+	}
+
 	return staging.ResolvedScope{
-		Scope:  provider.AzureAppConfigScope(sc.storeName),
-		Target: "store " + sc.storeName,
+		Scope:  scope,
+		Target: target,
 	}, nil
 }

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -108,8 +108,9 @@ func NewApp(initial provider.Scope) *App {
 
 // hydrateScope fills empty resource fields on an initial launch scope from the
 // environment. Flag-supplied values take precedence; unset ones fall back to
-// GOOGLE_CLOUD_PROJECT / AZURE_KEYVAULT_NAME / AZURE_APPCONFIG_NAME. AWS carries
-// no resource field (region comes from the ambient AWS config).
+// GOOGLE_CLOUD_PROJECT / AZURE_KEYVAULT_NAME / AZURE_APPCONFIG_NAME /
+// AZURE_APPCONFIG_NAMESPACE. AWS carries no resource field (region comes from
+// the ambient AWS config).
 func hydrateScope(s provider.Scope) provider.Scope {
 	switch s.Provider {
 	case provider.ProviderGoogleCloud:
@@ -123,6 +124,10 @@ func hydrateScope(s provider.Scope) provider.Scope {
 
 		if s.StoreName == "" {
 			s.StoreName = os.Getenv("AZURE_APPCONFIG_NAME")
+		}
+
+		if s.AppConfigNamespace == "" {
+			s.AppConfigNamespace = os.Getenv("AZURE_APPCONFIG_NAMESPACE")
 		}
 	case provider.ProviderAWS:
 		// region comes from the ambient AWS config; nothing to hydrate.
@@ -149,17 +154,22 @@ func (a *App) Startup(ctx context.Context) {
 //   - aws: (none; the ambient AWS config supplies the region)
 //   - googlecloud: ProjectID
 //   - azure: VaultName (Key Vault secret) and/or StoreName (App Configuration
-//     param)
+//     param); Namespace is the optional App Configuration namespace (Azure
+//     calls it a "label"), applied only to the App Configuration store — empty
+//     means the default (null) namespace.
 type ScopeSelection struct {
 	Provider  string `json:"provider"`
 	ProjectID string `json:"projectId"`
 	VaultName string `json:"vaultName"`
 	StoreName string `json:"storeName"`
+	Namespace string `json:"namespace"`
 }
 
 // SelectScope sets the current read/write provider scope. It performs no
 // network calls; store construction (and any credential resolution) is deferred
-// to the next param/secret operation.
+// to the next param/secret operation. For Azure the App Configuration namespace
+// (sel.Namespace) is carried on the scope; it is only meaningful for the App
+// Configuration store and harmless for every other provider/store.
 func (a *App) SelectScope(sel ScopeSelection) error {
 	scope, err := scopeFromSelection(sel)
 	if err != nil {
@@ -193,9 +203,10 @@ func scopeFromSelection(sel ScopeSelection) (provider.Scope, error) {
 		}
 
 		return provider.Scope{
-			Provider:  provider.ProviderAzure,
-			VaultName: sel.VaultName,
-			StoreName: sel.StoreName,
+			Provider:           provider.ProviderAzure,
+			VaultName:          sel.VaultName,
+			StoreName:          sel.StoreName,
+			AppConfigNamespace: sel.Namespace,
 		}, nil
 	default:
 		return provider.Scope{}, fmt.Errorf("%w: %q", errInvalidProvider, sel.Provider)
@@ -227,6 +238,7 @@ func selectionFromScope(s provider.Scope) *ScopeSelection {
 		ProjectID: s.ProjectID,
 		VaultName: s.VaultName,
 		StoreName: s.StoreName,
+		Namespace: s.AppConfigNamespace,
 	}
 }
 

--- a/internal/gui/frontend/src/App.svelte
+++ b/internal/gui/frontend/src/App.svelte
@@ -65,7 +65,7 @@
   // scope can land in the new one.
   const scopeKey = $derived(
     scope
-      ? [provider, scope.projectId, scope.vaultName, scope.storeName].join('|')
+      ? [provider, scope.projectId, scope.vaultName, scope.storeName, scope.namespace].join('|')
       : provider,
   );
 
@@ -125,6 +125,7 @@
       projectId: p === 'googlecloud' ? (src?.projectId ?? '') : '',
       vaultName: p === 'azure' ? (src?.vaultName ?? '') : '',
       storeName: p === 'azure' ? (src?.storeName ?? '') : '',
+      namespace: p === 'azure' ? (src?.namespace ?? '') : '',
     } as gui.ScopeSelection;
   }
 
@@ -334,12 +335,14 @@
         {#if effectiveView === 'param' && paramCap}
           <ParamView
             capability={paramCap}
+            {provider}
             onnavigatetostaging={() => handleNavigate('staging')}
             onstagingchange={handleStagingChange}
           />
         {:else if effectiveView === 'secret' && secretCap}
           <SecretView
             capability={secretCap}
+            {provider}
             onnavigatetostaging={() => handleNavigate('staging')}
             onstagingchange={handleStagingChange}
           />

--- a/internal/gui/frontend/src/lib/ParamView.svelte
+++ b/internal/gui/frontend/src/lib/ParamView.svelte
@@ -15,11 +15,12 @@
 
   interface Props {
     capability?: gui.ServiceCapability;
+    provider?: string;
     onnavigatetostaging?: () => void;
     onstagingchange?: () => void;
   }
 
-  let { capability, onnavigatetostaging, onstagingchange }: Props = $props();
+  let { capability, provider = '', onnavigatetostaging, onstagingchange }: Props = $props();
 
   // Capability-driven visibility. Absent capability defaults to AWS-like (true)
   // so the component degrades safely if mounted without one.
@@ -532,7 +533,7 @@
             {/if}
 
             {#if tagsEnabled}
-              <TagList tags={paramDetail.tags} serviceClass="param" onadd={openTagModal} onremove={openRemoveTagModal} />
+              <TagList tags={paramDetail.tags} serviceClass="param" {provider} onadd={openTagModal} onremove={openRemoveTagModal} />
             {/if}
 
             {#if historyEnabled && paramLog.length > 0}

--- a/internal/gui/frontend/src/lib/SecretView.svelte
+++ b/internal/gui/frontend/src/lib/SecretView.svelte
@@ -15,11 +15,12 @@
 
   interface Props {
     capability?: gui.ServiceCapability;
+    provider?: string;
     onnavigatetostaging?: () => void;
     onstagingchange?: () => void;
   }
 
-  let { capability, onnavigatetostaging, onstagingchange }: Props = $props();
+  let { capability, provider = '', onnavigatetostaging, onstagingchange }: Props = $props();
 
   // Capability-driven visibility. Absent capability defaults to AWS-like (true).
   const stagingEnabled = $derived(capability?.hasStaging ?? true);
@@ -576,7 +577,7 @@
             {/if}
 
             {#if tagsEnabled}
-              <TagList tags={secretDetail.tags} serviceClass="secret" onadd={openTagModal} onremove={openRemoveTagModal} />
+              <TagList tags={secretDetail.tags} serviceClass="secret" {provider} onadd={openTagModal} onremove={openRemoveTagModal} />
             {/if}
 
             {#if historyEnabled && secretLog.length > 0}

--- a/internal/gui/frontend/src/lib/Sidebar.svelte
+++ b/internal/gui/frontend/src/lib/Sidebar.svelte
@@ -54,6 +54,7 @@
   let projectInput = $state('');
   let vaultInput = $state('');
   let storeInput = $state('');
+  let namespaceInput = $state('');
   let formError = $state('');
   let firstFieldEl: HTMLInputElement | undefined = $state();
 
@@ -63,6 +64,7 @@
     projectInput = pendingProvider === 'googlecloud' ? (s?.projectId ?? '') : '';
     vaultInput = pendingProvider === 'azure' ? (s?.vaultName ?? '') : '';
     storeInput = pendingProvider === 'azure' ? (s?.storeName ?? '') : '';
+    namespaceInput = pendingProvider === 'azure' ? (s?.namespace ?? '') : '';
     formError = '';
   });
 
@@ -112,6 +114,7 @@
       projectId: projectInput.trim(),
       vaultName: '',
       storeName: '',
+      namespace: '',
     } as gui.ScopeSelection);
   }
 
@@ -122,6 +125,7 @@
       projectId: '',
       vaultName: vaultInput.trim(),
       storeName: storeInput.trim(),
+      namespace: namespaceInput.trim(),
     } as gui.ScopeSelection);
   }
 </script>
@@ -177,6 +181,15 @@
       />
       <label class="scope-label" for="azure-store">App Configuration store</label>
       <input id="azure-store" class="scope-input" type="text" placeholder="my-store (params)" bind:value={storeInput} />
+      <label class="scope-label" for="azure-namespace">Namespace</label>
+      <input
+        id="azure-namespace"
+        class="scope-input"
+        type="text"
+        placeholder="empty = default"
+        bind:value={namespaceInput}
+      />
+      <p class="scope-hint">Azure calls this a label; empty = default. Applies to the App Configuration store only.</p>
       {#if formError || scopeError}
         <div class="scope-error">{formError || scopeError}</div>
       {/if}
@@ -255,6 +268,12 @@
         <span class="aws-info-label">App Config</span>
         <span class="aws-info-value" title={scope?.storeName || '?'}>{scope?.storeName || '?'}</span>
       </div>
+      {#if scope?.storeName}
+        <div class="aws-info-row">
+          <span class="aws-info-label">Namespace</span>
+          <span class="aws-info-value" title={scope?.namespace || 'default'}>{scope?.namespace || 'default'}</span>
+        </div>
+      {/if}
       <button type="button" class="scope-change" disabled={!!pendingProvider} onclick={() => onchangescope?.()}>Change scope</button>
     </div>
   {/if}
@@ -358,6 +377,13 @@
   .scope-error {
     font-size: 11px;
     color: #e94560;
+    line-height: 1.4;
+  }
+
+  .scope-hint {
+    margin: 0;
+    font-size: 10px;
+    color: #666;
     line-height: 1.4;
   }
 

--- a/internal/gui/frontend/src/lib/TagList.svelte
+++ b/internal/gui/frontend/src/lib/TagList.svelte
@@ -4,16 +4,27 @@
   interface Props {
     tags: Array<{ key: string; value: string }> | undefined;
     serviceClass: 'param' | 'secret';
+    provider?: string;
     onadd: () => void;
     onremove: (key: string) => void;
   }
 
-  let { tags, serviceClass, onadd, onremove }: Props = $props();
+  let { tags, serviceClass, provider = '', onadd, onremove }: Props = $props();
+
+  // suve uses one metadata vocabulary ("Tags") across every provider. Google
+  // Cloud natively calls this same key=value metadata "labels", so surface a
+  // secondary, non-primary hint for GCloud users without renaming the field.
+  const nativeHint = $derived(provider === 'googlecloud' ? 'Google Cloud: labels' : '');
 </script>
 
 <div class="detail-section">
   <div class="section-header">
-    <h4>Tags</h4>
+    <div class="section-heading">
+      <h4>Tags</h4>
+      {#if nativeHint}
+        <span class="tag-native-hint" title={nativeHint}>{nativeHint}</span>
+      {/if}
+    </div>
     <button class="btn-action-sm" onclick={onadd}>+ Add</button>
   </div>
   {#if tags && tags.length > 0}
@@ -31,3 +42,19 @@
     <p class="no-tags">No tags</p>
   {/if}
 </div>
+
+<style>
+  .section-heading {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .tag-native-hint {
+    font-size: 10px;
+    color: #888;
+    font-weight: normal;
+    white-space: nowrap;
+  }
+</style>

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -79,6 +79,7 @@ export interface ScopeSelection {
   projectId: string;
   vaultName: string;
   storeName: string;
+  namespace: string;
 }
 
 // DetectResult mirrors the Go binding DTO (internal/gui/providers.go).
@@ -209,6 +210,7 @@ export const awsScopeSelection: ScopeSelection = {
   projectId: '',
   vaultName: '',
   storeName: '',
+  namespace: '',
 };
 
 /**
@@ -588,7 +590,7 @@ export function createNoAWSIdentityState(): Partial<MockState> {
 // ---- Provider-selection states (multi-cloud) ------------------------------
 
 function emptyScope(provider: string): ScopeSelection {
-  return { provider, projectId: '', vaultName: '', storeName: '' };
+  return { provider, projectId: '', vaultName: '', storeName: '', namespace: '' };
 }
 
 /**
@@ -784,6 +786,7 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
           projectId: p === 'googlecloud' ? (sel.projectId || '') : '',
           vaultName: p === 'azure' ? (sel.vaultName || '') : '',
           storeName: p === 'azure' ? (sel.storeName || '') : '',
+          namespace: p === 'azure' ? (sel.namespace || '') : '',
         };
       },
 

--- a/internal/gui/frontend/tests/scope-form.spec.ts
+++ b/internal/gui/frontend/tests/scope-form.spec.ts
@@ -78,6 +78,81 @@ test.describe('Azure scope form', () => {
     });
   });
 
+  test('namespace field feeds the SelectScope payload (trimmed) alongside the store', async ({ page }) => {
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForItemList(page);
+
+    await pickProvider(page, 'azure');
+    await page.locator('#azure-store').fill('the-store');
+    await page.locator('#azure-namespace').fill('  dev  '); // whitespace trimmed
+    await page.getByRole('button', { name: 'Connect' }).click();
+    await waitForItemList(page);
+
+    const calls = await getSelectScopeCalls(page);
+    expect(calls[calls.length - 1]).toMatchObject({
+      provider: 'azure',
+      storeName: 'the-store',
+      namespace: 'dev', // trimmed
+    });
+  });
+
+  test('an empty namespace submits as an empty string (App Config default label)', async ({ page }) => {
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForItemList(page);
+
+    await pickProvider(page, 'azure');
+    await page.locator('#azure-store').fill('the-store');
+    await page.locator('#azure-namespace').fill(''); // left empty
+    await page.getByRole('button', { name: 'Connect' }).click();
+    await waitForItemList(page);
+
+    const calls = await getSelectScopeCalls(page);
+    expect(calls[calls.length - 1]).toMatchObject({
+      provider: 'azure',
+      storeName: 'the-store',
+      namespace: '',
+    });
+  });
+
+  test('Change scope prefills the namespace from the current scope', async ({ page }) => {
+    // Azure launched with vault + store + a namespace already applied.
+    await setupWailsMocks(
+      page,
+      createAzureState({
+        currentScope: { provider: 'azure', projectId: '', vaultName: 'my-vault', storeName: 'my-store', namespace: 'dev' },
+      }),
+    );
+    await page.goto('/');
+    await waitForItemList(page);
+    await expect(page.locator('#azure-namespace')).toHaveCount(0); // connected: no form
+
+    // "Change scope" re-opens the form, prefilled with the current namespace.
+    await page.getByRole('button', { name: 'Change scope' }).click();
+    await expect(page.locator('#azure-vault')).toHaveValue('my-vault');
+    await expect(page.locator('#azure-store')).toHaveValue('my-store');
+    await expect(page.locator('#azure-namespace')).toHaveValue('dev');
+  });
+
+  test('namespace field is Azure-only (absent for Google Cloud and AWS)', async ({ page }) => {
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForItemList(page);
+
+    // Azure exposes the namespace field...
+    await pickProvider(page, 'azure');
+    await expect(page.locator('#azure-namespace')).toBeVisible();
+
+    // ...Google Cloud (project-only form) does not.
+    await pickProvider(page, 'googlecloud');
+    await expect(page.locator('#azure-namespace')).toHaveCount(0);
+
+    // ...AWS (no scope form) does not.
+    await pickProvider(page, 'aws');
+    await expect(page.locator('#azure-namespace')).toHaveCount(0);
+  });
+
   test('submitting an empty scope form disconnects and clears the cached scope', async ({ page }) => {
     // Connected to Azure (vault + store), so the scope is cached.
     await setupWailsMocks(page, createAzureState());

--- a/internal/gui/frontend/tests/tags-terminology.spec.ts
+++ b/internal/gui/frontend/tests/tags-terminology.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupWailsMocks,
+  createGoogleCloudState,
+  waitForItemList,
+  clickItemByName,
+} from './fixtures/wails-mock';
+
+// The Tags field keeps one vocabulary across every provider. Google Cloud
+// natively calls the same key=value metadata "labels", so TagList surfaces a
+// secondary hint ("Google Cloud: labels") for Google Cloud only — the field is
+// still titled "Tags" everywhere.
+test.describe('Tags terminology hint', () => {
+  test('Google Cloud: a tagged secret shows the "Google Cloud: labels" hint', async ({ page }) => {
+    await setupWailsMocks(
+      page,
+      createGoogleCloudState({
+        secretTags: { 'gcloud-secret-1': [{ key: 'team', value: 'backend' }] },
+      }),
+    );
+    await page.goto('/');
+    await waitForItemList(page);
+
+    // Google Cloud launches into the secret view.
+    await clickItemByName(page, 'gcloud-secret-1');
+    await expect(page.locator('.detail-panel')).toBeVisible();
+
+    // The field still reads "Tags", with the native-vocabulary hint beside it.
+    await expect(page.getByRole('heading', { name: 'Tags' })).toBeVisible();
+    const hint = page.locator('.tag-native-hint');
+    await expect(hint).toBeVisible();
+    await expect(hint).toHaveText('Google Cloud: labels');
+    await expect(page.locator('.tag-item')).toBeVisible();
+  });
+
+  test('AWS: a tagged parameter shows no native hint (field still titled "Tags")', async ({ page }) => {
+    // Default state is AWS; /app/config carries an existing tag.
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForItemList(page);
+
+    await clickItemByName(page, '/app/config');
+    await expect(page.locator('.detail-panel')).toBeVisible();
+
+    await expect(page.getByRole('heading', { name: 'Tags' })).toBeVisible();
+    await expect(page.locator('.tag-item')).toBeVisible();
+    // No native-vocabulary hint outside Google Cloud.
+    await expect(page.locator('.tag-native-hint')).toHaveCount(0);
+  });
+});

--- a/internal/gui/frontend/wailsjs/go/models.ts
+++ b/internal/gui/frontend/wailsjs/go/models.ts
@@ -316,17 +316,19 @@ export namespace gui {
 	    projectId: string;
 	    vaultName: string;
 	    storeName: string;
-	
+	    namespace: string;
+
 	    static createFrom(source: any = {}) {
 	        return new ScopeSelection(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.provider = source["provider"];
 	        this.projectId = source["projectId"];
 	        this.vaultName = source["vaultName"];
 	        this.storeName = source["storeName"];
+	        this.namespace = source["namespace"];
 	    }
 	}
 	export class SecretCreateResult {

--- a/internal/gui/scope_internal_test.go
+++ b/internal/gui/scope_internal_test.go
@@ -57,6 +57,13 @@ func TestApp_SelectScope(t *testing.T) {
 			},
 		},
 		{
+			name: "azure with store and app config namespace",
+			sel:  ScopeSelection{Provider: "azure", StoreName: "store", Namespace: "dev"},
+			wantScope: provider.Scope{
+				Provider: provider.ProviderAzure, StoreName: "store", AppConfigNamespace: "dev",
+			},
+		},
+		{
 			name:    "azure missing both vault and store",
 			sel:     ScopeSelection{Provider: "azure"},
 			wantErr: errAzureScopeRequired,
@@ -114,6 +121,11 @@ func TestApp_GetCurrentScope_RoundTrip(t *testing.T) {
 			name: "azure app config only",
 			sel:  ScopeSelection{Provider: "azure", StoreName: "store"},
 		},
+		{
+			// The App Configuration namespace round-trips through the scope.
+			name: "azure app config with namespace",
+			sel:  ScopeSelection{Provider: "azure", StoreName: "store", Namespace: "dev"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -149,6 +161,7 @@ func TestApp_GetCurrentScope_EnvDerivedInitialScope(t *testing.T) {
 func TestApp_GetCurrentScope_EnvDerivedAzure(t *testing.T) {
 	t.Setenv("AZURE_KEYVAULT_NAME", "env-vault")
 	t.Setenv("AZURE_APPCONFIG_NAME", "env-store")
+	t.Setenv("AZURE_APPCONFIG_NAMESPACE", "env-ns")
 
 	app := NewApp(provider.Scope{Provider: provider.ProviderAzure})
 
@@ -157,6 +170,36 @@ func TestApp_GetCurrentScope_EnvDerivedAzure(t *testing.T) {
 	assert.Equal(t, string(provider.ProviderAzure), got.Provider)
 	assert.Equal(t, "env-vault", got.VaultName)
 	assert.Equal(t, "env-store", got.StoreName)
+	assert.Equal(t, "env-ns", got.Namespace)
+}
+
+// TestApp_GetCurrentScope_EnvDerivedAzure_Namespace covers the App
+// Configuration namespace hydrating from AZURE_APPCONFIG_NAMESPACE while the
+// store name comes from its own env, mirroring the CLI's env channel.
+func TestApp_GetCurrentScope_EnvDerivedAzure_Namespace(t *testing.T) {
+	t.Setenv("AZURE_KEYVAULT_NAME", "")
+	t.Setenv("AZURE_APPCONFIG_NAME", "env-store")
+	t.Setenv("AZURE_APPCONFIG_NAMESPACE", "dev")
+
+	app := NewApp(provider.Scope{Provider: provider.ProviderAzure})
+
+	got := app.GetCurrentScope()
+	require.NotNil(t, got)
+	assert.Equal(t, "env-store", got.StoreName)
+	assert.Equal(t, "dev", got.Namespace)
+}
+
+// TestApp_GetCurrentScope_ExplicitNamespaceWinsOverEnv verifies a flag-supplied
+// namespace on the launch scope is not overwritten by the env fallback.
+func TestApp_GetCurrentScope_ExplicitNamespaceWinsOverEnv(t *testing.T) {
+	t.Setenv("AZURE_APPCONFIG_NAME", "env-store")
+	t.Setenv("AZURE_APPCONFIG_NAMESPACE", "env-ns")
+
+	app := NewApp(provider.Scope{Provider: provider.ProviderAzure, AppConfigNamespace: "flag-ns"})
+
+	got := app.GetCurrentScope()
+	require.NotNil(t, got)
+	assert.Equal(t, "flag-ns", got.Namespace)
 }
 
 // TestApp_GetCurrentScope_EnvDerivedAzure_VaultOnly covers a one-sided Azure

--- a/internal/provider/azure/appconfig/appconfig.go
+++ b/internal/provider/azure/appconfig/appconfig.go
@@ -14,8 +14,10 @@
 //
 // Two further constraints shape the adapter:
 //
-//   - It addresses the default (no) App Configuration label only; the default
-//     label is never exposed as a version.
+//   - The App Configuration label axis is exposed as suve's "namespace" (see
+//     the aznamespace subpackage): List forwards the raw value as a LabelFilter;
+//     single-key ops decode it to one literal label; empty is the null/default
+//     namespace. A label is never exposed as a version.
 //   - The azappconfig high-level SDK cannot round-trip setting tags: its
 //     SetSetting/AddSetting drop tags (and a write would clear existing ones).
 //     Tag/Untag therefore return ErrTagsUnsupported rather than silently losing
@@ -36,6 +38,7 @@ import (
 	"github.com/mpyw/suve/internal/debug"
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/azure/appconfig/aznamespace"
 	"github.com/mpyw/suve/internal/version/azureappconfigversion"
 )
 
@@ -46,31 +49,38 @@ var ErrTagsUnsupported = errors.New(
 	"tag mutation is not supported by Azure App Configuration (the azappconfig SDK cannot write setting tags)",
 )
 
-// Client is the narrow App Configuration surface this adapter needs. Every
-// method uses the default (no) label. The list method returns a drained slice
-// rather than the SDK's pager so tests can mock the interface trivially; the
-// production adapter (see Wrap) confines the pager draining and the concrete
+// Client is the narrow App Configuration surface this adapter needs. Single-key
+// methods take a resolved literal label ("" = the null/default label); the list
+// method takes a LabelFilter. The list method returns a drained slice rather
+// than the SDK's pager so tests can mock the interface trivially; the production
+// adapter (see Wrap) confines the pager draining and the concrete
 // *azappconfig.Client to this package.
 type Client interface {
-	GetSetting(ctx context.Context, key string) (azappconfig.GetSettingResponse, error)
-	SetSetting(ctx context.Context, key, value string) (azappconfig.SetSettingResponse, error)
-	AddSetting(ctx context.Context, key, value string) (azappconfig.AddSettingResponse, error)
-	DeleteSetting(ctx context.Context, key string) (azappconfig.DeleteSettingResponse, error)
-	ListSettings(ctx context.Context) ([]azappconfig.Setting, error)
+	GetSetting(ctx context.Context, key, label string) (azappconfig.GetSettingResponse, error)
+	SetSetting(ctx context.Context, key, value, label string) (azappconfig.SetSettingResponse, error)
+	AddSetting(ctx context.Context, key, value, label string) (azappconfig.AddSettingResponse, error)
+	DeleteSetting(ctx context.Context, key, label string) (azappconfig.DeleteSettingResponse, error)
+	ListSettings(ctx context.Context, filter string) ([]azappconfig.Setting, error)
 }
 
 // Store is the App Configuration implementation of provider.Store. It implements
 // neither Restorer nor Describer.
 type Store struct {
 	client Client
+	// namespace is the raw --namespace value selected for this store (the axis
+	// Azure calls a "label"). It is interpreted per operation: a LabelFilter for
+	// List, a decoded single literal label for single-key ops. Empty is the
+	// null (default) namespace.
+	namespace string
 }
 
 // Compile-time assertion that Store implements the provider contract.
 var _ provider.Store = (*Store)(nil)
 
-// New builds a Store backed by the given client.
-func New(client Client) *Store {
-	return &Store{client: client}
+// New builds a Store backed by the given client, scoped to the given raw
+// namespace value (empty = the null/default namespace).
+func New(client Client, namespace string) *Store {
+	return &Store{client: client, namespace: namespace}
 }
 
 // Resolve validates that the spec carries no version specifier (App
@@ -84,6 +94,12 @@ func (s *Store) Resolve(_ context.Context, _, spec string) (provider.VersionRef,
 		return provider.VersionRef{}, fmt.Errorf("%w", azureappconfigversion.ErrVersioningUnsupported)
 	}
 
+	// Resolve precedes every single-item read; reject a namespace value that
+	// names all/multiple namespaces here so the usage error surfaces early.
+	if _, err := aznamespace.Literal(s.namespace); err != nil {
+		return provider.VersionRef{}, err
+	}
+
 	return provider.NewVersionRef(""), nil
 }
 
@@ -91,7 +107,12 @@ func (s *Store) Resolve(_ context.Context, _, spec string) (provider.VersionRef,
 // is always plaintext; Version is left empty (App Configuration has no
 // versions); the setting's tags become Tags.
 func (s *Store) Get(ctx context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
-	resp, err := s.client.GetSetting(ctx, name)
+	label, err := aznamespace.Literal(s.namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.GetSetting(ctx, name, label)
 	if err != nil {
 		return nil, mapError(err, name, "get setting")
 	}
@@ -112,9 +133,12 @@ func (s *Store) History(_ context.Context, _ string) ([]domain.Version, error) {
 	return nil, fmt.Errorf("%w (no version history)", azureappconfigversion.ErrVersioningUnsupported)
 }
 
-// List returns the distinct key names in the store (across all labels), sorted.
+// List returns the distinct key names visible under the selected namespace
+// filter, sorted. The raw --namespace value is forwarded as an App
+// Configuration LabelFilter (empty -> the null-label filter); its `*`/`,`/`\`
+// grammar is honored natively by the service.
 func (s *Store) List(ctx context.Context) ([]string, error) {
-	settings, err := s.client.ListSettings(ctx)
+	settings, err := s.client.ListSettings(ctx, aznamespace.Filter(s.namespace))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list settings: %w", err)
 	}
@@ -150,7 +174,12 @@ func (s *Store) List(ctx context.Context) ([]string, error) {
 func (s *Store) Create(
 	ctx context.Context, name, value string, _ domain.ValueType, _ string, _ ...provider.WriteOption,
 ) (domain.Version, error) {
-	_, err := s.client.AddSetting(ctx, name, value)
+	label, err := aznamespace.Literal(s.namespace)
+	if err != nil {
+		return domain.Version{}, err
+	}
+
+	_, err = s.client.AddSetting(ctx, name, value, label)
 	if err != nil {
 		if isAlreadyExists(err) {
 			return domain.Version{}, fmt.Errorf("%w: %s", provider.ErrAlreadyExists, name)
@@ -168,7 +197,12 @@ func (s *Store) Create(
 func (s *Store) Put(
 	ctx context.Context, name, value string, _ domain.ValueType, _ string, _ ...provider.WriteOption,
 ) (domain.Version, error) {
-	if _, err := s.client.SetSetting(ctx, name, value); err != nil {
+	label, err := aznamespace.Literal(s.namespace)
+	if err != nil {
+		return domain.Version{}, err
+	}
+
+	if _, err := s.client.SetSetting(ctx, name, value, label); err != nil {
 		return domain.Version{}, fmt.Errorf("failed to set setting: %w", err)
 	}
 
@@ -177,7 +211,12 @@ func (s *Store) Put(
 
 // Delete removes a setting. Provider.DeleteOptions (AWS-specific) are ignored.
 func (s *Store) Delete(ctx context.Context, name string, _ ...provider.DeleteOption) error {
-	if _, err := s.client.DeleteSetting(ctx, name); err != nil {
+	label, err := aznamespace.Literal(s.namespace)
+	if err != nil {
+		return err
+	}
+
+	if _, err := s.client.DeleteSetting(ctx, name, label); err != nil {
 		return mapError(err, name, "delete setting")
 	}
 

--- a/internal/provider/azure/appconfig/appconfig_test.go
+++ b/internal/provider/azure/appconfig/appconfig_test.go
@@ -33,38 +33,44 @@ func serverError() error {
 }
 
 // mockClient is a configurable in-test implementation of appconfig.Client.
+// Single-key methods receive the resolved literal label; ListSettings receives
+// the LabelFilter.
 type mockClient struct {
-	getFunc    func(ctx context.Context, key string) (azappconfig.GetSettingResponse, error)
-	setFunc    func(ctx context.Context, key, value string) (azappconfig.SetSettingResponse, error)
-	addFunc    func(ctx context.Context, key, value string) (azappconfig.AddSettingResponse, error)
-	deleteFunc func(ctx context.Context, key string) (azappconfig.DeleteSettingResponse, error)
-	listFunc   func(ctx context.Context) ([]azappconfig.Setting, error)
+	getFunc    func(ctx context.Context, key, label string) (azappconfig.GetSettingResponse, error)
+	setFunc    func(ctx context.Context, key, value, label string) (azappconfig.SetSettingResponse, error)
+	addFunc    func(ctx context.Context, key, value, label string) (azappconfig.AddSettingResponse, error)
+	deleteFunc func(ctx context.Context, key, label string) (azappconfig.DeleteSettingResponse, error)
+	listFunc   func(ctx context.Context, filter string) ([]azappconfig.Setting, error)
 }
 
-func (m *mockClient) GetSetting(ctx context.Context, key string) (azappconfig.GetSettingResponse, error) {
-	return m.getFunc(ctx, key)
+func (m *mockClient) GetSetting(ctx context.Context, key, label string) (azappconfig.GetSettingResponse, error) {
+	return m.getFunc(ctx, key, label)
 }
 
-func (m *mockClient) SetSetting(ctx context.Context, key, value string) (azappconfig.SetSettingResponse, error) {
-	return m.setFunc(ctx, key, value)
+func (m *mockClient) SetSetting(
+	ctx context.Context, key, value, label string,
+) (azappconfig.SetSettingResponse, error) {
+	return m.setFunc(ctx, key, value, label)
 }
 
-func (m *mockClient) AddSetting(ctx context.Context, key, value string) (azappconfig.AddSettingResponse, error) {
-	return m.addFunc(ctx, key, value)
+func (m *mockClient) AddSetting(
+	ctx context.Context, key, value, label string,
+) (azappconfig.AddSettingResponse, error) {
+	return m.addFunc(ctx, key, value, label)
 }
 
-func (m *mockClient) DeleteSetting(ctx context.Context, key string) (azappconfig.DeleteSettingResponse, error) {
-	return m.deleteFunc(ctx, key)
+func (m *mockClient) DeleteSetting(ctx context.Context, key, label string) (azappconfig.DeleteSettingResponse, error) {
+	return m.deleteFunc(ctx, key, label)
 }
 
-func (m *mockClient) ListSettings(ctx context.Context) ([]azappconfig.Setting, error) {
-	return m.listFunc(ctx)
+func (m *mockClient) ListSettings(ctx context.Context, filter string) ([]azappconfig.Setting, error) {
+	return m.listFunc(ctx, filter)
 }
 
 func TestResolve_BareNameLatest(t *testing.T) {
 	t.Parallel()
 
-	store := appconfig.New(&mockClient{})
+	store := appconfig.New(&mockClient{}, "")
 	ref, err := store.Resolve(t.Context(), "my-key", "")
 	require.NoError(t, err)
 	assert.True(t, ref.IsLatest())
@@ -73,7 +79,7 @@ func TestResolve_BareNameLatest(t *testing.T) {
 func TestResolve_RejectsVersionSpecs(t *testing.T) {
 	t.Parallel()
 
-	store := appconfig.New(&mockClient{})
+	store := appconfig.New(&mockClient{}, "")
 
 	for _, spec := range []string{"#1", "#abc", "~1", ":prod"} {
 		_, err := store.Resolve(t.Context(), "my-key", spec)
@@ -81,11 +87,22 @@ func TestResolve_RejectsVersionSpecs(t *testing.T) {
 	}
 }
 
+func TestResolve_RejectsFilterNamespace(t *testing.T) {
+	t.Parallel()
+
+	for _, ns := range []string{"*", "dev,prod", "dev*"} {
+		store := appconfig.New(&mockClient{}, ns)
+		_, err := store.Resolve(t.Context(), "my-key", "")
+		require.Error(t, err, "ns=%q", ns)
+		assert.Contains(t, err.Error(), "single-item operation needs one")
+	}
+}
+
 func TestGet(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		getFunc: func(_ context.Context, key string) (azappconfig.GetSettingResponse, error) {
+		getFunc: func(_ context.Context, key, _ string) (azappconfig.GetSettingResponse, error) {
 			return azappconfig.GetSettingResponse{Setting: azappconfig.Setting{
 				Key:   lo.ToPtr(key),
 				Value: lo.ToPtr("30"),
@@ -93,7 +110,7 @@ func TestGet(t *testing.T) {
 			}}, nil
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	entry, err := store.Get(t.Context(), "app/timeout", provider.VersionRef{})
 	require.NoError(t, err)
@@ -104,15 +121,75 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, []domain.Tag{{Key: "env", Value: "prod"}}, entry.Tags)
 }
 
+func TestGet_AppliesNamespaceLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		namespace string
+		wantLabel string
+	}{
+		{name: "empty is null label", namespace: "", wantLabel: ""},
+		{name: "literal namespace", namespace: "dev", wantLabel: "dev"},
+		{name: "escaped star decodes to literal", namespace: `\*`, wantLabel: "*"},
+		{name: "escaped comma decodes to literal", namespace: `foo\,bar`, wantLabel: "foo,bar"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotLabel string
+
+			m := &mockClient{
+				getFunc: func(_ context.Context, key, label string) (azappconfig.GetSettingResponse, error) {
+					gotLabel = label
+
+					return azappconfig.GetSettingResponse{Setting: azappconfig.Setting{
+						Key:   lo.ToPtr(key),
+						Value: lo.ToPtr("v"),
+					}}, nil
+				},
+			}
+			store := appconfig.New(m, tt.namespace)
+
+			_, err := store.Get(t.Context(), "app/timeout", provider.VersionRef{})
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantLabel, gotLabel)
+		})
+	}
+}
+
+func TestGet_RejectsFilterNamespace(t *testing.T) {
+	t.Parallel()
+
+	for _, ns := range []string{"*", "dev,prod"} {
+		called := false
+		m := &mockClient{
+			getFunc: func(_ context.Context, _, _ string) (azappconfig.GetSettingResponse, error) {
+				called = true
+
+				return azappconfig.GetSettingResponse{}, nil
+			},
+		}
+		store := appconfig.New(m, ns)
+
+		_, err := store.Get(t.Context(), "app/timeout", provider.VersionRef{})
+		require.Error(t, err, "ns=%q", ns)
+		assert.Contains(t, err.Error(), "single-item operation needs one")
+		assert.False(t, called, "client must not be called when the namespace is a filter")
+	}
+}
+
 func TestGet_NotFound(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		getFunc: func(_ context.Context, _ string) (azappconfig.GetSettingResponse, error) {
+		getFunc: func(_ context.Context, _, _ string) (azappconfig.GetSettingResponse, error) {
 			return azappconfig.GetSettingResponse{}, notFound()
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	_, err := store.Get(t.Context(), "missing", provider.VersionRef{})
 	require.ErrorIs(t, err, provider.ErrNotFound)
@@ -122,14 +199,14 @@ func TestGet_NoTags(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		getFunc: func(_ context.Context, key string) (azappconfig.GetSettingResponse, error) {
+		getFunc: func(_ context.Context, key, _ string) (azappconfig.GetSettingResponse, error) {
 			return azappconfig.GetSettingResponse{Setting: azappconfig.Setting{
 				Key:   lo.ToPtr(key),
 				Value: lo.ToPtr("v"),
 			}}, nil
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	entry, err := store.Get(t.Context(), "app/timeout", provider.VersionRef{})
 	require.NoError(t, err)
@@ -140,11 +217,11 @@ func TestGet_Error(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		getFunc: func(_ context.Context, _ string) (azappconfig.GetSettingResponse, error) {
+		getFunc: func(_ context.Context, _, _ string) (azappconfig.GetSettingResponse, error) {
 			return azappconfig.GetSettingResponse{}, serverError()
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	_, err := store.Get(t.Context(), "app/timeout", provider.VersionRef{})
 	require.Error(t, err)
@@ -155,7 +232,7 @@ func TestGet_Error(t *testing.T) {
 func TestHistory_Unsupported(t *testing.T) {
 	t.Parallel()
 
-	store := appconfig.New(&mockClient{})
+	store := appconfig.New(&mockClient{}, "")
 
 	versions, err := store.History(t.Context(), "my-key")
 	require.Error(t, err)
@@ -167,7 +244,7 @@ func TestList(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		listFunc: func(_ context.Context) ([]azappconfig.Setting, error) {
+		listFunc: func(_ context.Context, _ string) ([]azappconfig.Setting, error) {
 			return []azappconfig.Setting{
 				{Key: lo.ToPtr("beta")},
 				{Key: lo.ToPtr("alpha")},
@@ -175,22 +252,58 @@ func TestList(t *testing.T) {
 			}, nil
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	names, err := store.List(t.Context())
 	require.NoError(t, err)
 	assert.Equal(t, []string{"alpha", "beta"}, names)
 }
 
+func TestList_ForwardsFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		namespace  string
+		wantFilter string
+	}{
+		{name: "empty is null-label filter", namespace: "", wantFilter: "\x00"},
+		{name: "wildcard all", namespace: "*", wantFilter: "*"},
+		{name: "OR-list", namespace: "dev,prod", wantFilter: "dev,prod"},
+		{name: "prefix wildcard", namespace: "dev*", wantFilter: "dev*"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotFilter string
+
+			m := &mockClient{
+				listFunc: func(_ context.Context, filter string) ([]azappconfig.Setting, error) {
+					gotFilter = filter
+
+					return nil, nil
+				},
+			}
+			store := appconfig.New(m, tt.namespace)
+
+			_, err := store.List(t.Context())
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantFilter, gotFilter)
+		})
+	}
+}
+
 func TestList_Error(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		listFunc: func(_ context.Context) ([]azappconfig.Setting, error) {
+		listFunc: func(_ context.Context, _ string) ([]azappconfig.Setting, error) {
 			return nil, serverError()
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	_, err := store.List(t.Context())
 	require.Error(t, err)
@@ -208,11 +321,11 @@ func TestCreate_AlreadyExists(t *testing.T) {
 			t.Parallel()
 
 			m := &mockClient{
-				addFunc: func(_ context.Context, _, _ string) (azappconfig.AddSettingResponse, error) {
+				addFunc: func(_ context.Context, _, _, _ string) (azappconfig.AddSettingResponse, error) {
 					return azappconfig.AddSettingResponse{}, errFn()
 				},
 			}
-			store := appconfig.New(m)
+			store := appconfig.New(m, "")
 
 			_, err := store.Create(t.Context(), "existing", "v", domain.ValueTypePlaintext, "")
 			require.ErrorIs(t, err, provider.ErrAlreadyExists)
@@ -224,11 +337,11 @@ func TestCreate_Error(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		addFunc: func(_ context.Context, _, _ string) (azappconfig.AddSettingResponse, error) {
+		addFunc: func(_ context.Context, _, _, _ string) (azappconfig.AddSettingResponse, error) {
 			return azappconfig.AddSettingResponse{}, serverError()
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	_, err := store.Create(t.Context(), "new-key", "v", domain.ValueTypePlaintext, "")
 	require.Error(t, err)
@@ -239,43 +352,64 @@ func TestCreate_Error(t *testing.T) {
 func TestCreate_New(t *testing.T) {
 	t.Parallel()
 
-	var added string
+	var added, addedLabel string
 
 	m := &mockClient{
-		addFunc: func(_ context.Context, key, value string) (azappconfig.AddSettingResponse, error) {
-			added = key
+		addFunc: func(_ context.Context, key, value, label string) (azappconfig.AddSettingResponse, error) {
+			added, addedLabel = key, label
 
 			assert.Equal(t, "v", value)
 
 			return azappconfig.AddSettingResponse{}, nil
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "dev")
 
 	version, err := store.Create(t.Context(), "new-key", "v", domain.ValueTypePlaintext, "")
 	require.NoError(t, err)
 	assert.Equal(t, "new-key", added)
+	assert.Equal(t, "dev", addedLabel)
 	assert.Empty(t, version.ID) // unversioned
+}
+
+func TestCreate_RejectsFilterNamespace(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	m := &mockClient{
+		addFunc: func(_ context.Context, _, _, _ string) (azappconfig.AddSettingResponse, error) {
+			called = true
+
+			return azappconfig.AddSettingResponse{}, nil
+		},
+	}
+	store := appconfig.New(m, "dev,prod")
+
+	_, err := store.Create(t.Context(), "new-key", "v", domain.ValueTypePlaintext, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "single-item operation needs one")
+	assert.False(t, called)
 }
 
 func TestPut(t *testing.T) {
 	t.Parallel()
 
-	var setKey, setVal string
+	var setKey, setVal, setLabel string
 
 	m := &mockClient{
-		setFunc: func(_ context.Context, key, value string) (azappconfig.SetSettingResponse, error) {
-			setKey, setVal = key, value
+		setFunc: func(_ context.Context, key, value, label string) (azappconfig.SetSettingResponse, error) {
+			setKey, setVal, setLabel = key, value, label
 
 			return azappconfig.SetSettingResponse{}, nil
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "dev")
 
 	version, err := store.Put(t.Context(), "app/timeout", "60", domain.ValueTypePlaintext, "")
 	require.NoError(t, err)
 	assert.Equal(t, "app/timeout", setKey)
 	assert.Equal(t, "60", setVal)
+	assert.Equal(t, "dev", setLabel)
 	assert.Empty(t, version.ID)
 }
 
@@ -283,44 +417,64 @@ func TestPut_Error(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		setFunc: func(_ context.Context, _, _ string) (azappconfig.SetSettingResponse, error) {
+		setFunc: func(_ context.Context, _, _, _ string) (azappconfig.SetSettingResponse, error) {
 			return azappconfig.SetSettingResponse{}, serverError()
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	_, err := store.Put(t.Context(), "app/timeout", "60", domain.ValueTypePlaintext, "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "set setting")
 }
 
+func TestPut_RejectsFilterNamespace(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	m := &mockClient{
+		setFunc: func(_ context.Context, _, _, _ string) (azappconfig.SetSettingResponse, error) {
+			called = true
+
+			return azappconfig.SetSettingResponse{}, nil
+		},
+	}
+	store := appconfig.New(m, "*")
+
+	_, err := store.Put(t.Context(), "app/timeout", "60", domain.ValueTypePlaintext, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "single-item operation needs one")
+	assert.False(t, called)
+}
+
 func TestDelete(t *testing.T) {
 	t.Parallel()
 
-	var deleted string
+	var deleted, deletedLabel string
 
 	m := &mockClient{
-		deleteFunc: func(_ context.Context, key string) (azappconfig.DeleteSettingResponse, error) {
-			deleted = key
+		deleteFunc: func(_ context.Context, key, label string) (azappconfig.DeleteSettingResponse, error) {
+			deleted, deletedLabel = key, label
 
 			return azappconfig.DeleteSettingResponse{}, nil
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "dev")
 
 	require.NoError(t, store.Delete(t.Context(), "app/timeout"))
 	assert.Equal(t, "app/timeout", deleted)
+	assert.Equal(t, "dev", deletedLabel)
 }
 
 func TestDelete_NotFound(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		deleteFunc: func(_ context.Context, _ string) (azappconfig.DeleteSettingResponse, error) {
+		deleteFunc: func(_ context.Context, _, _ string) (azappconfig.DeleteSettingResponse, error) {
 			return azappconfig.DeleteSettingResponse{}, notFound()
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	err := store.Delete(t.Context(), "missing")
 	require.ErrorIs(t, err, provider.ErrNotFound)
@@ -330,11 +484,11 @@ func TestDelete_Error(t *testing.T) {
 	t.Parallel()
 
 	m := &mockClient{
-		deleteFunc: func(_ context.Context, _ string) (azappconfig.DeleteSettingResponse, error) {
+		deleteFunc: func(_ context.Context, _, _ string) (azappconfig.DeleteSettingResponse, error) {
 			return azappconfig.DeleteSettingResponse{}, serverError()
 		},
 	}
-	store := appconfig.New(m)
+	store := appconfig.New(m, "")
 
 	err := store.Delete(t.Context(), "app/timeout")
 	require.Error(t, err)
@@ -342,10 +496,29 @@ func TestDelete_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "delete setting")
 }
 
+func TestDelete_RejectsFilterNamespace(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	m := &mockClient{
+		deleteFunc: func(_ context.Context, _, _ string) (azappconfig.DeleteSettingResponse, error) {
+			called = true
+
+			return azappconfig.DeleteSettingResponse{}, nil
+		},
+	}
+	store := appconfig.New(m, "a,b")
+
+	err := store.Delete(t.Context(), "app/timeout")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "single-item operation needs one")
+	assert.False(t, called)
+}
+
 func TestTagUntag_Unsupported(t *testing.T) {
 	t.Parallel()
 
-	store := appconfig.New(&mockClient{})
+	store := appconfig.New(&mockClient{}, "")
 
 	// Non-empty mutation is declined with a clear error.
 	require.ErrorIs(t, store.Tag(t.Context(), "k", map[string]string{"env": "prod"}), appconfig.ErrTagsUnsupported)

--- a/internal/provider/azure/appconfig/aznamespace/aznamespace.go
+++ b/internal/provider/azure/appconfig/aznamespace/aznamespace.go
@@ -1,0 +1,79 @@
+// Package aznamespace parses the value of the Azure App Configuration
+// --namespace / --ns flag (env AZURE_APPCONFIG_NAMESPACE).
+//
+// suve calls this axis a "namespace"; Azure App Configuration calls it a
+// "label". Structurally it is a k8s-style namespace — a flat identity partition
+// of the key space, with the null (unlabeled) label as the default namespace —
+// not key=value metadata (which suve unifies as tags). See #381 for the naming
+// rationale.
+//
+// The value has two interpretations depending on context:
+//
+//   - list/read: an App Configuration LabelFilter (see Filter). The filter
+//     grammar (`*` wildcard, `,` OR-list, `\` escape) is honored natively by
+//     the service, so `*`=all, `dev*`=prefix, `dev,prod`=multi all fall out.
+//   - single-item ops (show/set/delete/...): exactly one concrete namespace
+//     (see Literal). `\` escapes are decoded; any unescaped `*` or `,` is a
+//     usage error because those name all/multiple namespaces.
+package aznamespace
+
+import (
+	"fmt"
+	"strings"
+)
+
+// NullLabelFilter is the reserved App Configuration label filter that matches
+// ONLY settings with no label — the null (default) namespace. The service
+// encodes it as label=%00 (#352).
+const NullLabelFilter = "\x00"
+
+// Filter maps a raw --namespace value to an App Configuration LabelFilter for
+// list/read enumeration. An empty value maps to the null-label filter (the
+// default namespace); any other value is forwarded verbatim so the service's
+// native filter grammar (`*` wildcard, `,` OR-list, `\` escape) applies (#381).
+func Filter(raw string) string {
+	if raw == "" {
+		return NullLabelFilter
+	}
+
+	return raw
+}
+
+// Literal decodes a raw --namespace value to the single literal namespace a
+// single-item operation must target. `\` escapes are decoded (`\*` -> `*`,
+// `\,` -> `,`, `\\` -> `\`); an empty value maps to the null (default)
+// namespace (""). If any UNESCAPED `*` or `,` remains, the value names
+// all/multiple namespaces and a usage error is returned (#381).
+func Literal(raw string) (string, error) {
+	var b strings.Builder
+
+	escaped := false
+
+	for _, r := range raw {
+		if escaped {
+			b.WriteRune(r)
+
+			escaped = false
+
+			continue
+		}
+
+		switch r {
+		case '\\':
+			escaped = true
+		case '*', ',':
+			return "", fmt.Errorf(
+				"--namespace %q names all/multiple namespaces; a single-item operation needs one", raw,
+			)
+		default:
+			b.WriteRune(r)
+		}
+	}
+
+	// A trailing backslash escapes nothing; keep it as a literal backslash.
+	if escaped {
+		b.WriteRune('\\')
+	}
+
+	return b.String(), nil
+}

--- a/internal/provider/azure/appconfig/aznamespace/aznamespace_test.go
+++ b/internal/provider/azure/appconfig/aznamespace/aznamespace_test.go
@@ -1,0 +1,86 @@
+package aznamespace_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider/azure/appconfig/aznamespace"
+)
+
+func TestFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "empty maps to null-label filter", raw: "", want: "\x00"},
+		{name: "wildcard all forwarded", raw: "*", want: "*"},
+		{name: "OR-list forwarded", raw: "dev,prod", want: "dev,prod"},
+		{name: "prefix wildcard forwarded", raw: "dev*", want: "dev*"},
+		{name: "literal forwarded", raw: "dev", want: "dev"},
+		{name: "escaped reserved forwarded verbatim", raw: `\*`, want: `\*`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, aznamespace.Filter(tt.raw))
+		})
+	}
+}
+
+func TestLiteral(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "empty maps to null namespace", raw: "", want: ""},
+		{name: "plain literal", raw: "dev", want: "dev"},
+		{name: "escaped star decodes to literal star", raw: `\*`, want: "*"},
+		{name: "escaped comma decodes to literal comma", raw: `foo\,bar`, want: "foo,bar"},
+		{name: "escaped backslash decodes to single backslash", raw: `\\`, want: `\`},
+		{name: "trailing backslash kept literal", raw: `foo\`, want: `foo\`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := aznamespace.Literal(tt.raw)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestLiteral_UnescapedFilterCharsError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{name: "wildcard all", raw: "*"},
+		{name: "OR-list", raw: "dev,prod"},
+		{name: "prefix wildcard", raw: "dev*"},
+		{name: "comma after escaped star", raw: `\*,x`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := aznamespace.Literal(tt.raw)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "single-item operation needs one")
+		})
+	}
+}

--- a/internal/provider/azure/appconfig/client.go
+++ b/internal/provider/azure/appconfig/client.go
@@ -7,20 +7,14 @@ import (
 	"github.com/samber/lo"
 )
 
-// nullLabelFilter is the reserved App Configuration label filter that matches
-// ONLY settings with no label. The Get/Set/Add/Delete single-key operations all
-// address the null (default) label, so List must restrict to the same label —
-// otherwise it enumerates every label and surfaces phantom keys that show/stage
-// then cannot fetch. The service encodes this reserved value as label=%00.
-const nullLabelFilter = "\x00"
-
 // apiClient adapts the concrete *azappconfig.Client to the narrow Client
 // interface, draining the SDK's list pager into a slice. It is the only place
 // the concrete SDK client and its pager are referenced.
 //
-// Every operation uses the default (no) App Configuration label: options are
-// left nil so the store addresses the single default-labeled setting per key,
-// which the adapter presents as an unversioned parameter.
+// The label carrying suve's namespace is applied via the high-level SDK options
+// (GetSettingOptions.Label, SetSettingOptions.Label, ...) for single-key ops and
+// SettingSelector.LabelFilter for List. An empty label leaves the options nil so
+// the request is byte-for-byte identical to addressing the null (default) label.
 type apiClient struct {
 	c *azappconfig.Client
 }
@@ -33,33 +27,58 @@ func Wrap(c *azappconfig.Client) Client {
 // Compile-time assertion that apiClient satisfies Client.
 var _ Client = (*apiClient)(nil)
 
-func (a *apiClient) GetSetting(ctx context.Context, key string) (azappconfig.GetSettingResponse, error) {
-	return a.c.GetSetting(ctx, key, nil)
+// An empty label leaves the options pointer nil so the request addresses the
+// null (default) label exactly as it did before the namespace axis existed; a
+// non-empty label is carried via the option's Label field.
+
+func (a *apiClient) GetSetting(ctx context.Context, key, label string) (azappconfig.GetSettingResponse, error) {
+	var opts *azappconfig.GetSettingOptions
+	if label != "" {
+		opts = &azappconfig.GetSettingOptions{Label: lo.ToPtr(label)}
+	}
+
+	return a.c.GetSetting(ctx, key, opts)
 }
 
-func (a *apiClient) SetSetting(ctx context.Context, key, value string) (azappconfig.SetSettingResponse, error) {
-	return a.c.SetSetting(ctx, key, lo.ToPtr(value), nil)
+func (a *apiClient) SetSetting(ctx context.Context, key, value, label string) (azappconfig.SetSettingResponse, error) {
+	var opts *azappconfig.SetSettingOptions
+	if label != "" {
+		opts = &azappconfig.SetSettingOptions{Label: lo.ToPtr(label)}
+	}
+
+	return a.c.SetSetting(ctx, key, lo.ToPtr(value), opts)
 }
 
-func (a *apiClient) AddSetting(ctx context.Context, key, value string) (azappconfig.AddSettingResponse, error) {
-	return a.c.AddSetting(ctx, key, lo.ToPtr(value), nil)
+func (a *apiClient) AddSetting(ctx context.Context, key, value, label string) (azappconfig.AddSettingResponse, error) {
+	var opts *azappconfig.AddSettingOptions
+	if label != "" {
+		opts = &azappconfig.AddSettingOptions{Label: lo.ToPtr(label)}
+	}
+
+	return a.c.AddSetting(ctx, key, lo.ToPtr(value), opts)
 }
 
-func (a *apiClient) DeleteSetting(ctx context.Context, key string) (azappconfig.DeleteSettingResponse, error) {
-	return a.c.DeleteSetting(ctx, key, nil)
+func (a *apiClient) DeleteSetting(ctx context.Context, key, label string) (azappconfig.DeleteSettingResponse, error) {
+	var opts *azappconfig.DeleteSettingOptions
+	if label != "" {
+		opts = &azappconfig.DeleteSettingOptions{Label: lo.ToPtr(label)}
+	}
+
+	return a.c.DeleteSetting(ctx, key, opts)
 }
 
-// listSettingSelector is the selector used to enumerate settings: all keys but
-// ONLY the null (default) label, so List matches what the single-key operations
-// address. A nil LabelFilter (SettingSelector{}) would enumerate every label.
-func listSettingSelector() azappconfig.SettingSelector {
+// listSettingSelector is the selector used to enumerate settings: all keys,
+// restricted by the given LabelFilter. The filter is resolved by the store from
+// the raw --namespace value (empty -> the null-label filter, aznamespace.Filter).
+// A nil LabelFilter (SettingSelector{}) would enumerate every label.
+func listSettingSelector(filter string) azappconfig.SettingSelector {
 	return azappconfig.SettingSelector{
-		LabelFilter: lo.ToPtr(nullLabelFilter),
+		LabelFilter: lo.ToPtr(filter),
 	}
 }
 
-func (a *apiClient) ListSettings(ctx context.Context) ([]azappconfig.Setting, error) {
-	pager := a.c.NewListSettingsPager(listSettingSelector(), nil)
+func (a *apiClient) ListSettings(ctx context.Context, filter string) ([]azappconfig.Setting, error) {
+	pager := a.c.NewListSettingsPager(listSettingSelector(filter), nil)
 
 	var out []azappconfig.Setting
 

--- a/internal/provider/azure/appconfig/client_internal_test.go
+++ b/internal/provider/azure/appconfig/client_internal_test.go
@@ -5,21 +5,37 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider/azure/appconfig/aznamespace"
 )
 
-// TestListSettingSelector_FiltersNullLabel guards the #352 fix: List must
-// restrict to the null (default) label so it matches the single-key operations,
-// rather than enumerating every label (a nil LabelFilter). The reserved value
-// "\x00" is sent as label=%00, which App Configuration matches to label-less
-// key-values.
-func TestListSettingSelector_FiltersNullLabel(t *testing.T) {
+// TestListSettingSelector_ForwardsFilter checks that the selector forwards the
+// given LabelFilter verbatim (never a nil filter, which would enumerate every
+// label) and sets no key filter. The store resolves the raw --namespace value
+// into this filter via aznamespace.Filter.
+func TestListSettingSelector_ForwardsFilter(t *testing.T) {
 	t.Parallel()
 
-	sel := listSettingSelector()
+	for _, filter := range []string{"\x00", "dev", "dev,prod", "dev*", "*"} {
+		sel := listSettingSelector(filter)
 
-	require.NotNil(t, sel.LabelFilter, "List must set a label filter, not enumerate all labels")
+		require.NotNil(t, sel.LabelFilter, "List must set a label filter, not enumerate all labels")
+		assert.Equal(t, filter, *sel.LabelFilter)
+
+		// No key filter: all keys, restricted only by label.
+		assert.Nil(t, sel.KeyFilter)
+	}
+}
+
+// TestListSettingSelector_NullLabelDefault guards the #352 behavior end to end:
+// the empty namespace resolves to the null-label filter ("\x00", sent as
+// label=%00), so List matches only label-less key-values rather than every
+// label.
+func TestListSettingSelector_NullLabelDefault(t *testing.T) {
+	t.Parallel()
+
+	sel := listSettingSelector(aznamespace.Filter(""))
+
+	require.NotNil(t, sel.LabelFilter)
 	assert.Equal(t, "\x00", *sel.LabelFilter)
-
-	// No key filter: all keys, restricted only by label.
-	assert.Nil(t, sel.KeyFilter)
 }

--- a/internal/provider/azure/azure.go
+++ b/internal/provider/azure/azure.go
@@ -209,7 +209,7 @@ func appConfigStore(ctx context.Context, scope provider.Scope) (provider.Store, 
 			return nil, fmt.Errorf("failed to create Azure App Configuration client from connection string: %w", err)
 		}
 
-		return appconfig.New(appconfig.Wrap(client)), nil
+		return appconfig.New(appconfig.Wrap(client), scope.AppConfigNamespace), nil
 	}
 
 	cred, err := azidentity.NewDefaultAzureCredential(nil)
@@ -228,7 +228,7 @@ func appConfigStore(ctx context.Context, scope provider.Scope) (provider.Store, 
 		return nil, fmt.Errorf("failed to create Azure App Configuration client: %w", err)
 	}
 
-	return appconfig.New(appconfig.Wrap(client)), nil
+	return appconfig.New(appconfig.Wrap(client), scope.AppConfigNamespace), nil
 }
 
 // Register associates the Azure Factory with provider.ProviderAzure in reg.

--- a/internal/provider/scope.go
+++ b/internal/provider/scope.go
@@ -29,6 +29,11 @@ type Scope struct {
 	VaultName string `json:"vaultName,omitempty"`
 	// StoreName is the Azure App Configuration store name (Azure, param).
 	StoreName string `json:"storeName,omitempty"`
+	// AppConfigNamespace is the Azure App Configuration namespace — the axis
+	// Azure calls a "label" — selected for the store (Azure, param). Empty is
+	// the null (default) namespace. A single resolved namespace only; the
+	// filter grammar (`*`/`,`) never reaches staging (see #381).
+	AppConfigNamespace string `json:"appConfigNamespace,omitempty"`
 }
 
 // Key returns a stable, filesystem-safe key identifying the scope. It is used
@@ -45,6 +50,12 @@ func (s Scope) Key() string {
 		// resource — no subscription/resource-group needed.
 		if s.VaultName != "" {
 			return fmt.Sprintf("azure/keyvault/%s", s.VaultName)
+		}
+
+		// The null (default) namespace keeps the original backward-compatible
+		// path; a named namespace makes staging state per-(store, namespace).
+		if s.AppConfigNamespace != "" {
+			return fmt.Sprintf("azure/appconfig/%s/%s", s.StoreName, s.AppConfigNamespace)
 		}
 
 		return fmt.Sprintf("azure/appconfig/%s", s.StoreName)

--- a/internal/provider/scope_test.go
+++ b/internal/provider/scope_test.go
@@ -38,6 +38,16 @@ func TestScope_Key(t *testing.T) {
 			want:  "azure/appconfig/store1",
 		},
 		{
+			// A named namespace makes staging state per-(store, namespace).
+			name: "azure appconfig with namespace",
+			scope: provider.Scope{
+				Provider:           provider.ProviderAzure,
+				StoreName:          "store1",
+				AppConfigNamespace: "dev",
+			},
+			want: "azure/appconfig/store1/dev",
+		},
+		{
 			name:  "unknown provider",
 			scope: provider.Scope{},
 			want:  "",


### PR DESCRIPTION
Epic PR for **#410** — lands Azure App Configuration **namespaces** (#381 Phase 1) and the cross-provider **metadata terminology** (#409) coherently across CLI, docs, and GUI. Integrated on `epic/appconfig-namespace-terminology` rather than merged piecemeal, because the GUI depends on the Go namespace plumbing and the "namespace"/"tags" wording must be identical in CLI help, README, and GUI.

**Closes #409. Part of #381** (Phase 1 only — Phase 2 tag write remains open, see "Follow-up").

## What this delivers

### 1. App Configuration namespaces (#381 Phase 1)
App Config's `(key, label)` identity model is exposed under suve's term **namespace** (Azure calls it a "label"; structurally a k8s-style namespace — a flat identity partition of the key space, null = the default namespace — *not* metadata). One flag drives it:

- `--namespace <value>` (alias `--ns`) on the `azure param` commands, env default **`AZURE_APPCONFIG_NAMESPACE`**. Precedence: flag > env > null.
- The value is an App Configuration **label filter**:

  | Value | Meaning | Scope |
  |---|---|---|
  | unset / `""` | null namespace (default; also overrides an env default back to null) | all commands |
  | `"*"` | all namespaces (wildcard) | list/read only |
  | `"dev,prod"` | dev OR prod (`,` = OR-list) | list/read only |
  | `"dev*"` | prefix wildcard | list/read only |
  | `"dev"` | literal namespace `dev` | all commands |
  | `"\*"`, `"foo\,bar"` | literal namespace with a reserved char (`\` escape) | all commands |

- **List/read** forwards the value to `LabelFilter` (native `*`/`,`/`\` grammar); empty → the null-label filter (`\x00`, #352).
- **Single-item ops** decode `\` escapes to one literal namespace and reject an unescaped `*`/`,` with a usage error. Escaping works here too, so a namespace literally named `*` is addressable via `\*`.
- Parsing lives in the Azure-specific `internal/provider/azure/appconfig/aznamespace` package (`Filter` / `Literal`).
- `Scope.Key()` is per-`(store, namespace)` (staging isolation); the null namespace keeps the exact current `azure/appconfig/<store>` path (backward compatible).
- **#353 untouched**: the positional argument is still the whole key; the `*`/`,`/`\` grammar lives only inside the `--namespace` value, so colon keys stay addressable.

### 2. Metadata terminology (#409)
One cross-provider vocabulary as the primary UX; each provider's native term is a documented mapping (no per-provider aliases):
- Metadata → **tags** everywhere (AWS/Azure native "tags"; Google Cloud native "labels" surfaced as tags). gcloud `tag`/`untag` help now says *"Google Cloud calls these labels"*.
- App Config identity axis → **namespace** (Azure native "label").
- README gains a cross-provider terminology table + the ⚠️ naming-trap note (GCloud "labels" = metadata → tags; Azure App Config "label" = identity → namespace — opposite concepts).

### 3. GUI
App Config namespace selection (a namespace input in the Azure App Config scope UI, `ScopeSelection.Namespace` seeded from `AZURE_APPCONFIG_NAMESPACE`) and terminology hints (the field stays **Tags**; under Google Cloud a secondary "Google Cloud: labels" hint). Wails bindings updated. **Playwright coverage added** for the namespace input (payload trim, empty, "Change scope" prefill, Azure-only presence) and the tags hint (present under GCloud, absent under Azure/AWS).

## Sub-PRs (all merged into the epic branch)
- #411 — core namespaces (`aznamespace`, `Scope.AppConfigNamespace`, adapter, `--namespace`/`--ns` + env)
- #412 — terminology docs + gcloud help
- #414 — GUI (namespace selection + tags hint + bindings)
- #381 e2e — `TestAzureAppConfig_Namespace` against the emulator
- #415 — GUI Playwright coverage

## Follow-up (not in this PR)
- **#381 Phase 2 (tag write)** — was thought SDK-blocked, but is actually **unblocked by upgrading `azappconfig` v1.2.0 → v2** (v2 added `Tags` to `SetSettingOptions`/`AddSettingOptions` + `SettingSelector.TagsFilter`). Planned as an immediate follow-up PR: bump to v2, then GET-merge-PUT tag read/write with ETag, preserving existing tags on value writes. Tracked in #381. Until then `Tag`/`Untag` keep their existing unsupported errors (pre-existing behavior — not a regression).

## Verification
Integrated on the epic branch: `go build ./...`, `go test ./...`, lint `internal/…` (e2e,production) and `cmd/…` (production,webkit2_41) all **0 issues**; the App Config namespace **e2e passes against the emulator** (empirically confirmed to honor labels); frontend `npm run check`/`lint` clean and the **Playwright suite passes** (the sole webkit `keyboard-focus` case is a pre-existing flake, reproduced on the base tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
