### PR TITLE
refactor(usecase,cli): read Version.State / StagingLabels, not overloaded Label (Phase B, #419)

### DIFF
--- a/internal/cli/commands/azure/secret/secret_test.go
+++ b/internal/cli/commands/azure/secret/secret_test.go
@@ -132,7 +132,7 @@ func TestShowPresenter(t *testing.T) {
 				Name:    name,
 				Value:   "s3cr3t",
 				Type:    domain.ValueTypeSecret,
-				Version: domain.Version{ID: "abc123", Label: "enabled", Created: &created},
+				Version: domain.Version{ID: "abc123", State: "enabled", Created: &created},
 				Tags:    []domain.Tag{{Key: "env", Value: "prod"}},
 			}, nil
 		},
@@ -164,8 +164,8 @@ func TestLogPresenter(t *testing.T) {
 	store := &providermock.Store{
 		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
 			return []domain.Version{
-				{ID: "new", Label: "enabled", Created: &created},
-				{ID: "old", Label: "disabled", Created: &created},
+				{ID: "new", State: "enabled", Created: &created},
+				{ID: "old", State: "disabled", Created: &created},
 			}, nil
 		},
 		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
@@ -200,8 +200,8 @@ func TestLogPresenter_Patch(t *testing.T) {
 	store := &providermock.Store{
 		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
 			return []domain.Version{
-				{ID: "2", Label: "enabled", Created: &created},
-				{ID: "1", Label: "enabled", Created: &created},
+				{ID: "2", State: "enabled", Created: &created},
+				{ID: "1", State: "enabled", Created: &created},
 			}, nil
 		},
 		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {

--- a/internal/cli/commands/gcloud/gcloud_test.go
+++ b/internal/cli/commands/gcloud/gcloud_test.go
@@ -185,7 +185,7 @@ func TestShowPresenter(t *testing.T) {
 				Name:    name,
 				Value:   "s3cr3t",
 				Type:    domain.ValueTypeSecret,
-				Version: domain.Version{ID: "3", Label: "enabled", Created: &created},
+				Version: domain.Version{ID: "3", State: "enabled", Created: &created},
 				Tags:    []domain.Tag{{Key: "env", Value: "prod"}},
 			}, nil
 		},
@@ -221,8 +221,8 @@ func TestLogPresenter(t *testing.T) {
 	store := &providermock.Store{
 		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
 			return []domain.Version{
-				{ID: "2", Label: "enabled", Created: &created},
-				{ID: "1", Label: "destroyed", Created: &created},
+				{ID: "2", State: "enabled", Created: &created},
+				{ID: "1", State: "destroyed", Created: &created},
 			}, nil
 		},
 		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
@@ -259,8 +259,8 @@ func TestLogPresenter_Patch(t *testing.T) {
 	store := &providermock.Store{
 		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
 			return []domain.Version{
-				{ID: "2", Label: "enabled", Created: &created},
-				{ID: "1", Label: "enabled", Created: &created},
+				{ID: "2", State: "enabled", Created: &created},
+				{ID: "1", State: "enabled", Created: &created},
 			}, nil
 		},
 		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {

--- a/internal/cli/commands/generic/log/log_test.go
+++ b/internal/cli/commands/generic/log/log_test.go
@@ -691,8 +691,8 @@ func TestRunSecret(t *testing.T) {
 			name: "show version history",
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10},
 			store: secretLogStore([]domain.Version{
-				{ID: "v2", Label: "AWSCURRENT", Created: &now},
-				{ID: "v1", Label: "AWSPREVIOUS", Created: at(now, -time.Hour)},
+				{ID: "v2", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+				{ID: "v1", StagingLabels: []string{"AWSPREVIOUS"}, Created: at(now, -time.Hour)},
 			}, nil, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -705,8 +705,8 @@ func TestRunSecret(t *testing.T) {
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10},
 			opts: genericlog.Options{ShowPatch: true},
 			store: secretLogStore([]domain.Version{
-				{ID: testVersionID2, Label: "AWSCURRENT", Created: &now},
-				{ID: testVersionID1, Label: "AWSPREVIOUS", Created: at(now, -time.Hour)},
+				{ID: testVersionID2, StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+				{ID: testVersionID1, StagingLabels: []string{"AWSPREVIOUS"}, Created: at(now, -time.Hour)},
 			}, map[string]string{testVersionID1: "old-value", testVersionID2: "new-value"}, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -720,7 +720,7 @@ func TestRunSecret(t *testing.T) {
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10},
 			opts: genericlog.Options{ShowPatch: true},
 			store: secretLogStore([]domain.Version{
-				{ID: "only-version", Label: "AWSCURRENT", Created: &now},
+				{ID: "only-version", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
 			}, map[string]string{"only-version": "only-value"}, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -742,8 +742,8 @@ func TestRunSecret(t *testing.T) {
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10, Reverse: true},
 			opts: genericlog.Options{Reverse: true},
 			store: secretLogStore([]domain.Version{
-				{ID: "version-2", Label: "AWSCURRENT", Created: &now},
-				{ID: "version-1", Label: "AWSPREVIOUS", Created: at(now, -time.Hour)},
+				{ID: "version-2", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+				{ID: "version-1", StagingLabels: []string{"AWSPREVIOUS"}, Created: at(now, -time.Hour)},
 			}, nil, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -769,8 +769,8 @@ func TestRunSecret(t *testing.T) {
 			name: "version without CreatedDate",
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10},
 			store: secretLogStore([]domain.Version{
-				{ID: "v2", Label: "AWSCURRENT", Created: &now},
-				{ID: "v1", Label: "AWSPREVIOUS"},
+				{ID: "v2", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+				{ID: "v1", StagingLabels: []string{"AWSPREVIOUS"}},
 			}, nil, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -849,8 +849,8 @@ func TestRunSecret(t *testing.T) {
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10},
 			opts: genericlog.Options{Oneline: true},
 			store: secretLogStore([]domain.Version{
-				{ID: testVersionID2, Label: "AWSCURRENT", Created: &now},
-				{ID: testVersionID1, Label: "AWSPREVIOUS", Created: at(now, -time.Hour)},
+				{ID: testVersionID2, StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+				{ID: testVersionID1, StagingLabels: []string{"AWSPREVIOUS"}, Created: at(now, -time.Hour)},
 			}, nil, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -864,7 +864,7 @@ func TestRunSecret(t *testing.T) {
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10},
 			opts: genericlog.Options{Oneline: true},
 			store: secretLogStore([]domain.Version{
-				{ID: testVersionID2, Label: "AWSCURRENT", Created: &now},
+				{ID: testVersionID2, StagingLabels: []string{"AWSCURRENT"}, Created: &now},
 				{ID: testVersionID1},
 			}, nil, nil, nil),
 			check: func(t *testing.T, output string) {
@@ -876,8 +876,8 @@ func TestRunSecret(t *testing.T) {
 			name: "filter by since date",
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10, Since: at(now, -30*time.Minute)},
 			store: secretLogStore([]domain.Version{
-				{ID: "new-version", Label: "AWSCURRENT", Created: &now},
-				{ID: "old-version", Label: "AWSPREVIOUS", Created: at(now, -2*time.Hour)},
+				{ID: "new-version", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+				{ID: "old-version", StagingLabels: []string{"AWSPREVIOUS"}, Created: at(now, -2*time.Hour)},
 			}, nil, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -889,8 +889,8 @@ func TestRunSecret(t *testing.T) {
 			name: "filter by until date",
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10, Until: at(now, -30*time.Minute)},
 			store: secretLogStore([]domain.Version{
-				{ID: "new-version", Label: "AWSCURRENT", Created: &now},
-				{ID: "old-version", Label: "AWSPREVIOUS", Created: at(now, -2*time.Hour)},
+				{ID: "new-version", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+				{ID: "old-version", StagingLabels: []string{"AWSPREVIOUS"}, Created: at(now, -2*time.Hour)},
 			}, nil, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -932,7 +932,7 @@ func TestRunSecret(t *testing.T) {
 			name: "filter skips versions without CreatedDate",
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10, Since: at(now, -30*time.Minute)},
 			store: secretLogStore([]domain.Version{
-				{ID: "new-version", Label: "AWSCURRENT", Created: &now},
+				{ID: "new-version", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
 				{ID: "no-date-ver"},
 			}, nil, nil, nil),
 			check: func(t *testing.T, output string) {
@@ -946,8 +946,8 @@ func TestRunSecret(t *testing.T) {
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10},
 			opts: genericlog.Options{Output: output.FormatJSON},
 			store: secretLogStore([]domain.Version{
-				{ID: testVersionID2, Label: "AWSCURRENT", Created: &now},
-				{ID: testVersionID1, Label: "AWSPREVIOUS", Created: at(now, -time.Hour)},
+				{ID: testVersionID2, StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+				{ID: testVersionID1, StagingLabels: []string{"AWSPREVIOUS"}, Created: at(now, -time.Hour)},
 			}, map[string]string{testVersionID1: "old-value", testVersionID2: "new-value"}, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -962,7 +962,7 @@ func TestRunSecret(t *testing.T) {
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10},
 			opts: genericlog.Options{Output: output.FormatJSON},
 			store: secretLogStore([]domain.Version{
-				{ID: testVersionID1, Label: "AWSCURRENT", Created: &now},
+				{ID: testVersionID1, StagingLabels: []string{"AWSCURRENT"}, Created: &now},
 			}, nil, map[string]error{testVersionID1: errors.New("access denied")}, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()

--- a/internal/cli/commands/generic/show/show_test.go
+++ b/internal/cli/commands/generic/show/show_test.go
@@ -385,7 +385,7 @@ func TestRunSecret(t *testing.T) {
 			store: showStore(&domain.Entry{
 				Name:    "my-secret",
 				Value:   "secret-value",
-				Version: domain.Version{ID: "abc123", Label: "AWSCURRENT", Created: &now},
+				Version: domain.Version{ID: "abc123", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
 				Extra:   []domain.Field{{Label: "ARN", Value: testARN}},
 			}),
 			check: func(t *testing.T, output string) {
@@ -414,7 +414,7 @@ func TestRunSecret(t *testing.T) {
 			store: showStore(&domain.Entry{
 				Name:    "my-secret",
 				Value:   `{"zebra":"last","apple":"first"}`,
-				Version: domain.Version{ID: "abc123", Label: "AWSCURRENT", Created: &now},
+				Version: domain.Version{ID: "abc123", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
 				Extra:   []domain.Field{{Label: "ARN", Value: testARN}},
 			}),
 			check: func(t *testing.T, output string) {
@@ -522,7 +522,7 @@ func TestRunSecret(t *testing.T) {
 			store: showStore(&domain.Entry{
 				Name:    "my-secret",
 				Value:   "secret-value",
-				Version: domain.Version{ID: "abc123", Label: "AWSCURRENT", Created: &now},
+				Version: domain.Version{ID: "abc123", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
 				Extra:   []domain.Field{{Label: "ARN", Value: testARN}},
 				Tags: []domain.Tag{
 					{Key: "Environment", Value: "production"},
@@ -546,7 +546,7 @@ func TestRunSecret(t *testing.T) {
 			store: showStore(&domain.Entry{
 				Name:    "my-secret",
 				Value:   "secret-value",
-				Version: domain.Version{ID: "abc123", Label: "AWSCURRENT", Created: &now},
+				Version: domain.Version{ID: "abc123", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
 				Extra:   []domain.Field{{Label: "ARN", Value: testARN}},
 				Tags: []domain.Tag{
 					{Key: "Environment", Value: "production"},

--- a/internal/usecase/azure/azure_test.go
+++ b/internal/usecase/azure/azure_test.go
@@ -32,7 +32,7 @@ func TestShowUseCase(t *testing.T) {
 			return &domain.Entry{
 				Name:    name,
 				Value:   "hello",
-				Version: domain.Version{ID: "abc", Label: "enabled"},
+				Version: domain.Version{ID: "abc", State: "enabled"},
 				Tags:    []domain.Tag{{Key: "env", Value: "prod"}},
 			}, nil
 		},

--- a/internal/usecase/azure/log.go
+++ b/internal/usecase/azure/log.go
@@ -103,7 +103,7 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 
 		entries = append(entries, LogEntry{
 			Version:     v.ID,
-			State:       v.Label,
+			State:       v.State,
 			Value:       value,
 			CreatedDate: v.Created,
 			Error:       fetchErr,

--- a/internal/usecase/azure/show.go
+++ b/internal/usecase/azure/show.go
@@ -55,7 +55,7 @@ func (u *ShowUseCase) Execute(ctx context.Context, input ShowInput) (*ShowOutput
 		Name:        entry.Name,
 		Value:       entry.Value,
 		Version:     entry.Version.ID,
-		State:       entry.Version.Label,
+		State:       entry.Version.State,
 		CreatedDate: entry.Version.Created,
 		Tags: lo.Map(entry.Tags, func(tag domain.Tag, _ int) ShowTag {
 			return ShowTag{Key: tag.Key, Value: tag.Value}

--- a/internal/usecase/gcloud/gcloud.go
+++ b/internal/usecase/gcloud/gcloud.go
@@ -4,7 +4,7 @@
 // interfaces, exactly like the AWS secret use cases, but expose Google
 // Cloud-shaped outputs: integer versions, no ARN, no staging labels. The
 // per-version state (enabled/disabled/destroyed) is surfaced where the provider
-// supplies it via the neutral Version.Label.
+// supplies it via the neutral Version.State.
 package gcloud
 
 import (

--- a/internal/usecase/gcloud/gcloud_test.go
+++ b/internal/usecase/gcloud/gcloud_test.go
@@ -69,7 +69,7 @@ func TestShowUseCase(t *testing.T) {
 			return &domain.Entry{
 				Name:    name,
 				Value:   "hello",
-				Version: domain.Version{ID: "3", Label: "enabled"},
+				Version: domain.Version{ID: "3", State: "enabled"},
 				Tags:    []domain.Tag{{Key: "env", Value: "prod"}},
 			}, nil
 		},

--- a/internal/usecase/gcloud/log.go
+++ b/internal/usecase/gcloud/log.go
@@ -101,7 +101,7 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 
 		entries = append(entries, LogEntry{
 			Version:     v.ID,
-			State:       v.Label,
+			State:       v.State,
 			Value:       value,
 			CreatedDate: v.Created,
 			Error:       fetchErr,

--- a/internal/usecase/gcloud/show.go
+++ b/internal/usecase/gcloud/show.go
@@ -54,7 +54,7 @@ func (u *ShowUseCase) Execute(ctx context.Context, input ShowInput) (*ShowOutput
 		Name:        entry.Name,
 		Value:       entry.Value,
 		Version:     entry.Version.ID,
-		State:       entry.Version.Label,
+		State:       entry.Version.State,
 		CreatedDate: entry.Version.Created,
 		Tags: lo.Map(entry.Tags, func(tag domain.Tag, _ int) ShowTag {
 			return ShowTag{Key: tag.Key, Value: tag.Value}

--- a/internal/usecase/secret/log.go
+++ b/internal/usecase/secret/log.go
@@ -105,14 +105,13 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 
 		entries = append(entries, LogEntry{
 			VersionID:    v.ID,
-			VersionStage: stages(v.Label),
+			VersionStage: stages(v.StagingLabels),
 			Value:        value,
 			CreatedDate:  v.Created,
-			// The adapter picks the version's Label by priority, so AWSCURRENT
-			// always surfaces whenever the version carries it (even alongside a
-			// custom label). This equality is therefore a correct membership
-			// test, not a fragile "first stage" check (#317).
-			IsCurrent: v.Label == "AWSCURRENT",
+			// A version is current when AWSCURRENT is among its staging labels;
+			// membership (not a "first stage" check) keeps this correct even when
+			// the version carries additional custom labels (#317).
+			IsCurrent: slices.Contains(v.StagingLabels, "AWSCURRENT"),
 			Error:     fetchErr,
 		})
 	}

--- a/internal/usecase/secret/log_test.go
+++ b/internal/usecase/secret/log_test.go
@@ -44,8 +44,9 @@ func TestLogUseCase_Execute(t *testing.T) {
 
 	now := time.Now()
 	versions := []domain.Version{
-		{ID: "v3", Label: "AWSCURRENT", Created: &now},
-		{ID: "v2", Label: "AWSPREVIOUS", Created: tp(now, -time.Hour)},
+		// Unsorted, multi-valued staging labels: all must surface, sorted (#419).
+		{ID: "v3", StagingLabels: []string{"custom", "AWSCURRENT"}, Created: &now},
+		{ID: "v2", StagingLabels: []string{"AWSPREVIOUS"}, Created: tp(now, -time.Hour)},
 		{ID: "v1", Created: tp(now, -2*time.Hour)},
 	}
 	values := map[string]string{"v1": "value1", "v2": "value2", "v3": "value3"}
@@ -57,8 +58,9 @@ func TestLogUseCase_Execute(t *testing.T) {
 	require.Len(t, output.Entries, 3)
 	// Newest first.
 	assert.Equal(t, "v3", output.Entries[0].VersionID)
+	// IsCurrent is a membership test: AWSCURRENT alongside a custom label.
 	assert.True(t, output.Entries[0].IsCurrent)
-	assert.Contains(t, output.Entries[0].VersionStage, "AWSCURRENT")
+	assert.Equal(t, []string{"AWSCURRENT", "custom"}, output.Entries[0].VersionStage)
 	assert.Equal(t, "value3", output.Entries[0].Value)
 	assert.False(t, output.Entries[2].IsCurrent)
 }
@@ -94,8 +96,8 @@ func TestLogUseCase_Execute_Reverse(t *testing.T) {
 
 	now := time.Now()
 	versions := []domain.Version{
-		{ID: "v2", Label: "AWSCURRENT", Created: &now},
-		{ID: "v1", Label: "AWSPREVIOUS", Created: tp(now, -time.Hour)},
+		{ID: "v2", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+		{ID: "v1", StagingLabels: []string{"AWSPREVIOUS"}, Created: tp(now, -time.Hour)},
 	}
 
 	uc := &secret.LogUseCase{Reader: logStore(versions, map[string]string{}, nil)}

--- a/internal/usecase/secret/show.go
+++ b/internal/usecase/secret/show.go
@@ -59,7 +59,7 @@ func (u *ShowUseCase) Execute(ctx context.Context, input ShowInput) (*ShowOutput
 		ARN:          extraValue(entry, "ARN"),
 		Value:        entry.Value,
 		VersionID:    entry.Version.ID,
-		VersionStage: stages(entry.Version.Label),
+		VersionStage: stages(entry.Version.StagingLabels),
 		Description:  entry.Description,
 		CreatedDate:  entry.Version.Created,
 		Tags: lo.Map(entry.Tags, func(tag domain.Tag, _ int) ShowTag {

--- a/internal/usecase/secret/show_test.go
+++ b/internal/usecase/secret/show_test.go
@@ -42,10 +42,12 @@ func TestShowUseCase_Execute(t *testing.T) {
 
 	now := time.Now()
 	store := showStore(&domain.Entry{
-		Name:    "my-secret",
-		Value:   "secret-value",
-		Type:    domain.ValueTypeSecret,
-		Version: domain.Version{ID: "abc123", Label: "AWSCURRENT", Created: &now},
+		Name:  "my-secret",
+		Value: "secret-value",
+		Type:  domain.ValueTypeSecret,
+		// Multiple staging labels (unsorted) must all surface, deterministically
+		// sorted for stable output (#419).
+		Version: domain.Version{ID: "abc123", StagingLabels: []string{"AWSCURRENT", "custom"}, Created: &now},
 		Extra:   []domain.Field{{Label: "ARN", Value: "arn:aws:secretsmanager:us-east-1:123:secret:my-secret"}},
 	})
 
@@ -56,7 +58,7 @@ func TestShowUseCase_Execute(t *testing.T) {
 	assert.Equal(t, "my-secret", output.Name)
 	assert.Equal(t, "secret-value", output.Value)
 	assert.Equal(t, "abc123", output.VersionID)
-	assert.Contains(t, output.VersionStage, "AWSCURRENT")
+	assert.Equal(t, []string{"AWSCURRENT", "custom"}, output.VersionStage)
 	assert.NotNil(t, output.CreatedDate)
 	// Regression guard: the ARN must be surfaced from the entry's Extra metadata.
 	assert.Equal(t, "arn:aws:secretsmanager:us-east-1:123:secret:my-secret", output.ARN)
@@ -68,7 +70,7 @@ func TestShowUseCase_Execute_WithVersionID(t *testing.T) {
 	store := showStore(&domain.Entry{
 		Name:    "my-secret",
 		Value:   "old-value",
-		Version: domain.Version{ID: "old-version-id", Label: "AWSPREVIOUS"},
+		Version: domain.Version{ID: "old-version-id", StagingLabels: []string{"AWSPREVIOUS"}},
 	})
 
 	uc := &secret.ShowUseCase{Reader: store}
@@ -85,7 +87,7 @@ func TestShowUseCase_Execute_WithLabel(t *testing.T) {
 	store := showStore(&domain.Entry{
 		Name:    "my-secret",
 		Value:   "current-value",
-		Version: domain.Version{ID: "current-id", Label: "AWSCURRENT"},
+		Version: domain.Version{ID: "current-id", StagingLabels: []string{"AWSCURRENT"}},
 	})
 
 	uc := &secret.ShowUseCase{Reader: store}

--- a/internal/usecase/secret/version.go
+++ b/internal/usecase/secret/version.go
@@ -1,6 +1,7 @@
 package secret
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 
@@ -52,13 +53,16 @@ func extraValue(entry *domain.Entry, label string) string {
 	return ""
 }
 
-// stages converts a single provider-neutral version Label into the []string
-// staging-label slice the secret outputs expose. An empty label yields nil so
-// that callers omit the field entirely (matching the pre-migration behavior).
-func stages(label string) []string {
-	if label == "" {
+// stages returns a deterministically sorted copy of a version's AWS Secrets
+// Manager staging labels for stable output. An empty slice yields nil so that
+// callers omit the field entirely (matching the pre-migration behavior).
+func stages(labels []string) []string {
+	if len(labels) == 0 {
 		return nil
 	}
 
-	return []string{label}
+	out := slices.Clone(labels)
+	slices.Sort(out)
+
+	return out
 }


### PR DESCRIPTION
## Phase B of #419 — usecases + CLI presenters

Migrates the **usecase** and **CLI presenter** layers off the overloaded `domain.Version.Label` onto the semantic fields introduced in Phase A (`State` + `StagingLabels`, dual-written by the adapters). Based on `epic/version-state-vs-staging-labels`, targets that epic branch.

### Usecases migrated off `Version.Label`
- **AWS Secrets Manager** (`internal/usecase/secret/log.go`, `show.go`, `version.go`): now reads the **full** `Version.StagingLabels` set (deterministically sorted for stable output) instead of a single representative label, and derives `IsCurrent` from `slices.Contains(StagingLabels, "AWSCURRENT")`. The `stages()` helper now takes `[]string` and returns a sorted copy.
- **Google Cloud** (`internal/usecase/gcloud/log.go`, `show.go`): reads `Version.State`.
- **Azure Key Vault** (`internal/usecase/azure/log.go`, `show.go`): reads `Version.State`.

### AWS SM fidelity improvement
Previously `log`/`show` surfaced only one representative staging label (`stages(v.Label)`, `v.Label == "AWSCURRENT"`). They now surface **all** staging labels a version carries (e.g. `AWSCURRENT` + a custom label), sorted for stable output. `IsCurrent` is a correct membership test.

### CLI presenters
No presenter logic changed: `gcloud`/`azure` presenters already render **"State"** and `secret` renders its **stage** wording, all reading the usecase `State`/`VersionStage` output fields (never `Version.Label` directly). Output for GCloud/KV is byte-for-byte identical (only the source field changed); AWS SM may now list multiple staging labels where it showed one — intended.

### Tests
- Updated usecase + CLI golden/expected-output fixtures: GCloud/KV state from `State`; AWS SM from sorted `StagingLabels`.
- Added multi-staging-label coverage (`AWSCURRENT` + `custom`) in both secret `log` and `show` usecase tests, asserting all labels surface sorted and `IsCurrent` holds via membership.

### Verification
- `go build ./...` — OK
- `go test ./...` — pass
- `golangci-lint run --allow-parallel-runners --build-tags=e2e,production ./internal/usecase/... ./internal/cli/...` — 0 issues
- No `\.Label\b` reader of `domain.Version.Label` remains under `internal/usecase` or `internal/cli` (remaining hits are `secretversion.AbsoluteSpec.Label`, `domain.Field.Label`, and `confirm` choice labels — unrelated concepts).

### Follow-ups
- **Phase C (GUI)** exposes `state` / `stagingLabels` in the GUI DTO + `SecretView.svelte`, then removes `domain.Version.Label` and the adapters' dual-write. Not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)