### PR TITLE
feat(domain): split Version.State from staging labels (Phase A of #419)

### DIFF
--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -21,13 +21,45 @@ const (
 	ValueTypeList ValueType = "list" // AWS StringList
 )
 
-// Version identifies one version of an entry. Label is optional and may be
-// empty for providers without human-facing version labels.
+// Version identifies one version of an entry.
+//
+// It carries two independent, provider-specific axes that must NOT be
+// conflated (#419):
+//
+//   - StagingLabels are movable pointers naming "which version is current"
+//     (AWS Secrets Manager: AWSCURRENT / AWSPENDING / AWSPREVIOUS). Rotation
+//     moves a label from one version to another; a version may carry several
+//     labels or none (unlabeled versions are passively retained history, still
+//     readable by ID). Multi-valued.
+//   - State is a per-version enable/disable switch for reading that specific
+//     version's value (Google Cloud + Azure Key Vault). It is single-valued and
+//     orthogonal to "which version is latest".
+//
+// Providers that have neither concept (AWS SSM, Azure App Configuration) leave
+// both empty.
 type Version struct {
 	// ID is the provider-internal version identifier.
 	ID string
 	// Label is an optional human-facing label (empty when unsupported).
+	//
+	// NOTE: Label is overloaded to mean a representative staging label (AWS
+	// Secrets Manager) OR a per-version state (Google Cloud, Azure Key Vault).
+	// It is retained for back-compat during the #419 migration; prefer
+	// StagingLabels or State in new code. A later cleanup removes it once all
+	// readers migrate (do NOT mark it Deprecated yet: that would trip staticcheck
+	// SA1019 on the existing dual-write readers this phase must preserve).
 	Label string
+	// State is the per-version lifecycle state: "enabled" / "disabled" /
+	// "destroyed", or "" when the provider has no such concept. It is a
+	// per-version switch controlling whether that version's value can be read
+	// (Google Cloud + Azure Key Vault); it is orthogonal to which version is
+	// latest. Empty for AWS Secrets Manager, AWS SSM and Azure App Config.
+	State string
+	// StagingLabels are the AWS Secrets Manager staging labels for this version
+	// (all of them, e.g. AWSCURRENT / AWSPREVIOUS). A staging label is a movable
+	// pointer naming "which version is current", not a per-version state.
+	// nil/empty for every other provider.
+	StagingLabels []string
 	// Created is the version creation time, if known.
 	Created *time.Time
 }

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -21,9 +21,11 @@ func TestEntry_Fields(t *testing.T) {
 		Value: "hunter2",
 		Type:  domain.ValueTypeSecret,
 		Version: domain.Version{
-			ID:      "v3",
-			Label:   "current",
-			Created: &created,
+			ID:            "v3",
+			Label:         "current",
+			State:         "enabled",
+			StagingLabels: []string{"AWSCURRENT", "AWSPREVIOUS"},
+			Created:       &created,
 		},
 		Description: "example",
 		Tags:        []domain.Tag{{Key: "env", Value: "prod"}},
@@ -35,6 +37,8 @@ func TestEntry_Fields(t *testing.T) {
 	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
 	assert.Equal(t, "v3", entry.Version.ID)
 	assert.Equal(t, "current", entry.Version.Label)
+	assert.Equal(t, "enabled", entry.Version.State)
+	assert.Equal(t, []string{"AWSCURRENT", "AWSPREVIOUS"}, entry.Version.StagingLabels)
 	assert.Equal(t, &created, entry.Version.Created)
 	assert.Equal(t, "example", entry.Description)
 	assert.Len(t, entry.Tags, 1)

--- a/internal/provider/aws/secret/secret.go
+++ b/internal/provider/aws/secret/secret.go
@@ -254,9 +254,10 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 		Value: aws.ToString(out.SecretString),
 		Type:  domain.ValueTypeSecret,
 		Version: domain.Version{
-			ID:      aws.ToString(out.VersionId),
-			Label:   representativeStage(out.VersionStages),
-			Created: out.CreatedDate,
+			ID:            aws.ToString(out.VersionId),
+			Label:         representativeStage(out.VersionStages),
+			StagingLabels: out.VersionStages,
+			Created:       out.CreatedDate,
 		},
 		Modified: out.CreatedDate,
 		Extra:    []domain.Field{{Label: "ARN", Value: aws.ToString(out.ARN)}},
@@ -286,9 +287,10 @@ func (s *Store) History(ctx context.Context, name string) ([]domain.Version, err
 
 	return lo.Map(list, func(v types.SecretVersionsListEntry, _ int) domain.Version {
 		return domain.Version{
-			ID:      aws.ToString(v.VersionId),
-			Label:   representativeStage(v.VersionStages),
-			Created: v.CreatedDate,
+			ID:            aws.ToString(v.VersionId),
+			Label:         representativeStage(v.VersionStages),
+			StagingLabels: v.VersionStages,
+			Created:       v.CreatedDate,
 		}
 	}), nil
 }
@@ -505,9 +507,10 @@ func (s *Store) Describe(ctx context.Context, name string) (*domain.Entry, error
 			return slices.Contains(v.VersionStages, "AWSCURRENT")
 		}); found {
 			entry.Version = domain.Version{
-				ID:      aws.ToString(cur.VersionId),
-				Label:   representativeStage(cur.VersionStages),
-				Created: cur.CreatedDate,
+				ID:            aws.ToString(cur.VersionId),
+				Label:         representativeStage(cur.VersionStages),
+				StagingLabels: cur.VersionStages,
+				Created:       cur.CreatedDate,
 			}
 		}
 	}

--- a/internal/provider/aws/secret/secret_test.go
+++ b/internal/provider/aws/secret/secret_test.go
@@ -205,6 +205,9 @@ func TestGet_MapsEntryWithDescriptionAndTags(t *testing.T) {
 	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
 	assert.Equal(t, "id-3", entry.Version.ID)
 	assert.Equal(t, "AWSCURRENT", entry.Version.Label)
+	// StagingLabels carries the full stage set; State is empty (no such concept).
+	assert.Equal(t, []string{"AWSCURRENT"}, entry.Version.StagingLabels)
+	assert.Empty(t, entry.Version.State)
 	assert.Equal(t, "my desc", entry.Description)
 	require.Len(t, entry.Tags, 1)
 	assert.Equal(t, "env", entry.Tags[0].Key)
@@ -254,6 +257,8 @@ func TestGet_LabelPrefersAWSCURRENTRegardlessOfOrder(t *testing.T) {
 	entry, err := store.Get(t.Context(), "my-secret", provider.NewVersionRef("id-3"))
 	require.NoError(t, err)
 	assert.Equal(t, "AWSCURRENT", entry.Version.Label)
+	// The representative Label collapses to one; StagingLabels keeps them all.
+	assert.Equal(t, []string{"my-custom-label", "AWSPREVIOUS", "AWSCURRENT"}, entry.Version.StagingLabels)
 }
 
 // Priority ordering among the well-known and custom labels: AWSPENDING beats
@@ -287,9 +292,11 @@ func TestHistory_LabelPriorityOrdering(t *testing.T) {
 	// Newest first: id-2 (AWSPENDING preferred over AWSPREVIOUS).
 	assert.Equal(t, "id-2", versions[0].ID)
 	assert.Equal(t, "AWSPENDING", versions[0].Label)
+	assert.Equal(t, []string{"AWSPREVIOUS", "AWSPENDING"}, versions[0].StagingLabels)
 	// Custom-only labels tie-break lexicographically: "alpha" < "zeta".
 	assert.Equal(t, "id-1", versions[1].ID)
 	assert.Equal(t, "alpha", versions[1].Label)
+	assert.Equal(t, []string{"zeta", "alpha"}, versions[1].StagingLabels)
 }
 
 func TestHistory_NewestFirst(t *testing.T) {
@@ -642,6 +649,7 @@ func TestDescribe(t *testing.T) {
 	assert.Equal(t, "the desc", entry.Description)
 	assert.Equal(t, "id-3", entry.Version.ID)
 	assert.Equal(t, "AWSCURRENT", entry.Version.Label)
+	assert.Equal(t, []string{"AWSCURRENT"}, entry.Version.StagingLabels)
 	// The version's own creation time, not the secret-level CreatedDate.
 	require.NotNil(t, entry.Version.Created)
 	assert.Equal(t, currentVersionCreated, *entry.Version.Created)

--- a/internal/provider/azure/keyvault/keyvault.go
+++ b/internal/provider/azure/keyvault/keyvault.go
@@ -168,6 +168,7 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 	if attr := resp.Attributes; attr != nil {
 		entry.Version.Created = attr.Created
 		entry.Version.Label = enabledLabel(attr.Enabled)
+		entry.Version.State = enabledLabel(attr.Enabled)
 		entry.Modified = attr.Updated
 	}
 
@@ -186,6 +187,7 @@ func (s *Store) History(ctx context.Context, name string) ([]domain.Version, err
 		return domain.Version{
 			ID:      v.id,
 			Label:   boolLabel(v.enabled),
+			State:   boolLabel(v.enabled),
 			Created: v.created,
 		}
 	}), nil

--- a/internal/provider/azure/keyvault/keyvault_test.go
+++ b/internal/provider/azure/keyvault/keyvault_test.go
@@ -154,6 +154,9 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
 	assert.Equal(t, "v1", entry.Version.ID)
 	assert.Equal(t, "enabled", entry.Version.Label)
+	// State carries the per-version enable/disable; StagingLabels is not a Key Vault concept.
+	assert.Equal(t, "enabled", entry.Version.State)
+	assert.Empty(t, entry.Version.StagingLabels)
 	assert.Equal(t, []domain.Tag{{Key: "env", Value: "prod"}}, entry.Tags)
 }
 
@@ -193,8 +196,12 @@ func TestHistory(t *testing.T) {
 	// Newest first.
 	assert.Equal(t, "new", versions[0].ID)
 	assert.Equal(t, "enabled", versions[0].Label)
+	assert.Equal(t, "enabled", versions[0].State)
+	assert.Empty(t, versions[0].StagingLabels)
 	assert.Equal(t, "old", versions[1].ID)
 	assert.Equal(t, "disabled", versions[1].Label)
+	assert.Equal(t, "disabled", versions[1].State)
+	assert.Empty(t, versions[1].StagingLabels)
 }
 
 func TestList(t *testing.T) {

--- a/internal/provider/gcloud/secret/secret.go
+++ b/internal/provider/gcloud/secret/secret.go
@@ -210,6 +210,7 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 		created := toTime(sv.GetCreateTime())
 		entry.Version.Created = created
 		entry.Version.Label = stateLabel(sv.GetState())
+		entry.Version.State = stateLabel(sv.GetState())
 		entry.Modified = created
 	}
 
@@ -240,6 +241,7 @@ func (s *Store) History(ctx context.Context, name string) ([]domain.Version, err
 		return domain.Version{
 			ID:      versionNumber(v.GetName()),
 			Label:   stateLabel(v.GetState()),
+			State:   stateLabel(v.GetState()),
 			Created: toTime(v.GetCreateTime()),
 		}
 	}), nil

--- a/internal/provider/gcloud/secret/secret_test.go
+++ b/internal/provider/gcloud/secret/secret_test.go
@@ -261,8 +261,13 @@ func TestHistory(t *testing.T) {
 	// Newest first: version 2 (enabled) then 1 (destroyed).
 	assert.Equal(t, "2", versions[0].ID)
 	assert.Equal(t, "enabled", versions[0].Label)
+	// State carries the per-version lifecycle; StagingLabels is not a GCloud concept.
+	assert.Equal(t, "enabled", versions[0].State)
+	assert.Empty(t, versions[0].StagingLabels)
 	assert.Equal(t, "1", versions[1].ID)
 	assert.Equal(t, "destroyed", versions[1].Label)
+	assert.Equal(t, "destroyed", versions[1].State)
+	assert.Empty(t, versions[1].StagingLabels)
 }
 
 func TestList(t *testing.T) {


### PR DESCRIPTION
## Phase A of #419 — split version *state* from *staging labels* in `domain.Version`

`domain.Version.Label` is overloaded to carry two fundamentally different concepts depending on provider: an AWS Secrets Manager **staging label** (a movable "which version is current" pointer, multi-valued) vs. a per-version **state** (`enabled`/`disabled`/`destroyed`, a single on/off switch on Google Cloud + Azure Key Vault). This phase models the two axes explicitly and **dual-writes** them, leaving `Label` exactly as-is so nothing downstream breaks yet.

### Domain change (`internal/domain/domain.go`)
Two new fields on `Version` (alongside the retained `ID`, `Label`, `Created`):
- `State string` — per-version lifecycle state (`enabled`/`disabled`/`destroyed`, `""` when the provider has no such concept).
- `StagingLabels []string` — the full set of AWS Secrets Manager staging labels; nil/empty otherwise.

Both are documented with the two mental models. `Label` is kept for back-compat during the migration (intentionally **not** marked `Deprecated:` yet — that would trip staticcheck SA1019 on the dual-write readers this phase must preserve).

### Per-adapter dual-write (existing `Label:` assignments untouched)
- **AWS Secrets Manager** (`internal/provider/aws/secret/secret.go`, `Get`/`History`/`Describe`) — sets `StagingLabels` to the full `VersionStages` slice (recovering the labels previously lost by collapsing to a representative one). `State` left empty.
- **Google Cloud** (`internal/provider/gcloud/secret/secret.go`, `Get`/`History`) — sets `State = stateLabel(...)`. `StagingLabels` left empty.
- **Azure Key Vault** (`internal/provider/azure/keyvault/keyvault.go`, `Get`/`History`) — sets `State = enabledLabel(...)`/`boolLabel(...)`. `StagingLabels` left empty.
- **AWS SSM** + **Azure App Config** — set neither (unchanged).

### Behavior-preserving
`Label` is written exactly as before everywhere, so all current readers (usecases, CLI, GUI) see no change.

### Tests
- `internal/domain` version test asserts the new fields.
- AWS SM: `StagingLabels` carries the full `VersionStages` (e.g. `["AWSCURRENT","AWSPREVIOUS"]`), `State` empty, `Label` still the representative one.
- GCloud: `State` == the state string, `StagingLabels` empty, `Label` unchanged.
- Key Vault: `State` == `enabled`/`disabled`, `StagingLabels` empty, `Label` unchanged.

### Verification
- `go build ./...` — clean.
- `go test ./...` — all green.
- `golangci-lint run --allow-parallel-runners --build-tags=e2e,production ./internal/domain/... ./internal/provider/...` — 0 issues. (The only issue under `./internal/...` is a pre-existing `internal/gui/assets.go` embed typecheck for the unbuilt `frontend/dist`, untouched by this PR.)

### Follow-ups
- **Phase B** — thread `State`/`StagingLabels` through `log`/`show` usecases and CLI presenters (render "State" vs "Staging labels").
- **Phase C** — expose them in the GUI DTO + `SecretView.svelte`, then drop `Label`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
