### PR TITLE
feat(gui): namespace filter dropdown + per-entry namespace display for Azure App Configuration (#425)

### DIFF
--- a/internal/gui/frontend/src/App.svelte
+++ b/internal/gui/frontend/src/App.svelte
@@ -336,6 +336,7 @@
           <ParamView
             capability={paramCap}
             {provider}
+            initialNamespace={scope?.namespace ?? ''}
             onnavigatetostaging={() => handleNavigate('staging')}
             onstagingchange={handleStagingChange}
           />

--- a/internal/gui/frontend/src/lib/ParamView.svelte
+++ b/internal/gui/frontend/src/lib/ParamView.svelte
@@ -16,17 +16,37 @@
   interface Props {
     capability?: gui.ServiceCapability;
     provider?: string;
+    // initialNamespace is the scope's current App Configuration namespace (empty
+    // = the null/default namespace); it seeds the Namespace dropdown's initial
+    // selection. Only meaningful for Azure App Configuration.
+    initialNamespace?: string;
     onnavigatetostaging?: () => void;
     onstagingchange?: () => void;
   }
 
-  let { capability, provider = '', onnavigatetostaging, onstagingchange }: Props = $props();
+  let { capability, provider = '', initialNamespace = '', onnavigatetostaging, onstagingchange }: Props = $props();
 
   // Capability-driven visibility. Absent capability defaults to AWS-like (true)
   // so the component degrades safely if mounted without one.
   const stagingEnabled = $derived(capability?.hasStaging ?? true);
   const tagsEnabled = $derived(capability?.hasTags ?? true);
   const historyEnabled = $derived(capability?.hasVersionHistory ?? true);
+
+  // The namespace axis (Azure calls it a "label") exists only for Azure App
+  // Configuration; ParamView under the Azure provider is always App Config
+  // (Key Vault is a secret store, rendered by SecretView).
+  const isAppConfig = $derived(provider === 'azure');
+
+  // Namespace dropdown sentinels. (NULL) is the null/default namespace (empty
+  // string); * means all namespaces (no client-side filter). Both are displayed
+  // literally in the dropdown per #425.
+  const NS_NULL = '(NULL)';
+  const NS_ALL = '*';
+  // Selected namespace filter; defaults to the scope's current namespace
+  // ((NULL) when empty). App Config only.
+  let selectedNamespace = $state(initialNamespace === '' ? NS_NULL : initialNamespace);
+  // The namespace of the currently selected row, shown in the detail panel.
+  let selectedEntryNamespace = $state('');
 
   const PAGE_SIZE = 50;
   const debounce = createDebouncer(300);
@@ -51,6 +71,27 @@
   let paramLog: gui.ParamLogEntry[] = $state([]);
   let detailLoading = $state(false);
   let showValue = $state(false);
+
+  // Namespace dropdown options (App Config only): (NULL) first, then the
+  // distinct namespaces present in the loaded rows (sorted), then * (all). The
+  // scope's current namespace is always included so the default is selectable
+  // even before its rows load.
+  const namespaceOptions = $derived.by(() => {
+    const discovered = new Set<string>();
+    for (const e of entries) {
+      if (e.namespace) discovered.add(e.namespace);
+    }
+    if (initialNamespace && initialNamespace !== NS_ALL) discovered.add(initialNamespace);
+    return [NS_NULL, ...[...discovered].sort(), NS_ALL];
+  });
+
+  // Rows actually displayed. Non-App-Config providers show every row; App Config
+  // narrows by the selected namespace client-side (like the prefix/regex filters).
+  const visibleEntries = $derived.by(() => {
+    if (!isAppConfig || selectedNamespace === NS_ALL) return entries;
+    if (selectedNamespace === NS_NULL) return entries.filter((e) => !e.namespace);
+    return entries.filter((e) => e.namespace === selectedNamespace);
+  });
 
   // Staging status for the selected item
   let stagingStatus: { hasEntry: boolean; hasTags: boolean } | null = $state(null);
@@ -175,8 +216,9 @@
     }
   }
 
