### PR TITLE
test(gui): Playwright coverage for App Configuration namespace input + Google Cloud tags hint

### DIFF
--- a/internal/gui/frontend/tests/scope-form.spec.ts
+++ b/internal/gui/frontend/tests/scope-form.spec.ts
@@ -78,6 +78,81 @@ test.describe('Azure scope form', () => {
     });
   });
 
+  test('namespace field feeds the SelectScope payload (trimmed) alongside the store', async ({ page }) => {
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForItemList(page);
+
+    await pickProvider(page, 'azure');
+    await page.locator('#azure-store').fill('the-store');
+    await page.locator('#azure-namespace').fill('  dev  '); // whitespace trimmed
+    await page.getByRole('button', { name: 'Connect' }).click();
+    await waitForItemList(page);
+
+    const calls = await getSelectScopeCalls(page);
+    expect(calls[calls.length - 1]).toMatchObject({
+      provider: 'azure',
+      storeName: 'the-store',
+      namespace: 'dev', // trimmed
+    });
+  });
+
+  test('an empty namespace submits as an empty string (App Config default label)', async ({ page }) => {
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForItemList(page);
+
+    await pickProvider(page, 'azure');
+    await page.locator('#azure-store').fill('the-store');
+    await page.locator('#azure-namespace').fill(''); // left empty
+    await page.getByRole('button', { name: 'Connect' }).click();
+    await waitForItemList(page);
+
+    const calls = await getSelectScopeCalls(page);
+    expect(calls[calls.length - 1]).toMatchObject({
+      provider: 'azure',
+      storeName: 'the-store',
+      namespace: '',
+    });
+  });
+
+  test('Change scope prefills the namespace from the current scope', async ({ page }) => {
+    // Azure launched with vault + store + a namespace already applied.
+    await setupWailsMocks(
+      page,
+      createAzureState({
+        currentScope: { provider: 'azure', projectId: '', vaultName: 'my-vault', storeName: 'my-store', namespace: 'dev' },
+      }),
+    );
+    await page.goto('/');
+    await waitForItemList(page);
+    await expect(page.locator('#azure-namespace')).toHaveCount(0); // connected: no form
+
+    // "Change scope" re-opens the form, prefilled with the current namespace.
+    await page.getByRole('button', { name: 'Change scope' }).click();
+    await expect(page.locator('#azure-vault')).toHaveValue('my-vault');
+    await expect(page.locator('#azure-store')).toHaveValue('my-store');
+    await expect(page.locator('#azure-namespace')).toHaveValue('dev');
+  });
+
+  test('namespace field is Azure-only (absent for Google Cloud and AWS)', async ({ page }) => {
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForItemList(page);
+
+    // Azure exposes the namespace field...
+    await pickProvider(page, 'azure');
+    await expect(page.locator('#azure-namespace')).toBeVisible();
+
+    // ...Google Cloud (project-only form) does not.
+    await pickProvider(page, 'googlecloud');
+    await expect(page.locator('#azure-namespace')).toHaveCount(0);
+
+    // ...AWS (no scope form) does not.
+    await pickProvider(page, 'aws');
+    await expect(page.locator('#azure-namespace')).toHaveCount(0);
+  });
+
   test('submitting an empty scope form disconnects and clears the cached scope', async ({ page }) => {
     // Connected to Azure (vault + store), so the scope is cached.
     await setupWailsMocks(page, createAzureState());

--- a/internal/gui/frontend/tests/tags-terminology.spec.ts
+++ b/internal/gui/frontend/tests/tags-terminology.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupWailsMocks,
+  createGoogleCloudState,
+  waitForItemList,
+  clickItemByName,
+} from './fixtures/wails-mock';
+
+// The Tags field keeps one vocabulary across every provider. Google Cloud
+// natively calls the same key=value metadata "labels", so TagList surfaces a
+// secondary hint ("Google Cloud: labels") for Google Cloud only — the field is
+// still titled "Tags" everywhere.
+test.describe('Tags terminology hint', () => {
+  test('Google Cloud: a tagged secret shows the "Google Cloud: labels" hint', async ({ page }) => {
+    await setupWailsMocks(
+      page,
+      createGoogleCloudState({
+        secretTags: { 'gcloud-secret-1': [{ key: 'team', value: 'backend' }] },
+      }),
+    );
+    await page.goto('/');
+    await waitForItemList(page);
+
+    // Google Cloud launches into the secret view.
+    await clickItemByName(page, 'gcloud-secret-1');
+    await expect(page.locator('.detail-panel')).toBeVisible();
+
+    // The field still reads "Tags", with the native-vocabulary hint beside it.
+    await expect(page.getByRole('heading', { name: 'Tags' })).toBeVisible();
+    const hint = page.locator('.tag-native-hint');
+    await expect(hint).toBeVisible();
+    await expect(hint).toHaveText('Google Cloud: labels');
+    await expect(page.locator('.tag-item')).toBeVisible();
+  });
+
+  test('AWS: a tagged parameter shows no native hint (field still titled "Tags")', async ({ page }) => {
+    // Default state is AWS; /app/config carries an existing tag.
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForItemList(page);
+
+    await clickItemByName(page, '/app/config');
+    await expect(page.locator('.detail-panel')).toBeVisible();
+
+    await expect(page.getByRole('heading', { name: 'Tags' })).toBeVisible();
+    await expect(page.locator('.tag-item')).toBeVisible();
+    // No native-vocabulary hint outside Google Cloud.
+    await expect(page.locator('.tag-native-hint')).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds Playwright test coverage for the GUI namespace + terminology feature of Epic #410 (namespace input in `Sidebar.svelte`, tags hint in `TagList.svelte`). Tests only — no component/app behavior changed. Targets the epic branch.

## Specs / cases added

### `tests/scope-form.spec.ts` (Azure scope form)
- **namespace field feeds the SelectScope payload (trimmed)** — pick Azure, fill `#azure-store` = `the-store` and `#azure-namespace` = `  dev  `, submit → captured `getSelectScopeCalls` payload asserts `storeName: 'the-store'`, `namespace: 'dev'` (surrounding whitespace trimmed).
- **an empty namespace submits as an empty string** — submit with `#azure-namespace` empty → payload `namespace: ''`.
- **Change scope prefills the namespace from the current scope** — an initial connected Azure scope with `namespace: 'dev'`; open "Change scope" and assert `#azure-namespace` shows `dev` (alongside the existing `my-vault`/`my-store` prefill).
- **namespace field is Azure-only** — `#azure-namespace` is visible for Azure and has count 0 for Google Cloud and AWS (mirrors the existing `#azure-vault` count==0 assertions).

### `tests/tags-terminology.spec.ts` (new)
- **Google Cloud hint present** — under a Google Cloud scope, view a tagged secret and assert `.tag-native-hint` is visible with text `Google Cloud: labels` (field still titled "Tags").
- **AWS hint absent** — under the default AWS scope, view a tagged parameter and assert `.tag-native-hint` has count 0 (hint hidden; "Tags" heading + tag item still render).

## Verification
- `npm run check` — 0 errors (3 pre-existing warnings only).
- `npm run lint` — clean.
- `go build ./...` — clean (no Go changes).
- `npm run test` (full Playwright suite, chromium/firefox/webkit): **1526 passed, 1 failed**.
  - The single failure is `[webkit] tests/keyboard-focus.spec.ts:54 › should allow Tab navigation through item list` — **confirmed pre-existing**: it fails identically on the untouched base tree (verified via `git stash -u` + isolated re-run) and is unrelated to these test-only additions.
  - All new cases pass across all three browsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)