### PR TITLE
fix(gui): label GCloud/Key Vault version state as "State", not "Labels"

### DIFF
--- a/internal/gui/frontend/src/lib/SecretView.svelte
+++ b/internal/gui/frontend/src/lib/SecretView.svelte
@@ -30,6 +30,12 @@
   const forceDeleteEnabled = $derived(capability?.hasForceDelete ?? true);
   const recoveryWindowEnabled = $derived(capability?.hasRecoveryWindow ?? true);
 
+  // Version.Label is overloaded per provider: AWS Secrets Manager carries genuine
+  // staging labels (AWSCURRENT/AWSPENDING/...), while Google Cloud and Azure Key
+  // Vault carry the per-version state (enabled/disabled/destroyed). Only AWS has
+  // staging labels, so label the heading accordingly.
+  const versionMetaLabel = $derived(provider === 'aws' ? 'Labels' : 'State');
+
   const PAGE_SIZE = 50;
   const debounce = createDebouncer(300);
   const diffMode = createDiffMode<string>();
@@ -548,7 +554,7 @@
               </div>
               {#if (secretDetail.versionStage || []).length > 0}
                 <div class="meta-item">
-                  <span class="meta-label">Labels</span>
+                  <span class="meta-label">{versionMetaLabel}</span>
                   <span class="meta-value">
                     {#each secretDetail.versionStage || [] as stage}
                       <span class="badge badge-stage">{stage}</span>

--- a/internal/gui/frontend/tests/secret.spec.ts
+++ b/internal/gui/frontend/tests/secret.spec.ts
@@ -5,6 +5,8 @@ import {
   createSecret,
   createMultiTagState,
   createNoTagsState,
+  createGoogleCloudState,
+  createAzureState,
   waitForItemList,
   clickItemByName,
   openCreateModal,
@@ -485,5 +487,67 @@ test.describe('Secret provider-neutral presence gating (#268)', () => {
 
   test('still renders always-present metadata (Version ID)', async ({ page }) => {
     await expect(page.locator('.meta-label').filter({ hasText: 'Version ID' })).toBeVisible();
+  });
+});
+
+// domain.Version.Label is overloaded: AWS Secrets Manager carries genuine
+// staging labels (AWSCURRENT/...), while Google Cloud and Azure Key Vault carry
+// the per-version STATE (enabled/disabled/destroyed). The version-meta heading
+// must therefore read "Labels" only for AWS and "State" for the others (#418).
+test.describe('Secret version-meta heading is provider-aware (#418)', () => {
+  const metaLabel = (page: import('@playwright/test').Page, text: string) =>
+    page.locator('.detail-meta .meta-label').filter({ hasText: text });
+
+  test('Google Cloud: version state is headed "State" (not "Labels"), badge shows the state', async ({ page }) => {
+    await setupWailsMocks(
+      page,
+      createGoogleCloudState({
+        secrets: [{ name: 'gcloud-secret-1', value: 'v1', arn: '', versionStage: ['enabled'] }],
+      }),
+    );
+    await page.goto('/');
+    await waitForItemList(page);
+
+    // Google Cloud launches straight into the secret view.
+    await clickItemByName(page, 'gcloud-secret-1');
+    await expect(page.locator('.detail-panel')).toBeVisible();
+
+    await expect(metaLabel(page, 'State')).toBeVisible();
+    await expect(metaLabel(page, 'Labels')).toHaveCount(0);
+    await expect(page.locator('.detail-meta .badge-stage')).toHaveText('enabled');
+  });
+
+  test('Azure Key Vault: version state is headed "State" (not "Labels")', async ({ page }) => {
+    await setupWailsMocks(
+      page,
+      createAzureState({
+        secrets: [{ name: 'kv-secret', value: 'v', arn: '', versionStage: ['enabled'], versionId: 'a1b2c3d4e5f6' }],
+      }),
+    );
+    await page.goto('/');
+    await navigateTo(page, 'Key Vault');
+    await waitForItemList(page);
+
+    await clickItemByName(page, 'kv-secret');
+    await expect(page.locator('.detail-panel')).toBeVisible();
+
+    await expect(metaLabel(page, 'State')).toBeVisible();
+    await expect(metaLabel(page, 'Labels')).toHaveCount(0);
+    await expect(page.locator('.detail-meta .badge-stage')).toHaveText('enabled');
+  });
+
+  test('AWS Secrets Manager: staging label is headed "Labels" (not "State")', async ({ page }) => {
+    // Default state is AWS; my-secret carries the default ['AWSCURRENT'] staging label.
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await navigateTo(page, 'Secret');
+    await waitForItemList(page);
+
+    await clickItemByName(page, 'my-secret');
+    await expect(page.locator('.detail-panel')).toBeVisible();
+
+    await expect(metaLabel(page, 'Labels')).toBeVisible();
+    await expect(metaLabel(page, 'State')).toHaveCount(0);
+    await expect(page.locator('.detail-meta .badge-stage')).toHaveText('AWSCURRENT');
   });
 });


### PR DESCRIPTION
## Root cause

suve's neutral `domain.Version.Label` is overloaded per provider:

- **AWS Secrets Manager** → genuine **staging labels** (`AWSCURRENT`/`AWSPENDING`/`AWSPREVIOUS`) — "Labels" is correct.
- **Google Cloud** → version **state** via `stateLabel(state)` (`enabled`/`disabled`/`destroyed`).
- **Azure Key Vault** → enabled/disabled **state** via `enabledLabel(...)`.

The GUI carried this in `SecretDetail.versionStage` and rendered it under a hardcoded **"Labels"** heading for all providers. So for GCloud & Key Vault the heading was a misnomer ("Labels: enabled"), and on GCloud it collided with the real labels (which suve surfaces as **Tags**, hinted "Google Cloud: labels").

## Change

Provider-aware heading in `internal/gui/frontend/src/lib/SecretView.svelte`:

```svelte
const versionMetaLabel = $derived(provider === 'aws' ? 'Labels' : 'State');
```

Since only AWS Secrets Manager has staging labels, the current-version metadata heading now reads **"Labels"** for AWS and **"State"** for Google Cloud and Azure Key Vault.

This is a display-heading fix only. The badge values, `badge-stage` styling, the version-history badges, the Go bindings, adapters, and `domain.Version` are all untouched. The cleaner long-term domain split (distinct state vs staging-label fields) noted in the issue is explicitly out of scope.

## Tests (Playwright)

Added a `Secret version-meta heading is provider-aware (#418)` block to `internal/gui/frontend/tests/secret.spec.ts`, using the existing `createGoogleCloudState` / `createAzureState` / default-AWS fixtures:

- **Google Cloud** secret with a version state → heading reads **"State"** (not "Labels"), and the `enabled` `.badge-stage` is shown.
- **Azure Key Vault** secret → heading reads **"State"**, `enabled` badge shown.
- **AWS Secrets Manager** secret with an `AWSCURRENT` staging label → heading reads **"Labels"** (not "State"), badge shows `AWSCURRENT`.

Selectors are resilient: `.detail-meta .meta-label` filtered by text, plus `.detail-meta .badge-stage`.

## Verification (`internal/gui/frontend/`)

- `npm run check` — 0 errors (3 pre-existing warnings, unrelated).
- `npm run lint` — clean.
- `npm run test` — **1553 passed**, 9 new cases pass across chromium/firefox/webkit. The sole failure is the known pre-existing `[webkit] keyboard-focus.spec.ts` flake — confirmed it also fails on the base tree (`git stash` + isolated run), unrelated to this change.
- `go build ./...` from repo root — succeeds (no Go changes).

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)