-  async function selectParam(name: string) {
+  async function selectParam(name: string, namespace = '') {
     selectedParam = name;
+    selectedEntryNamespace = namespace;
     detailLoading = true;
     showValue = withValue;
     stagingStatus = null;
@@ -247,7 +289,7 @@
         await ParamSet(setForm.name, setForm.value, setForm.type);
         await loadParams({ prefix, filter, recursive, withValue });
         if (isEdit) {
-          await selectParam(setForm.name);
+          await selectParam(setForm.name, selectedEntryNamespace);
         }
       } else {
         if (isEdit) {
@@ -258,7 +300,7 @@
         onstagingchange?.();
         // Refresh staging status to update the indicator
         if (isEdit) {
-          await selectParam(setForm.name);
+          await selectParam(setForm.name, selectedEntryNamespace);
         }
       }
       showSetModal = false;
@@ -346,7 +388,7 @@
         onstagingchange?.();
       }
       showTagModal = false;
-      await selectParam(selectedParam);
+      await selectParam(selectedParam, selectedEntryNamespace);
     } catch (err) {
       tagError = parseError(err);
     } finally {
@@ -372,7 +414,7 @@
         onstagingchange?.();
       }
       showRemoveTagModal = false;
-      await selectParam(selectedParam);
+      await selectParam(selectedParam, selectedEntryNamespace);
     } catch (err) {
       removeTagError = parseError(err);
     } finally {
@@ -415,6 +457,16 @@
       <input type="checkbox" bind:checked={withValue} />
       Show Values
     </label>
+    {#if isAppConfig}
+      <label class="checkbox-label namespace-filter">
+        Namespace
+        <select class="filter-input namespace-select" bind:value={selectedNamespace} aria-label="Namespace">
+          {#each namespaceOptions as ns}
+            <option value={ns}>{ns}</option>
+          {/each}
+        </select>
+      </label>
+    {/if}
     <button class="btn-primary" onclick={() => loadParams({ prefix, filter, recursive, withValue })} disabled={loading}>
       {loading ? 'Loading...' : 'Refresh'}
     </button>
@@ -429,16 +481,19 @@
 
   <div class="content">
     <div class="list-panel" class:collapsed={selectedParam !== null}>
-      {#if entries.length === 0 && !loading}
+      {#if visibleEntries.length === 0 && !loading}
         <div class="empty-state">
           No parameters found. Try adjusting the prefix filter.
         </div>
       {:else}
         <ul class="item-list">
-          {#each entries as entry}
-            <li class="item-entry" class:selected={selectedParam === entry.name}>
-              <button class="item-button" onclick={() => selectParam(entry.name)}>
+          {#each visibleEntries as entry}
+            <li class="item-entry" class:selected={selectedParam === entry.name && selectedEntryNamespace === entry.namespace}>
+              <button class="item-button" onclick={() => selectParam(entry.name, entry.namespace)}>
                 <span class="item-name param">{entry.name}</span>
+                {#if isAppConfig}
+                  <span class="namespace-badge">{entry.namespace || NS_NULL}</span>
+                {/if}
                 {#if entry.value !== undefined}
                   <span class="item-value">{entry.value}</span>
                 {/if}
@@ -511,6 +566,12 @@
                 <div class="meta-item">
                   <span class="meta-label">Version</span>
                   <span class="meta-value">{paramDetail.version}</span>
+                </div>
+              {/if}
+              {#if isAppConfig}
+                <div class="meta-item">
+                  <span class="meta-label">Namespace</span>
+                  <span class="meta-value namespace-value">{selectedEntryNamespace || NS_NULL}</span>
                 </div>
               {/if}
               {#if typeEnabled}
@@ -767,5 +828,27 @@
 
   .value-display.masked {
     font-style: italic;
+  }
+
+  /* Namespace filter dropdown (App Configuration only). */
+  .namespace-filter {
+    gap: 6px;
+  }
+
+  .namespace-select {
+    width: auto;
+    min-width: 90px;
+  }
+
+  /* Per-row namespace badge in the list. */
+  .namespace-badge {
+    display: inline-block;
+    margin-left: 8px;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 11px;
+    background: rgba(120, 120, 120, 0.18);
+    color: #888;
+    white-space: nowrap;
   }
 </style>

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -8,6 +8,10 @@ export interface Parameter {
   name: string;
   type: 'String' | 'SecureString' | 'StringList';
   value: string;
+  // Azure App Configuration namespace (the axis Azure calls a "label"). Empty /
+  // omitted is the null/default namespace. Populated into ParamListEntry.namespace
+  // by ParamList so the GUI can filter by namespace client-side (#425).
+  namespace?: string;
 }
 
 export interface Secret {
@@ -673,6 +677,26 @@ export function createAzureState(overrides: Partial<MockState> = {}): Partial<Mo
 }
 
 /**
+ * Azure App Configuration with settings spanning multiple namespaces (the axis
+ * Azure calls a "label"): some in the null/default namespace, some in `dev`,
+ * some in `prd`. The scope's namespace is left empty (the null/default), so the
+ * Namespace dropdown defaults to (NULL). Drives the #425 namespace filter +
+ * per-entry namespace display specs.
+ */
+export function createAzureNamespaceState(overrides: Partial<MockState> = {}): Partial<MockState> {
+  return createAzureState({
+    params: [
+      { name: 'app/config', type: 'String', value: 'null-val', namespace: '' },
+      { name: 'app/db', type: 'String', value: 'dev-db', namespace: 'dev' },
+      { name: 'app/cache', type: 'String', value: 'dev-cache', namespace: 'dev' },
+      { name: 'app/queue', type: 'String', value: 'prd-queue', namespace: 'prd' },
+    ],
+    paramTags: {},
+    ...overrides,
+  });
+}
+
+/**
  * No explicit initial provider and two providers active → the app must show a
  * selector prompt and preselect nothing.
  */
@@ -848,7 +872,8 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
               name: p.name,
               type: p.type,
               secret: p.type === 'SecureString',
-              value: withValue ? p.value : undefined
+              value: withValue ? p.value : undefined,
+              namespace: p.namespace ?? (state.currentScope?.namespace ?? '')
             })),
             nextToken: hasMore ? String(endIndex) : '',
           };
@@ -859,7 +884,8 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
             name: p.name,
             type: p.type,
             secret: p.type === 'SecureString',
-            value: withValue ? p.value : undefined
+            value: withValue ? p.value : undefined,
+            namespace: p.namespace ?? (state.currentScope?.namespace ?? '')
           })),
           nextToken: '',
         };

--- a/internal/gui/frontend/tests/namespace-filter.spec.ts
+++ b/internal/gui/frontend/tests/namespace-filter.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupWailsMocks,
+  createAzureNamespaceState,
+  waitForItemList,
+} from './fixtures/wails-mock';
+
+// #425 — Azure App Configuration Namespace ▾ dropdown: client-side filtering of
+// the loaded rows by namespace, plus per-entry / detail namespace display. The
+// list is loaded across ALL namespaces (LabelFilter "*") so each row carries its
+// namespace; the dropdown narrows the displayed rows without a backend
+// round-trip. Azure App Configuration only.
+
+const NULL = '(NULL)';
+
+/** Names shown in the (visible) list, in DOM order. */
+async function visibleNames(page: import('@playwright/test').Page): Promise<string[]> {
+  return page.locator('.item-list .item-name').allInnerTexts();
+}
+
+test.describe('App Configuration namespace filter (#425)', () => {
+  test('dropdown lists [(NULL), dev, prd, *] and defaults to the scope namespace', async ({ page }) => {
+    await setupWailsMocks(page, createAzureNamespaceState());
+    await page.goto('/');
+    await waitForItemList(page);
+
+    const select = page.locator('.namespace-select');
+    await expect(select).toBeVisible();
+
+    // Options: (NULL) first, discovered namespaces sorted, * last.
+    await expect(select.locator('option')).toHaveText([NULL, 'dev', 'prd', '*']);
+
+    // Scope namespace is empty → default selection is (NULL), so only the
+    // null/default-namespace row is shown initially.
+    await expect(select).toHaveValue(NULL);
+    expect(await visibleNames(page)).toEqual(['app/config']);
+  });
+
+  test('selecting a namespace filters the displayed rows client-side', async ({ page }) => {
+    await setupWailsMocks(page, createAzureNamespaceState());
+    await page.goto('/');
+    await waitForItemList(page);
+
+    const select = page.locator('.namespace-select');
+
+    // dev → only the two dev rows.
+    await select.selectOption('dev');
+    expect((await visibleNames(page)).sort()).toEqual(['app/cache', 'app/db']);
+
+    // (NULL) → only the null-namespace row.
+    await select.selectOption(NULL);
+    expect(await visibleNames(page)).toEqual(['app/config']);
+
+    // * → every row across all namespaces.
+    await select.selectOption('*');
+    expect((await visibleNames(page)).sort()).toEqual(['app/cache', 'app/config', 'app/db', 'app/queue']);
+  });
+
+  test('each row shows its namespace as a badge', async ({ page }) => {
+    await setupWailsMocks(page, createAzureNamespaceState());
+    await page.goto('/');
+    await waitForItemList(page);
+
+    // Show everything so all namespaces are visible at once.
+    await page.locator('.namespace-select').selectOption('*');
+
+    const badgeFor = (name: string) =>
+      page.locator('.item-entry').filter({ hasText: name }).locator('.namespace-badge');
+
+    await expect(badgeFor('app/config')).toHaveText(NULL); // null/default
+    await expect(badgeFor('app/db')).toHaveText('dev');
+    await expect(badgeFor('app/queue')).toHaveText('prd');
+  });
+
+  test('detail panel shows the selected entry\'s namespace', async ({ page }) => {
+    await setupWailsMocks(page, createAzureNamespaceState());
+    await page.goto('/');
+    await waitForItemList(page);
+
+    await page.locator('.namespace-select').selectOption('*');
+
+    const namespaceMeta = page.locator('.meta-item').filter({ hasText: 'Namespace' });
+
+    // A namespaced row.
+    await page.locator('.item-button').filter({ hasText: 'app/db' }).click();
+    await expect(page.locator('.detail-panel')).toBeVisible();
+    await expect(namespaceMeta).toContainText('dev');
+
+    // A null/default-namespace row shows (NULL).
+    await page.locator('.item-button').filter({ hasText: 'app/config' }).click();
+    await expect(namespaceMeta).toContainText(NULL);
+  });
+
+  test('non-Azure-App-Config providers do not show the dropdown', async ({ page }) => {
+    // Default state is AWS Parameter Store — no namespace axis.
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await waitForItemList(page);
+
+    await expect(page.locator('.namespace-select')).toHaveCount(0);
+    await expect(page.locator('.namespace-badge')).toHaveCount(0);
+  });
+});

--- a/internal/gui/frontend/wailsjs/go/models.ts
+++ b/internal/gui/frontend/wailsjs/go/models.ts
@@ -73,17 +73,19 @@ export namespace gui {
 	    type: string;
 	    secret: boolean;
 	    value?: string;
-	
+	    namespace: string;
+
 	    static createFrom(source: any = {}) {
 	        return new ParamListEntry(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.name = source["name"];
 	        this.type = source["type"];
 	        this.secret = source["secret"];
 	        this.value = source["value"];
+	        this.namespace = source["namespace"];
 	    }
 	}
 	export class ParamListResult {

--- a/internal/gui/param.go
+++ b/internal/gui/param.go
@@ -3,14 +3,27 @@
 package gui
 
 import (
+	"context"
 	"errors"
+	"regexp"
+
+	"github.com/samber/lo"
 
 	"github.com/mpyw/suve/internal/cli/commands/param/paramtype"
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/azure/appconfig"
 	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/usecase/param"
 )
+
+// appConfigNamespaceLister is the App-Config-specific extension the GUI type-
+// asserts on the resolved param store to load entries across ALL namespaces
+// (#425). Only the Azure App Configuration store implements it; the neutral
+// provider.Reader.List contract is untouched, so other providers never match.
+type appConfigNamespaceLister interface {
+	ListWithNamespaces(ctx context.Context) ([]appconfig.KeyNamespace, error)
+}
 
 // =============================================================================
 // Param Types
@@ -30,6 +43,12 @@ type ParamListEntry struct {
 	// provider-neutrally derived from the domain value type.
 	Secret bool    `json:"secret"`
 	Value  *string `json:"value,omitempty"`
+	// Namespace carries each entry's namespace for Azure App Configuration (the
+	// axis Azure calls a "label"); empty is the null/default namespace. It is
+	// populated only when the current scope is Azure App Configuration (the list
+	// is then loaded across ALL namespaces so the GUI can filter client-side,
+	// #425); for every other provider it stays empty.
+	Namespace string `json:"namespace"`
 }
 
 // ParamShowTag represents a tag key-value pair.
@@ -94,11 +113,20 @@ type ParamDeleteResult struct {
 // Param Methods
 // =============================================================================
 
-// ParamList lists SSM parameters.
+// ParamList lists parameters. For Azure App Configuration it loads entries
+// across ALL namespaces (each carrying its namespace) so the GUI can filter by
+// namespace client-side (#425); every other provider uses the neutral
+// param.ListUseCase path and leaves Namespace empty.
 func (a *App) ParamList(prefix string, recursive bool, withValue bool, filter string, _ int, _ string) (*ParamListResult, error) {
 	store, err := a.paramStore()
 	if err != nil {
 		return nil, err
+	}
+
+	// Azure App Configuration: if the store exposes the cross-namespace lister,
+	// list every namespace so each entry carries its own namespace.
+	if lister, ok := store.(appConfigNamespaceLister); ok {
+		return a.paramListWithNamespaces(lister, prefix, recursive, withValue, filter)
 	}
 
 	uc := &param.ListUseCase{Reader: store}
@@ -119,6 +147,51 @@ func (a *App) ParamList(prefix string, recursive bool, withValue bool, filter st
 			Name:  e.Name,
 			Value: e.Value,
 		}
+	}
+
+	return &ParamListResult{Entries: entries}, nil
+}
+
+// paramListWithNamespaces builds the list for Azure App Configuration from the
+// all-namespaces load, so each entry carries its namespace. The same
+// prefix/recursive/regex client-side filtering as param.ListUseCase is applied
+// (via param.MatchPrefix); namespace filtering itself is done in the frontend.
+func (a *App) paramListWithNamespaces(
+	lister appConfigNamespaceLister, prefix string, recursive, withValue bool, filter string,
+) (*ParamListResult, error) {
+	var filterRegex *regexp.Regexp
+
+	if filter != "" {
+		re, err := regexp.Compile(filter)
+		if err != nil {
+			return nil, err
+		}
+
+		filterRegex = re
+	}
+
+	items, err := lister.ListWithNamespaces(a.ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]ParamListEntry, 0, len(items))
+
+	for _, item := range items {
+		if !param.MatchPrefix(item.Key, prefix, recursive) {
+			continue
+		}
+
+		if filterRegex != nil && !filterRegex.MatchString(item.Key) {
+			continue
+		}
+
+		entry := ParamListEntry{Name: item.Key, Namespace: item.Namespace}
+		if withValue {
+			entry.Value = lo.ToPtr(item.Value)
+		}
+
+		entries = append(entries, entry)
 	}
 
 	return &ParamListResult{Entries: entries}, nil

--- a/internal/gui/param_internal_test.go
+++ b/internal/gui/param_internal_test.go
@@ -1,0 +1,99 @@
+//go:build production || dev
+
+package gui
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/azure/appconfig"
+	"github.com/mpyw/suve/internal/provider/providermock"
+)
+
+// fakeNamespaceLister is a minimal appConfigNamespaceLister for testing the
+// Azure App Configuration all-namespaces list path without a real client.
+type fakeNamespaceLister struct {
+	items []appconfig.KeyNamespace
+	err   error
+}
+
+func (f *fakeNamespaceLister) ListWithNamespaces(_ context.Context) ([]appconfig.KeyNamespace, error) {
+	return f.items, f.err
+}
+
+func TestParamListWithNamespaces_PopulatesNamespace(t *testing.T) {
+	t.Parallel()
+
+	lister := &fakeNamespaceLister{
+		items: []appconfig.KeyNamespace{
+			{Key: "app/config", Namespace: "", Value: "n"},
+			{Key: "app/config", Namespace: "dev", Value: "d"},
+			{Key: "app/db", Namespace: "prd", Value: "p"},
+		},
+	}
+	app := &App{ctx: t.Context()}
+
+	// withValue=true so values flow through from the list response.
+	res, err := app.paramListWithNamespaces(lister, "", true, true, "")
+	require.NoError(t, err)
+	require.Len(t, res.Entries, 3)
+
+	assert.Equal(t, "app/config", res.Entries[0].Name)
+	assert.Empty(t, res.Entries[0].Namespace, "empty namespace is the null/default")
+	require.NotNil(t, res.Entries[0].Value)
+	assert.Equal(t, "n", *res.Entries[0].Value)
+
+	assert.Equal(t, "app/config", res.Entries[1].Name)
+	assert.Equal(t, "dev", res.Entries[1].Namespace)
+
+	assert.Equal(t, "app/db", res.Entries[2].Name)
+	assert.Equal(t, "prd", res.Entries[2].Namespace)
+}
+
+func TestParamListWithNamespaces_FiltersPrefixAndRegex(t *testing.T) {
+	t.Parallel()
+
+	lister := &fakeNamespaceLister{
+		items: []appconfig.KeyNamespace{
+			{Key: "app/config", Namespace: "dev"},
+			{Key: "app/db/url", Namespace: "dev"},
+			{Key: "other/thing", Namespace: "prd"},
+		},
+	}
+	app := &App{ctx: t.Context()}
+
+	// Prefix "app" recursive: keeps both app/* entries, drops other/thing.
+	res, err := app.paramListWithNamespaces(lister, "app", true, false, "")
+	require.NoError(t, err)
+	require.Len(t, res.Entries, 2)
+	assert.Nil(t, res.Entries[0].Value, "withValue=false leaves Value nil")
+
+	// Regex filter further narrows to the db entry.
+	res, err = app.paramListWithNamespaces(lister, "app", true, false, "db")
+	require.NoError(t, err)
+	require.Len(t, res.Entries, 1)
+	assert.Equal(t, "app/db/url", res.Entries[0].Name)
+}
+
+// TestAppConfigNamespaceLister_Gate documents the type-assertion gate that
+// decides the list path: the concrete App Configuration store implements the
+// App-Config-specific lister (so entries carry a namespace), while a neutral
+// provider store does not (so ParamList takes the generic path and leaves the
+// namespace empty).
+func TestAppConfigNamespaceLister_Gate(t *testing.T) {
+	t.Parallel()
+
+	var appConfigStore provider.Store = appconfig.New(nil, "")
+
+	_, isLister := appConfigStore.(appConfigNamespaceLister)
+	assert.True(t, isLister, "App Configuration store must expose ListWithNamespaces")
+
+	var neutralStore provider.Store = &providermock.Store{}
+
+	_, isLister = neutralStore.(appConfigNamespaceLister)
+	assert.False(t, isLister, "neutral provider stores must not expose ListWithNamespaces")
+}

--- a/internal/provider/azure/appconfig/appconfig.go
+++ b/internal/provider/azure/appconfig/appconfig.go
@@ -172,6 +172,54 @@ func (s *Store) List(ctx context.Context) ([]string, error) {
 	return names, nil
 }
 
+// KeyNamespace pairs an App Configuration setting's key with the namespace it
+// lives in — the axis Azure calls a "label". An empty Namespace is the null
+// (default) namespace. Value carries the setting's current value so a caller can
+// display it without a second round-trip (App Configuration's list response
+// already includes it). This type and ListWithNamespaces are App-Config-specific
+// and are NOT part of the neutral provider seam: only a caller that has
+// type-asserted the concrete App Configuration store can reach them.
+type KeyNamespace struct {
+	Key       string
+	Namespace string
+	Value     string
+}
+
+// ListWithNamespaces returns every setting across ALL namespaces (LabelFilter
+// "*"), each paired with its namespace and value, sorted by key then namespace.
+// Unlike List it deliberately IGNORES the store's configured namespace so a
+// caller (the GUI, #425) can present a cross-namespace list and filter it
+// client-side. It is an App-Config-specific extension and leaves the neutral
+// provider.Reader.List contract untouched. A key that exists under several
+// namespaces yields one entry per (key, namespace) pair.
+func (s *Store) ListWithNamespaces(ctx context.Context) ([]KeyNamespace, error) {
+	settings, err := s.client.ListSettings(ctx, aznamespace.AllNamespacesFilter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list settings across namespaces: %w", err)
+	}
+
+	out := make([]KeyNamespace, 0, len(settings))
+	for _, setting := range settings {
+		out = append(out, KeyNamespace{
+			Key:       lo.FromPtr(setting.Key),
+			Namespace: lo.FromPtr(setting.Label),
+			Value:     lo.FromPtr(setting.Value),
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Key != out[j].Key {
+			return out[i].Key < out[j].Key
+		}
+
+		return out[i].Namespace < out[j].Namespace
+	})
+
+	debug.From(ctx).Logf("azure appconfig: ListWithNamespaces -> %d settings across all namespaces\n", len(out))
+
+	return out, nil
+}
+
 // Create creates a new setting (create-only) via AddSetting and returns an empty
 // version (App Configuration is unversioned). It returns a wrapped
 // provider.ErrAlreadyExists if the setting already exists. The valueType and

--- a/internal/provider/azure/appconfig/appconfig_test.go
+++ b/internal/provider/azure/appconfig/appconfig_test.go
@@ -312,6 +312,56 @@ func TestList_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "list settings")
 }
 
+func TestListWithNamespaces(t *testing.T) {
+	t.Parallel()
+
+	var gotFilter string
+
+	m := &mockClient{
+		listFunc: func(_ context.Context, filter string) ([]azappconfig.Setting, error) {
+			gotFilter = filter
+
+			// Settings span the null (unlabeled) namespace and "dev"/"prd", in
+			// an unsorted order to exercise the sort.
+			return []azappconfig.Setting{
+				{Key: lo.ToPtr("beta"), Label: lo.ToPtr("prd"), Value: lo.ToPtr("bp")},
+				{Key: lo.ToPtr("alpha"), Value: lo.ToPtr("a-null")},
+				{Key: lo.ToPtr("alpha"), Label: lo.ToPtr("dev"), Value: lo.ToPtr("ad")},
+				{Key: lo.ToPtr("beta"), Value: lo.ToPtr("b-null")},
+			}, nil
+		},
+	}
+	// The store is scoped to "dev", but ListWithNamespaces must ignore that and
+	// enumerate ALL namespaces via the "*" wildcard filter.
+	store := appconfig.New(m, "dev")
+
+	items, err := store.ListWithNamespaces(t.Context())
+	require.NoError(t, err)
+
+	assert.Equal(t, "*", gotFilter, "must list across all namespaces regardless of the store's namespace")
+	assert.Equal(t, []appconfig.KeyNamespace{
+		{Key: "alpha", Namespace: "", Value: "a-null"},
+		{Key: "alpha", Namespace: "dev", Value: "ad"},
+		{Key: "beta", Namespace: "", Value: "b-null"},
+		{Key: "beta", Namespace: "prd", Value: "bp"},
+	}, items)
+}
+
+func TestListWithNamespaces_Error(t *testing.T) {
+	t.Parallel()
+
+	m := &mockClient{
+		listFunc: func(_ context.Context, _ string) ([]azappconfig.Setting, error) {
+			return nil, serverError()
+		},
+	}
+	store := appconfig.New(m, "")
+
+	_, err := store.ListWithNamespaces(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list settings across namespaces")
+}
+
 func TestCreate_AlreadyExists(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/azure/appconfig/aznamespace/aznamespace.go
+++ b/internal/provider/azure/appconfig/aznamespace/aznamespace.go
@@ -27,6 +27,12 @@ import (
 // encodes it as label=%00 (#352).
 const NullLabelFilter = "\x00"
 
+// AllNamespacesFilter is the App Configuration label filter that matches every
+// namespace (the degenerate `*` wildcard). Cross-namespace enumeration (see
+// appconfig.Store.ListWithNamespaces, #425) uses it to deliberately ignore the
+// store's configured namespace.
+const AllNamespacesFilter = "*"
+
 // Filter maps a raw --namespace value to an App Configuration LabelFilter for
 // list/read enumeration. An empty value maps to the null-label filter (the
 // default namespace); any other value is forwarded verbatim so the service's

--- a/internal/usecase/param/list.go
+++ b/internal/usecase/param/list.go
@@ -59,7 +59,7 @@ func (u *ListUseCase) Execute(ctx context.Context, input ListInput) (*ListOutput
 
 	// Apply prefix/recursive and regex filtering client-side.
 	filtered := lo.Filter(names, func(name string, _ int) bool {
-		if !matchPrefix(name, input.Prefix, input.Recursive) {
+		if !MatchPrefix(name, input.Prefix, input.Recursive) {
 			return false
 		}
 
@@ -78,7 +78,7 @@ func (u *ListUseCase) Execute(ctx context.Context, input ListInput) (*ListOutput
 	return u.buildOutput(ctx, input.WithValue, filtered), nil
 }
 
-// matchPrefix reports whether name is in scope for the given prefix, using AWS
+// MatchPrefix reports whether name is in scope for the given prefix, using AWS
 // Parameter Store PATH-HIERARCHY semantics (the old server-side Path filter):
 //
 //   - An empty prefix matches everything (the old code applied no Path filter,
@@ -91,7 +91,7 @@ func (u *ListUseCase) Execute(ctx context.Context, input ListInput) (*ListOutput
 //     "prefix/" must contain no further "/".
 //
 // A trailing slash on the prefix is normalized so "/app/" behaves like "/app".
-func matchPrefix(name, prefix string, recursive bool) bool {
+func MatchPrefix(name, prefix string, recursive bool) bool {
 	if prefix == "" {
 		return true
 	}


### PR DESCRIPTION
Closes #425.

## What

In the GUI App Configuration `ParamView`, add a **Namespace ▾** dropdown that **client-side-filters** the displayed settings by namespace, and **show each entry's namespace** in the list and detail. Azure App Configuration only (Key Vault / GCloud / AWS have no such axis).

## App-Config-only all-namespaces list path (neutral seam untouched)

- `provider.Reader.List(ctx) ([]string, error)` is **unchanged** — the shared seam is not disturbed.
- New App-Config-specific `appconfig.Store.ListWithNamespaces(ctx) ([]KeyNamespace, error)` lists across **all** namespaces (`LabelFilter = "*"`, deliberately ignoring the store's configured namespace), returning `KeyNamespace{Key, Namespace, Value}` (empty `Namespace` == the null/default). `Value` rides along from the same list response, so "Show Values" needs no extra round-trip and stays correct per-namespace.
- The GUI (`internal/gui/param.go`) **type-asserts** a small App-Config-scoped interface (`ListWithNamespaces`) on the resolved param store. Only the Azure App Configuration store implements it; every other provider falls through to the existing `param.ListUseCase` path with namespace empty. The prefix matcher is exported (`param.MatchPrefix`) and reused so the all-namespaces path keeps identical prefix/recursive/regex filtering.

## DTO

- `ParamListEntry` gains a `namespace` field (`internal/gui/param.go`), hand-mirrored in `wailsjs/go/models.ts` (`wails generate` can't run here).

## Frontend (`ParamView.svelte`)

- A **Namespace ▾** dropdown in the filter bar, shown only for Azure App Config. Options in order: **`(NULL)`** (the null/default namespace), the **distinct namespaces present in the loaded rows** (sorted), then **`*`** (all). Default selection = the scope's current namespace (`(NULL)` if empty), passed from `App.svelte` via `initialNamespace`.
- Selecting an option **filters the displayed rows client-side** (like Prefix/Filter): `(NULL)` → empty-namespace rows; a name → that namespace; `*` → all. No re-scope, no backend round-trip.
- **Per-entry display**: each row shows a namespace badge (`(NULL)` when empty), and the detail panel shows the selected entry's namespace.

## Tests

Per the standing rule, the GUI-facing layers ship tests; the CLI gains **no new surface** (Phase 1 already supports `--namespace "*"` listing), so no redundant CLI e2e was added.

- **Go unit** (`internal/provider/azure/appconfig/appconfig_test.go`): `ListWithNamespaces` returns `{Key, Namespace, Value}` across null + `dev`/`prd` labels, sorted, forcing the `*` filter regardless of the store's namespace; plus an error path. **GUI** (`internal/gui/param_internal_test.go`): `paramListWithNamespaces` populates `namespace` (and values, and prefix/regex filtering) for App Config; the type-assert gate matches the App Config store and rejects a neutral store (other providers leave namespace empty).
- **GUI Playwright** (`internal/gui/frontend/tests/namespace-filter.spec.ts`): with an App Config scope whose rows span namespaces, asserts the dropdown lists `[(NULL), dev, prd, *]`; selecting `dev`/`(NULL)`/`*` filters accordingly; each row shows its namespace badge; the detail shows the selected entry's namespace; non-Azure-App-Config providers show no dropdown.

## Verification

- `go build ./...`, `go test ./...` — pass. `golangci-lint run --allow-parallel-runners --build-tags=e2e,production ./internal/...` — **0 issues**.
- Frontend: `npm run check` — **0 errors**; `npm run lint` — **clean**; `npm run test` (Playwright, 3 browsers) — new spec passes 15/15; full suite passes except the **known pre-existing `[webkit] keyboard-focus.spec.ts` "Tab navigation" flake**, confirmed failing identically on the base tree (unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)