### PR TITLE
feat(domain,gui): split Version.State from staging labels in GUI; drop overloaded Label (Phase C)

### DIFF
--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -40,15 +40,6 @@ const (
 type Version struct {
 	// ID is the provider-internal version identifier.
 	ID string
-	// Label is an optional human-facing label (empty when unsupported).
-	//
-	// NOTE: Label is overloaded to mean a representative staging label (AWS
-	// Secrets Manager) OR a per-version state (Google Cloud, Azure Key Vault).
-	// It is retained for back-compat during the #419 migration; prefer
-	// StagingLabels or State in new code. A later cleanup removes it once all
-	// readers migrate (do NOT mark it Deprecated yet: that would trip staticcheck
-	// SA1019 on the existing dual-write readers this phase must preserve).
-	Label string
 	// State is the per-version lifecycle state: "enabled" / "disabled" /
 	// "destroyed", or "" when the provider has no such concept. It is a
 	// per-version switch controlling whether that version's value can be read

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -22,7 +22,6 @@ func TestEntry_Fields(t *testing.T) {
 		Type:  domain.ValueTypeSecret,
 		Version: domain.Version{
 			ID:            "v3",
-			Label:         "current",
 			State:         "enabled",
 			StagingLabels: []string{"AWSCURRENT", "AWSPREVIOUS"},
 			Created:       &created,
@@ -36,7 +35,6 @@ func TestEntry_Fields(t *testing.T) {
 	assert.Equal(t, "hunter2", entry.Value)
 	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
 	assert.Equal(t, "v3", entry.Version.ID)
-	assert.Equal(t, "current", entry.Version.Label)
 	assert.Equal(t, "enabled", entry.Version.State)
 	assert.Equal(t, []string{"AWSCURRENT", "AWSPREVIOUS"}, entry.Version.StagingLabels)
 	assert.Equal(t, &created, entry.Version.Created)

--- a/internal/gui/frontend/src/lib/SecretView.svelte
+++ b/internal/gui/frontend/src/lib/SecretView.svelte
@@ -30,11 +30,11 @@
   const forceDeleteEnabled = $derived(capability?.hasForceDelete ?? true);
   const recoveryWindowEnabled = $derived(capability?.hasRecoveryWindow ?? true);
 
-  // Version.Label is overloaded per provider: AWS Secrets Manager carries genuine
-  // staging labels (AWSCURRENT/AWSPENDING/...), while Google Cloud and Azure Key
-  // Vault carry the per-version state (enabled/disabled/destroyed). Only AWS has
-  // staging labels, so label the heading accordingly.
-  const versionMetaLabel = $derived(provider === 'aws' ? 'Labels' : 'State');
+  // Staging labels and per-version state are two independent concepts (#419), so
+  // render each from the field that actually carries it rather than guessing
+  // from the provider string. AWS Secrets Manager populates stagingLabels
+  // (AWSCURRENT/AWSPENDING/...); Google Cloud + Azure Key Vault populate state
+  // (enabled/disabled/destroyed). A version never has both.
 
   const PAGE_SIZE = 50;
   const debounce = createDebouncer(300);
@@ -552,12 +552,19 @@
                 <span class="meta-label">Version ID</span>
                 <span class="meta-value mono">{secretDetail.versionId}</span>
               </div>
-              {#if (secretDetail.versionStage || []).length > 0}
+              {#if secretDetail.state}
                 <div class="meta-item">
-                  <span class="meta-label">{versionMetaLabel}</span>
+                  <span class="meta-label">State</span>
                   <span class="meta-value">
-                    {#each secretDetail.versionStage || [] as stage}
-                      <span class="badge badge-stage">{stage}</span>
+                    <span class="badge badge-stage">{secretDetail.state}</span>
+                  </span>
+                </div>
+              {:else if (secretDetail.stagingLabels || []).length > 0}
+                <div class="meta-item">
+                  <span class="meta-label">Staging labels</span>
+                  <span class="meta-value">
+                    {#each secretDetail.stagingLabels || [] as label}
+                      <span class="badge badge-stage">{label}</span>
                     {/each}
                   </span>
                 </div>
@@ -625,10 +632,14 @@
                           {/if}
                           <span class="history-date">{formatDate(logEntry.created)}</span>
                         </div>
-                        {#if (logEntry.stages || []).length > 0}
+                        {#if logEntry.state}
                           <div class="history-labels">
-                            {#each logEntry.stages || [] as stage}
-                              <span class="badge badge-stage small">{stage}</span>
+                            <span class="badge badge-stage small">{logEntry.state}</span>
+                          </div>
+                        {:else if (logEntry.stagingLabels || []).length > 0}
+                          <div class="history-labels">
+                            {#each logEntry.stagingLabels || [] as label}
+                              <span class="badge badge-stage small">{label}</span>
                             {/each}
                           </div>
                         {/if}

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -15,10 +15,15 @@ export interface Secret {
   value: string;
   // Optional overrides for SecretShow. When omitted, SecretShow synthesizes an
   // AWS-shaped ARN and an ['AWSCURRENT'] staging label (backward compatible).
-  // A provider without these (e.g. an empty arn / empty stages, as Google Cloud
-  // and Azure return) drives the presence-gated rendering in SecretView.
+  // A provider without these (e.g. an empty arn / empty stagingLabels, as Google
+  // Cloud and Azure return) drives the presence-gated rendering in SecretView.
+  //
+  // stagingLabels and state are the two independent concepts (#419): AWS Secrets
+  // Manager populates stagingLabels; Google Cloud + Azure Key Vault populate
+  // state (enabled/disabled/destroyed). A version never has both.
   arn?: string;
-  versionStage?: string[];
+  stagingLabels?: string[];
+  state?: string;
   versionId?: string;
 }
 
@@ -60,7 +65,10 @@ export interface ParamLogEntry {
 
 export interface SecretLogEntry {
   versionId: string;
-  stages: string[];
+  // Two independent concepts (#419): stagingLabels for AWS Secrets Manager,
+  // state (enabled/disabled/destroyed) for Google Cloud + Azure Key Vault.
+  stagingLabels?: string[];
+  state?: string;
   value: string;
   isCurrent: boolean;
   created: string;
@@ -292,9 +300,9 @@ export const defaultMockState: MockState = {
   },
   secretVersions: {
     'my-secret': [
-      { versionId: 'v3-current', stages: ['AWSCURRENT'], value: 'secret-value-1', isCurrent: true, created: new Date().toISOString() },
-      { versionId: 'v2-previous', stages: ['AWSPREVIOUS'], value: 'secret-value-old', isCurrent: false, created: new Date(Date.now() - 86400000).toISOString() },
-      { versionId: 'v1-initial', stages: [], value: 'secret-value-initial', isCurrent: false, created: new Date(Date.now() - 172800000).toISOString() },
+      { versionId: 'v3-current', stagingLabels: ['AWSCURRENT'], value: 'secret-value-1', isCurrent: true, created: new Date().toISOString() },
+      { versionId: 'v2-previous', stagingLabels: ['AWSPREVIOUS'], value: 'secret-value-old', isCurrent: false, created: new Date(Date.now() - 86400000).toISOString() },
+      { versionId: 'v1-initial', stagingLabels: [], value: 'secret-value-initial', isCurrent: false, created: new Date(Date.now() - 172800000).toISOString() },
     ],
   },
   enablePagination: false,
@@ -446,9 +454,9 @@ export function createVersionHistoryState(): Partial<MockState> {
     },
     secretVersions: {
       'my-secret': [
-        { versionId: 'ver-003', stages: ['AWSCURRENT'], value: '{"current": "v3"}', isCurrent: true, created: new Date().toISOString() },
-        { versionId: 'ver-002', stages: ['AWSPREVIOUS'], value: '{"previous": "v2"}', isCurrent: false, created: new Date(Date.now() - 86400000).toISOString() },
-        { versionId: 'ver-001', stages: [], value: '{"initial": "v1"}', isCurrent: false, created: new Date(Date.now() - 172800000).toISOString() },
+        { versionId: 'ver-003', stagingLabels: ['AWSCURRENT'], value: '{"current": "v3"}', isCurrent: true, created: new Date().toISOString() },
+        { versionId: 'ver-002', stagingLabels: ['AWSPREVIOUS'], value: '{"previous": "v2"}', isCurrent: false, created: new Date(Date.now() - 86400000).toISOString() },
+        { versionId: 'ver-001', stagingLabels: [], value: '{"initial": "v1"}', isCurrent: false, created: new Date(Date.now() - 172800000).toISOString() },
       ],
     },
   };
@@ -609,15 +617,16 @@ export function createGoogleCloudState(overrides: Partial<MockState> = {}): Part
       secretActive: ['googlecloud'],
       stageActive: [],
     },
-    // Google Cloud secret versions are integers and carry no ARN/staging labels.
+    // Google Cloud secret versions are integers and carry no ARN/staging labels;
+    // they carry a per-version state (enabled/disabled/destroyed) instead.
     secrets: [
-      { name: 'gcloud-secret-1', value: 'v1', arn: '', versionStage: [] },
-      { name: 'gcloud-secret-2', value: 'v2', arn: '', versionStage: [] },
+      { name: 'gcloud-secret-1', value: 'v1', arn: '', stagingLabels: [], state: 'enabled' },
+      { name: 'gcloud-secret-2', value: 'v2', arn: '', stagingLabels: [], state: 'enabled' },
     ],
     secretVersions: {
       'gcloud-secret-1': [
-        { versionId: '2', stages: [], value: 'v2', isCurrent: true, created: new Date().toISOString() },
-        { versionId: '1', stages: [], value: 'v1', isCurrent: false, created: new Date(Date.now() - 86400000).toISOString() },
+        { versionId: '2', stagingLabels: [], state: 'enabled', value: 'v2', isCurrent: true, created: new Date().toISOString() },
+        { versionId: '1', stagingLabels: [], state: 'disabled', value: 'v1', isCurrent: false, created: new Date(Date.now() - 86400000).toISOString() },
       ],
     },
     ...overrides,
@@ -646,11 +655,12 @@ export function createAzureState(overrides: Partial<MockState> = {}): Partial<Mo
     },
     // App Configuration values are untyped/unversioned; Key Vault has no ARN.
     params: [{ name: 'app/config/key', type: 'String', value: 'v' }],
-    secrets: [{ name: 'kv-secret', value: 'v', arn: '', versionStage: [], versionId: 'a1b2c3d4e5f6' }],
-    // Key Vault versions are opaque hex ids with no AWS staging labels.
+    secrets: [{ name: 'kv-secret', value: 'v', arn: '', stagingLabels: [], state: 'enabled', versionId: 'a1b2c3d4e5f6' }],
+    // Key Vault versions are opaque hex ids with no AWS staging labels; they
+    // carry a per-version enabled/disabled state instead.
     secretVersions: {
       'kv-secret': [
-        { versionId: 'a1b2c3d4e5f6', stages: [], value: 'v', isCurrent: true, created: new Date().toISOString() },
+        { versionId: 'a1b2c3d4e5f6', stagingLabels: [], state: 'enabled', value: 'v', isCurrent: true, created: new Date().toISOString() },
       ],
     },
     ...overrides,
@@ -990,7 +1000,8 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
           name,
           arn: secret?.arn !== undefined ? secret.arn : `arn:aws:secretsmanager:us-east-1:123456789:secret:${name}`,
           versionId: secret?.versionId ?? 'v1',
-          versionStage: secret?.versionStage !== undefined ? secret.versionStage : ['AWSCURRENT'],
+          stagingLabels: secret?.stagingLabels !== undefined ? secret.stagingLabels : ['AWSCURRENT'],
+          state: secret?.state ?? '',
           value: secret?.value || 'mock-secret',
           description: '',
           createdDate: new Date().toISOString(),
@@ -999,7 +1010,7 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
       },
       SecretLog: async (name: string, _limit?: number) => {
         const versions = state.secretVersions[name] || [
-          { versionId: 'v1', stages: ['AWSCURRENT'], value: 'current', isCurrent: true, created: new Date().toISOString() },
+          { versionId: 'v1', stagingLabels: ['AWSCURRENT'], value: 'current', isCurrent: true, created: new Date().toISOString() },
         ];
         return {
           name,

--- a/internal/gui/frontend/tests/secret.spec.ts
+++ b/internal/gui/frontend/tests/secret.spec.ts
@@ -39,10 +39,10 @@ test.describe('Secret CRUD Operations', () => {
       await expect(page.locator('.detail-title')).toContainText('my-secret');
     });
 
-    test('should display secret metadata (version ID, labels)', async ({ page }) => {
+    test('should display secret metadata (version ID, staging labels)', async ({ page }) => {
       await clickItemByName(page, 'my-secret');
       await expect(page.locator('.meta-label').filter({ hasText: 'Version ID' })).toBeVisible();
-      await expect(page.locator('.meta-label').filter({ hasText: 'Labels' })).toBeVisible();
+      await expect(page.locator('.meta-label').filter({ hasText: 'Staging labels' })).toBeVisible();
     });
 
     test('should display ARN', async ({ page }) => {
@@ -462,12 +462,13 @@ test.describe('Secret Edge Cases', () => {
 });
 
 test.describe('Secret provider-neutral presence gating (#268)', () => {
-  // A secret from a provider without an ARN or staging labels (as Google Cloud
-  // and Azure return) must not render the AWS-only ARN section or the Labels
-  // row — the fields are presence-gated, no capability flag involved.
+  // A secret from a provider without an ARN, staging labels, or a state (as an
+  // AWS SSM-style value would be) must not render the AWS-only ARN section or a
+  // State/Staging-labels row — the fields are presence-gated, no capability flag
+  // involved.
   test.beforeEach(async ({ page }) => {
     await setupWailsMocks(page, {
-      secrets: [{ name: 'neutral-secret', value: 'v', arn: '', versionStage: [] }],
+      secrets: [{ name: 'neutral-secret', value: 'v', arn: '', stagingLabels: [], state: '' }],
       secretTags: {},
     } as Partial<MockState>);
     await page.goto('/');
@@ -481,8 +482,9 @@ test.describe('Secret provider-neutral presence gating (#268)', () => {
     await expect(page.locator('.arn-display')).toHaveCount(0);
   });
 
-  test('hides the Labels row when there are no staging labels', async ({ page }) => {
-    await expect(page.locator('.meta-label').filter({ hasText: 'Labels' })).toHaveCount(0);
+  test('hides the State / Staging-labels row when neither is set', async ({ page }) => {
+    await expect(page.locator('.meta-label').filter({ hasText: 'State' })).toHaveCount(0);
+    await expect(page.locator('.meta-label').filter({ hasText: 'Staging labels' })).toHaveCount(0);
   });
 
   test('still renders always-present metadata (Version ID)', async ({ page }) => {
@@ -490,19 +492,21 @@ test.describe('Secret provider-neutral presence gating (#268)', () => {
   });
 });
 
-// domain.Version.Label is overloaded: AWS Secrets Manager carries genuine
-// staging labels (AWSCURRENT/...), while Google Cloud and Azure Key Vault carry
-// the per-version STATE (enabled/disabled/destroyed). The version-meta heading
-// must therefore read "Labels" only for AWS and "State" for the others (#418).
-test.describe('Secret version-meta heading is provider-aware (#418)', () => {
+// Staging labels and per-version state are two independent concepts (#419):
+// AWS Secrets Manager carries genuine staging labels (AWSCURRENT/...), while
+// Google Cloud and Azure Key Vault carry the per-version state
+// (enabled/disabled/destroyed). The version-meta heading is now driven by which
+// field is populated, NOT by the provider string (superseding the #418/#420
+// heuristic).
+test.describe('Secret version-meta heading is concept-driven (#419)', () => {
   const metaLabel = (page: import('@playwright/test').Page, text: string) =>
     page.locator('.detail-meta .meta-label').filter({ hasText: text });
 
-  test('Google Cloud: version state is headed "State" (not "Labels"), badge shows the state', async ({ page }) => {
+  test('Google Cloud: per-version state is headed "State", badge shows the state', async ({ page }) => {
     await setupWailsMocks(
       page,
       createGoogleCloudState({
-        secrets: [{ name: 'gcloud-secret-1', value: 'v1', arn: '', versionStage: ['enabled'] }],
+        secrets: [{ name: 'gcloud-secret-1', value: 'v1', arn: '', stagingLabels: [], state: 'enabled' }],
       }),
     );
     await page.goto('/');
@@ -513,15 +517,15 @@ test.describe('Secret version-meta heading is provider-aware (#418)', () => {
     await expect(page.locator('.detail-panel')).toBeVisible();
 
     await expect(metaLabel(page, 'State')).toBeVisible();
-    await expect(metaLabel(page, 'Labels')).toHaveCount(0);
+    await expect(metaLabel(page, 'Staging labels')).toHaveCount(0);
     await expect(page.locator('.detail-meta .badge-stage')).toHaveText('enabled');
   });
 
-  test('Azure Key Vault: version state is headed "State" (not "Labels")', async ({ page }) => {
+  test('Azure Key Vault: per-version state is headed "State"', async ({ page }) => {
     await setupWailsMocks(
       page,
       createAzureState({
-        secrets: [{ name: 'kv-secret', value: 'v', arn: '', versionStage: ['enabled'], versionId: 'a1b2c3d4e5f6' }],
+        secrets: [{ name: 'kv-secret', value: 'v', arn: '', stagingLabels: [], state: 'enabled', versionId: 'a1b2c3d4e5f6' }],
       }),
     );
     await page.goto('/');
@@ -532,13 +536,15 @@ test.describe('Secret version-meta heading is provider-aware (#418)', () => {
     await expect(page.locator('.detail-panel')).toBeVisible();
 
     await expect(metaLabel(page, 'State')).toBeVisible();
-    await expect(metaLabel(page, 'Labels')).toHaveCount(0);
+    await expect(metaLabel(page, 'Staging labels')).toHaveCount(0);
     await expect(page.locator('.detail-meta .badge-stage')).toHaveText('enabled');
   });
 
-  test('AWS Secrets Manager: staging label is headed "Labels" (not "State")', async ({ page }) => {
-    // Default state is AWS; my-secret carries the default ['AWSCURRENT'] staging label.
-    await setupWailsMocks(page);
+  test('AWS Secrets Manager: staging labels are headed "Staging labels", every label badge shows', async ({ page }) => {
+    // AWS default; seed multiple staging labels to prove they all render.
+    await setupWailsMocks(page, {
+      secrets: [{ name: 'my-secret', value: 'v', stagingLabels: ['AWSCURRENT', 'AWSPREVIOUS'] }],
+    } as Partial<MockState>);
     await page.goto('/');
     await navigateTo(page, 'Secret');
     await waitForItemList(page);
@@ -546,8 +552,8 @@ test.describe('Secret version-meta heading is provider-aware (#418)', () => {
     await clickItemByName(page, 'my-secret');
     await expect(page.locator('.detail-panel')).toBeVisible();
 
-    await expect(metaLabel(page, 'Labels')).toBeVisible();
+    await expect(metaLabel(page, 'Staging labels')).toBeVisible();
     await expect(metaLabel(page, 'State')).toHaveCount(0);
-    await expect(page.locator('.detail-meta .badge-stage')).toHaveText('AWSCURRENT');
+    await expect(page.locator('.detail-meta .badge-stage')).toHaveText(['AWSCURRENT', 'AWSPREVIOUS']);
   });
 });

--- a/internal/gui/frontend/wailsjs/go/models.ts
+++ b/internal/gui/frontend/wailsjs/go/models.ts
@@ -433,19 +433,21 @@ export namespace gui {
 	}
 	export class SecretLogEntry {
 	    versionId: string;
-	    stages: string[];
+	    stagingLabels: string[];
+	    state?: string;
 	    value: string;
 	    isCurrent: boolean;
 	    created?: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new SecretLogEntry(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.versionId = source["versionId"];
-	        this.stages = source["stages"];
+	        this.stagingLabels = source["stagingLabels"];
+	        this.state = source["state"];
 	        this.value = source["value"];
 	        this.isCurrent = source["isCurrent"];
 	        this.created = source["created"];
@@ -515,22 +517,24 @@ export namespace gui {
 	    name: string;
 	    arn: string;
 	    versionId: string;
-	    versionStage: string[];
+	    stagingLabels: string[];
+	    state?: string;
 	    value: string;
 	    description?: string;
 	    createdDate?: string;
 	    tags: SecretShowTag[];
-	
+
 	    static createFrom(source: any = {}) {
 	        return new SecretShowResult(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.name = source["name"];
 	        this.arn = source["arn"];
 	        this.versionId = source["versionId"];
-	        this.versionStage = source["versionStage"];
+	        this.stagingLabels = source["stagingLabels"];
+	        this.state = source["state"];
 	        this.value = source["value"];
 	        this.description = source["description"];
 	        this.createdDate = source["createdDate"];

--- a/internal/gui/secret.go
+++ b/internal/gui/secret.go
@@ -38,15 +38,22 @@ type SecretShowTag struct {
 }
 
 // SecretShowResult represents the result of showing a secret.
+//
+// StagingLabels and State carry two independent concepts that must NOT be
+// conflated (#419): StagingLabels holds AWS Secrets Manager staging labels
+// (empty for other providers), while State holds the per-version lifecycle
+// state (enabled/disabled/destroyed) for Google Cloud + Azure Key Vault (empty
+// for AWS). A version never has both.
 type SecretShowResult struct {
-	Name         string          `json:"name"`
-	ARN          string          `json:"arn"`
-	VersionID    string          `json:"versionId"`
-	VersionStage []string        `json:"versionStage"`
-	Value        string          `json:"value"`
-	Description  string          `json:"description,omitempty"`
-	CreatedDate  string          `json:"createdDate,omitempty"`
-	Tags         []SecretShowTag `json:"tags"`
+	Name          string          `json:"name"`
+	ARN           string          `json:"arn"`
+	VersionID     string          `json:"versionId"`
+	StagingLabels []string        `json:"stagingLabels"`
+	State         string          `json:"state,omitempty"`
+	Value         string          `json:"value"`
+	Description   string          `json:"description,omitempty"`
+	CreatedDate   string          `json:"createdDate,omitempty"`
+	Tags          []SecretShowTag `json:"tags"`
 }
 
 // SecretLogResult represents the result of showing secret history.
@@ -56,12 +63,19 @@ type SecretLogResult struct {
 }
 
 // SecretLogEntry represents a single version in the history.
+//
+// StagingLabels and State carry two independent concepts that must NOT be
+// conflated (#419): StagingLabels holds AWS Secrets Manager staging labels
+// (empty for other providers), while State holds the per-version lifecycle
+// state (enabled/disabled/destroyed) for Google Cloud + Azure Key Vault (empty
+// for AWS). A version never has both.
 type SecretLogEntry struct {
-	VersionID string   `json:"versionId"`
-	Stages    []string `json:"stages"`
-	Value     string   `json:"value"`
-	IsCurrent bool     `json:"isCurrent"`
-	Created   string   `json:"created,omitempty"`
+	VersionID     string   `json:"versionId"`
+	StagingLabels []string `json:"stagingLabels"`
+	State         string   `json:"state,omitempty"`
+	Value         string   `json:"value"`
+	IsCurrent     bool     `json:"isCurrent"`
+	Created       string   `json:"created,omitempty"`
 }
 
 // SecretCreateResult represents the result of creating a secret.
@@ -154,13 +168,14 @@ func (a *App) SecretShow(specStr string) (*SecretShowResult, error) {
 	}
 
 	r := &SecretShowResult{
-		Name:         result.Name,
-		ARN:          result.ARN,
-		VersionID:    result.VersionID,
-		VersionStage: result.VersionStage,
-		Value:        result.Value,
-		Description:  result.Description,
-		Tags:         make([]SecretShowTag, 0, len(result.Tags)),
+		Name:          result.Name,
+		ARN:           result.ARN,
+		VersionID:     result.VersionID,
+		StagingLabels: result.VersionStage,
+		State:         result.State,
+		Value:         result.Value,
+		Description:   result.Description,
+		Tags:          make([]SecretShowTag, 0, len(result.Tags)),
 	}
 	if result.CreatedDate != nil {
 		r.CreatedDate = timeutil.FormatRFC3339(*result.CreatedDate)
@@ -196,10 +211,11 @@ func (a *App) SecretLog(name string, maxResults int32) (*SecretLogResult, error)
 	entries := make([]SecretLogEntry, len(result.Entries))
 	for i, e := range result.Entries {
 		entry := SecretLogEntry{
-			VersionID: e.VersionID,
-			Stages:    e.VersionStage,
-			Value:     e.Value,
-			IsCurrent: e.IsCurrent,
+			VersionID:     e.VersionID,
+			StagingLabels: e.VersionStage,
+			State:         e.State,
+			Value:         e.Value,
+			IsCurrent:     e.IsCurrent,
 		}
 		if e.CreatedDate != nil {
 			entry.Created = timeutil.FormatRFC3339(*e.CreatedDate)

--- a/internal/provider/aws/secret/secret.go
+++ b/internal/provider/aws/secret/secret.go
@@ -255,7 +255,6 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 		Type:  domain.ValueTypeSecret,
 		Version: domain.Version{
 			ID:            aws.ToString(out.VersionId),
-			Label:         representativeStage(out.VersionStages),
 			StagingLabels: out.VersionStages,
 			Created:       out.CreatedDate,
 		},
@@ -288,7 +287,6 @@ func (s *Store) History(ctx context.Context, name string) ([]domain.Version, err
 	return lo.Map(list, func(v types.SecretVersionsListEntry, _ int) domain.Version {
 		return domain.Version{
 			ID:            aws.ToString(v.VersionId),
-			Label:         representativeStage(v.VersionStages),
 			StagingLabels: v.VersionStages,
 			Created:       v.CreatedDate,
 		}
@@ -508,7 +506,6 @@ func (s *Store) Describe(ctx context.Context, name string) (*domain.Entry, error
 		}); found {
 			entry.Version = domain.Version{
 				ID:            aws.ToString(cur.VersionId),
-				Label:         representativeStage(cur.VersionStages),
 				StagingLabels: cur.VersionStages,
 				Created:       cur.CreatedDate,
 			}
@@ -554,29 +551,6 @@ func (s *Store) Untag(ctx context.Context, name string, keys []string) error {
 	}
 
 	return nil
-}
-
-// representativeStage picks a single, DETERMINISTIC staging label to surface as
-// the version's provider-neutral Label. A version can carry several labels and
-// AWS returns them in an unspecified order, so choosing stages[0] made both the
-// displayed label and any "is this AWSCURRENT?" check non-deterministic (#317).
-//
-// A well-known label wins in fixed priority order (AWSCURRENT > AWSPENDING >
-// AWSPREVIOUS); otherwise the lexicographically smallest custom label is used
-// so the choice is stable. It returns "" when there are no labels.
-func representativeStage(stages []string) string {
-	if len(stages) == 0 {
-		return ""
-	}
-
-	// Well-known AWS staging labels, highest priority first.
-	for _, known := range []string{"AWSCURRENT", "AWSPENDING", "AWSPREVIOUS"} {
-		if slices.Contains(stages, known) {
-			return known
-		}
-	}
-
-	return slices.Min(stages)
 }
 
 // mapTags maps Secrets Manager tags to provider-neutral domain tags.

--- a/internal/provider/aws/secret/secret_test.go
+++ b/internal/provider/aws/secret/secret_test.go
@@ -204,7 +204,6 @@ func TestGet_MapsEntryWithDescriptionAndTags(t *testing.T) {
 	assert.Equal(t, "s3cr3t", entry.Value)
 	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
 	assert.Equal(t, "id-3", entry.Version.ID)
-	assert.Equal(t, "AWSCURRENT", entry.Version.Label)
 	// StagingLabels carries the full stage set; State is empty (no such concept).
 	assert.Equal(t, []string{"AWSCURRENT"}, entry.Version.StagingLabels)
 	assert.Empty(t, entry.Version.State)
@@ -256,14 +255,13 @@ func TestGet_LabelPrefersAWSCURRENTRegardlessOfOrder(t *testing.T) {
 
 	entry, err := store.Get(t.Context(), "my-secret", provider.NewVersionRef("id-3"))
 	require.NoError(t, err)
-	assert.Equal(t, "AWSCURRENT", entry.Version.Label)
-	// The representative Label collapses to one; StagingLabels keeps them all.
+	// StagingLabels keeps every staging label AWS returned, in order.
 	assert.Equal(t, []string{"my-custom-label", "AWSPREVIOUS", "AWSCURRENT"}, entry.Version.StagingLabels)
 }
 
-// Priority ordering among the well-known and custom labels: AWSPENDING beats
-// AWSPREVIOUS, and custom-only labels tie-break lexicographically (#317).
-func TestHistory_LabelPriorityOrdering(t *testing.T) {
+// History preserves every staging label AWS returns for a version, in the
+// order AWS reported them (no collapsing to a single representative).
+func TestHistory_StagingLabels(t *testing.T) {
 	t.Parallel()
 
 	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -289,13 +287,10 @@ func TestHistory_LabelPriorityOrdering(t *testing.T) {
 	versions, err := store.History(t.Context(), "my-secret")
 	require.NoError(t, err)
 	require.Len(t, versions, 2)
-	// Newest first: id-2 (AWSPENDING preferred over AWSPREVIOUS).
+	// Newest first: id-2.
 	assert.Equal(t, "id-2", versions[0].ID)
-	assert.Equal(t, "AWSPENDING", versions[0].Label)
 	assert.Equal(t, []string{"AWSPREVIOUS", "AWSPENDING"}, versions[0].StagingLabels)
-	// Custom-only labels tie-break lexicographically: "alpha" < "zeta".
 	assert.Equal(t, "id-1", versions[1].ID)
-	assert.Equal(t, "alpha", versions[1].Label)
 	assert.Equal(t, []string{"zeta", "alpha"}, versions[1].StagingLabels)
 }
 
@@ -312,7 +307,7 @@ func TestHistory_NewestFirst(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, versions, 3)
 	assert.Equal(t, "id-3", versions[0].ID)
-	assert.Equal(t, "AWSCURRENT", versions[0].Label)
+	assert.Equal(t, []string{"AWSCURRENT"}, versions[0].StagingLabels)
 	assert.Equal(t, "id-1", versions[2].ID)
 }
 
@@ -648,7 +643,6 @@ func TestDescribe(t *testing.T) {
 	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
 	assert.Equal(t, "the desc", entry.Description)
 	assert.Equal(t, "id-3", entry.Version.ID)
-	assert.Equal(t, "AWSCURRENT", entry.Version.Label)
 	assert.Equal(t, []string{"AWSCURRENT"}, entry.Version.StagingLabels)
 	// The version's own creation time, not the secret-level CreatedDate.
 	require.NotNil(t, entry.Version.Created)

--- a/internal/provider/azure/keyvault/keyvault.go
+++ b/internal/provider/azure/keyvault/keyvault.go
@@ -167,7 +167,6 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 
 	if attr := resp.Attributes; attr != nil {
 		entry.Version.Created = attr.Created
-		entry.Version.Label = enabledLabel(attr.Enabled)
 		entry.Version.State = enabledLabel(attr.Enabled)
 		entry.Modified = attr.Updated
 	}
@@ -176,7 +175,7 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 }
 
 // History returns the secret's version history, newest first. The per-version
-// enabled/disabled state is surfaced in the neutral Version.Label for display.
+// enabled/disabled state is surfaced in the neutral Version.State for display.
 func (s *Store) History(ctx context.Context, name string) ([]domain.Version, error) {
 	versions, err := s.versionsNewestFirst(ctx, name)
 	if err != nil {
@@ -186,7 +185,6 @@ func (s *Store) History(ctx context.Context, name string) ([]domain.Version, err
 	return lo.Map(versions, func(v secretVersion, _ int) domain.Version {
 		return domain.Version{
 			ID:      v.id,
-			Label:   boolLabel(v.enabled),
 			State:   boolLabel(v.enabled),
 			Created: v.created,
 		}

--- a/internal/provider/azure/keyvault/keyvault_resolve_test.go
+++ b/internal/provider/azure/keyvault/keyvault_resolve_test.go
@@ -245,7 +245,7 @@ func TestGet_NilFieldsTolerated(t *testing.T) {
 	entry, err := store.Get(t.Context(), "my-secret", provider.VersionRef{})
 	require.NoError(t, err)
 	assert.Empty(t, entry.Version.ID)
-	assert.Empty(t, entry.Version.Label)
+	assert.Empty(t, entry.Version.State)
 }
 
 // TestStore_ErrorPaths covers the non-not-found error branches of the write and

--- a/internal/provider/azure/keyvault/keyvault_test.go
+++ b/internal/provider/azure/keyvault/keyvault_test.go
@@ -153,7 +153,6 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, "s3cr3t", entry.Value)
 	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
 	assert.Equal(t, "v1", entry.Version.ID)
-	assert.Equal(t, "enabled", entry.Version.Label)
 	// State carries the per-version enable/disable; StagingLabels is not a Key Vault concept.
 	assert.Equal(t, "enabled", entry.Version.State)
 	assert.Empty(t, entry.Version.StagingLabels)
@@ -195,11 +194,9 @@ func TestHistory(t *testing.T) {
 	require.Len(t, versions, 2)
 	// Newest first.
 	assert.Equal(t, "new", versions[0].ID)
-	assert.Equal(t, "enabled", versions[0].Label)
 	assert.Equal(t, "enabled", versions[0].State)
 	assert.Empty(t, versions[0].StagingLabels)
 	assert.Equal(t, "old", versions[1].ID)
-	assert.Equal(t, "disabled", versions[1].Label)
 	assert.Equal(t, "disabled", versions[1].State)
 	assert.Empty(t, versions[1].StagingLabels)
 }

--- a/internal/provider/gcloud/secret/secret.go
+++ b/internal/provider/gcloud/secret/secret.go
@@ -209,7 +209,6 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 	}); verr == nil && sv != nil {
 		created := toTime(sv.GetCreateTime())
 		entry.Version.Created = created
-		entry.Version.Label = stateLabel(sv.GetState())
 		entry.Version.State = stateLabel(sv.GetState())
 		entry.Modified = created
 	}
@@ -225,7 +224,7 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 }
 
 // History returns the secret's version history, newest first. The per-version
-// state (enabled/disabled/destroyed) is surfaced in the neutral Version.Label
+// state (enabled/disabled/destroyed) is surfaced in the neutral Version.State
 // for display; destroyed/disabled versions have no accessible value.
 func (s *Store) History(ctx context.Context, name string) ([]domain.Version, error) {
 	versions, err := s.client.ListSecretVersions(ctx, &secretmanagerpb.ListSecretVersionsRequest{
@@ -240,7 +239,6 @@ func (s *Store) History(ctx context.Context, name string) ([]domain.Version, err
 	return lo.Map(versions, func(v *secretmanagerpb.SecretVersion, _ int) domain.Version {
 		return domain.Version{
 			ID:      versionNumber(v.GetName()),
-			Label:   stateLabel(v.GetState()),
 			State:   stateLabel(v.GetState()),
 			Created: toTime(v.GetCreateTime()),
 		}

--- a/internal/provider/gcloud/secret/secret_more_test.go
+++ b/internal/provider/gcloud/secret/secret_more_test.go
@@ -147,11 +147,11 @@ func TestHistory_StateLabelsAndUnparsable(t *testing.T) {
 	// Numeric versions sort newest-first; the unparsable name (versionInt == -1)
 	// sorts last.
 	assert.Equal(t, "5", versions[0].ID)
-	assert.Equal(t, "enabled", versions[0].Label)
+	assert.Equal(t, "enabled", versions[0].State)
 	assert.Equal(t, "2", versions[1].ID)
-	assert.Equal(t, "disabled", versions[1].Label)
+	assert.Equal(t, "disabled", versions[1].State)
 	assert.Equal(t, "weird", versions[2].ID)
-	assert.Empty(t, versions[2].Label)
+	assert.Empty(t, versions[2].State)
 }
 
 func TestList_Error(t *testing.T) {

--- a/internal/provider/gcloud/secret/secret_test.go
+++ b/internal/provider/gcloud/secret/secret_test.go
@@ -260,12 +260,10 @@ func TestHistory(t *testing.T) {
 	require.Len(t, versions, 2)
 	// Newest first: version 2 (enabled) then 1 (destroyed).
 	assert.Equal(t, "2", versions[0].ID)
-	assert.Equal(t, "enabled", versions[0].Label)
 	// State carries the per-version lifecycle; StagingLabels is not a GCloud concept.
 	assert.Equal(t, "enabled", versions[0].State)
 	assert.Empty(t, versions[0].StagingLabels)
 	assert.Equal(t, "1", versions[1].ID)
-	assert.Equal(t, "destroyed", versions[1].Label)
 	assert.Equal(t, "destroyed", versions[1].State)
 	assert.Empty(t, versions[1].StagingLabels)
 }

--- a/internal/usecase/secret/log.go
+++ b/internal/usecase/secret/log.go
@@ -19,9 +19,16 @@ type LogInput struct {
 }
 
 // LogEntry represents a single version entry.
+//
+// VersionStage and State carry the two independent, provider-specific axes that
+// must NOT be conflated (#419): VersionStage holds AWS Secrets Manager staging
+// labels (empty for other providers), while State holds the per-version
+// lifecycle state (enabled/disabled/destroyed) for Google Cloud + Azure Key
+// Vault (empty for AWS). A version never has both.
 type LogEntry struct {
 	VersionID    string
 	VersionStage []string
+	State        string
 	Value        string
 	CreatedDate  *time.Time
 	IsCurrent    bool
@@ -106,6 +113,7 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 		entries = append(entries, LogEntry{
 			VersionID:    v.ID,
 			VersionStage: stages(v.StagingLabels),
+			State:        v.State,
 			Value:        value,
 			CreatedDate:  v.Created,
 			// A version is current when AWSCURRENT is among its staging labels;

--- a/internal/usecase/secret/log_test.go
+++ b/internal/usecase/secret/log_test.go
@@ -61,8 +61,34 @@ func TestLogUseCase_Execute(t *testing.T) {
 	// IsCurrent is a membership test: AWSCURRENT alongside a custom label.
 	assert.True(t, output.Entries[0].IsCurrent)
 	assert.Equal(t, []string{"AWSCURRENT", "custom"}, output.Entries[0].VersionStage)
+	// AWS Secrets Manager carries staging labels, not a per-version state (#419).
+	assert.Empty(t, output.Entries[0].State)
 	assert.Equal(t, "value3", output.Entries[0].Value)
 	assert.False(t, output.Entries[2].IsCurrent)
+}
+
+// TestLogUseCase_Execute_State asserts that a GCloud/Key Vault-style history
+// (per-version State set, no staging labels) surfaces State on each entry and
+// leaves VersionStage empty — the two concepts must not be conflated (#419).
+func TestLogUseCase_Execute_State(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	versions := []domain.Version{
+		{ID: "2", State: "enabled", Created: &now},
+		{ID: "1", State: "disabled", Created: tp(now, -time.Hour)},
+	}
+	values := map[string]string{"1": "value1", "2": "value2"}
+
+	uc := &secret.LogUseCase{Reader: logStore(versions, values, nil)}
+
+	output, err := uc.Execute(t.Context(), secret.LogInput{Name: "my-secret", MaxResults: 10})
+	require.NoError(t, err)
+	require.Len(t, output.Entries, 2)
+	assert.Equal(t, "enabled", output.Entries[0].State)
+	assert.Empty(t, output.Entries[0].VersionStage)
+	assert.Equal(t, "disabled", output.Entries[1].State)
+	assert.Empty(t, output.Entries[1].VersionStage)
 }
 
 func TestLogUseCase_Execute_Empty(t *testing.T) {

--- a/internal/usecase/secret/show.go
+++ b/internal/usecase/secret/show.go
@@ -24,12 +24,19 @@ type ShowTag struct {
 }
 
 // ShowOutput holds the result of the show use case.
+//
+// VersionStage and State carry the two independent, provider-specific axes that
+// must NOT be conflated (#419): VersionStage holds AWS Secrets Manager staging
+// labels (empty for other providers), while State holds the per-version
+// lifecycle state (enabled/disabled/destroyed) for Google Cloud + Azure Key
+// Vault (empty for AWS). A version never has both.
 type ShowOutput struct {
 	Name         string
 	ARN          string
 	Value        string
 	VersionID    string
 	VersionStage []string
+	State        string
 	Description  string
 	CreatedDate  *time.Time
 	Tags         []ShowTag
@@ -60,6 +67,7 @@ func (u *ShowUseCase) Execute(ctx context.Context, input ShowInput) (*ShowOutput
 		Value:        entry.Value,
 		VersionID:    entry.Version.ID,
 		VersionStage: stages(entry.Version.StagingLabels),
+		State:        entry.Version.State,
 		Description:  entry.Description,
 		CreatedDate:  entry.Version.Created,
 		Tags: lo.Map(entry.Tags, func(tag domain.Tag, _ int) ShowTag {

--- a/internal/usecase/secret/show_test.go
+++ b/internal/usecase/secret/show_test.go
@@ -59,9 +59,32 @@ func TestShowUseCase_Execute(t *testing.T) {
 	assert.Equal(t, "secret-value", output.Value)
 	assert.Equal(t, "abc123", output.VersionID)
 	assert.Equal(t, []string{"AWSCURRENT", "custom"}, output.VersionStage)
+	// AWS Secrets Manager carries staging labels, not a per-version state (#419).
+	assert.Empty(t, output.State)
 	assert.NotNil(t, output.CreatedDate)
 	// Regression guard: the ARN must be surfaced from the entry's Extra metadata.
 	assert.Equal(t, "arn:aws:secretsmanager:us-east-1:123:secret:my-secret", output.ARN)
+}
+
+// TestShowUseCase_Execute_State asserts that a GCloud/Key Vault-style version
+// (per-version State set, no staging labels) surfaces State and leaves
+// VersionStage empty — the two concepts must not be conflated (#419).
+func TestShowUseCase_Execute_State(t *testing.T) {
+	t.Parallel()
+
+	store := showStore(&domain.Entry{
+		Name:    "my-secret",
+		Value:   "secret-value",
+		Type:    domain.ValueTypeSecret,
+		Version: domain.Version{ID: "2", State: "enabled"},
+	})
+
+	uc := &secret.ShowUseCase{Reader: store}
+
+	output, err := uc.Execute(t.Context(), secret.ShowInput{Spec: mustParseSpec(t, "my-secret")})
+	require.NoError(t, err)
+	assert.Equal(t, "enabled", output.State)
+	assert.Empty(t, output.VersionStage)
 }
 
 func TestShowUseCase_Execute_WithVersionID(t *testing.T) {


### PR DESCRIPTION
Phase C (GUI + final cleanup) of Epic #419 — the last phase. Targets the epic integration branch `epic/version-state-vs-staging-labels` (Phases A #421 + B #422 already merged there).

## GUI regression fix (the reason this phase exists)
The GUI's Secret view reuses the **neutral** `internal/usecase/secret` `LogUseCase`/`ShowUseCase` for **every** secret provider (AWS SM, Google Cloud Secret Manager, Azure Key Vault) — see `internal/gui/secret.go`. Phase B changed that usecase's stage output to read `v.StagingLabels`, which is populated **only for AWS SM** and is empty for GCloud/Key Vault, and it did not expose `v.State`. As a result the GUI showed **no state** for GCloud/Key Vault secret versions (previously `enabled`/`disabled` via the old overloaded `Label`). The CLI was unaffected (it uses per-provider usecases).

This PR restores GCloud/KV state in the GUI by carrying **both** concepts through the neutral usecase.

## Changes
- **Secret usecase carries both concepts** (`internal/usecase/secret/log.go`, `show.go`): `LogEntry`/`ShowOutput` now expose `VersionStage []string` (AWS SM staging labels; empty for GCloud/KV) **and** a new `State string` (GCloud/KV `enabled`/`disabled`/`destroyed`; empty for AWS SM), populated from `v.State`.
- **GUI DTO split** (`internal/gui/secret.go`): `SecretShowResult` / `SecretLogEntry` replace `versionStage`/`stages` with explicit `stagingLabels []string` + `state string` (JSON `stagingLabels`, `state`). `wailsjs/go/models.ts` was **hand-edited** to match (no display available to run `wails generate`); the existing `TestDTOContract` guards Go ↔ TS field parity and passes.
- **Frontend renders by concept, not provider string** (`SecretView.svelte`): the interim `provider === 'aws' ? 'Labels' : 'State'` heuristic from #418/#420 is **removed**. Rendering is now driven by which field is populated — `state` → heading **"State"** + state badge; `stagingLabels` → heading **"Staging labels"** + one badge per label. Applied to both the current-version metadata block and the version-history badges; `badge-stage` styling kept.
- **Final cleanup — `domain.Version.Label` removed**: the overloaded field is deleted from `internal/domain/domain.go`. Adapter dual-writes dropped — AWS SM's `representativeStage(...)` helper is deleted (it only fed `Label`); GCloud and Key Vault keep `State` only. A whole-repo grep confirms no `Version.Label` references remain; all other `.Label` hits are unrelated concepts (`domain.Field.Label`, `secretversion.AbsoluteSpec.Label`, confirm choice labels, Azure App Config's own `Label` option) and were left untouched.
- **Tests**: secret usecase gains State cases (a GCloud/KV-style version with `State` set + `StagingLabels` empty surfaces `State`; an AWS-SM version surfaces `VersionStage` with empty `State`); adapter + domain tests migrated off `Version.Label`; Playwright `secret.spec.ts` gains concept-driven heading cases (GCloud → "State" + `enabled` badge; Azure Key Vault → "State"; AWS SM with multiple staging labels → "Staging labels" + every label badge) that supersede the #418/#420 cases. The mock fixture (`wails-mock.ts`) was updated to the split DTO shape.

## Verification
- `go build -tags production ./...` — clean
- `go test ./...` — pass (72 packages ok)
- `golangci-lint run --allow-parallel-runners --build-tags=e2e,production ./internal/...` — 0 issues
- `npm run check` — 0 errors (3 pre-existing unrelated warnings); `npm run lint` — clean; `npm run build` — ok
- Playwright — `secret.spec.ts` 174/174 pass across all 3 browsers; full suite 1552 pass. Two webkit failures are pre-existing and unrelated: `filter-search.spec.ts` (flake — passed on rerun) and `keyboard-focus.spec.ts:54` (confirmed failing identically on the base tree `b2423d2`, in files this PR does not touch).
- e2e not run (per scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)