### PR TITLE
feat(gui): move Azure App Config namespace filter to the sidebar footer

### DIFF
--- a/internal/gui/frontend/src/App.svelte
+++ b/internal/gui/frontend/src/App.svelte
@@ -15,7 +15,7 @@
   import SecretView from './lib/SecretView.svelte';
   import Sidebar from './lib/Sidebar.svelte';
   import StagingView from './lib/StagingView.svelte';
-  import { parseError } from './lib/viewUtils';
+  import { NS_ALL, NS_NULL, parseError } from './lib/viewUtils';
 
   type ViewKey = 'param' | 'secret' | 'staging';
 
@@ -34,6 +34,23 @@
   let accountId = $state('');
   let region = $state('');
   let profile = $state('');
+
+  // ---- Azure App Configuration namespace filter -----------------------------
+  // App owns the client-side namespace filter so the dropdown can live in the
+  // sidebar footer while ParamView does the filtering. selectedNamespace defaults
+  // to the scope's namespace ((NULL) when empty); discoveredNamespaces is reported
+  // by ParamView from its loaded rows. It never re-scopes — purely a display filter.
+  let selectedNamespace = $state(NS_NULL);
+  let discoveredNamespaces = $state<string[]>([]);
+
+  // Footer dropdown options: (NULL) first, discovered namespaces (sorted), then *
+  // (all). The scope's current namespace is folded in so the default stays
+  // selectable even before its rows load.
+  const namespaceOptions = $derived.by(() => {
+    const set = new Set(discoveredNamespaces);
+    if (scope?.namespace) set.add(scope.namespace);
+    return [NS_NULL, ...[...set].sort(), NS_ALL];
+  });
 
   // pendingProvider is a provider the user selected that still needs scope input:
   // its form shows in the sidebar while the previously-active provider stays
