### PR TITLE
fix(gui): make tag-only staged changes visible & actionable in the Staging Area

### DIFF
--- a/internal/gui/frontend/src/lib/StagingSection.svelte
+++ b/internal/gui/frontend/src/lib/StagingSection.svelte
@@ -66,6 +66,11 @@
   function findTagEntry(name: string): gui.StagingDiffTagEntry | undefined {
     return tagEntries.find(t => t.name === name);
   }
+
+  // Tag entries with no matching value entry represent a tag-only staged change.
+  // The value-entry loop only draws tags nested inside a value entry, so these
+  // get their own rows and are counted toward the section total and gating.
+  const tagOnlyEntries = $derived(tagEntries.filter(t => !entries.some(e => e.name === t.name)));
 </script>
 
 <div class="section">
@@ -74,16 +79,16 @@
       <span class="section-icon">{icon}</span>
       {title}
     </h3>
-    <span class="count-badge">{entries.length}</span>
+    <span class="count-badge">{entries.length + tagOnlyEntries.length}</span>
     <div class="section-actions">
-      {#if entries.length > 0}
+      {#if entries.length + tagOnlyEntries.length > 0}
         <button class="btn-section btn-apply-sm" onclick={onapply}>Apply</button>
         <button class="btn-section btn-reset-sm" onclick={onreset}>Reset</button>
       {/if}
     </div>
   </div>
 
-  {#if entries.length === 0}
+  {#if entries.length === 0 && tagOnlyEntries.length === 0}
     <div class="empty-state">{emptyText}</div>
   {:else}
     <ul class="entry-list">
@@ -160,6 +165,43 @@
               <pre class="entry-value">{entry.stagedValue}</pre>
             {/if}
           {/if}
+        </li>
+      {/each}
+      {#each tagOnlyEntries as tagEntry}
+        <li class="entry-item">
+          <div class="entry-header">
+            <span class="entry-name">{tagEntry.name}</span>
+            <div class="entry-actions">
+              <button class="btn-entry btn-unstage" onclick={() => onunstage(tagEntry.name)}>Unstage</button>
+            </div>
+          </div>
+          <div class="entry-tags">
+            {#if hasTags}
+            {#if tagEntry.addTags && Object.keys(tagEntry.addTags).length > 0}
+              <div class="tag-changes tag-add">
+                <span class="tag-label">+ Tags:</span>
+                {#each Object.entries(tagEntry.addTags) as [key, value]}
+                  <button class="tag-item tag-item-editable" type="button" onclick={() => onedittag(tagEntry.name, key, value)}>
+                    {key}={value}
+                    <span class="tag-delete-btn" role="button" tabindex="0" onclick={(e: MouseEvent) => { e.stopPropagation(); onremovetag(tagEntry.name, key); }} onkeydown={(e: KeyboardEvent) => { e.stopPropagation(); if (e.key === 'Enter') onremovetag(tagEntry.name, key); }}>×</span>
+                  </button>
+                {/each}
+              </div>
+            {/if}
+            {#if tagEntry.removeTags && Object.keys(tagEntry.removeTags).length > 0}
+              <div class="tag-changes tag-remove">
+                <span class="tag-label">- Tags:</span>
+                {#each Object.entries(tagEntry.removeTags) as [key, value]}
+                  <span class="tag-item">
+                    {value ? `${key}=${value}` : key}
+                    <button class="tag-cancel-btn" onclick={() => oncanceluntag(tagEntry.name, key)} title="Cancel untag">↩</button>
+                  </span>
+                {/each}
+              </div>
+            {/if}
+            <button class="btn-add-tag" onclick={() => onaddtag(tagEntry.name)}>+ Add Tag</button>
+            {/if}
+          </div>
         </li>
       {/each}
     </ul>

--- a/internal/gui/frontend/src/lib/StagingView.svelte
+++ b/internal/gui/frontend/src/lib/StagingView.svelte
@@ -503,18 +503,18 @@
     <div class="actions-center">
       <button
         class="btn-action btn-apply"
-        onclick={() => openApplyModal(paramEntries.length > 0 ? 'param' : 'secret')}
-        disabled={paramEntries.length === 0 && secretEntries.length === 0}
+        onclick={() => openApplyModal((paramEntries.length > 0 || paramTagEntries.length > 0) ? 'param' : 'secret')}
+        disabled={paramEntries.length === 0 && secretEntries.length === 0 && paramTagEntries.length === 0 && secretTagEntries.length === 0}
       >
         Apply All
       </button>
       <button
         class="btn-action btn-reset"
         onclick={() => {
-          if (paramEntries.length > 0) openResetModal('param');
-          if (secretEntries.length > 0) openResetModal('secret');
+          if (paramEntries.length > 0 || paramTagEntries.length > 0) openResetModal('param');
+          if (secretEntries.length > 0 || secretTagEntries.length > 0) openResetModal('secret');
         }}
-        disabled={paramEntries.length === 0 && secretEntries.length === 0}
+        disabled={paramEntries.length === 0 && secretEntries.length === 0 && paramTagEntries.length === 0 && secretTagEntries.length === 0}
       >
         Reset All
       </button>
@@ -538,7 +538,7 @@
           <button
             class="dropdown-item"
             onclick={() => { showStashDropdown = false; openPersistModal(); }}
-            disabled={loading || (paramEntries.length === 0 && secretEntries.length === 0)}
+            disabled={loading || (paramEntries.length === 0 && secretEntries.length === 0 && paramTagEntries.length === 0 && secretTagEntries.length === 0)}
           >
             <span class="dropdown-icon">⏏️</span>
             Push <span class="dropdown-desc">(Persist)</span>

--- a/internal/gui/frontend/tests/staging.spec.ts
+++ b/internal/gui/frontend/tests/staging.spec.ts
@@ -598,3 +598,102 @@ test.describe('Staging Edge Cases', () => {
     await expect(page.locator('.entry-item')).toBeVisible();
   });
 });
+
+// ============================================================================
+// Tag-Only Staged Changes (regression: #416)
+//
+// A staged change with ONLY tag edits (no value change) must be rendered,
+// counted, and actionable in its service section. Before the fix the sidebar
+// badge counted it while the section showed count 0 / "No staged changes" and
+// Apply/Reset/Stash were all disabled.
+// ============================================================================
+
+test.describe('Tag-Only Staged Changes (#416)', () => {
+  // Parametrize across both AWS services so the fix is proven for value-less
+  // tag changes on param and secret alike. sectionIndex: param is the first
+  // .section, secret the second (both services exist under the AWS provider).
+  const cases = [
+    {
+      service: 'param',
+      sectionIndex: 0,
+      name: '/app/config',
+      seed: (tags: ReturnType<typeof createStagedTags>[]) => createTagOnlyStagedState(tags, []),
+      valueAndTag: (): Partial<MockState> => ({
+        stagedParam: [createStagedValue('/app/config', 'update', 'new-value')],
+        stagedParamTags: [createStagedTags('/app/config', { env: 'prod' }, {})],
+        stagedSecret: [],
+        stagedSecretTags: [],
+      }),
+    },
+    {
+      service: 'secret',
+      sectionIndex: 1,
+      name: 'my-secret',
+      seed: (tags: ReturnType<typeof createStagedTags>[]) => createTagOnlyStagedState([], tags),
+      valueAndTag: (): Partial<MockState> => ({
+        stagedParam: [],
+        stagedParamTags: [],
+        stagedSecret: [createStagedValue('my-secret', 'update', 'new-value')],
+        stagedSecretTags: [createStagedTags('my-secret', { env: 'prod' }, {})],
+      }),
+    },
+  ] as const;
+
+  for (const c of cases) {
+    test(`${c.service}: tag-only change renders in its section with count 1 and no empty-state`, async ({ page }) => {
+      const state = c.seed([createStagedTags(c.name, { env: 'staging' }, { old: 'gone' })]);
+      await setupWailsMocks(page, state);
+      await page.goto('/');
+      await navigateTo(page, 'Staging');
+      await page.waitForFunction(() => document.querySelector('.entry-item') !== null);
+
+      const section = page.locator('.section').nth(c.sectionIndex);
+      // Section shows exactly one entry (the tag-only row), count badge 1.
+      await expect(section.locator('.entry-item')).toHaveCount(1);
+      await expect(section.locator('.count-badge')).toHaveText('1');
+      // Empty-state must NOT be shown for this section.
+      await expect(section.locator('.empty-state')).toHaveCount(0);
+      // Entry renders the name and both the add / remove tag chips.
+      await expect(section.locator('.entry-name')).toHaveText(c.name);
+      await expect(section.locator('.tag-add')).toContainText('env=staging');
+      await expect(section.locator('.tag-remove')).toContainText('old');
+      // Tag-only rows carry no value operation badge.
+      await expect(section.locator('.operation-badge')).toHaveCount(0);
+      // Per-section Apply / Reset are enabled.
+      await expect(section.locator('.btn-apply-sm')).toBeEnabled();
+      await expect(section.locator('.btn-reset-sm')).toBeEnabled();
+    });
+
+    test(`${c.service}: Apply All / Reset All / Stash enabled with only a tag-only change`, async ({ page }) => {
+      const state = c.seed([createStagedTags(c.name, { env: 'staging' }, {})]);
+      await setupWailsMocks(page, state);
+      await page.goto('/');
+      await navigateTo(page, 'Staging');
+      await page.waitForFunction(() => document.querySelector('.entry-item') !== null);
+
+      await expect(page.getByRole('button', { name: 'Apply All' })).toBeEnabled();
+      await expect(page.getByRole('button', { name: 'Reset All' })).toBeEnabled();
+
+      // Open the Stash dropdown and confirm Push (Persist) is enabled.
+      await page.getByRole('button', { name: /Stash/ }).click();
+      await expect(page.getByRole('button', { name: /Push/ })).toBeEnabled();
+    });
+
+    test(`${c.service}: value + tag change on the same name renders a single row`, async ({ page }) => {
+      await setupWailsMocks(page, c.valueAndTag());
+      await page.goto('/');
+      await navigateTo(page, 'Staging');
+      await page.waitForFunction(() => document.querySelector('.entry-item') !== null);
+
+      const section = page.locator('.section').nth(c.sectionIndex);
+      // Regression guard: the new tag-only loop must NOT duplicate a name that
+      // already has a value entry.
+      await expect(section.locator('.entry-item')).toHaveCount(1);
+      await expect(section.locator('.count-badge')).toHaveText('1');
+      await expect(section.locator('.entry-name')).toHaveText(c.name);
+      // Value operation badge and the tag chip both belong to the one row.
+      await expect(section.locator('.operation-badge')).toHaveText(/update/i);
+      await expect(section.locator('.tag-add')).toContainText('env=prod');
+    });
+  }
+});


### PR DESCRIPTION
## Root cause

In the GUI Staging Area, a staged change with **only tag edits** (no value change) was counted by the sidebar badge but was invisible and unactionable in the main panel: the service section showed count `0` / "No staged changes" and Apply/Reset/Stash were disabled.

The frontend drove all rendering, counting, and gating off the value-`entries` array only. Staged tags (`tagEntries`) were drawn solely as a sub-element of a matching value entry (`findTagEntry(entry.name)` inside the `{#each entries}` loop), so a **tag-only** change — which has no value entry — fell through every render path and gate. The sidebar total already added tag entries, so the badge disagreed with the sections. Regression from #241.

Go bindings already return `entries` and `tagEntries` correctly; this is purely the Svelte render/gating layer.

## Changes

### `internal/gui/frontend/src/lib/StagingSection.svelte`
- Derived `tagOnlyEntries` = `tagEntries` whose `name` has no matching value entry.
- Count badge, empty-state condition, and the per-section Apply/Reset gate now use `entries.length + tagOnlyEntries.length`.
- After the existing `{#each entries}` block, render tag-only entries as their own rows, reusing the same `.entry-tags` add (`+`)/remove (`-`) markup and classes driven by `tagEntry.addTags`/`tagEntry.removeTags`. No operation badge, no value/diff area, no Edit button; keeps an Unstage button and the tag edit controls for consistency.

### `internal/gui/frontend/src/lib/StagingView.svelte`
- Apply All: `disabled` now also considers `paramTagEntries`/`secretTagEntries`, and the service it opens treats a service as non-empty when it has value OR tag entries.
- Reset All: same `disabled` fix; the reset loop fires for a service with value OR tag entries.
- Stash Push: `disabled` gate now includes tag entries.
- (The `oncountchange` total was already correct and left unchanged.)

## Playwright cases added (`tests/staging.spec.ts`, parametrized param + secret)
- Tag-only staged change → section shows the entry (name + add/remove tag chips), count badge is **1**, empty-state is **not** shown, per-section Apply/Reset enabled, no operation badge.
- Apply All / Reset All / Stash Push are **enabled** with only a tag-only change staged.
- Regression guard: a value+tag change on the same name renders exactly **one** row (not duplicated by the new tag-only loop), with the value operation badge and tag chip on that single row.

## Test run
- `npm run check`: 0 errors (3 pre-existing warnings).
- `npm run lint`: clean.
- `npm run test` (chromium/firefox/webkit): **1526 passed, 1 failed** — the single failure is the pre-existing `[webkit] keyboard-focus.spec.ts:54 "should allow Tab navigation through item list"` flake, confirmed to fail identically on the base tree (`git stash` + isolated run); unrelated to this change. All 18 new tag-only cases pass on all three browsers.
- `go build ./...` from repo root: clean (no Go changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)