### PR TITLE
feat(domain): separate version state (enabled/disabled/destroyed) from staging labels (#419)

### DIFF
--- a/internal/cli/commands/azure/secret/secret_test.go
+++ b/internal/cli/commands/azure/secret/secret_test.go
@@ -132,7 +132,7 @@ func TestShowPresenter(t *testing.T) {
 				Name:    name,
 				Value:   "s3cr3t",
 				Type:    domain.ValueTypeSecret,
-				Version: domain.Version{ID: "abc123", Label: "enabled", Created: &created},
+				Version: domain.Version{ID: "abc123", State: "enabled", Created: &created},
 				Tags:    []domain.Tag{{Key: "env", Value: "prod"}},
 			}, nil
 		},
@@ -164,8 +164,8 @@ func TestLogPresenter(t *testing.T) {
 	store := &providermock.Store{
 		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
 			return []domain.Version{
-				{ID: "new", Label: "enabled", Created: &created},
-				{ID: "old", Label: "disabled", Created: &created},
+				{ID: "new", State: "enabled", Created: &created},
+				{ID: "old", State: "disabled", Created: &created},
 			}, nil
 		},
 		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
@@ -200,8 +200,8 @@ func TestLogPresenter_Patch(t *testing.T) {
 	store := &providermock.Store{
 		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
 			return []domain.Version{
-				{ID: "2", Label: "enabled", Created: &created},
-				{ID: "1", Label: "enabled", Created: &created},
+				{ID: "2", State: "enabled", Created: &created},
+				{ID: "1", State: "enabled", Created: &created},
 			}, nil
 		},
 		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {

--- a/internal/cli/commands/gcloud/gcloud_test.go
+++ b/internal/cli/commands/gcloud/gcloud_test.go
@@ -185,7 +185,7 @@ func TestShowPresenter(t *testing.T) {
 				Name:    name,
 				Value:   "s3cr3t",
 				Type:    domain.ValueTypeSecret,
-				Version: domain.Version{ID: "3", Label: "enabled", Created: &created},
+				Version: domain.Version{ID: "3", State: "enabled", Created: &created},
 				Tags:    []domain.Tag{{Key: "env", Value: "prod"}},
 			}, nil
 		},
@@ -221,8 +221,8 @@ func TestLogPresenter(t *testing.T) {
 	store := &providermock.Store{
 		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
 			return []domain.Version{
-				{ID: "2", Label: "enabled", Created: &created},
-				{ID: "1", Label: "destroyed", Created: &created},
+				{ID: "2", State: "enabled", Created: &created},
+				{ID: "1", State: "destroyed", Created: &created},
 			}, nil
 		},
 		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
@@ -259,8 +259,8 @@ func TestLogPresenter_Patch(t *testing.T) {
 	store := &providermock.Store{
 		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
 			return []domain.Version{
-				{ID: "2", Label: "enabled", Created: &created},
-				{ID: "1", Label: "enabled", Created: &created},
+				{ID: "2", State: "enabled", Created: &created},
+				{ID: "1", State: "enabled", Created: &created},
 			}, nil
 		},
 		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {

--- a/internal/cli/commands/generic/log/log_test.go
+++ b/internal/cli/commands/generic/log/log_test.go
@@ -691,8 +691,8 @@ func TestRunSecret(t *testing.T) {
 			name: "show version history",
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10},
 			store: secretLogStore([]domain.Version{
-				{ID: "v2", Label: "AWSCURRENT", Created: &now},
-				{ID: "v1", Label: "AWSPREVIOUS", Created: at(now, -time.Hour)},
+				{ID: "v2", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+				{ID: "v1", StagingLabels: []string{"AWSPREVIOUS"}, Created: at(now, -time.Hour)},
 			}, nil, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -705,8 +705,8 @@ func TestRunSecret(t *testing.T) {
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10},
 			opts: genericlog.Options{ShowPatch: true},
 			store: secretLogStore([]domain.Version{
-				{ID: testVersionID2, Label: "AWSCURRENT", Created: &now},
-				{ID: testVersionID1, Label: "AWSPREVIOUS", Created: at(now, -time.Hour)},
+				{ID: testVersionID2, StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+				{ID: testVersionID1, StagingLabels: []string{"AWSPREVIOUS"}, Created: at(now, -time.Hour)},
 			}, map[string]string{testVersionID1: "old-value", testVersionID2: "new-value"}, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -720,7 +720,7 @@ func TestRunSecret(t *testing.T) {
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10},
 			opts: genericlog.Options{ShowPatch: true},
 			store: secretLogStore([]domain.Version{
-				{ID: "only-version", Label: "AWSCURRENT", Created: &now},
+				{ID: "only-version", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
 			}, map[string]string{"only-version": "only-value"}, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -742,8 +742,8 @@ func TestRunSecret(t *testing.T) {
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10, Reverse: true},
 			opts: genericlog.Options{Reverse: true},
 			store: secretLogStore([]domain.Version{
-				{ID: "version-2", Label: "AWSCURRENT", Created: &now},
-				{ID: "version-1", Label: "AWSPREVIOUS", Created: at(now, -time.Hour)},
+				{ID: "version-2", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+				{ID: "version-1", StagingLabels: []string{"AWSPREVIOUS"}, Created: at(now, -time.Hour)},
 			}, nil, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -769,8 +769,8 @@ func TestRunSecret(t *testing.T) {
 			name: "version without CreatedDate",
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10},
 			store: secretLogStore([]domain.Version{
-				{ID: "v2", Label: "AWSCURRENT", Created: &now},
-				{ID: "v1", Label: "AWSPREVIOUS"},
+				{ID: "v2", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+				{ID: "v1", StagingLabels: []string{"AWSPREVIOUS"}},
 			}, nil, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -849,8 +849,8 @@ func TestRunSecret(t *testing.T) {
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10},
 			opts: genericlog.Options{Oneline: true},
 			store: secretLogStore([]domain.Version{
-				{ID: testVersionID2, Label: "AWSCURRENT", Created: &now},
-				{ID: testVersionID1, Label: "AWSPREVIOUS", Created: at(now, -time.Hour)},
+				{ID: testVersionID2, StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+				{ID: testVersionID1, StagingLabels: []string{"AWSPREVIOUS"}, Created: at(now, -time.Hour)},
 			}, nil, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -864,7 +864,7 @@ func TestRunSecret(t *testing.T) {
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10},
 			opts: genericlog.Options{Oneline: true},
 			store: secretLogStore([]domain.Version{
-				{ID: testVersionID2, Label: "AWSCURRENT", Created: &now},
+				{ID: testVersionID2, StagingLabels: []string{"AWSCURRENT"}, Created: &now},
 				{ID: testVersionID1},
 			}, nil, nil, nil),
 			check: func(t *testing.T, output string) {
@@ -876,8 +876,8 @@ func TestRunSecret(t *testing.T) {
 			name: "filter by since date",
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10, Since: at(now, -30*time.Minute)},
 			store: secretLogStore([]domain.Version{
-				{ID: "new-version", Label: "AWSCURRENT", Created: &now},
-				{ID: "old-version", Label: "AWSPREVIOUS", Created: at(now, -2*time.Hour)},
+				{ID: "new-version", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+				{ID: "old-version", StagingLabels: []string{"AWSPREVIOUS"}, Created: at(now, -2*time.Hour)},
 			}, nil, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -889,8 +889,8 @@ func TestRunSecret(t *testing.T) {
 			name: "filter by until date",
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10, Until: at(now, -30*time.Minute)},
 			store: secretLogStore([]domain.Version{
-				{ID: "new-version", Label: "AWSCURRENT", Created: &now},
-				{ID: "old-version", Label: "AWSPREVIOUS", Created: at(now, -2*time.Hour)},
+				{ID: "new-version", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+				{ID: "old-version", StagingLabels: []string{"AWSPREVIOUS"}, Created: at(now, -2*time.Hour)},
 			}, nil, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -932,7 +932,7 @@ func TestRunSecret(t *testing.T) {
 			name: "filter skips versions without CreatedDate",
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10, Since: at(now, -30*time.Minute)},
 			store: secretLogStore([]domain.Version{
-				{ID: "new-version", Label: "AWSCURRENT", Created: &now},
+				{ID: "new-version", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
 				{ID: "no-date-ver"},
 			}, nil, nil, nil),
 			check: func(t *testing.T, output string) {
@@ -946,8 +946,8 @@ func TestRunSecret(t *testing.T) {
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10},
 			opts: genericlog.Options{Output: output.FormatJSON},
 			store: secretLogStore([]domain.Version{
-				{ID: testVersionID2, Label: "AWSCURRENT", Created: &now},
-				{ID: testVersionID1, Label: "AWSPREVIOUS", Created: at(now, -time.Hour)},
+				{ID: testVersionID2, StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+				{ID: testVersionID1, StagingLabels: []string{"AWSPREVIOUS"}, Created: at(now, -time.Hour)},
 			}, map[string]string{testVersionID1: "old-value", testVersionID2: "new-value"}, nil, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()
@@ -962,7 +962,7 @@ func TestRunSecret(t *testing.T) {
 			req:  genericlog.Request{Name: "my-secret", MaxResults: 10},
 			opts: genericlog.Options{Output: output.FormatJSON},
 			store: secretLogStore([]domain.Version{
-				{ID: testVersionID1, Label: "AWSCURRENT", Created: &now},
+				{ID: testVersionID1, StagingLabels: []string{"AWSCURRENT"}, Created: &now},
 			}, nil, map[string]error{testVersionID1: errors.New("access denied")}, nil),
 			check: func(t *testing.T, output string) {
 				t.Helper()

--- a/internal/cli/commands/generic/show/show_test.go
+++ b/internal/cli/commands/generic/show/show_test.go
@@ -385,7 +385,7 @@ func TestRunSecret(t *testing.T) {
 			store: showStore(&domain.Entry{
 				Name:    "my-secret",
 				Value:   "secret-value",
-				Version: domain.Version{ID: "abc123", Label: "AWSCURRENT", Created: &now},
+				Version: domain.Version{ID: "abc123", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
 				Extra:   []domain.Field{{Label: "ARN", Value: testARN}},
 			}),
 			check: func(t *testing.T, output string) {
@@ -414,7 +414,7 @@ func TestRunSecret(t *testing.T) {
 			store: showStore(&domain.Entry{
 				Name:    "my-secret",
 				Value:   `{"zebra":"last","apple":"first"}`,
-				Version: domain.Version{ID: "abc123", Label: "AWSCURRENT", Created: &now},
+				Version: domain.Version{ID: "abc123", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
 				Extra:   []domain.Field{{Label: "ARN", Value: testARN}},
 			}),
 			check: func(t *testing.T, output string) {
@@ -522,7 +522,7 @@ func TestRunSecret(t *testing.T) {
 			store: showStore(&domain.Entry{
 				Name:    "my-secret",
 				Value:   "secret-value",
-				Version: domain.Version{ID: "abc123", Label: "AWSCURRENT", Created: &now},
+				Version: domain.Version{ID: "abc123", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
 				Extra:   []domain.Field{{Label: "ARN", Value: testARN}},
 				Tags: []domain.Tag{
 					{Key: "Environment", Value: "production"},
@@ -546,7 +546,7 @@ func TestRunSecret(t *testing.T) {
 			store: showStore(&domain.Entry{
 				Name:    "my-secret",
 				Value:   "secret-value",
-				Version: domain.Version{ID: "abc123", Label: "AWSCURRENT", Created: &now},
+				Version: domain.Version{ID: "abc123", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
 				Extra:   []domain.Field{{Label: "ARN", Value: testARN}},
 				Tags: []domain.Tag{
 					{Key: "Environment", Value: "production"},

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -21,13 +21,45 @@ const (
 	ValueTypeList ValueType = "list" // AWS StringList
 )
 
-// Version identifies one version of an entry. Label is optional and may be
-// empty for providers without human-facing version labels.
+// Version identifies one version of an entry.
+//
+// It carries two independent, provider-specific axes that must NOT be
+// conflated (#419):
+//
+//   - StagingLabels are movable pointers naming "which version is current"
+//     (AWS Secrets Manager: AWSCURRENT / AWSPENDING / AWSPREVIOUS). Rotation
+//     moves a label from one version to another; a version may carry several
+//     labels or none (unlabeled versions are passively retained history, still
+//     readable by ID). Multi-valued.
+//   - State is a per-version enable/disable switch for reading that specific
+//     version's value (Google Cloud + Azure Key Vault). It is single-valued and
+//     orthogonal to "which version is latest".
+//
+// Providers that have neither concept (AWS SSM, Azure App Configuration) leave
+// both empty.
 type Version struct {
 	// ID is the provider-internal version identifier.
 	ID string
 	// Label is an optional human-facing label (empty when unsupported).
+	//
+	// NOTE: Label is overloaded to mean a representative staging label (AWS
+	// Secrets Manager) OR a per-version state (Google Cloud, Azure Key Vault).
+	// It is retained for back-compat during the #419 migration; prefer
+	// StagingLabels or State in new code. A later cleanup removes it once all
+	// readers migrate (do NOT mark it Deprecated yet: that would trip staticcheck
+	// SA1019 on the existing dual-write readers this phase must preserve).
 	Label string
+	// State is the per-version lifecycle state: "enabled" / "disabled" /
+	// "destroyed", or "" when the provider has no such concept. It is a
+	// per-version switch controlling whether that version's value can be read
+	// (Google Cloud + Azure Key Vault); it is orthogonal to which version is
+	// latest. Empty for AWS Secrets Manager, AWS SSM and Azure App Config.
+	State string
+	// StagingLabels are the AWS Secrets Manager staging labels for this version
+	// (all of them, e.g. AWSCURRENT / AWSPREVIOUS). A staging label is a movable
+	// pointer naming "which version is current", not a per-version state.
+	// nil/empty for every other provider.
+	StagingLabels []string
 	// Created is the version creation time, if known.
 	Created *time.Time
 }

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -40,15 +40,6 @@ const (
 type Version struct {
 	// ID is the provider-internal version identifier.
 	ID string
-	// Label is an optional human-facing label (empty when unsupported).
-	//
-	// NOTE: Label is overloaded to mean a representative staging label (AWS
-	// Secrets Manager) OR a per-version state (Google Cloud, Azure Key Vault).
-	// It is retained for back-compat during the #419 migration; prefer
-	// StagingLabels or State in new code. A later cleanup removes it once all
-	// readers migrate (do NOT mark it Deprecated yet: that would trip staticcheck
-	// SA1019 on the existing dual-write readers this phase must preserve).
-	Label string
 	// State is the per-version lifecycle state: "enabled" / "disabled" /
 	// "destroyed", or "" when the provider has no such concept. It is a
 	// per-version switch controlling whether that version's value can be read

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -22,7 +22,6 @@ func TestEntry_Fields(t *testing.T) {
 		Type:  domain.ValueTypeSecret,
 		Version: domain.Version{
 			ID:            "v3",
-			Label:         "current",
 			State:         "enabled",
 			StagingLabels: []string{"AWSCURRENT", "AWSPREVIOUS"},
 			Created:       &created,
@@ -36,7 +35,6 @@ func TestEntry_Fields(t *testing.T) {
 	assert.Equal(t, "hunter2", entry.Value)
 	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
 	assert.Equal(t, "v3", entry.Version.ID)
-	assert.Equal(t, "current", entry.Version.Label)
 	assert.Equal(t, "enabled", entry.Version.State)
 	assert.Equal(t, []string{"AWSCURRENT", "AWSPREVIOUS"}, entry.Version.StagingLabels)
 	assert.Equal(t, &created, entry.Version.Created)

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -21,9 +21,11 @@ func TestEntry_Fields(t *testing.T) {
 		Value: "hunter2",
 		Type:  domain.ValueTypeSecret,
 		Version: domain.Version{
-			ID:      "v3",
-			Label:   "current",
-			Created: &created,
+			ID:            "v3",
+			Label:         "current",
+			State:         "enabled",
+			StagingLabels: []string{"AWSCURRENT", "AWSPREVIOUS"},
+			Created:       &created,
 		},
 		Description: "example",
 		Tags:        []domain.Tag{{Key: "env", Value: "prod"}},
@@ -35,6 +37,8 @@ func TestEntry_Fields(t *testing.T) {
 	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
 	assert.Equal(t, "v3", entry.Version.ID)
 	assert.Equal(t, "current", entry.Version.Label)
+	assert.Equal(t, "enabled", entry.Version.State)
+	assert.Equal(t, []string{"AWSCURRENT", "AWSPREVIOUS"}, entry.Version.StagingLabels)
 	assert.Equal(t, &created, entry.Version.Created)
 	assert.Equal(t, "example", entry.Description)
 	assert.Len(t, entry.Tags, 1)

--- a/internal/gui/frontend/src/lib/SecretView.svelte
+++ b/internal/gui/frontend/src/lib/SecretView.svelte
@@ -30,11 +30,11 @@
   const forceDeleteEnabled = $derived(capability?.hasForceDelete ?? true);
   const recoveryWindowEnabled = $derived(capability?.hasRecoveryWindow ?? true);
 
-  // Version.Label is overloaded per provider: AWS Secrets Manager carries genuine
-  // staging labels (AWSCURRENT/AWSPENDING/...), while Google Cloud and Azure Key
-  // Vault carry the per-version state (enabled/disabled/destroyed). Only AWS has
-  // staging labels, so label the heading accordingly.
-  const versionMetaLabel = $derived(provider === 'aws' ? 'Labels' : 'State');
+  // Staging labels and per-version state are two independent concepts (#419), so
+  // render each from the field that actually carries it rather than guessing
+  // from the provider string. AWS Secrets Manager populates stagingLabels
+  // (AWSCURRENT/AWSPENDING/...); Google Cloud + Azure Key Vault populate state
+  // (enabled/disabled/destroyed). A version never has both.
 
   const PAGE_SIZE = 50;
   const debounce = createDebouncer(300);
@@ -552,12 +552,19 @@
                 <span class="meta-label">Version ID</span>
                 <span class="meta-value mono">{secretDetail.versionId}</span>
               </div>
-              {#if (secretDetail.versionStage || []).length > 0}
+              {#if secretDetail.state}
                 <div class="meta-item">
-                  <span class="meta-label">{versionMetaLabel}</span>
+                  <span class="meta-label">State</span>
                   <span class="meta-value">
-                    {#each secretDetail.versionStage || [] as stage}
-                      <span class="badge badge-stage">{stage}</span>
+                    <span class="badge badge-stage">{secretDetail.state}</span>
+                  </span>
+                </div>
+              {:else if (secretDetail.stagingLabels || []).length > 0}
+                <div class="meta-item">
+                  <span class="meta-label">Staging labels</span>
+                  <span class="meta-value">
+                    {#each secretDetail.stagingLabels || [] as label}
+                      <span class="badge badge-stage">{label}</span>
                     {/each}
                   </span>
                 </div>
@@ -625,10 +632,14 @@
                           {/if}
                           <span class="history-date">{formatDate(logEntry.created)}</span>
                         </div>
-                        {#if (logEntry.stages || []).length > 0}
+                        {#if logEntry.state}
                           <div class="history-labels">
-                            {#each logEntry.stages || [] as stage}
-                              <span class="badge badge-stage small">{stage}</span>
+                            <span class="badge badge-stage small">{logEntry.state}</span>
+                          </div>
+                        {:else if (logEntry.stagingLabels || []).length > 0}
+                          <div class="history-labels">
+                            {#each logEntry.stagingLabels || [] as label}
+                              <span class="badge badge-stage small">{label}</span>
                             {/each}
                           </div>
                         {/if}

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -15,10 +15,15 @@ export interface Secret {
   value: string;
   // Optional overrides for SecretShow. When omitted, SecretShow synthesizes an
   // AWS-shaped ARN and an ['AWSCURRENT'] staging label (backward compatible).
-  // A provider without these (e.g. an empty arn / empty stages, as Google Cloud
-  // and Azure return) drives the presence-gated rendering in SecretView.
+  // A provider without these (e.g. an empty arn / empty stagingLabels, as Google
+  // Cloud and Azure return) drives the presence-gated rendering in SecretView.
+  //
+  // stagingLabels and state are the two independent concepts (#419): AWS Secrets
+  // Manager populates stagingLabels; Google Cloud + Azure Key Vault populate
+  // state (enabled/disabled/destroyed). A version never has both.
   arn?: string;
-  versionStage?: string[];
+  stagingLabels?: string[];
+  state?: string;
   versionId?: string;
 }
 
@@ -60,7 +65,10 @@ export interface ParamLogEntry {
 
 export interface SecretLogEntry {
   versionId: string;
-  stages: string[];
+  // Two independent concepts (#419): stagingLabels for AWS Secrets Manager,
+  // state (enabled/disabled/destroyed) for Google Cloud + Azure Key Vault.
+  stagingLabels?: string[];
+  state?: string;
   value: string;
   isCurrent: boolean;
   created: string;
@@ -292,9 +300,9 @@ export const defaultMockState: MockState = {
   },
   secretVersions: {
     'my-secret': [
-      { versionId: 'v3-current', stages: ['AWSCURRENT'], value: 'secret-value-1', isCurrent: true, created: new Date().toISOString() },
-      { versionId: 'v2-previous', stages: ['AWSPREVIOUS'], value: 'secret-value-old', isCurrent: false, created: new Date(Date.now() - 86400000).toISOString() },
-      { versionId: 'v1-initial', stages: [], value: 'secret-value-initial', isCurrent: false, created: new Date(Date.now() - 172800000).toISOString() },
+      { versionId: 'v3-current', stagingLabels: ['AWSCURRENT'], value: 'secret-value-1', isCurrent: true, created: new Date().toISOString() },
+      { versionId: 'v2-previous', stagingLabels: ['AWSPREVIOUS'], value: 'secret-value-old', isCurrent: false, created: new Date(Date.now() - 86400000).toISOString() },
+      { versionId: 'v1-initial', stagingLabels: [], value: 'secret-value-initial', isCurrent: false, created: new Date(Date.now() - 172800000).toISOString() },
     ],
   },
   enablePagination: false,
@@ -446,9 +454,9 @@ export function createVersionHistoryState(): Partial<MockState> {
     },
     secretVersions: {
       'my-secret': [
-        { versionId: 'ver-003', stages: ['AWSCURRENT'], value: '{"current": "v3"}', isCurrent: true, created: new Date().toISOString() },
-        { versionId: 'ver-002', stages: ['AWSPREVIOUS'], value: '{"previous": "v2"}', isCurrent: false, created: new Date(Date.now() - 86400000).toISOString() },
-        { versionId: 'ver-001', stages: [], value: '{"initial": "v1"}', isCurrent: false, created: new Date(Date.now() - 172800000).toISOString() },
+        { versionId: 'ver-003', stagingLabels: ['AWSCURRENT'], value: '{"current": "v3"}', isCurrent: true, created: new Date().toISOString() },
+        { versionId: 'ver-002', stagingLabels: ['AWSPREVIOUS'], value: '{"previous": "v2"}', isCurrent: false, created: new Date(Date.now() - 86400000).toISOString() },
+        { versionId: 'ver-001', stagingLabels: [], value: '{"initial": "v1"}', isCurrent: false, created: new Date(Date.now() - 172800000).toISOString() },
       ],
     },
   };
@@ -609,15 +617,16 @@ export function createGoogleCloudState(overrides: Partial<MockState> = {}): Part
       secretActive: ['googlecloud'],
       stageActive: [],
     },
-    // Google Cloud secret versions are integers and carry no ARN/staging labels.
+    // Google Cloud secret versions are integers and carry no ARN/staging labels;
+    // they carry a per-version state (enabled/disabled/destroyed) instead.
     secrets: [
-      { name: 'gcloud-secret-1', value: 'v1', arn: '', versionStage: [] },
-      { name: 'gcloud-secret-2', value: 'v2', arn: '', versionStage: [] },
+      { name: 'gcloud-secret-1', value: 'v1', arn: '', stagingLabels: [], state: 'enabled' },
+      { name: 'gcloud-secret-2', value: 'v2', arn: '', stagingLabels: [], state: 'enabled' },
     ],
     secretVersions: {
       'gcloud-secret-1': [
-        { versionId: '2', stages: [], value: 'v2', isCurrent: true, created: new Date().toISOString() },
-        { versionId: '1', stages: [], value: 'v1', isCurrent: false, created: new Date(Date.now() - 86400000).toISOString() },
+        { versionId: '2', stagingLabels: [], state: 'enabled', value: 'v2', isCurrent: true, created: new Date().toISOString() },
+        { versionId: '1', stagingLabels: [], state: 'disabled', value: 'v1', isCurrent: false, created: new Date(Date.now() - 86400000).toISOString() },
       ],
     },
     ...overrides,
@@ -646,11 +655,12 @@ export function createAzureState(overrides: Partial<MockState> = {}): Partial<Mo
     },
     // App Configuration values are untyped/unversioned; Key Vault has no ARN.
     params: [{ name: 'app/config/key', type: 'String', value: 'v' }],
-    secrets: [{ name: 'kv-secret', value: 'v', arn: '', versionStage: [], versionId: 'a1b2c3d4e5f6' }],
-    // Key Vault versions are opaque hex ids with no AWS staging labels.
+    secrets: [{ name: 'kv-secret', value: 'v', arn: '', stagingLabels: [], state: 'enabled', versionId: 'a1b2c3d4e5f6' }],
+    // Key Vault versions are opaque hex ids with no AWS staging labels; they
+    // carry a per-version enabled/disabled state instead.
     secretVersions: {
       'kv-secret': [
-        { versionId: 'a1b2c3d4e5f6', stages: [], value: 'v', isCurrent: true, created: new Date().toISOString() },
+        { versionId: 'a1b2c3d4e5f6', stagingLabels: [], state: 'enabled', value: 'v', isCurrent: true, created: new Date().toISOString() },
       ],
     },
     ...overrides,
@@ -990,7 +1000,8 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
           name,
           arn: secret?.arn !== undefined ? secret.arn : `arn:aws:secretsmanager:us-east-1:123456789:secret:${name}`,
           versionId: secret?.versionId ?? 'v1',
-          versionStage: secret?.versionStage !== undefined ? secret.versionStage : ['AWSCURRENT'],
+          stagingLabels: secret?.stagingLabels !== undefined ? secret.stagingLabels : ['AWSCURRENT'],
+          state: secret?.state ?? '',
           value: secret?.value || 'mock-secret',
           description: '',
           createdDate: new Date().toISOString(),
@@ -999,7 +1010,7 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
       },
       SecretLog: async (name: string, _limit?: number) => {
         const versions = state.secretVersions[name] || [
-          { versionId: 'v1', stages: ['AWSCURRENT'], value: 'current', isCurrent: true, created: new Date().toISOString() },
+          { versionId: 'v1', stagingLabels: ['AWSCURRENT'], value: 'current', isCurrent: true, created: new Date().toISOString() },
         ];
         return {
           name,

--- a/internal/gui/frontend/tests/secret.spec.ts
+++ b/internal/gui/frontend/tests/secret.spec.ts
@@ -39,10 +39,10 @@ test.describe('Secret CRUD Operations', () => {
       await expect(page.locator('.detail-title')).toContainText('my-secret');
     });
 
-    test('should display secret metadata (version ID, labels)', async ({ page }) => {
+    test('should display secret metadata (version ID, staging labels)', async ({ page }) => {
       await clickItemByName(page, 'my-secret');
       await expect(page.locator('.meta-label').filter({ hasText: 'Version ID' })).toBeVisible();
-      await expect(page.locator('.meta-label').filter({ hasText: 'Labels' })).toBeVisible();
+      await expect(page.locator('.meta-label').filter({ hasText: 'Staging labels' })).toBeVisible();
     });
 
     test('should display ARN', async ({ page }) => {
@@ -462,12 +462,13 @@ test.describe('Secret Edge Cases', () => {
 });
 
 test.describe('Secret provider-neutral presence gating (#268)', () => {
-  // A secret from a provider without an ARN or staging labels (as Google Cloud
-  // and Azure return) must not render the AWS-only ARN section or the Labels
-  // row — the fields are presence-gated, no capability flag involved.
+  // A secret from a provider without an ARN, staging labels, or a state (as an
+  // AWS SSM-style value would be) must not render the AWS-only ARN section or a
+  // State/Staging-labels row — the fields are presence-gated, no capability flag
+  // involved.
   test.beforeEach(async ({ page }) => {
     await setupWailsMocks(page, {
-      secrets: [{ name: 'neutral-secret', value: 'v', arn: '', versionStage: [] }],
+      secrets: [{ name: 'neutral-secret', value: 'v', arn: '', stagingLabels: [], state: '' }],
       secretTags: {},
     } as Partial<MockState>);
     await page.goto('/');
@@ -481,8 +482,9 @@ test.describe('Secret provider-neutral presence gating (#268)', () => {
     await expect(page.locator('.arn-display')).toHaveCount(0);
   });
 
-  test('hides the Labels row when there are no staging labels', async ({ page }) => {
-    await expect(page.locator('.meta-label').filter({ hasText: 'Labels' })).toHaveCount(0);
+  test('hides the State / Staging-labels row when neither is set', async ({ page }) => {
+    await expect(page.locator('.meta-label').filter({ hasText: 'State' })).toHaveCount(0);
+    await expect(page.locator('.meta-label').filter({ hasText: 'Staging labels' })).toHaveCount(0);
   });
 
   test('still renders always-present metadata (Version ID)', async ({ page }) => {
@@ -490,19 +492,21 @@ test.describe('Secret provider-neutral presence gating (#268)', () => {
   });
 });
 
-// domain.Version.Label is overloaded: AWS Secrets Manager carries genuine
-// staging labels (AWSCURRENT/...), while Google Cloud and Azure Key Vault carry
-// the per-version STATE (enabled/disabled/destroyed). The version-meta heading
-// must therefore read "Labels" only for AWS and "State" for the others (#418).
-test.describe('Secret version-meta heading is provider-aware (#418)', () => {
+// Staging labels and per-version state are two independent concepts (#419):
+// AWS Secrets Manager carries genuine staging labels (AWSCURRENT/...), while
+// Google Cloud and Azure Key Vault carry the per-version state
+// (enabled/disabled/destroyed). The version-meta heading is now driven by which
+// field is populated, NOT by the provider string (superseding the #418/#420
+// heuristic).
+test.describe('Secret version-meta heading is concept-driven (#419)', () => {
   const metaLabel = (page: import('@playwright/test').Page, text: string) =>
     page.locator('.detail-meta .meta-label').filter({ hasText: text });
 
-  test('Google Cloud: version state is headed "State" (not "Labels"), badge shows the state', async ({ page }) => {
+  test('Google Cloud: per-version state is headed "State", badge shows the state', async ({ page }) => {
     await setupWailsMocks(
       page,
       createGoogleCloudState({
-        secrets: [{ name: 'gcloud-secret-1', value: 'v1', arn: '', versionStage: ['enabled'] }],
+        secrets: [{ name: 'gcloud-secret-1', value: 'v1', arn: '', stagingLabels: [], state: 'enabled' }],
       }),
     );
     await page.goto('/');
@@ -513,15 +517,15 @@ test.describe('Secret version-meta heading is provider-aware (#418)', () => {
     await expect(page.locator('.detail-panel')).toBeVisible();
 
     await expect(metaLabel(page, 'State')).toBeVisible();
-    await expect(metaLabel(page, 'Labels')).toHaveCount(0);
+    await expect(metaLabel(page, 'Staging labels')).toHaveCount(0);
     await expect(page.locator('.detail-meta .badge-stage')).toHaveText('enabled');
   });
 
-  test('Azure Key Vault: version state is headed "State" (not "Labels")', async ({ page }) => {
+  test('Azure Key Vault: per-version state is headed "State"', async ({ page }) => {
     await setupWailsMocks(
       page,
       createAzureState({
-        secrets: [{ name: 'kv-secret', value: 'v', arn: '', versionStage: ['enabled'], versionId: 'a1b2c3d4e5f6' }],
+        secrets: [{ name: 'kv-secret', value: 'v', arn: '', stagingLabels: [], state: 'enabled', versionId: 'a1b2c3d4e5f6' }],
       }),
     );
     await page.goto('/');
@@ -532,13 +536,15 @@ test.describe('Secret version-meta heading is provider-aware (#418)', () => {
     await expect(page.locator('.detail-panel')).toBeVisible();
 
     await expect(metaLabel(page, 'State')).toBeVisible();
-    await expect(metaLabel(page, 'Labels')).toHaveCount(0);
+    await expect(metaLabel(page, 'Staging labels')).toHaveCount(0);
     await expect(page.locator('.detail-meta .badge-stage')).toHaveText('enabled');
   });
 
-  test('AWS Secrets Manager: staging label is headed "Labels" (not "State")', async ({ page }) => {
-    // Default state is AWS; my-secret carries the default ['AWSCURRENT'] staging label.
-    await setupWailsMocks(page);
+  test('AWS Secrets Manager: staging labels are headed "Staging labels", every label badge shows', async ({ page }) => {
+    // AWS default; seed multiple staging labels to prove they all render.
+    await setupWailsMocks(page, {
+      secrets: [{ name: 'my-secret', value: 'v', stagingLabels: ['AWSCURRENT', 'AWSPREVIOUS'] }],
+    } as Partial<MockState>);
     await page.goto('/');
     await navigateTo(page, 'Secret');
     await waitForItemList(page);
@@ -546,8 +552,8 @@ test.describe('Secret version-meta heading is provider-aware (#418)', () => {
     await clickItemByName(page, 'my-secret');
     await expect(page.locator('.detail-panel')).toBeVisible();
 
-    await expect(metaLabel(page, 'Labels')).toBeVisible();
+    await expect(metaLabel(page, 'Staging labels')).toBeVisible();
     await expect(metaLabel(page, 'State')).toHaveCount(0);
-    await expect(page.locator('.detail-meta .badge-stage')).toHaveText('AWSCURRENT');
+    await expect(page.locator('.detail-meta .badge-stage')).toHaveText(['AWSCURRENT', 'AWSPREVIOUS']);
   });
 });

--- a/internal/gui/frontend/wailsjs/go/models.ts
+++ b/internal/gui/frontend/wailsjs/go/models.ts
@@ -433,19 +433,21 @@ export namespace gui {
 	}
 	export class SecretLogEntry {
 	    versionId: string;
-	    stages: string[];
+	    stagingLabels: string[];
+	    state?: string;
 	    value: string;
 	    isCurrent: boolean;
 	    created?: string;
-	
+
 	    static createFrom(source: any = {}) {
 	        return new SecretLogEntry(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.versionId = source["versionId"];
-	        this.stages = source["stages"];
+	        this.stagingLabels = source["stagingLabels"];
+	        this.state = source["state"];
 	        this.value = source["value"];
 	        this.isCurrent = source["isCurrent"];
 	        this.created = source["created"];
@@ -515,22 +517,24 @@ export namespace gui {
 	    name: string;
 	    arn: string;
 	    versionId: string;
-	    versionStage: string[];
+	    stagingLabels: string[];
+	    state?: string;
 	    value: string;
 	    description?: string;
 	    createdDate?: string;
 	    tags: SecretShowTag[];
-	
+
 	    static createFrom(source: any = {}) {
 	        return new SecretShowResult(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.name = source["name"];
 	        this.arn = source["arn"];
 	        this.versionId = source["versionId"];
-	        this.versionStage = source["versionStage"];
+	        this.stagingLabels = source["stagingLabels"];
+	        this.state = source["state"];
 	        this.value = source["value"];
 	        this.description = source["description"];
 	        this.createdDate = source["createdDate"];

--- a/internal/gui/secret.go
+++ b/internal/gui/secret.go
@@ -38,15 +38,22 @@ type SecretShowTag struct {
 }
 
 // SecretShowResult represents the result of showing a secret.
+//
+// StagingLabels and State carry two independent concepts that must NOT be
+// conflated (#419): StagingLabels holds AWS Secrets Manager staging labels
+// (empty for other providers), while State holds the per-version lifecycle
+// state (enabled/disabled/destroyed) for Google Cloud + Azure Key Vault (empty
+// for AWS). A version never has both.
 type SecretShowResult struct {
-	Name         string          `json:"name"`
-	ARN          string          `json:"arn"`
-	VersionID    string          `json:"versionId"`
-	VersionStage []string        `json:"versionStage"`
-	Value        string          `json:"value"`
-	Description  string          `json:"description,omitempty"`
-	CreatedDate  string          `json:"createdDate,omitempty"`
-	Tags         []SecretShowTag `json:"tags"`
+	Name          string          `json:"name"`
+	ARN           string          `json:"arn"`
+	VersionID     string          `json:"versionId"`
+	StagingLabels []string        `json:"stagingLabels"`
+	State         string          `json:"state,omitempty"`
+	Value         string          `json:"value"`
+	Description   string          `json:"description,omitempty"`
+	CreatedDate   string          `json:"createdDate,omitempty"`
+	Tags          []SecretShowTag `json:"tags"`
 }
 
 // SecretLogResult represents the result of showing secret history.
@@ -56,12 +63,19 @@ type SecretLogResult struct {
 }
 
 // SecretLogEntry represents a single version in the history.
+//
+// StagingLabels and State carry two independent concepts that must NOT be
+// conflated (#419): StagingLabels holds AWS Secrets Manager staging labels
+// (empty for other providers), while State holds the per-version lifecycle
+// state (enabled/disabled/destroyed) for Google Cloud + Azure Key Vault (empty
+// for AWS). A version never has both.
 type SecretLogEntry struct {
-	VersionID string   `json:"versionId"`
-	Stages    []string `json:"stages"`
-	Value     string   `json:"value"`
-	IsCurrent bool     `json:"isCurrent"`
-	Created   string   `json:"created,omitempty"`
+	VersionID     string   `json:"versionId"`
+	StagingLabels []string `json:"stagingLabels"`
+	State         string   `json:"state,omitempty"`
+	Value         string   `json:"value"`
+	IsCurrent     bool     `json:"isCurrent"`
+	Created       string   `json:"created,omitempty"`
 }
 
 // SecretCreateResult represents the result of creating a secret.
@@ -154,13 +168,14 @@ func (a *App) SecretShow(specStr string) (*SecretShowResult, error) {
 	}
 
 	r := &SecretShowResult{
-		Name:         result.Name,
-		ARN:          result.ARN,
-		VersionID:    result.VersionID,
-		VersionStage: result.VersionStage,
-		Value:        result.Value,
-		Description:  result.Description,
-		Tags:         make([]SecretShowTag, 0, len(result.Tags)),
+		Name:          result.Name,
+		ARN:           result.ARN,
+		VersionID:     result.VersionID,
+		StagingLabels: result.VersionStage,
+		State:         result.State,
+		Value:         result.Value,
+		Description:   result.Description,
+		Tags:          make([]SecretShowTag, 0, len(result.Tags)),
 	}
 	if result.CreatedDate != nil {
 		r.CreatedDate = timeutil.FormatRFC3339(*result.CreatedDate)
@@ -196,10 +211,11 @@ func (a *App) SecretLog(name string, maxResults int32) (*SecretLogResult, error)
 	entries := make([]SecretLogEntry, len(result.Entries))
 	for i, e := range result.Entries {
 		entry := SecretLogEntry{
-			VersionID: e.VersionID,
-			Stages:    e.VersionStage,
-			Value:     e.Value,
-			IsCurrent: e.IsCurrent,
+			VersionID:     e.VersionID,
+			StagingLabels: e.VersionStage,
+			State:         e.State,
+			Value:         e.Value,
+			IsCurrent:     e.IsCurrent,
 		}
 		if e.CreatedDate != nil {
 			entry.Created = timeutil.FormatRFC3339(*e.CreatedDate)

--- a/internal/provider/aws/secret/secret.go
+++ b/internal/provider/aws/secret/secret.go
@@ -255,7 +255,6 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 		Type:  domain.ValueTypeSecret,
 		Version: domain.Version{
 			ID:            aws.ToString(out.VersionId),
-			Label:         representativeStage(out.VersionStages),
 			StagingLabels: out.VersionStages,
 			Created:       out.CreatedDate,
 		},
@@ -288,7 +287,6 @@ func (s *Store) History(ctx context.Context, name string) ([]domain.Version, err
 	return lo.Map(list, func(v types.SecretVersionsListEntry, _ int) domain.Version {
 		return domain.Version{
 			ID:            aws.ToString(v.VersionId),
-			Label:         representativeStage(v.VersionStages),
 			StagingLabels: v.VersionStages,
 			Created:       v.CreatedDate,
 		}
@@ -508,7 +506,6 @@ func (s *Store) Describe(ctx context.Context, name string) (*domain.Entry, error
 		}); found {
 			entry.Version = domain.Version{
 				ID:            aws.ToString(cur.VersionId),
-				Label:         representativeStage(cur.VersionStages),
 				StagingLabels: cur.VersionStages,
 				Created:       cur.CreatedDate,
 			}
@@ -554,29 +551,6 @@ func (s *Store) Untag(ctx context.Context, name string, keys []string) error {
 	}
 
 	return nil
-}
-
-// representativeStage picks a single, DETERMINISTIC staging label to surface as
-// the version's provider-neutral Label. A version can carry several labels and
-// AWS returns them in an unspecified order, so choosing stages[0] made both the
-// displayed label and any "is this AWSCURRENT?" check non-deterministic (#317).
-//
-// A well-known label wins in fixed priority order (AWSCURRENT > AWSPENDING >
-// AWSPREVIOUS); otherwise the lexicographically smallest custom label is used
-// so the choice is stable. It returns "" when there are no labels.
-func representativeStage(stages []string) string {
-	if len(stages) == 0 {
-		return ""
-	}
-
-	// Well-known AWS staging labels, highest priority first.
-	for _, known := range []string{"AWSCURRENT", "AWSPENDING", "AWSPREVIOUS"} {
-		if slices.Contains(stages, known) {
-			return known
-		}
-	}
-
-	return slices.Min(stages)
 }
 
 // mapTags maps Secrets Manager tags to provider-neutral domain tags.

--- a/internal/provider/aws/secret/secret.go
+++ b/internal/provider/aws/secret/secret.go
@@ -254,9 +254,10 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 		Value: aws.ToString(out.SecretString),
 		Type:  domain.ValueTypeSecret,
 		Version: domain.Version{
-			ID:      aws.ToString(out.VersionId),
-			Label:   representativeStage(out.VersionStages),
-			Created: out.CreatedDate,
+			ID:            aws.ToString(out.VersionId),
+			Label:         representativeStage(out.VersionStages),
+			StagingLabels: out.VersionStages,
+			Created:       out.CreatedDate,
 		},
 		Modified: out.CreatedDate,
 		Extra:    []domain.Field{{Label: "ARN", Value: aws.ToString(out.ARN)}},
@@ -286,9 +287,10 @@ func (s *Store) History(ctx context.Context, name string) ([]domain.Version, err
 
 	return lo.Map(list, func(v types.SecretVersionsListEntry, _ int) domain.Version {
 		return domain.Version{
-			ID:      aws.ToString(v.VersionId),
-			Label:   representativeStage(v.VersionStages),
-			Created: v.CreatedDate,
+			ID:            aws.ToString(v.VersionId),
+			Label:         representativeStage(v.VersionStages),
+			StagingLabels: v.VersionStages,
+			Created:       v.CreatedDate,
 		}
 	}), nil
 }
@@ -505,9 +507,10 @@ func (s *Store) Describe(ctx context.Context, name string) (*domain.Entry, error
 			return slices.Contains(v.VersionStages, "AWSCURRENT")
 		}); found {
 			entry.Version = domain.Version{
-				ID:      aws.ToString(cur.VersionId),
-				Label:   representativeStage(cur.VersionStages),
-				Created: cur.CreatedDate,
+				ID:            aws.ToString(cur.VersionId),
+				Label:         representativeStage(cur.VersionStages),
+				StagingLabels: cur.VersionStages,
+				Created:       cur.CreatedDate,
 			}
 		}
 	}

--- a/internal/provider/aws/secret/secret_test.go
+++ b/internal/provider/aws/secret/secret_test.go
@@ -205,6 +205,9 @@ func TestGet_MapsEntryWithDescriptionAndTags(t *testing.T) {
 	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
 	assert.Equal(t, "id-3", entry.Version.ID)
 	assert.Equal(t, "AWSCURRENT", entry.Version.Label)
+	// StagingLabels carries the full stage set; State is empty (no such concept).
+	assert.Equal(t, []string{"AWSCURRENT"}, entry.Version.StagingLabels)
+	assert.Empty(t, entry.Version.State)
 	assert.Equal(t, "my desc", entry.Description)
 	require.Len(t, entry.Tags, 1)
 	assert.Equal(t, "env", entry.Tags[0].Key)
@@ -254,6 +257,8 @@ func TestGet_LabelPrefersAWSCURRENTRegardlessOfOrder(t *testing.T) {
 	entry, err := store.Get(t.Context(), "my-secret", provider.NewVersionRef("id-3"))
 	require.NoError(t, err)
 	assert.Equal(t, "AWSCURRENT", entry.Version.Label)
+	// The representative Label collapses to one; StagingLabels keeps them all.
+	assert.Equal(t, []string{"my-custom-label", "AWSPREVIOUS", "AWSCURRENT"}, entry.Version.StagingLabels)
 }
 
 // Priority ordering among the well-known and custom labels: AWSPENDING beats
@@ -287,9 +292,11 @@ func TestHistory_LabelPriorityOrdering(t *testing.T) {
 	// Newest first: id-2 (AWSPENDING preferred over AWSPREVIOUS).
 	assert.Equal(t, "id-2", versions[0].ID)
 	assert.Equal(t, "AWSPENDING", versions[0].Label)
+	assert.Equal(t, []string{"AWSPREVIOUS", "AWSPENDING"}, versions[0].StagingLabels)
 	// Custom-only labels tie-break lexicographically: "alpha" < "zeta".
 	assert.Equal(t, "id-1", versions[1].ID)
 	assert.Equal(t, "alpha", versions[1].Label)
+	assert.Equal(t, []string{"zeta", "alpha"}, versions[1].StagingLabels)
 }
 
 func TestHistory_NewestFirst(t *testing.T) {
@@ -642,6 +649,7 @@ func TestDescribe(t *testing.T) {
 	assert.Equal(t, "the desc", entry.Description)
 	assert.Equal(t, "id-3", entry.Version.ID)
 	assert.Equal(t, "AWSCURRENT", entry.Version.Label)
+	assert.Equal(t, []string{"AWSCURRENT"}, entry.Version.StagingLabels)
 	// The version's own creation time, not the secret-level CreatedDate.
 	require.NotNil(t, entry.Version.Created)
 	assert.Equal(t, currentVersionCreated, *entry.Version.Created)

--- a/internal/provider/aws/secret/secret_test.go
+++ b/internal/provider/aws/secret/secret_test.go
@@ -204,7 +204,6 @@ func TestGet_MapsEntryWithDescriptionAndTags(t *testing.T) {
 	assert.Equal(t, "s3cr3t", entry.Value)
 	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
 	assert.Equal(t, "id-3", entry.Version.ID)
-	assert.Equal(t, "AWSCURRENT", entry.Version.Label)
 	// StagingLabels carries the full stage set; State is empty (no such concept).
 	assert.Equal(t, []string{"AWSCURRENT"}, entry.Version.StagingLabels)
 	assert.Empty(t, entry.Version.State)
@@ -256,14 +255,13 @@ func TestGet_LabelPrefersAWSCURRENTRegardlessOfOrder(t *testing.T) {
 
 	entry, err := store.Get(t.Context(), "my-secret", provider.NewVersionRef("id-3"))
 	require.NoError(t, err)
-	assert.Equal(t, "AWSCURRENT", entry.Version.Label)
-	// The representative Label collapses to one; StagingLabels keeps them all.
+	// StagingLabels keeps every staging label AWS returned, in order.
 	assert.Equal(t, []string{"my-custom-label", "AWSPREVIOUS", "AWSCURRENT"}, entry.Version.StagingLabels)
 }
 
-// Priority ordering among the well-known and custom labels: AWSPENDING beats
-// AWSPREVIOUS, and custom-only labels tie-break lexicographically (#317).
-func TestHistory_LabelPriorityOrdering(t *testing.T) {
+// History preserves every staging label AWS returns for a version, in the
+// order AWS reported them (no collapsing to a single representative).
+func TestHistory_StagingLabels(t *testing.T) {
 	t.Parallel()
 
 	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -289,13 +287,10 @@ func TestHistory_LabelPriorityOrdering(t *testing.T) {
 	versions, err := store.History(t.Context(), "my-secret")
 	require.NoError(t, err)
 	require.Len(t, versions, 2)
-	// Newest first: id-2 (AWSPENDING preferred over AWSPREVIOUS).
+	// Newest first: id-2.
 	assert.Equal(t, "id-2", versions[0].ID)
-	assert.Equal(t, "AWSPENDING", versions[0].Label)
 	assert.Equal(t, []string{"AWSPREVIOUS", "AWSPENDING"}, versions[0].StagingLabels)
-	// Custom-only labels tie-break lexicographically: "alpha" < "zeta".
 	assert.Equal(t, "id-1", versions[1].ID)
-	assert.Equal(t, "alpha", versions[1].Label)
 	assert.Equal(t, []string{"zeta", "alpha"}, versions[1].StagingLabels)
 }
 
@@ -312,7 +307,7 @@ func TestHistory_NewestFirst(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, versions, 3)
 	assert.Equal(t, "id-3", versions[0].ID)
-	assert.Equal(t, "AWSCURRENT", versions[0].Label)
+	assert.Equal(t, []string{"AWSCURRENT"}, versions[0].StagingLabels)
 	assert.Equal(t, "id-1", versions[2].ID)
 }
 
@@ -648,7 +643,6 @@ func TestDescribe(t *testing.T) {
 	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
 	assert.Equal(t, "the desc", entry.Description)
 	assert.Equal(t, "id-3", entry.Version.ID)
-	assert.Equal(t, "AWSCURRENT", entry.Version.Label)
 	assert.Equal(t, []string{"AWSCURRENT"}, entry.Version.StagingLabels)
 	// The version's own creation time, not the secret-level CreatedDate.
 	require.NotNil(t, entry.Version.Created)

--- a/internal/provider/azure/keyvault/keyvault.go
+++ b/internal/provider/azure/keyvault/keyvault.go
@@ -167,7 +167,6 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 
 	if attr := resp.Attributes; attr != nil {
 		entry.Version.Created = attr.Created
-		entry.Version.Label = enabledLabel(attr.Enabled)
 		entry.Version.State = enabledLabel(attr.Enabled)
 		entry.Modified = attr.Updated
 	}
@@ -176,7 +175,7 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 }
 
 // History returns the secret's version history, newest first. The per-version
-// enabled/disabled state is surfaced in the neutral Version.Label for display.
+// enabled/disabled state is surfaced in the neutral Version.State for display.
 func (s *Store) History(ctx context.Context, name string) ([]domain.Version, error) {
 	versions, err := s.versionsNewestFirst(ctx, name)
 	if err != nil {
@@ -186,7 +185,6 @@ func (s *Store) History(ctx context.Context, name string) ([]domain.Version, err
 	return lo.Map(versions, func(v secretVersion, _ int) domain.Version {
 		return domain.Version{
 			ID:      v.id,
-			Label:   boolLabel(v.enabled),
 			State:   boolLabel(v.enabled),
 			Created: v.created,
 		}

--- a/internal/provider/azure/keyvault/keyvault.go
+++ b/internal/provider/azure/keyvault/keyvault.go
@@ -168,6 +168,7 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 	if attr := resp.Attributes; attr != nil {
 		entry.Version.Created = attr.Created
 		entry.Version.Label = enabledLabel(attr.Enabled)
+		entry.Version.State = enabledLabel(attr.Enabled)
 		entry.Modified = attr.Updated
 	}
 
@@ -186,6 +187,7 @@ func (s *Store) History(ctx context.Context, name string) ([]domain.Version, err
 		return domain.Version{
 			ID:      v.id,
 			Label:   boolLabel(v.enabled),
+			State:   boolLabel(v.enabled),
 			Created: v.created,
 		}
 	}), nil

--- a/internal/provider/azure/keyvault/keyvault_resolve_test.go
+++ b/internal/provider/azure/keyvault/keyvault_resolve_test.go
@@ -245,7 +245,7 @@ func TestGet_NilFieldsTolerated(t *testing.T) {
 	entry, err := store.Get(t.Context(), "my-secret", provider.VersionRef{})
 	require.NoError(t, err)
 	assert.Empty(t, entry.Version.ID)
-	assert.Empty(t, entry.Version.Label)
+	assert.Empty(t, entry.Version.State)
 }
 
 // TestStore_ErrorPaths covers the non-not-found error branches of the write and

--- a/internal/provider/azure/keyvault/keyvault_test.go
+++ b/internal/provider/azure/keyvault/keyvault_test.go
@@ -154,6 +154,9 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
 	assert.Equal(t, "v1", entry.Version.ID)
 	assert.Equal(t, "enabled", entry.Version.Label)
+	// State carries the per-version enable/disable; StagingLabels is not a Key Vault concept.
+	assert.Equal(t, "enabled", entry.Version.State)
+	assert.Empty(t, entry.Version.StagingLabels)
 	assert.Equal(t, []domain.Tag{{Key: "env", Value: "prod"}}, entry.Tags)
 }
 
@@ -193,8 +196,12 @@ func TestHistory(t *testing.T) {
 	// Newest first.
 	assert.Equal(t, "new", versions[0].ID)
 	assert.Equal(t, "enabled", versions[0].Label)
+	assert.Equal(t, "enabled", versions[0].State)
+	assert.Empty(t, versions[0].StagingLabels)
 	assert.Equal(t, "old", versions[1].ID)
 	assert.Equal(t, "disabled", versions[1].Label)
+	assert.Equal(t, "disabled", versions[1].State)
+	assert.Empty(t, versions[1].StagingLabels)
 }
 
 func TestList(t *testing.T) {

--- a/internal/provider/azure/keyvault/keyvault_test.go
+++ b/internal/provider/azure/keyvault/keyvault_test.go
@@ -153,7 +153,6 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, "s3cr3t", entry.Value)
 	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
 	assert.Equal(t, "v1", entry.Version.ID)
-	assert.Equal(t, "enabled", entry.Version.Label)
 	// State carries the per-version enable/disable; StagingLabels is not a Key Vault concept.
 	assert.Equal(t, "enabled", entry.Version.State)
 	assert.Empty(t, entry.Version.StagingLabels)
@@ -195,11 +194,9 @@ func TestHistory(t *testing.T) {
 	require.Len(t, versions, 2)
 	// Newest first.
 	assert.Equal(t, "new", versions[0].ID)
-	assert.Equal(t, "enabled", versions[0].Label)
 	assert.Equal(t, "enabled", versions[0].State)
 	assert.Empty(t, versions[0].StagingLabels)
 	assert.Equal(t, "old", versions[1].ID)
-	assert.Equal(t, "disabled", versions[1].Label)
 	assert.Equal(t, "disabled", versions[1].State)
 	assert.Empty(t, versions[1].StagingLabels)
 }

--- a/internal/provider/gcloud/secret/secret.go
+++ b/internal/provider/gcloud/secret/secret.go
@@ -210,6 +210,7 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 		created := toTime(sv.GetCreateTime())
 		entry.Version.Created = created
 		entry.Version.Label = stateLabel(sv.GetState())
+		entry.Version.State = stateLabel(sv.GetState())
 		entry.Modified = created
 	}
 
@@ -240,6 +241,7 @@ func (s *Store) History(ctx context.Context, name string) ([]domain.Version, err
 		return domain.Version{
 			ID:      versionNumber(v.GetName()),
 			Label:   stateLabel(v.GetState()),
+			State:   stateLabel(v.GetState()),
 			Created: toTime(v.GetCreateTime()),
 		}
 	}), nil

--- a/internal/provider/gcloud/secret/secret.go
+++ b/internal/provider/gcloud/secret/secret.go
@@ -209,7 +209,6 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 	}); verr == nil && sv != nil {
 		created := toTime(sv.GetCreateTime())
 		entry.Version.Created = created
-		entry.Version.Label = stateLabel(sv.GetState())
 		entry.Version.State = stateLabel(sv.GetState())
 		entry.Modified = created
 	}
@@ -225,7 +224,7 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 }
 
 // History returns the secret's version history, newest first. The per-version
-// state (enabled/disabled/destroyed) is surfaced in the neutral Version.Label
+// state (enabled/disabled/destroyed) is surfaced in the neutral Version.State
 // for display; destroyed/disabled versions have no accessible value.
 func (s *Store) History(ctx context.Context, name string) ([]domain.Version, error) {
 	versions, err := s.client.ListSecretVersions(ctx, &secretmanagerpb.ListSecretVersionsRequest{
@@ -240,7 +239,6 @@ func (s *Store) History(ctx context.Context, name string) ([]domain.Version, err
 	return lo.Map(versions, func(v *secretmanagerpb.SecretVersion, _ int) domain.Version {
 		return domain.Version{
 			ID:      versionNumber(v.GetName()),
-			Label:   stateLabel(v.GetState()),
 			State:   stateLabel(v.GetState()),
 			Created: toTime(v.GetCreateTime()),
 		}

--- a/internal/provider/gcloud/secret/secret_more_test.go
+++ b/internal/provider/gcloud/secret/secret_more_test.go
@@ -147,11 +147,11 @@ func TestHistory_StateLabelsAndUnparsable(t *testing.T) {
 	// Numeric versions sort newest-first; the unparsable name (versionInt == -1)
 	// sorts last.
 	assert.Equal(t, "5", versions[0].ID)
-	assert.Equal(t, "enabled", versions[0].Label)
+	assert.Equal(t, "enabled", versions[0].State)
 	assert.Equal(t, "2", versions[1].ID)
-	assert.Equal(t, "disabled", versions[1].Label)
+	assert.Equal(t, "disabled", versions[1].State)
 	assert.Equal(t, "weird", versions[2].ID)
-	assert.Empty(t, versions[2].Label)
+	assert.Empty(t, versions[2].State)
 }
 
 func TestList_Error(t *testing.T) {

--- a/internal/provider/gcloud/secret/secret_test.go
+++ b/internal/provider/gcloud/secret/secret_test.go
@@ -260,12 +260,10 @@ func TestHistory(t *testing.T) {
 	require.Len(t, versions, 2)
 	// Newest first: version 2 (enabled) then 1 (destroyed).
 	assert.Equal(t, "2", versions[0].ID)
-	assert.Equal(t, "enabled", versions[0].Label)
 	// State carries the per-version lifecycle; StagingLabels is not a GCloud concept.
 	assert.Equal(t, "enabled", versions[0].State)
 	assert.Empty(t, versions[0].StagingLabels)
 	assert.Equal(t, "1", versions[1].ID)
-	assert.Equal(t, "destroyed", versions[1].Label)
 	assert.Equal(t, "destroyed", versions[1].State)
 	assert.Empty(t, versions[1].StagingLabels)
 }

--- a/internal/provider/gcloud/secret/secret_test.go
+++ b/internal/provider/gcloud/secret/secret_test.go
@@ -261,8 +261,13 @@ func TestHistory(t *testing.T) {
 	// Newest first: version 2 (enabled) then 1 (destroyed).
 	assert.Equal(t, "2", versions[0].ID)
 	assert.Equal(t, "enabled", versions[0].Label)
+	// State carries the per-version lifecycle; StagingLabels is not a GCloud concept.
+	assert.Equal(t, "enabled", versions[0].State)
+	assert.Empty(t, versions[0].StagingLabels)
 	assert.Equal(t, "1", versions[1].ID)
 	assert.Equal(t, "destroyed", versions[1].Label)
+	assert.Equal(t, "destroyed", versions[1].State)
+	assert.Empty(t, versions[1].StagingLabels)
 }
 
 func TestList(t *testing.T) {

--- a/internal/usecase/azure/azure_test.go
+++ b/internal/usecase/azure/azure_test.go
@@ -32,7 +32,7 @@ func TestShowUseCase(t *testing.T) {
 			return &domain.Entry{
 				Name:    name,
 				Value:   "hello",
-				Version: domain.Version{ID: "abc", Label: "enabled"},
+				Version: domain.Version{ID: "abc", State: "enabled"},
 				Tags:    []domain.Tag{{Key: "env", Value: "prod"}},
 			}, nil
 		},

--- a/internal/usecase/azure/log.go
+++ b/internal/usecase/azure/log.go
@@ -103,7 +103,7 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 
 		entries = append(entries, LogEntry{
 			Version:     v.ID,
-			State:       v.Label,
+			State:       v.State,
 			Value:       value,
 			CreatedDate: v.Created,
 			Error:       fetchErr,

--- a/internal/usecase/azure/show.go
+++ b/internal/usecase/azure/show.go
@@ -55,7 +55,7 @@ func (u *ShowUseCase) Execute(ctx context.Context, input ShowInput) (*ShowOutput
 		Name:        entry.Name,
 		Value:       entry.Value,
 		Version:     entry.Version.ID,
-		State:       entry.Version.Label,
+		State:       entry.Version.State,
 		CreatedDate: entry.Version.Created,
 		Tags: lo.Map(entry.Tags, func(tag domain.Tag, _ int) ShowTag {
 			return ShowTag{Key: tag.Key, Value: tag.Value}

--- a/internal/usecase/gcloud/gcloud.go
+++ b/internal/usecase/gcloud/gcloud.go
@@ -4,7 +4,7 @@
 // interfaces, exactly like the AWS secret use cases, but expose Google
 // Cloud-shaped outputs: integer versions, no ARN, no staging labels. The
 // per-version state (enabled/disabled/destroyed) is surfaced where the provider
-// supplies it via the neutral Version.Label.
+// supplies it via the neutral Version.State.
 package gcloud
 
 import (

--- a/internal/usecase/gcloud/gcloud_test.go
+++ b/internal/usecase/gcloud/gcloud_test.go
@@ -69,7 +69,7 @@ func TestShowUseCase(t *testing.T) {
 			return &domain.Entry{
 				Name:    name,
 				Value:   "hello",
-				Version: domain.Version{ID: "3", Label: "enabled"},
+				Version: domain.Version{ID: "3", State: "enabled"},
 				Tags:    []domain.Tag{{Key: "env", Value: "prod"}},
 			}, nil
 		},

--- a/internal/usecase/gcloud/log.go
+++ b/internal/usecase/gcloud/log.go
@@ -101,7 +101,7 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 
 		entries = append(entries, LogEntry{
 			Version:     v.ID,
-			State:       v.Label,
+			State:       v.State,
 			Value:       value,
 			CreatedDate: v.Created,
 			Error:       fetchErr,

--- a/internal/usecase/gcloud/show.go
+++ b/internal/usecase/gcloud/show.go
@@ -54,7 +54,7 @@ func (u *ShowUseCase) Execute(ctx context.Context, input ShowInput) (*ShowOutput
 		Name:        entry.Name,
 		Value:       entry.Value,
 		Version:     entry.Version.ID,
-		State:       entry.Version.Label,
+		State:       entry.Version.State,
 		CreatedDate: entry.Version.Created,
 		Tags: lo.Map(entry.Tags, func(tag domain.Tag, _ int) ShowTag {
 			return ShowTag{Key: tag.Key, Value: tag.Value}

--- a/internal/usecase/secret/log.go
+++ b/internal/usecase/secret/log.go
@@ -105,14 +105,13 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 
 		entries = append(entries, LogEntry{
 			VersionID:    v.ID,
-			VersionStage: stages(v.Label),
+			VersionStage: stages(v.StagingLabels),
 			Value:        value,
 			CreatedDate:  v.Created,
-			// The adapter picks the version's Label by priority, so AWSCURRENT
-			// always surfaces whenever the version carries it (even alongside a
-			// custom label). This equality is therefore a correct membership
-			// test, not a fragile "first stage" check (#317).
-			IsCurrent: v.Label == "AWSCURRENT",
+			// A version is current when AWSCURRENT is among its staging labels;
+			// membership (not a "first stage" check) keeps this correct even when
+			// the version carries additional custom labels (#317).
+			IsCurrent: slices.Contains(v.StagingLabels, "AWSCURRENT"),
 			Error:     fetchErr,
 		})
 	}

--- a/internal/usecase/secret/log.go
+++ b/internal/usecase/secret/log.go
@@ -19,9 +19,16 @@ type LogInput struct {
 }
 
 // LogEntry represents a single version entry.
+//
+// VersionStage and State carry the two independent, provider-specific axes that
+// must NOT be conflated (#419): VersionStage holds AWS Secrets Manager staging
+// labels (empty for other providers), while State holds the per-version
+// lifecycle state (enabled/disabled/destroyed) for Google Cloud + Azure Key
+// Vault (empty for AWS). A version never has both.
 type LogEntry struct {
 	VersionID    string
 	VersionStage []string
+	State        string
 	Value        string
 	CreatedDate  *time.Time
 	IsCurrent    bool
@@ -106,6 +113,7 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 		entries = append(entries, LogEntry{
 			VersionID:    v.ID,
 			VersionStage: stages(v.StagingLabels),
+			State:        v.State,
 			Value:        value,
 			CreatedDate:  v.Created,
 			// A version is current when AWSCURRENT is among its staging labels;

--- a/internal/usecase/secret/log_test.go
+++ b/internal/usecase/secret/log_test.go
@@ -44,8 +44,9 @@ func TestLogUseCase_Execute(t *testing.T) {
 
 	now := time.Now()
 	versions := []domain.Version{
-		{ID: "v3", Label: "AWSCURRENT", Created: &now},
-		{ID: "v2", Label: "AWSPREVIOUS", Created: tp(now, -time.Hour)},
+		// Unsorted, multi-valued staging labels: all must surface, sorted (#419).
+		{ID: "v3", StagingLabels: []string{"custom", "AWSCURRENT"}, Created: &now},
+		{ID: "v2", StagingLabels: []string{"AWSPREVIOUS"}, Created: tp(now, -time.Hour)},
 		{ID: "v1", Created: tp(now, -2*time.Hour)},
 	}
 	values := map[string]string{"v1": "value1", "v2": "value2", "v3": "value3"}
@@ -57,8 +58,9 @@ func TestLogUseCase_Execute(t *testing.T) {
 	require.Len(t, output.Entries, 3)
 	// Newest first.
 	assert.Equal(t, "v3", output.Entries[0].VersionID)
+	// IsCurrent is a membership test: AWSCURRENT alongside a custom label.
 	assert.True(t, output.Entries[0].IsCurrent)
-	assert.Contains(t, output.Entries[0].VersionStage, "AWSCURRENT")
+	assert.Equal(t, []string{"AWSCURRENT", "custom"}, output.Entries[0].VersionStage)
 	assert.Equal(t, "value3", output.Entries[0].Value)
 	assert.False(t, output.Entries[2].IsCurrent)
 }
@@ -94,8 +96,8 @@ func TestLogUseCase_Execute_Reverse(t *testing.T) {
 
 	now := time.Now()
 	versions := []domain.Version{
-		{ID: "v2", Label: "AWSCURRENT", Created: &now},
-		{ID: "v1", Label: "AWSPREVIOUS", Created: tp(now, -time.Hour)},
+		{ID: "v2", StagingLabels: []string{"AWSCURRENT"}, Created: &now},
+		{ID: "v1", StagingLabels: []string{"AWSPREVIOUS"}, Created: tp(now, -time.Hour)},
 	}
 
 	uc := &secret.LogUseCase{Reader: logStore(versions, map[string]string{}, nil)}

--- a/internal/usecase/secret/log_test.go
+++ b/internal/usecase/secret/log_test.go
@@ -61,8 +61,34 @@ func TestLogUseCase_Execute(t *testing.T) {
 	// IsCurrent is a membership test: AWSCURRENT alongside a custom label.
 	assert.True(t, output.Entries[0].IsCurrent)
 	assert.Equal(t, []string{"AWSCURRENT", "custom"}, output.Entries[0].VersionStage)
+	// AWS Secrets Manager carries staging labels, not a per-version state (#419).
+	assert.Empty(t, output.Entries[0].State)
 	assert.Equal(t, "value3", output.Entries[0].Value)
 	assert.False(t, output.Entries[2].IsCurrent)
+}
+
+// TestLogUseCase_Execute_State asserts that a GCloud/Key Vault-style history
+// (per-version State set, no staging labels) surfaces State on each entry and
+// leaves VersionStage empty — the two concepts must not be conflated (#419).
+func TestLogUseCase_Execute_State(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	versions := []domain.Version{
+		{ID: "2", State: "enabled", Created: &now},
+		{ID: "1", State: "disabled", Created: tp(now, -time.Hour)},
+	}
+	values := map[string]string{"1": "value1", "2": "value2"}
+
+	uc := &secret.LogUseCase{Reader: logStore(versions, values, nil)}
+
+	output, err := uc.Execute(t.Context(), secret.LogInput{Name: "my-secret", MaxResults: 10})
+	require.NoError(t, err)
+	require.Len(t, output.Entries, 2)
+	assert.Equal(t, "enabled", output.Entries[0].State)
+	assert.Empty(t, output.Entries[0].VersionStage)
+	assert.Equal(t, "disabled", output.Entries[1].State)
+	assert.Empty(t, output.Entries[1].VersionStage)
 }
 
 func TestLogUseCase_Execute_Empty(t *testing.T) {

--- a/internal/usecase/secret/show.go
+++ b/internal/usecase/secret/show.go
@@ -24,12 +24,19 @@ type ShowTag struct {
 }
 
 // ShowOutput holds the result of the show use case.
+//
+// VersionStage and State carry the two independent, provider-specific axes that
+// must NOT be conflated (#419): VersionStage holds AWS Secrets Manager staging
+// labels (empty for other providers), while State holds the per-version
+// lifecycle state (enabled/disabled/destroyed) for Google Cloud + Azure Key
+// Vault (empty for AWS). A version never has both.
 type ShowOutput struct {
 	Name         string
 	ARN          string
 	Value        string
 	VersionID    string
 	VersionStage []string
+	State        string
 	Description  string
 	CreatedDate  *time.Time
 	Tags         []ShowTag
@@ -60,6 +67,7 @@ func (u *ShowUseCase) Execute(ctx context.Context, input ShowInput) (*ShowOutput
 		Value:        entry.Value,
 		VersionID:    entry.Version.ID,
 		VersionStage: stages(entry.Version.StagingLabels),
+		State:        entry.Version.State,
 		Description:  entry.Description,
 		CreatedDate:  entry.Version.Created,
 		Tags: lo.Map(entry.Tags, func(tag domain.Tag, _ int) ShowTag {

--- a/internal/usecase/secret/show.go
+++ b/internal/usecase/secret/show.go
@@ -59,7 +59,7 @@ func (u *ShowUseCase) Execute(ctx context.Context, input ShowInput) (*ShowOutput
 		ARN:          extraValue(entry, "ARN"),
 		Value:        entry.Value,
 		VersionID:    entry.Version.ID,
-		VersionStage: stages(entry.Version.Label),
+		VersionStage: stages(entry.Version.StagingLabels),
 		Description:  entry.Description,
 		CreatedDate:  entry.Version.Created,
 		Tags: lo.Map(entry.Tags, func(tag domain.Tag, _ int) ShowTag {

--- a/internal/usecase/secret/show_test.go
+++ b/internal/usecase/secret/show_test.go
@@ -59,9 +59,32 @@ func TestShowUseCase_Execute(t *testing.T) {
 	assert.Equal(t, "secret-value", output.Value)
 	assert.Equal(t, "abc123", output.VersionID)
 	assert.Equal(t, []string{"AWSCURRENT", "custom"}, output.VersionStage)
+	// AWS Secrets Manager carries staging labels, not a per-version state (#419).
+	assert.Empty(t, output.State)
 	assert.NotNil(t, output.CreatedDate)
 	// Regression guard: the ARN must be surfaced from the entry's Extra metadata.
 	assert.Equal(t, "arn:aws:secretsmanager:us-east-1:123:secret:my-secret", output.ARN)
+}
+
+// TestShowUseCase_Execute_State asserts that a GCloud/Key Vault-style version
+// (per-version State set, no staging labels) surfaces State and leaves
+// VersionStage empty — the two concepts must not be conflated (#419).
+func TestShowUseCase_Execute_State(t *testing.T) {
+	t.Parallel()
+
+	store := showStore(&domain.Entry{
+		Name:    "my-secret",
+		Value:   "secret-value",
+		Type:    domain.ValueTypeSecret,
+		Version: domain.Version{ID: "2", State: "enabled"},
+	})
+
+	uc := &secret.ShowUseCase{Reader: store}
+
+	output, err := uc.Execute(t.Context(), secret.ShowInput{Spec: mustParseSpec(t, "my-secret")})
+	require.NoError(t, err)
+	assert.Equal(t, "enabled", output.State)
+	assert.Empty(t, output.VersionStage)
 }
 
 func TestShowUseCase_Execute_WithVersionID(t *testing.T) {

--- a/internal/usecase/secret/show_test.go
+++ b/internal/usecase/secret/show_test.go
@@ -42,10 +42,12 @@ func TestShowUseCase_Execute(t *testing.T) {
 
 	now := time.Now()
 	store := showStore(&domain.Entry{
-		Name:    "my-secret",
-		Value:   "secret-value",
-		Type:    domain.ValueTypeSecret,
-		Version: domain.Version{ID: "abc123", Label: "AWSCURRENT", Created: &now},
+		Name:  "my-secret",
+		Value: "secret-value",
+		Type:  domain.ValueTypeSecret,
+		// Multiple staging labels (unsorted) must all surface, deterministically
+		// sorted for stable output (#419).
+		Version: domain.Version{ID: "abc123", StagingLabels: []string{"AWSCURRENT", "custom"}, Created: &now},
 		Extra:   []domain.Field{{Label: "ARN", Value: "arn:aws:secretsmanager:us-east-1:123:secret:my-secret"}},
 	})
 
@@ -56,7 +58,7 @@ func TestShowUseCase_Execute(t *testing.T) {
 	assert.Equal(t, "my-secret", output.Name)
 	assert.Equal(t, "secret-value", output.Value)
 	assert.Equal(t, "abc123", output.VersionID)
-	assert.Contains(t, output.VersionStage, "AWSCURRENT")
+	assert.Equal(t, []string{"AWSCURRENT", "custom"}, output.VersionStage)
 	assert.NotNil(t, output.CreatedDate)
 	// Regression guard: the ARN must be surfaced from the entry's Extra metadata.
 	assert.Equal(t, "arn:aws:secretsmanager:us-east-1:123:secret:my-secret", output.ARN)
@@ -68,7 +70,7 @@ func TestShowUseCase_Execute_WithVersionID(t *testing.T) {
 	store := showStore(&domain.Entry{
 		Name:    "my-secret",
 		Value:   "old-value",
-		Version: domain.Version{ID: "old-version-id", Label: "AWSPREVIOUS"},
+		Version: domain.Version{ID: "old-version-id", StagingLabels: []string{"AWSPREVIOUS"}},
 	})
 
 	uc := &secret.ShowUseCase{Reader: store}
@@ -85,7 +87,7 @@ func TestShowUseCase_Execute_WithLabel(t *testing.T) {
 	store := showStore(&domain.Entry{
 		Name:    "my-secret",
 		Value:   "current-value",
-		Version: domain.Version{ID: "current-id", Label: "AWSCURRENT"},
+		Version: domain.Version{ID: "current-id", StagingLabels: []string{"AWSCURRENT"}},
 	})
 
 	uc := &secret.ShowUseCase{Reader: store}

--- a/internal/usecase/secret/version.go
+++ b/internal/usecase/secret/version.go
@@ -1,6 +1,7 @@
 package secret
 
 import (
+	"slices"
 	"strconv"
 	"strings"
 
@@ -52,13 +53,16 @@ func extraValue(entry *domain.Entry, label string) string {
 	return ""
 }
 
-// stages converts a single provider-neutral version Label into the []string
-// staging-label slice the secret outputs expose. An empty label yields nil so
-// that callers omit the field entirely (matching the pre-migration behavior).
-func stages(label string) []string {
-	if label == "" {
+// stages returns a deterministically sorted copy of a version's AWS Secrets
+// Manager staging labels for stable output. An empty slice yields nil so that
+// callers omit the field entirely (matching the pre-migration behavior).
+func stages(labels []string) []string {
+	if len(labels) == 0 {
 		return nil
 	}
 
-	return []string{label}
+	out := slices.Clone(labels)
+	slices.Sort(out)
+
+	return out
 }


### PR DESCRIPTION
Epic **#419** — stops overloading `domain.Version.Label` and models the two genuinely different concepts explicitly:

- **`State`** (`enabled`/`disabled`/`destroyed`, `""` when N/A) — a per-version enable/disable switch. **Google Cloud + Azure Key Vault.**
- **`StagingLabels []string`** (AWSCURRENT/AWSPENDING/…) — movable pointers naming "which version is current". **AWS Secrets Manager** (all of them; the old single `Label` collapsed them to one representative).
- AWS SSM Parameter Store: neither (integer versions only).

## Phases (all merged onto the epic branch)
- **#421 (A)** — `domain.Version` gains `State` + `StagingLabels`; adapters dual-write (behavior-preserving).
- **#422 (B)** — usecases + CLI presenters read the semantic fields; AWS SM now surfaces **all** staging labels; no `Version.Label` readers remain in usecase/cli.
- **#423 (C)** — GUI: the neutral secret usecase now carries **both** `State` and `StagingLabels` (fixing a regression where GCloud/KV state was dropped from the GUI in B); GUI DTO split into `state`/`stagingLabels`; `SecretView` renders by which field is populated (removing the interim `provider === 'aws'` heuristic from #418/#420); **`domain.Version.Label` deleted** along with the adapter dual-write.

## Verification (integrated epic branch)
`go build ./...`, `go test ./...`, `golangci-lint --build-tags=e2e,production ./internal/...` and `--build-tags=production,webkit2_41 ./cmd/...` → **0 issues**. Frontend `npm run check`/`lint`/`build` clean; Playwright `secret.spec.ts` 174/174 across chromium/firefox/webkit (pre-existing webkit `keyboard-focus` flake unrelated). No `domain.Version.Label` references remain anywhere.

Closes #419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)