@@ -243,6 +260,7 @@
     try {
       await SelectScope(sel);
       scope = await GetCurrentScope();
+      resetNamespaceFilter();
       provider = sel.provider;
       pendingProvider = '';
       scopeReady = true;
@@ -264,6 +282,21 @@
     accountId = '';
     region = '';
     profile = '';
+  }
+
+  // Re-seed the namespace filter to the (new) scope's namespace and drop the
+  // discovered list; ParamView re-reports it after the {#key} remount reloads.
+  function resetNamespaceFilter() {
+    discoveredNamespaces = [];
+    selectedNamespace = scope?.namespace ? scope.namespace : NS_NULL;
+  }
+
+  function handleNamespaces(ns: string[]) {
+    discoveredNamespaces = ns;
+  }
+
+  function handleChangeNamespace(ns: string) {
+    selectedNamespace = ns;
   }
 
   function handleNavigate(view: ViewKey) {
@@ -318,11 +351,14 @@
     {accountId}
     {region}
     {profile}
+    {namespaceOptions}
+    {selectedNamespace}
     onnavigate={handleNavigate}
     onselectprovider={handleSelectProvider}
     onselectscope={handleSelectScope}
     oncancelscope={handleCancelScope}
     onchangescope={handleChangeScope}
+    onchangenamespace={handleChangeNamespace}
   />
 
   <main class="main-content">
@@ -336,7 +372,8 @@
           <ParamView
             capability={paramCap}
             {provider}
-            initialNamespace={scope?.namespace ?? ''}
+            {selectedNamespace}
+            onnamespaces={handleNamespaces}
             onnavigatetostaging={() => handleNavigate('staging')}
             onstagingchange={handleStagingChange}
           />

--- a/internal/gui/frontend/src/lib/ParamView.svelte
+++ b/internal/gui/frontend/src/lib/ParamView.svelte
@@ -10,21 +10,24 @@
   import StagingBanner from './StagingBanner.svelte';
   import TagList from './TagList.svelte';
   import { createDiffMode } from './useDiffMode.svelte';
-  import { createDebouncer, formatDate, maskValue, parseError } from './viewUtils';
+  import { createDebouncer, formatDate, maskValue, NS_ALL, NS_NULL, parseError } from './viewUtils';
   import './common.css';
 
   interface Props {
     capability?: gui.ServiceCapability;
     provider?: string;
-    // initialNamespace is the scope's current App Configuration namespace (empty
-    // = the null/default namespace); it seeds the Namespace dropdown's initial
-    // selection. Only meaningful for Azure App Configuration.
-    initialNamespace?: string;
+    // selectedNamespace is the App Configuration namespace filter, owned by App
+    // (the dropdown lives in the sidebar footer). (NULL) → null/default rows, a
+    // name → that namespace, * → all. Only meaningful for Azure App Configuration.
+    selectedNamespace?: string;
+    // onnamespaces reports the distinct namespaces present in the loaded rows
+    // (sorted) so App can build the footer dropdown's options.
+    onnamespaces?: (ns: string[]) => void;
     onnavigatetostaging?: () => void;
     onstagingchange?: () => void;
   }
 
-  let { capability, provider = '', initialNamespace = '', onnavigatetostaging, onstagingchange }: Props = $props();
+  let { capability, provider = '', selectedNamespace = NS_NULL, onnamespaces, onnavigatetostaging, onstagingchange }: Props = $props();
 
   // Capability-driven visibility. Absent capability defaults to AWS-like (true)
   // so the component degrades safely if mounted without one.
@@ -37,14 +40,6 @@
   // (Key Vault is a secret store, rendered by SecretView).
   const isAppConfig = $derived(provider === 'azure');
 
-  // Namespace dropdown sentinels. (NULL) is the null/default namespace (empty
-  // string); * means all namespaces (no client-side filter). Both are displayed
-  // literally in the dropdown per #425.
-  const NS_NULL = '(NULL)';
-  const NS_ALL = '*';
-  // Selected namespace filter; defaults to the scope's current namespace
-  // ((NULL) when empty). App Config only.
-  let selectedNamespace = $state(initialNamespace === '' ? NS_NULL : initialNamespace);
   // The namespace of the currently selected row, shown in the detail panel.
   let selectedEntryNamespace = $state('');
 
@@ -72,17 +67,15 @@
   let detailLoading = $state(false);
   let showValue = $state(false);
 
-  // Namespace dropdown options (App Config only): (NULL) first, then the
-  // distinct namespaces present in the loaded rows (sorted), then * (all). The
-  // scope's current namespace is always included so the default is selectable
-  // even before its rows load.
-  const namespaceOptions = $derived.by(() => {
+  // Report the distinct namespaces present in the loaded rows (sorted) up to App
+  // (App Config only), which owns the footer Namespace dropdown and its options.
+  $effect(() => {
+    if (!isAppConfig) return;
     const discovered = new Set<string>();
     for (const e of entries) {
       if (e.namespace) discovered.add(e.namespace);
     }
-    if (initialNamespace && initialNamespace !== NS_ALL) discovered.add(initialNamespace);
-    return [NS_NULL, ...[...discovered].sort(), NS_ALL];
+    onnamespaces?.([...discovered].sort());
   });
 
   // Rows actually displayed. Non-App-Config providers show every row; App Config
@@ -457,16 +450,6 @@
       <input type="checkbox" bind:checked={withValue} />
       Show Values
     </label>
-    {#if isAppConfig}
-      <label class="checkbox-label namespace-filter">
-        Namespace
-        <select class="filter-input namespace-select" bind:value={selectedNamespace} aria-label="Namespace">
-          {#each namespaceOptions as ns}
-            <option value={ns}>{ns}</option>
-          {/each}
-        </select>
-      </label>
-    {/if}
     <button class="btn-primary" onclick={() => loadParams({ prefix, filter, recursive, withValue })} disabled={loading}>
       {loading ? 'Loading...' : 'Refresh'}
     </button>
@@ -828,16 +811,6 @@
 
   .value-display.masked {
     font-style: italic;
-  }
-
-  /* Namespace filter dropdown (App Configuration only). */
-  .namespace-filter {
-    gap: 6px;
-  }
-
-  .namespace-select {
-    width: auto;
-    min-width: 90px;
   }
 
   /* Per-row namespace badge in the list. */

--- a/internal/gui/frontend/src/lib/Sidebar.svelte
+++ b/internal/gui/frontend/src/lib/Sidebar.svelte
@@ -18,11 +18,18 @@
     accountId?: string;
     region?: string;
     profile?: string;
+    // Azure App Configuration namespace filter (footer dropdown). namespaceOptions
+    // are the choices ((NULL), discovered, *); selectedNamespace is the current
+    // value; onchangenamespace reports a new selection. Client-side only — this
+    // does NOT re-scope.
+    namespaceOptions?: string[];
+    selectedNamespace?: string;
     onnavigate?: (view: ViewKey) => void;
     onselectprovider?: (provider: string) => void;
     onselectscope?: (sel: gui.ScopeSelection) => void;
     oncancelscope?: () => void;
     onchangescope?: () => void;
+    onchangenamespace?: (ns: string) => void;
   }
 
   let {
@@ -40,11 +47,14 @@
     accountId = '',
     region = '',
     profile = '',
+    namespaceOptions = [],
+    selectedNamespace = '',
     onnavigate,
     onselectprovider,
     onselectscope,
     oncancelscope,
     onchangescope,
+    onchangenamespace,
   }: Props = $props();
 
   // Service key → stable nav icon/letter (labels come from capability names).
@@ -94,6 +104,10 @@
   function handleProviderChange(e: Event) {
     const value = (e.currentTarget as HTMLSelectElement).value;
     onselectprovider?.(value);
+  }
+
+  function handleNamespaceChange(e: Event) {
+    onchangenamespace?.((e.currentTarget as HTMLSelectElement).value);
   }
 
   // Escape while a scope form is open cancels the pending selection.
@@ -186,10 +200,10 @@
         id="azure-namespace"
         class="scope-input"
         type="text"
-        placeholder="empty = default"
+        placeholder="empty = (NULL)"
         bind:value={namespaceInput}
       />
-      <p class="scope-hint">Azure calls this a label; empty = default. Applies to the App Configuration store only.</p>
+      <p class="scope-hint">Azure calls this a label; empty = (NULL). Applies to the App Configuration store only.</p>
       {#if formError || scopeError}
         <div class="scope-error">{formError || scopeError}</div>
       {/if}
@@ -269,9 +283,21 @@
         <span class="aws-info-value" title={scope?.storeName || '?'}>{scope?.storeName || '?'}</span>
       </div>
       {#if scope?.storeName}
+        <!-- The scope's Namespace row is a client-side filter dropdown (App
+             Configuration only). Changing it filters ParamView's rows without
+             re-scoping; the "Change scope" button below re-points the scope. -->
         <div class="aws-info-row">
           <span class="aws-info-label">Namespace</span>
-          <span class="aws-info-value" title={scope?.namespace || 'default'}>{scope?.namespace || 'default'}</span>
+          <select
+            class="aws-info-value namespace-select"
+            value={selectedNamespace}
+            onchange={handleNamespaceChange}
+            aria-label="Namespace"
+          >
+            {#each namespaceOptions as ns}
+              <option value={ns}>{ns}</option>
+            {/each}
+          </select>
         </div>
       {/if}
       <button type="button" class="scope-change" disabled={!!pendingProvider} onclick={() => onchangescope?.()}>Change scope</button>
@@ -514,5 +540,21 @@
   .aws-info-profile {
     color: #e94560;
     font-weight: bold;
+  }
+
+  /* Namespace filter dropdown in the scope-info footer (App Configuration only).
+     Styled to sit inline with the info rows like the read-only values it
+     replaced. */
+  .namespace-select {
+    max-width: 60%;
+    box-sizing: border-box;
+    padding: 2px 4px;
+    background: #252542;
+    color: #a0a0a0;
+    border: 1px solid #2d2d44;
+    border-radius: 4px;
+    font-family: monospace;
+    font-size: 10px;
+    cursor: pointer;
   }
 </style>

--- a/internal/gui/frontend/src/lib/viewUtils.ts
+++ b/internal/gui/frontend/src/lib/viewUtils.ts
@@ -2,6 +2,12 @@
  * Shared utility functions for ParamView and SecretView
  */
 
+// Azure App Configuration namespace sentinels, shared by App/Sidebar/ParamView.
+// NS_NULL is the null/default namespace (empty string); NS_ALL means "all
+// namespaces" (no client-side filter). Both are displayed literally (#425).
+export const NS_NULL = '(NULL)';
+export const NS_ALL = '*';
+
 /**
  * Mask sensitive values for display
  */

--- a/internal/gui/frontend/tests/namespace-filter.spec.ts
+++ b/internal/gui/frontend/tests/namespace-filter.spec.ts
@@ -5,13 +5,18 @@ import {
   waitForItemList,
 } from './fixtures/wails-mock';
 
-// #425 — Azure App Configuration Namespace ▾ dropdown: client-side filtering of
-// the loaded rows by namespace, plus per-entry / detail namespace display. The
-// list is loaded across ALL namespaces (LabelFilter "*") so each row carries its
-// namespace; the dropdown narrows the displayed rows without a backend
-// round-trip. Azure App Configuration only.
+// #425 / #427 follow-up — Azure App Configuration namespace filter. The dropdown
+// now lives in the SIDEBAR FOOTER's connected-scope block (the "Namespace" row is
+// itself the <select>), not ParamView's top-right filter bar. It still filters
+// the loaded rows client-side by namespace, with per-entry / detail namespace
+// display. The list is loaded across ALL namespaces (LabelFilter "*") so each row
+// carries its namespace; the dropdown narrows the displayed rows without a
+// backend round-trip and without re-scoping. Azure App Configuration only.
 
 const NULL = '(NULL)';
+
+// The namespace dropdown is the footer scope-info "Namespace" row's <select>.
+const nsSelect = (page: import('@playwright/test').Page) => page.locator('.sidebar .namespace-select');
 
 /** Names shown in the (visible) list, in DOM order. */
 async function visibleNames(page: import('@playwright/test').Page): Promise<string[]> {
@@ -19,12 +24,12 @@ async function visibleNames(page: import('@playwright/test').Page): Promise<stri
 }
 
 test.describe('App Configuration namespace filter (#425)', () => {
-  test('dropdown lists [(NULL), dev, prd, *] and defaults to the scope namespace', async ({ page }) => {
+  test('footer dropdown lists [(NULL), dev, prd, *] and defaults to the scope namespace', async ({ page }) => {
     await setupWailsMocks(page, createAzureNamespaceState());
     await page.goto('/');
     await waitForItemList(page);
 
-    const select = page.locator('.namespace-select');
+    const select = nsSelect(page);
     await expect(select).toBeVisible();
 
     // Options: (NULL) first, discovered namespaces sorted, * last.
@@ -36,12 +41,12 @@ test.describe('App Configuration namespace filter (#425)', () => {
     expect(await visibleNames(page)).toEqual(['app/config']);
   });
 
-  test('selecting a namespace filters the displayed rows client-side', async ({ page }) => {
+  test('selecting a namespace in the footer filters the displayed rows client-side', async ({ page }) => {
     await setupWailsMocks(page, createAzureNamespaceState());
     await page.goto('/');
     await waitForItemList(page);
 
-    const select = page.locator('.namespace-select');
+    const select = nsSelect(page);
 
     // dev → only the two dev rows.
     await select.selectOption('dev');
@@ -62,7 +67,7 @@ test.describe('App Configuration namespace filter (#425)', () => {
     await waitForItemList(page);
 
     // Show everything so all namespaces are visible at once.
-    await page.locator('.namespace-select').selectOption('*');
+    await nsSelect(page).selectOption('*');
 
     const badgeFor = (name: string) =>
       page.locator('.item-entry').filter({ hasText: name }).locator('.namespace-badge');
@@ -77,7 +82,7 @@ test.describe('App Configuration namespace filter (#425)', () => {
     await page.goto('/');
     await waitForItemList(page);
 
-    await page.locator('.namespace-select').selectOption('*');
+    await nsSelect(page).selectOption('*');
 
     const namespaceMeta = page.locator('.meta-item').filter({ hasText: 'Namespace' });
 


### PR DESCRIPTION
## What & why

The Azure App Configuration **namespace-filter dropdown** used to sit in `ParamView.svelte`'s top-right filter bar, next to Prefix / Filter / Show Values / Refresh. That made the bar too wide and cut off the **Refresh** button.

This PR **relocates the dropdown into the sidebar footer**: the connected-scope block's read-only **"Namespace"** row *becomes* the `<select>` in place. It remains a purely **client-side** filter — selecting a namespace filters the already-loaded rows and does **not** re-scope / reload (no `SelectScope`).

## Changes

- **State lift to `App.svelte`.** App now owns `selectedNamespace` (defaults to the scope's namespace, `(NULL)` when empty) and the discovered-namespace list, and derives `namespaceOptions` = `[(NULL), …discovered sorted, *]`.
  - `Sidebar.svelte` hosts the dropdown (gated on `scope?.storeName`, same as before) via `namespaceOptions` + `selectedNamespace` + `onchangenamespace`. The separate "Change scope" button is unchanged.
  - `ParamView.svelte` receives `selectedNamespace` as a prop for its client-side row filtering (replacing its local state) and reports the namespaces present in its loaded rows up via `onnamespaces`. Per-row badge and detail namespace still render `(NULL)`.
  - The `(NULL)` / `*` sentinels moved to a shared `viewUtils` export.
- **`(NULL)` terminology unification.** The scope form's namespace placeholder (`empty = default` → `empty = (NULL)`) and hint (`…empty = default…` → `…empty = (NULL)…`). The dropdown, per-row badges, and detail already used `(NULL)`.
- **Playwright** (`namespace-filter.spec.ts`): selectors retargeted to the footer dropdown (`.sidebar .namespace-select`). Coverage preserved — option ordering `[(NULL), <discovered sorted>, *]`, `dev` / `(NULL)` / `*` filtering, per-row badge, detail namespace, and absent for non-App-Config providers.

## Verification (in `internal/gui/frontend/`)

- `npm run check` — **0 errors** (3 pre-existing warnings in Modal/StagingView/tsconfig, unrelated).
- `npm run lint` — **clean**.
- `npm run test` — **1568 passed**, plus the **pre-existing `[webkit] keyboard-focus.spec.ts:54` flake** (confirmed failing identically on the clean `gui-polish` base tree; it uses default AWS state and is untouched by this change). `namespace-filter.spec.ts` passes 15/15 across all 3 browsers.
- `go build ./...` from repo root — **OK** (no Go changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)