### PR TITLE
feat(gui): App Configuration namespace selection + Google Cloud tags hint

### DIFF
--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -108,8 +108,9 @@ func NewApp(initial provider.Scope) *App {
 
 // hydrateScope fills empty resource fields on an initial launch scope from the
 // environment. Flag-supplied values take precedence; unset ones fall back to
-// GOOGLE_CLOUD_PROJECT / AZURE_KEYVAULT_NAME / AZURE_APPCONFIG_NAME. AWS carries
-// no resource field (region comes from the ambient AWS config).
+// GOOGLE_CLOUD_PROJECT / AZURE_KEYVAULT_NAME / AZURE_APPCONFIG_NAME /
+// AZURE_APPCONFIG_NAMESPACE. AWS carries no resource field (region comes from
+// the ambient AWS config).
 func hydrateScope(s provider.Scope) provider.Scope {
 	switch s.Provider {
 	case provider.ProviderGoogleCloud:
@@ -123,6 +124,10 @@ func hydrateScope(s provider.Scope) provider.Scope {
 
 		if s.StoreName == "" {
 			s.StoreName = os.Getenv("AZURE_APPCONFIG_NAME")
+		}
+
+		if s.AppConfigNamespace == "" {
+			s.AppConfigNamespace = os.Getenv("AZURE_APPCONFIG_NAMESPACE")
 		}
 	case provider.ProviderAWS:
 		// region comes from the ambient AWS config; nothing to hydrate.
@@ -149,17 +154,22 @@ func (a *App) Startup(ctx context.Context) {
 //   - aws: (none; the ambient AWS config supplies the region)
 //   - googlecloud: ProjectID
 //   - azure: VaultName (Key Vault secret) and/or StoreName (App Configuration
-//     param)
+//     param); Namespace is the optional App Configuration namespace (Azure
+//     calls it a "label"), applied only to the App Configuration store — empty
+//     means the default (null) namespace.
 type ScopeSelection struct {
 	Provider  string `json:"provider"`
 	ProjectID string `json:"projectId"`
 	VaultName string `json:"vaultName"`
 	StoreName string `json:"storeName"`
+	Namespace string `json:"namespace"`
 }
 
 // SelectScope sets the current read/write provider scope. It performs no
 // network calls; store construction (and any credential resolution) is deferred
-// to the next param/secret operation.
+// to the next param/secret operation. For Azure the App Configuration namespace
+// (sel.Namespace) is carried on the scope; it is only meaningful for the App
+// Configuration store and harmless for every other provider/store.
 func (a *App) SelectScope(sel ScopeSelection) error {
 	scope, err := scopeFromSelection(sel)
 	if err != nil {
@@ -193,9 +203,10 @@ func scopeFromSelection(sel ScopeSelection) (provider.Scope, error) {
 		}
 
 		return provider.Scope{
-			Provider:  provider.ProviderAzure,
-			VaultName: sel.VaultName,
-			StoreName: sel.StoreName,
+			Provider:           provider.ProviderAzure,
+			VaultName:          sel.VaultName,
+			StoreName:          sel.StoreName,
+			AppConfigNamespace: sel.Namespace,
 		}, nil
 	default:
 		return provider.Scope{}, fmt.Errorf("%w: %q", errInvalidProvider, sel.Provider)
@@ -227,6 +238,7 @@ func selectionFromScope(s provider.Scope) *ScopeSelection {
 		ProjectID: s.ProjectID,
 		VaultName: s.VaultName,
 		StoreName: s.StoreName,
+		Namespace: s.AppConfigNamespace,
 	}
 }
 

--- a/internal/gui/frontend/src/App.svelte
+++ b/internal/gui/frontend/src/App.svelte
@@ -65,7 +65,7 @@
   // scope can land in the new one.
   const scopeKey = $derived(
     scope
-      ? [provider, scope.projectId, scope.vaultName, scope.storeName].join('|')
+      ? [provider, scope.projectId, scope.vaultName, scope.storeName, scope.namespace].join('|')
       : provider,
   );
 
@@ -125,6 +125,7 @@
       projectId: p === 'googlecloud' ? (src?.projectId ?? '') : '',
       vaultName: p === 'azure' ? (src?.vaultName ?? '') : '',
       storeName: p === 'azure' ? (src?.storeName ?? '') : '',
+      namespace: p === 'azure' ? (src?.namespace ?? '') : '',
     } as gui.ScopeSelection;
   }
 
@@ -334,12 +335,14 @@
         {#if effectiveView === 'param' && paramCap}
           <ParamView
             capability={paramCap}
+            {provider}
             onnavigatetostaging={() => handleNavigate('staging')}
             onstagingchange={handleStagingChange}
           />
         {:else if effectiveView === 'secret' && secretCap}
           <SecretView
             capability={secretCap}
+            {provider}
             onnavigatetostaging={() => handleNavigate('staging')}
             onstagingchange={handleStagingChange}
           />

--- a/internal/gui/frontend/src/lib/ParamView.svelte
+++ b/internal/gui/frontend/src/lib/ParamView.svelte
@@ -15,11 +15,12 @@
 
   interface Props {
     capability?: gui.ServiceCapability;
+    provider?: string;
     onnavigatetostaging?: () => void;
     onstagingchange?: () => void;
   }
 
-  let { capability, onnavigatetostaging, onstagingchange }: Props = $props();
+  let { capability, provider = '', onnavigatetostaging, onstagingchange }: Props = $props();
 
   // Capability-driven visibility. Absent capability defaults to AWS-like (true)
   // so the component degrades safely if mounted without one.
@@ -532,7 +533,7 @@
             {/if}
 
             {#if tagsEnabled}
-              <TagList tags={paramDetail.tags} serviceClass="param" onadd={openTagModal} onremove={openRemoveTagModal} />
+              <TagList tags={paramDetail.tags} serviceClass="param" {provider} onadd={openTagModal} onremove={openRemoveTagModal} />
             {/if}
 
             {#if historyEnabled && paramLog.length > 0}

--- a/internal/gui/frontend/src/lib/SecretView.svelte
+++ b/internal/gui/frontend/src/lib/SecretView.svelte
@@ -15,11 +15,12 @@
 
   interface Props {
     capability?: gui.ServiceCapability;
+    provider?: string;
     onnavigatetostaging?: () => void;
     onstagingchange?: () => void;
   }
 
-  let { capability, onnavigatetostaging, onstagingchange }: Props = $props();
+  let { capability, provider = '', onnavigatetostaging, onstagingchange }: Props = $props();
 
   // Capability-driven visibility. Absent capability defaults to AWS-like (true).
   const stagingEnabled = $derived(capability?.hasStaging ?? true);
@@ -576,7 +577,7 @@
             {/if}
 
             {#if tagsEnabled}
-              <TagList tags={secretDetail.tags} serviceClass="secret" onadd={openTagModal} onremove={openRemoveTagModal} />
+              <TagList tags={secretDetail.tags} serviceClass="secret" {provider} onadd={openTagModal} onremove={openRemoveTagModal} />
             {/if}
 
             {#if historyEnabled && secretLog.length > 0}

--- a/internal/gui/frontend/src/lib/Sidebar.svelte
+++ b/internal/gui/frontend/src/lib/Sidebar.svelte
@@ -54,6 +54,7 @@
   let projectInput = $state('');
   let vaultInput = $state('');
   let storeInput = $state('');
+  let namespaceInput = $state('');
   let formError = $state('');
   let firstFieldEl: HTMLInputElement | undefined = $state();
 
@@ -63,6 +64,7 @@
     projectInput = pendingProvider === 'googlecloud' ? (s?.projectId ?? '') : '';
     vaultInput = pendingProvider === 'azure' ? (s?.vaultName ?? '') : '';
     storeInput = pendingProvider === 'azure' ? (s?.storeName ?? '') : '';
+    namespaceInput = pendingProvider === 'azure' ? (s?.namespace ?? '') : '';
     formError = '';
   });
 
@@ -112,6 +114,7 @@
       projectId: projectInput.trim(),
       vaultName: '',
       storeName: '',
+      namespace: '',
     } as gui.ScopeSelection);
   }
 
@@ -122,6 +125,7 @@
       projectId: '',
       vaultName: vaultInput.trim(),
       storeName: storeInput.trim(),
+      namespace: namespaceInput.trim(),
     } as gui.ScopeSelection);
   }
 </script>
@@ -177,6 +181,15 @@
       />
       <label class="scope-label" for="azure-store">App Configuration store</label>
       <input id="azure-store" class="scope-input" type="text" placeholder="my-store (params)" bind:value={storeInput} />
+      <label class="scope-label" for="azure-namespace">Namespace</label>
+      <input
+        id="azure-namespace"
+        class="scope-input"
+        type="text"
+        placeholder="empty = default"
+        bind:value={namespaceInput}
+      />
+      <p class="scope-hint">Azure calls this a label; empty = default. Applies to the App Configuration store only.</p>
       {#if formError || scopeError}
         <div class="scope-error">{formError || scopeError}</div>
       {/if}
@@ -255,6 +268,12 @@
         <span class="aws-info-label">App Config</span>
         <span class="aws-info-value" title={scope?.storeName || '?'}>{scope?.storeName || '?'}</span>
       </div>
+      {#if scope?.storeName}
+        <div class="aws-info-row">
+          <span class="aws-info-label">Namespace</span>
+          <span class="aws-info-value" title={scope?.namespace || 'default'}>{scope?.namespace || 'default'}</span>
+        </div>
+      {/if}
       <button type="button" class="scope-change" disabled={!!pendingProvider} onclick={() => onchangescope?.()}>Change scope</button>
     </div>
   {/if}
@@ -358,6 +377,13 @@
   .scope-error {
     font-size: 11px;
     color: #e94560;
+    line-height: 1.4;
+  }
+
+  .scope-hint {
+    margin: 0;
+    font-size: 10px;
+    color: #666;
     line-height: 1.4;
   }
 

--- a/internal/gui/frontend/src/lib/TagList.svelte
+++ b/internal/gui/frontend/src/lib/TagList.svelte
@@ -4,16 +4,27 @@
   interface Props {
     tags: Array<{ key: string; value: string }> | undefined;
     serviceClass: 'param' | 'secret';
+    provider?: string;
     onadd: () => void;
     onremove: (key: string) => void;
   }
 
-  let { tags, serviceClass, onadd, onremove }: Props = $props();
+  let { tags, serviceClass, provider = '', onadd, onremove }: Props = $props();
+
+  // suve uses one metadata vocabulary ("Tags") across every provider. Google
+  // Cloud natively calls this same key=value metadata "labels", so surface a
+  // secondary, non-primary hint for GCloud users without renaming the field.
+  const nativeHint = $derived(provider === 'googlecloud' ? 'Google Cloud: labels' : '');
 </script>
 
 <div class="detail-section">
   <div class="section-header">
-    <h4>Tags</h4>
+    <div class="section-heading">
+      <h4>Tags</h4>
+      {#if nativeHint}
+        <span class="tag-native-hint" title={nativeHint}>{nativeHint}</span>
+      {/if}
+    </div>
     <button class="btn-action-sm" onclick={onadd}>+ Add</button>
   </div>
   {#if tags && tags.length > 0}
@@ -31,3 +42,19 @@
     <p class="no-tags">No tags</p>
   {/if}
 </div>
+
+<style>
+  .section-heading {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+    min-width: 0;
+  }
+
+  .tag-native-hint {
+    font-size: 10px;
+    color: #888;
+    font-weight: normal;
+    white-space: nowrap;
+  }
+</style>

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -79,6 +79,7 @@ export interface ScopeSelection {
   projectId: string;
   vaultName: string;
   storeName: string;
+  namespace: string;
 }
 
 // DetectResult mirrors the Go binding DTO (internal/gui/providers.go).
@@ -209,6 +210,7 @@ export const awsScopeSelection: ScopeSelection = {
   projectId: '',
   vaultName: '',
   storeName: '',
+  namespace: '',
 };
 
 /**
@@ -588,7 +590,7 @@ export function createNoAWSIdentityState(): Partial<MockState> {
 // ---- Provider-selection states (multi-cloud) ------------------------------
 
 function emptyScope(provider: string): ScopeSelection {
-  return { provider, projectId: '', vaultName: '', storeName: '' };
+  return { provider, projectId: '', vaultName: '', storeName: '', namespace: '' };
 }
 
 /**
@@ -784,6 +786,7 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
           projectId: p === 'googlecloud' ? (sel.projectId || '') : '',
           vaultName: p === 'azure' ? (sel.vaultName || '') : '',
           storeName: p === 'azure' ? (sel.storeName || '') : '',
+          namespace: p === 'azure' ? (sel.namespace || '') : '',
         };
       },
 

--- a/internal/gui/frontend/wailsjs/go/models.ts
+++ b/internal/gui/frontend/wailsjs/go/models.ts
@@ -316,17 +316,19 @@ export namespace gui {
 	    projectId: string;
 	    vaultName: string;
 	    storeName: string;
-	
+	    namespace: string;
+
 	    static createFrom(source: any = {}) {
 	        return new ScopeSelection(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.provider = source["provider"];
 	        this.projectId = source["projectId"];
 	        this.vaultName = source["vaultName"];
 	        this.storeName = source["storeName"];
+	        this.namespace = source["namespace"];
 	    }
 	}
 	export class SecretCreateResult {

--- a/internal/gui/scope_internal_test.go
+++ b/internal/gui/scope_internal_test.go
@@ -57,6 +57,13 @@ func TestApp_SelectScope(t *testing.T) {
 			},
 		},
 		{
+			name: "azure with store and app config namespace",
+			sel:  ScopeSelection{Provider: "azure", StoreName: "store", Namespace: "dev"},
+			wantScope: provider.Scope{
+				Provider: provider.ProviderAzure, StoreName: "store", AppConfigNamespace: "dev",
+			},
+		},
+		{
 			name:    "azure missing both vault and store",
 			sel:     ScopeSelection{Provider: "azure"},
 			wantErr: errAzureScopeRequired,
@@ -114,6 +121,11 @@ func TestApp_GetCurrentScope_RoundTrip(t *testing.T) {
 			name: "azure app config only",
 			sel:  ScopeSelection{Provider: "azure", StoreName: "store"},
 		},
+		{
+			// The App Configuration namespace round-trips through the scope.
+			name: "azure app config with namespace",
+			sel:  ScopeSelection{Provider: "azure", StoreName: "store", Namespace: "dev"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -149,6 +161,7 @@ func TestApp_GetCurrentScope_EnvDerivedInitialScope(t *testing.T) {
 func TestApp_GetCurrentScope_EnvDerivedAzure(t *testing.T) {
 	t.Setenv("AZURE_KEYVAULT_NAME", "env-vault")
 	t.Setenv("AZURE_APPCONFIG_NAME", "env-store")
+	t.Setenv("AZURE_APPCONFIG_NAMESPACE", "env-ns")
 
 	app := NewApp(provider.Scope{Provider: provider.ProviderAzure})
 
@@ -157,6 +170,36 @@ func TestApp_GetCurrentScope_EnvDerivedAzure(t *testing.T) {
 	assert.Equal(t, string(provider.ProviderAzure), got.Provider)
 	assert.Equal(t, "env-vault", got.VaultName)
 	assert.Equal(t, "env-store", got.StoreName)
+	assert.Equal(t, "env-ns", got.Namespace)
+}
+
+// TestApp_GetCurrentScope_EnvDerivedAzure_Namespace covers the App
+// Configuration namespace hydrating from AZURE_APPCONFIG_NAMESPACE while the
+// store name comes from its own env, mirroring the CLI's env channel.
+func TestApp_GetCurrentScope_EnvDerivedAzure_Namespace(t *testing.T) {
+	t.Setenv("AZURE_KEYVAULT_NAME", "")
+	t.Setenv("AZURE_APPCONFIG_NAME", "env-store")
+	t.Setenv("AZURE_APPCONFIG_NAMESPACE", "dev")
+
+	app := NewApp(provider.Scope{Provider: provider.ProviderAzure})
+
+	got := app.GetCurrentScope()
+	require.NotNil(t, got)
+	assert.Equal(t, "env-store", got.StoreName)
+	assert.Equal(t, "dev", got.Namespace)
+}
+
+// TestApp_GetCurrentScope_ExplicitNamespaceWinsOverEnv verifies a flag-supplied
+// namespace on the launch scope is not overwritten by the env fallback.
+func TestApp_GetCurrentScope_ExplicitNamespaceWinsOverEnv(t *testing.T) {
+	t.Setenv("AZURE_APPCONFIG_NAME", "env-store")
+	t.Setenv("AZURE_APPCONFIG_NAMESPACE", "env-ns")
+
+	app := NewApp(provider.Scope{Provider: provider.ProviderAzure, AppConfigNamespace: "flag-ns"})
+
+	got := app.GetCurrentScope()
+	require.NotNil(t, got)
+	assert.Equal(t, "flag-ns", got.Namespace)
 }
 
 // TestApp_GetCurrentScope_EnvDerivedAzure_VaultOnly covers a one-sided Azure


### PR DESCRIPTION
## Summary

Brings the GUI in line with the CLI for Epic #410 (task 3): the Azure App Configuration **namespace** axis can now be selected in the GUI, and metadata terminology is made consistent (the field stays **Tags**; Google Cloud users get a secondary "labels" hint). Targets the epic integration branch, not `main`.

## Go binding layer (`internal/gui/app.go`)
- Added `Namespace string` (JSON `namespace`) to `ScopeSelection`.
- `SelectScope` sets `scope.AppConfigNamespace = sel.Namespace`. This is the only read-path change needed: the Azure adapter already builds the App Configuration store from `scope.AppConfigNamespace` (`internal/provider/azure/azure.go`), so everything downstream flows via `provider.Scope` → `registry.Store`. Meaningful only for App Config; harmless for every other provider/store.
- `hydrateScope` seeds the namespace from `AZURE_APPCONFIG_NAMESPACE` when empty, right beside the existing `AZURE_APPCONFIG_NAME` hydration.
- `selectionFromScope` projects the namespace back so `GetCurrentScope` prefills the form.
- Updated the doc comments on `ScopeSelection` / `SelectScope`.

## Frontend — namespace input
- `Sidebar.svelte`: added a free-text **Namespace** input to the Azure App Configuration scope form (placeholder `empty = default`, help text `Azure calls this a label; empty = default. Applies to the App Configuration store only.`), wired into the `ScopeSelection` (`namespace`) sent to `SelectScope`. Added a read-only **Namespace** row to the Azure scope info. No discovery/dropdown (future work).
- `App.svelte`: carries `namespace` through `buildSelection` and the `{#key}` `scopeKey` so a namespace change fully remounts the views.

## Frontend — metadata terminology
- `TagList.svelte`: the field stays **"Tags"**; when the active provider is Google Cloud it shows a small secondary `Google Cloud: labels` hint next to the heading. No rename.
- `ParamView.svelte` / `SecretView.svelte`: accept and forward a `provider` prop to `TagList`.

## Bindings
The wails bindings task (`mise generate-gui-bindings`) drives `wails dev`, which needs a display/runtime not available in this environment, so `internal/gui/frontend/wailsjs/go/models.ts` was **hand-edited** to add the `namespace` field to `ScopeSelection` (constructor + field). **These should be regenerated on CI.**

## Verification
- `go build ./...` — pass.
- `go build -tags production ./cmd/...` — pass (frontend built locally to embed `dist`; only wails Objective-C deprecation warnings).
- `go test -tags production ./internal/gui/...` — pass (added namespace round-trip + `AZURE_APPCONFIG_NAMESPACE` hydration tests).
- `golangci-lint run --allow-parallel-runners --build-tags=e2e,production ./internal/gui/...` — 0 issues.
- Frontend (toolchain present): `npm install`, `npm run check` (0 errors), `npm run build` (ok), `npm run lint` (clean).
- Playwright (`npm run test`, all 3 browsers after installing them): **1506 passed, 3 failed**. Two were parallel-load flakes that pass in isolation; the third (`keyboard-focus.spec.ts:54`, webkit Tab-navigation) also fails on the base tree with my changes stashed, confirming it is a pre-existing environment-specific flake unrelated to this change. Updated the `wails-mock.ts` fixture to carry `namespace`.

Part of #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)