### PR TITLE
feat(gui): carry launch scope + service through the --gui launch

### DIFF
--- a/cmd/suve/gui.go
+++ b/cmd/suve/gui.go
@@ -15,10 +15,12 @@ import (
 	"github.com/mpyw/suve/internal/provider"
 )
 
-// launchGUI runs the GUI with the given initial scope and exits. It is the
-// short-circuit used by the --gui flags' Before hooks.
-func launchGUI(ctx context.Context, initial provider.Scope) (context.Context, error) {
-	if err := gui.Run(initial); err != nil {
+// launchGUI runs the GUI with the given initial scope + service and exits. It
+// is the short-circuit used by the --gui flags' Before hooks. service is the
+// launched service ("param"/"secret", or "" when launched at the group level or
+// bare), so the GUI can open on the matching view.
+func launchGUI(ctx context.Context, initial provider.Scope, service string) (context.Context, error) {
+	if err := gui.Run(initial, service); err != nil {
 		return ctx, err
 	}
 
@@ -71,7 +73,7 @@ func groupProvider(name string) provider.Provider {
 func registerGUIFlag() {
 	// Bare `suve --gui`: initial provider resolved from the environment.
 	commands.App.Flags = append(commands.App.Flags, &cli.BoolFlag{
-		Name:  "gui",
+		Name:  guiFlagName,
 		Usage: "Launch GUI mode (picks the active provider, or opens the in-app picker if none is unambiguous)",
 	})
 	// Wrap (do not replace) the root Before: the app already installs one
@@ -79,13 +81,13 @@ func registerGUIFlag() {
 	// the GUI build. Chain to it on the non-GUI path, mirroring attachGUIFlag.
 	inner := commands.App.Before
 	commands.App.Before = func(ctx context.Context, cmd *cli.Command) (context.Context, error) {
-		if cmd.Bool("gui") {
+		if cmd.Bool(guiFlagName) {
 			// Launch with the uniquely-active provider when the environment
 			// resolves one; otherwise (0 or 2+ active) InitialProviderFromEnv
 			// returns "", and the GUI opens at its in-app provider picker rather
 			// than erroring. No scope flags on the bare form, so the GUI hydrates
-			// any resource fields from env.
-			return launchGUI(ctx, provider.Scope{Provider: gui.InitialProviderFromEnv()})
+			// any resource fields from env. No specific service on the bare form.
+			return launchGUI(ctx, provider.Scope{Provider: gui.InitialProviderFromEnv()}, "")
 		}
 
 		if inner != nil {
@@ -95,46 +97,68 @@ func registerGUIFlag() {
 		return ctx, nil
 	}
 
-	// Azure's --vault-name / --store-name live on its secret / param subgroups.
-	const (
-		subcommandSecret = "secret"
-		subcommandParam  = "param"
-	)
-
-	// Per-provider `suve <group> --gui`: launch with that provider pre-selected.
-	// Azure attaches --gui to its secret / param subgroups too, letting those
-	// flags seed the launch scope.
+	// Per-provider `suve <group> --gui`: launch with that provider pre-selected
+	// and no specific service. Azure attaches --gui to its secret / param
+	// subgroups too, letting those flags seed the launch scope AND carry the
+	// launched service (param|secret) into the GUI.
 	for _, group := range commands.App.Commands {
 		p := groupProvider(group.Name)
 		if p == "" {
 			continue
 		}
 
-		attachGUIFlag(group, p)
+		attachGUIFlag(group, p, "")
 
 		if p == provider.ProviderAzure {
 			for _, sub := range group.Commands {
-				if sub.Name == subcommandSecret || sub.Name == subcommandParam {
-					attachGUIFlag(sub, p)
+				// Key off the canonical subcommand name (not the typed alias, which
+				// urfave/cli has already resolved to this command) so kv/keyvault map
+				// to the same "secret" service.
+				if svc := guiService(sub.Name); svc != "" {
+					attachGUIFlag(sub, p, svc)
 				}
 			}
 		}
 	}
 }
 
+// guiFlagName is the name of the --gui launch flag, attached to the root, each
+// provider group, and Azure's service subgroups.
+const guiFlagName = "gui"
+
+// Azure's --vault-name / --store-name live on its secret / param subgroups.
+const (
+	subcommandSecret = "secret"
+	subcommandParam  = "param"
+)
+
+// guiService maps a provider subgroup's canonical name to the launch service
+// ("param"/"secret"), or "" when the command is not a service subgroup. The
+// returned value doubles as the frontend service identifier (InitialService).
+func guiService(name string) string {
+	switch name {
+	case subcommandParam, subcommandSecret:
+		return name
+	default:
+		return ""
+	}
+}
+
 // attachGUIFlag adds a --gui flag to a command (a provider group or one of its
 // subgroups) and wraps its Before hook so `--gui` launches the GUI with that
-// provider, seeding the initial scope from the command's scope flags.
-func attachGUIFlag(cmd *cli.Command, p provider.Provider) {
+// provider, seeding the initial scope from the command's scope flags. service
+// ("param"/"secret", or "" for a group) is the launched service carried into
+// the GUI so it opens on the matching view.
+func attachGUIFlag(cmd *cli.Command, p provider.Provider, service string) {
 	cmd.Flags = append(cmd.Flags, &cli.BoolFlag{
-		Name:  "gui",
+		Name:  guiFlagName,
 		Usage: "Launch GUI mode for this provider",
 	})
 
 	inner := cmd.Before
 	cmd.Before = func(ctx context.Context, c *cli.Command) (context.Context, error) {
-		if c.Bool("gui") {
-			return launchGUI(ctx, guiScope(c, p))
+		if c.Bool(guiFlagName) {
+			return launchGUI(ctx, guiScope(c, p), service)
 		}
 
 		if inner != nil {

--- a/cmd/suve/gui_test.go
+++ b/cmd/suve/gui_test.go
@@ -1,0 +1,130 @@
+//go:build production || dev
+
+package main
+
+import (
+	"context"
+	"slices"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+
+	"github.com/mpyw/suve/internal/cli/commands"
+	"github.com/mpyw/suve/internal/provider"
+)
+
+// runScope drives a throwaway cli.Command carrying the given flags/args and
+// returns the guiScope it derives for provider p. Running the command is the
+// reliable way to populate urfave/cli flag values.
+func runScope(t *testing.T, p provider.Provider, flags []cli.Flag, args []string) provider.Scope {
+	t.Helper()
+
+	var got provider.Scope
+
+	cmd := &cli.Command{
+		Name:  args[0],
+		Flags: flags,
+		Action: func(_ context.Context, c *cli.Command) error {
+			got = guiScope(c, p)
+
+			return nil
+		},
+	}
+	require.NoError(t, cmd.Run(t.Context(), args))
+
+	return got
+}
+
+func TestGuiScope_CarriesAzureFields(t *testing.T) {
+	t.Parallel()
+
+	flags := []cli.Flag{
+		&cli.StringFlag{Name: "vault-name"},
+		&cli.StringFlag{Name: "store-name"},
+		&cli.StringFlag{Name: "namespace"},
+	}
+	got := runScope(t, provider.ProviderAzure, flags,
+		[]string{"param", "--store-name", "my-store", "--namespace", "dev"})
+
+	assert.Equal(t, provider.ProviderAzure, got.Provider)
+	assert.Equal(t, "my-store", got.StoreName)
+	// The launch scope carries --namespace so the GUI opens on it.
+	assert.Equal(t, "dev", got.AppConfigNamespace)
+}
+
+func TestGuiScope_CarriesGoogleCloudProject(t *testing.T) {
+	t.Parallel()
+
+	flags := []cli.Flag{&cli.StringFlag{Name: "project"}}
+	got := runScope(t, provider.ProviderGoogleCloud, flags,
+		[]string{"secret", "--project", "my-project"})
+
+	assert.Equal(t, provider.ProviderGoogleCloud, got.Provider)
+	assert.Equal(t, "my-project", got.ProjectID)
+}
+
+func TestGuiService(t *testing.T) {
+	t.Parallel()
+
+	// The canonical subgroup names map to their service identifier; anything else
+	// (group level, unknown) carries no specific service.
+	assert.Equal(t, "param", guiService("param"))
+	assert.Equal(t, "secret", guiService("secret"))
+	assert.Empty(t, guiService("azure"))
+	assert.Empty(t, guiService(""))
+	assert.Empty(t, guiService("stage"))
+}
+
+// TestRegisterGUIFlag_AttachesServiceSubgroups verifies --gui is attached to
+// Azure's param/secret subgroups (which carry the launched service), not only
+// to the provider group. It is the sole test touching the process-wide
+// commands.App (no other test reads or mutates it), so parallel execution is
+// safe.
+func TestRegisterGUIFlag_AttachesServiceSubgroups(t *testing.T) {
+	t.Parallel()
+
+	registerGUIFlag()
+
+	hasGUIFlag := func(c *cli.Command) bool {
+		for _, f := range c.Flags {
+			if slices.Contains(f.Names(), guiFlagName) {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	var azure *cli.Command
+
+	for _, group := range commands.App.Commands {
+		if group.Name == "azure" {
+			azure = group
+
+			break
+		}
+	}
+
+	require.NotNil(t, azure, "azure group must exist")
+	assert.True(t, hasGUIFlag(azure), "azure group carries --gui")
+
+	var sawParam, sawSecret bool
+
+	for _, sub := range azure.Commands {
+		switch sub.Name {
+		case "param":
+			sawParam = true
+
+			assert.True(t, hasGUIFlag(sub), "azure param subgroup carries --gui")
+		case "secret":
+			sawSecret = true
+
+			assert.True(t, hasGUIFlag(sub), "azure secret subgroup carries --gui")
+		}
+	}
+
+	assert.True(t, sawParam, "azure param subgroup must exist")
+	assert.True(t, sawSecret, "azure secret subgroup must exist")
+}

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -77,6 +77,13 @@ type App struct {
 	// via InitialProvider for the initial selection.
 	initialProvider provider.Provider
 
+	// initialService is the service the GUI was launched with ("param" or
+	// "secret"), captured from the subcommand carrying `--gui` (e.g.
+	// `suve azure param --gui`). Empty means no specific service (launched at the
+	// group level or bare). Surfaced to the frontend via InitialService so it can
+	// open the matching view.
+	initialService string
+
 	// scope is the current read/write provider scope, selected from the
 	// frontend via SelectScope. Guarded by scopeMu.
 	scope   provider.Scope
@@ -95,13 +102,15 @@ type App struct {
 	stagingStoreMu sync.Mutex // protects stagingStore + stagingStores
 }
 
-// NewApp creates a new App with the given initial launch scope. Empty resource
-// fields on the scope are hydrated from the ambient environment, so an explicit
-// selection (e.g. from a --project / --vault-name / --store-name flag) wins,
-// while an unset one still falls back to env.
-func NewApp(initial provider.Scope) *App {
+// NewApp creates a new App with the given initial launch scope and service.
+// Empty resource fields on the scope are hydrated from the ambient environment,
+// so an explicit selection (e.g. from a --project / --vault-name / --store-name
+// flag) wins, while an unset one still falls back to env. service is the launch
+// service ("param"/"secret", or "" for none) surfaced via InitialService.
+func NewApp(initial provider.Scope, service string) *App {
 	return &App{
 		initialProvider: initial.Provider,
+		initialService:  service,
 		scope:           hydrateScope(initial),
 	}
 }
@@ -142,6 +151,13 @@ func hydrateScope(s provider.Scope) provider.Scope {
 // explicit `--gui` provider was chosen), so the frontend can pre-select it.
 func (a *App) InitialProvider() string {
 	return string(a.initialProvider)
+}
+
+// InitialService returns the service the GUI was launched with ("param" or
+// "secret"), or "" when no specific service was chosen (group-level or bare
+// `--gui`), so the frontend can open the matching view.
+func (a *App) InitialService() string {
+	return a.initialService
 }
 
 // Startup is called when the app starts.

--- a/internal/gui/app_internal_test.go
+++ b/internal/gui/app_internal_test.go
@@ -27,10 +27,23 @@ func TestErrInvalidService(t *testing.T) {
 func TestNewApp(t *testing.T) {
 	t.Parallel()
 
-	app := NewApp(provider.Scope{Provider: provider.ProviderAWS})
+	app := NewApp(provider.Scope{Provider: provider.ProviderAWS}, "")
 	assert.NotNil(t, app)
 	// Verify the staging store is nil (lazy initialization).
 	assert.Nil(t, app.stagingStore)
+}
+
+func TestNewApp_InitialService(t *testing.T) {
+	t.Parallel()
+
+	// The launched service is surfaced verbatim via InitialService.
+	assert.Equal(t, "param",
+		NewApp(provider.Scope{Provider: provider.ProviderAzure}, "param").InitialService())
+	assert.Equal(t, "secret",
+		NewApp(provider.Scope{Provider: provider.ProviderAzure}, "secret").InitialService())
+	// A group-level / bare launch carries no specific service.
+	assert.Empty(t,
+		NewApp(provider.Scope{Provider: provider.ProviderAzure}, "").InitialService())
 }
 
 func TestHydrateScope_FlagWinsElseEnv(t *testing.T) {
@@ -38,13 +51,16 @@ func TestHydrateScope_FlagWinsElseEnv(t *testing.T) {
 	t.Setenv("GOOGLE_CLOUD_PROJECT", "env-project")
 	t.Setenv("AZURE_KEYVAULT_NAME", "env-vault")
 	t.Setenv("AZURE_APPCONFIG_NAME", "env-store")
+	t.Setenv("AZURE_APPCONFIG_NAMESPACE", "env-ns")
 
 	// Flag-supplied values win over the environment.
 	gc := hydrateScope(provider.Scope{Provider: provider.ProviderGoogleCloud, ProjectID: "flag-project"})
 	assert.Equal(t, "flag-project", gc.ProjectID)
 
-	az := hydrateScope(provider.Scope{Provider: provider.ProviderAzure, VaultName: "flag-vault"})
+	az := hydrateScope(provider.Scope{Provider: provider.ProviderAzure, VaultName: "flag-vault", AppConfigNamespace: "flag-ns"})
 	assert.Equal(t, "flag-vault", az.VaultName)
+	// The namespace flag wins over AZURE_APPCONFIG_NAMESPACE.
+	assert.Equal(t, "flag-ns", az.AppConfigNamespace)
 	// The unset side still falls back to env.
 	assert.Equal(t, "env-store", az.StoreName)
 
@@ -53,6 +69,8 @@ func TestHydrateScope_FlagWinsElseEnv(t *testing.T) {
 	azEnv := hydrateScope(provider.Scope{Provider: provider.ProviderAzure})
 	assert.Equal(t, "env-vault", azEnv.VaultName)
 	assert.Equal(t, "env-store", azEnv.StoreName)
+	// The namespace falls back to AZURE_APPCONFIG_NAMESPACE when the flag is unset.
+	assert.Equal(t, "env-ns", azEnv.AppConfigNamespace)
 
 	// AWS carries no resource field (region from ambient config).
 	assert.Equal(t, provider.Scope{Provider: provider.ProviderAWS}, hydrateScope(provider.Scope{Provider: provider.ProviderAWS}))
@@ -61,7 +79,7 @@ func TestHydrateScope_FlagWinsElseEnv(t *testing.T) {
 func TestApp_Startup(t *testing.T) {
 	t.Parallel()
 
-	app := NewApp(provider.Scope{Provider: provider.ProviderAWS})
+	app := NewApp(provider.Scope{Provider: provider.ProviderAWS}, "")
 	assert.Nil(t, app.ctx)
 
 	app.Startup(t.Context())

--- a/internal/gui/frontend/src/App.svelte
+++ b/internal/gui/frontend/src/App.svelte
@@ -6,6 +6,7 @@
     GetAWSIdentity,
     GetCurrentScope,
     InitialProvider,
+    InitialService,
     SelectScope,
     StagingStatus,
   } from '../wailsjs/go/gui/App';
@@ -114,6 +115,14 @@
         picked = uniqueActiveProvider(detected);
       }
 
+      // The launched service (from e.g. `suve azure param --gui`) selects the
+      // initial view. effectiveView clamps it to a service the provider actually
+      // offers, so an empty/unsupported value falls back to the default.
+      const launchedService = await withRetry(() => InitialService());
+      if (launchedService === 'param' || launchedService === 'secret') {
+        activeView = launchedService;
+      }
+
       if (picked) {
         await handleSelectProvider(picked);
       }
@@ -133,16 +142,26 @@
     return only ?? '';
   }
 
-  // buildSelection assembles the auto-apply candidate from the best prefill
-  // source (localStorage-cached scope, else the backend's env-derived scope).
+  // buildSelection assembles the auto-apply candidate for provider p.
+  //
+  // Launch wins, cache fills gaps: the launch-derived backend scope (from --gui
+  // flags + env, via GetCurrentScope) takes precedence PER FIELD, and the
+  // localStorage cache only supplies fields the launch left empty. This keeps
+  // `AZURE_APPCONFIG_NAMESPACE=dev` / `--namespace dev` (and --vault-name /
+  // --store-name / --project) authoritative over a stale cache, while a bare
+  // `suve --gui` (launch scope has only the provider) still restores the cached
+  // resource fields.
   function buildSelection(p: string): gui.ScopeSelection {
-    const src = readCachedScope(p) ?? (scope?.provider === p ? scope : null);
+    const cached = readCachedScope(p);
+    const launch = scope?.provider === p ? scope : null;
+    const pick = (field: keyof gui.ScopeSelection): string =>
+      (launch?.[field] || cached?.[field] || '') as string;
     return {
       provider: p,
-      projectId: p === 'googlecloud' ? (src?.projectId ?? '') : '',
-      vaultName: p === 'azure' ? (src?.vaultName ?? '') : '',
-      storeName: p === 'azure' ? (src?.storeName ?? '') : '',
-      namespace: p === 'azure' ? (src?.namespace ?? '') : '',
+      projectId: p === 'googlecloud' ? pick('projectId') : '',
+      vaultName: p === 'azure' ? pick('vaultName') : '',
+      storeName: p === 'azure' ? pick('storeName') : '',
+      namespace: p === 'azure' ? pick('namespace') : '',
     } as gui.ScopeSelection;
   }
 

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -156,6 +156,9 @@ export interface MockState {
   // Provider selection (multi-cloud). Defaults describe an AWS-only environment
   // so existing AWS specs are unaffected.
   initialProvider: string;
+  // initialService is the launched service ('param'/'secret', or '' for none),
+  // mirroring the Go App.InitialService binding. Drives the initial view.
+  initialService: string;
   currentScope: ScopeSelection;
   detectResult: DetectResult;
   capabilities: ProviderCapability[];
@@ -323,6 +326,7 @@ export const defaultMockState: MockState = {
     tags: [],
   },
   initialProvider: 'aws',
+  initialService: '',
   currentScope: awsScopeSelection,
   detectResult: awsOnlyDetectResult,
   capabilities: defaultCapabilities,
@@ -793,6 +797,7 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
       DetectProviders: async () => state.detectResult,
       Capabilities: async () => state.capabilities,
       InitialProvider: async () => state.initialProvider,
+      InitialService: async () => state.initialService,
       GetCurrentScope: async () => state.currentScope,
       SelectScope: async (sel: any) => {
         calls.push('SelectScope');

--- a/internal/gui/frontend/tests/launch-context.spec.ts
+++ b/internal/gui/frontend/tests/launch-context.spec.ts
@@ -1,0 +1,158 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  setupWailsMocks,
+  createAzureState,
+  createAzureNamespaceState,
+  getSelectScopeCalls,
+  waitForItemList,
+} from './fixtures/wails-mock';
+
+// GUI launch-context (--gui) coverage:
+//   Bug 1 — launch scope (flags + env) must win over a stale localStorage cache
+//           per field, and the footer Namespace dropdown must seed from the
+//           effective (launch) namespace on the initial connect.
+//   Bug 2 — the launched service (param|secret, via InitialService) must select
+//           the initial view.
+
+const nav = (page: Page) => page.locator('.nav');
+const nsSelect = (page: Page) => page.locator('.sidebar .namespace-select');
+
+// Seed a localStorage-cached scope for a provider BEFORE the app boots, so
+// buildSelection sees it as the cache source.
+async function seedCachedScope(
+  page: Page,
+  provider: string,
+  scope: Record<string, string>
+): Promise<void> {
+  await page.addInitScript(
+    ({ key, value }) => {
+      localStorage.setItem(key, value);
+    },
+    { key: `suve.scope.${provider}`, value: JSON.stringify({ provider, ...scope }) }
+  );
+}
+
+test.describe('GUI launch context (--gui)', () => {
+  test.describe('Bug 1 — launch scope wins over the cache', () => {
+    test('namespace from the launch scope seeds the footer dropdown (no cache)', async ({
+      page,
+    }) => {
+      // Launch scope carries namespace `dev` (as AZURE_APPCONFIG_NAMESPACE=dev /
+      // --namespace dev would); no localStorage cache exists.
+      await setupWailsMocks(
+        page,
+        createAzureNamespaceState({
+          currentScope: {
+            provider: 'azure',
+            projectId: '',
+            vaultName: 'my-vault',
+            storeName: 'my-store',
+            namespace: 'dev',
+          },
+        })
+      );
+      await page.goto('/');
+      await waitForItemList(page);
+
+      // The footer Namespace dropdown defaults to the launch namespace, not (NULL).
+      await expect(nsSelect(page)).toHaveValue('dev');
+    });
+
+    test('launch scope beats a stale cache, per field', async ({ page }) => {
+      // Stale cache points at different vault/store and an empty namespace.
+      await seedCachedScope(page, 'azure', {
+        projectId: '',
+        vaultName: 'cached-vault',
+        storeName: 'cached-store',
+        namespace: '',
+      });
+      // Launch scope (backend) carries the authoritative values.
+      await setupWailsMocks(
+        page,
+        createAzureNamespaceState({
+          currentScope: {
+            provider: 'azure',
+            projectId: '',
+            vaultName: 'my-vault',
+            storeName: 'my-store',
+            namespace: 'dev',
+          },
+        })
+      );
+      await page.goto('/');
+      await waitForItemList(page);
+
+      // The auto-applied SelectScope uses the launch values, field by field —
+      // the cache did not override them.
+      const calls = await getSelectScopeCalls(page);
+      expect(calls.length).toBeGreaterThan(0);
+      expect(calls[0]).toMatchObject({
+        provider: 'azure',
+        vaultName: 'my-vault',
+        storeName: 'my-store',
+        namespace: 'dev',
+      });
+      await expect(nsSelect(page)).toHaveValue('dev');
+    });
+
+    test('bare launch (empty launch fields) restores the cached scope', async ({ page }) => {
+      // Cache holds the last-used Azure scope.
+      await seedCachedScope(page, 'azure', {
+        projectId: '',
+        vaultName: 'cached-vault',
+        storeName: 'cached-store',
+        namespace: 'cached-ns',
+      });
+      // Bare `suve --gui`: backend scope has the provider but empty resource
+      // fields (nothing on the command line, nothing in env).
+      await setupWailsMocks(
+        page,
+        createAzureState({
+          currentScope: {
+            provider: 'azure',
+            projectId: '',
+            vaultName: '',
+            storeName: '',
+            namespace: '',
+          },
+        })
+      );
+      await page.goto('/');
+      await waitForItemList(page);
+
+      // The cache fills every gap the empty launch left.
+      const calls = await getSelectScopeCalls(page);
+      expect(calls.length).toBeGreaterThan(0);
+      expect(calls[0]).toMatchObject({
+        provider: 'azure',
+        vaultName: 'cached-vault',
+        storeName: 'cached-store',
+        namespace: 'cached-ns',
+      });
+    });
+  });
+
+  test.describe('Bug 2 — InitialService selects the initial view', () => {
+    test('InitialService=secret opens the Key Vault view', async ({ page }) => {
+      await setupWailsMocks(page, createAzureState({ initialService: 'secret' }));
+      await page.goto('/');
+      await waitForItemList(page);
+
+      const kvTab = nav(page).getByRole('button', { name: /Key Vault/i });
+      await expect(kvTab).toHaveClass(/active/);
+      // The App Configuration (param) tab exists but is NOT the active one.
+      await expect(nav(page).getByRole('button', { name: /App Configuration/i })).not.toHaveClass(
+        /active/
+      );
+    });
+
+    test('InitialService=param opens the App Configuration view', async ({ page }) => {
+      await setupWailsMocks(page, createAzureState({ initialService: 'param' }));
+      await page.goto('/');
+      await waitForItemList(page);
+
+      const acTab = nav(page).getByRole('button', { name: /App Configuration/i });
+      await expect(acTab).toHaveClass(/active/);
+    });
+  });
+});

--- a/internal/gui/frontend/wailsjs/go/gui/App.d.ts
+++ b/internal/gui/frontend/wailsjs/go/gui/App.d.ts
@@ -12,6 +12,8 @@ export function GetCurrentScope():Promise<gui.ScopeSelection>;
 
 export function InitialProvider():Promise<string>;
 
+export function InitialService():Promise<string>;
+
 export function ParamAddTag(arg1:string,arg2:string,arg3:string):Promise<void>;
 
 export function ParamDelete(arg1:string):Promise<gui.ParamDeleteResult>;

--- a/internal/gui/frontend/wailsjs/go/gui/App.js
+++ b/internal/gui/frontend/wailsjs/go/gui/App.js
@@ -22,6 +22,10 @@ export function InitialProvider() {
   return window['go']['gui']['App']['InitialProvider']();
 }
 
+export function InitialService() {
+  return window['go']['gui']['App']['InitialService']();
+}
+
 export function ParamAddTag(arg1, arg2, arg3) {
   return window['go']['gui']['App']['ParamAddTag'](arg1, arg2, arg3);
 }

--- a/internal/gui/run.go
+++ b/internal/gui/run.go
@@ -10,11 +10,13 @@ import (
 	"github.com/mpyw/suve/internal/provider"
 )
 
-// Run starts the GUI application with the given initial launch scope. A zero
-// Provider means "no explicit choice" — the frontend falls back to env
-// detection; a set Provider (with optional resource fields) pre-selects it.
-func Run(initial provider.Scope) error {
-	app := NewApp(initial)
+// Run starts the GUI application with the given initial launch scope and
+// service. A zero Provider means "no explicit choice" — the frontend falls back
+// to env detection; a set Provider (with optional resource fields) pre-selects
+// it. service ("param"/"secret", or "" for none) is the launched service the
+// frontend opens on.
+func Run(initial provider.Scope, service string) error {
+	app := NewApp(initial, service)
 
 	opts := &options.App{
 		Title:  "suve",

--- a/internal/gui/scope_internal_test.go
+++ b/internal/gui/scope_internal_test.go
@@ -79,7 +79,7 @@ func TestApp_SelectScope(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			app := NewApp(provider.Scope{Provider: provider.ProviderAWS})
+			app := NewApp(provider.Scope{Provider: provider.ProviderAWS}, "")
 
 			err := app.SelectScope(tt.sel)
 			if tt.wantErr != nil {
@@ -132,7 +132,7 @@ func TestApp_GetCurrentScope_RoundTrip(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			app := NewApp(provider.Scope{Provider: provider.ProviderAWS})
+			app := NewApp(provider.Scope{Provider: provider.ProviderAWS}, "")
 			require.NoError(t, app.SelectScope(tt.sel))
 
 			got := app.GetCurrentScope()
@@ -150,7 +150,7 @@ func TestApp_GetCurrentScope_RoundTrip(t *testing.T) {
 func TestApp_GetCurrentScope_EnvDerivedInitialScope(t *testing.T) {
 	t.Setenv("GOOGLE_CLOUD_PROJECT", "env-project")
 
-	app := NewApp(provider.Scope{Provider: provider.ProviderGoogleCloud})
+	app := NewApp(provider.Scope{Provider: provider.ProviderGoogleCloud}, "")
 
 	got := app.GetCurrentScope()
 	require.NotNil(t, got)
@@ -163,7 +163,7 @@ func TestApp_GetCurrentScope_EnvDerivedAzure(t *testing.T) {
 	t.Setenv("AZURE_APPCONFIG_NAME", "env-store")
 	t.Setenv("AZURE_APPCONFIG_NAMESPACE", "env-ns")
 
-	app := NewApp(provider.Scope{Provider: provider.ProviderAzure})
+	app := NewApp(provider.Scope{Provider: provider.ProviderAzure}, "")
 
 	got := app.GetCurrentScope()
 	require.NotNil(t, got)
@@ -181,7 +181,7 @@ func TestApp_GetCurrentScope_EnvDerivedAzure_Namespace(t *testing.T) {
 	t.Setenv("AZURE_APPCONFIG_NAME", "env-store")
 	t.Setenv("AZURE_APPCONFIG_NAMESPACE", "dev")
 
-	app := NewApp(provider.Scope{Provider: provider.ProviderAzure})
+	app := NewApp(provider.Scope{Provider: provider.ProviderAzure}, "")
 
 	got := app.GetCurrentScope()
 	require.NotNil(t, got)
@@ -195,7 +195,7 @@ func TestApp_GetCurrentScope_ExplicitNamespaceWinsOverEnv(t *testing.T) {
 	t.Setenv("AZURE_APPCONFIG_NAME", "env-store")
 	t.Setenv("AZURE_APPCONFIG_NAMESPACE", "env-ns")
 
-	app := NewApp(provider.Scope{Provider: provider.ProviderAzure, AppConfigNamespace: "flag-ns"})
+	app := NewApp(provider.Scope{Provider: provider.ProviderAzure, AppConfigNamespace: "flag-ns"}, "")
 
 	got := app.GetCurrentScope()
 	require.NotNil(t, got)
@@ -210,7 +210,7 @@ func TestApp_GetCurrentScope_EnvDerivedAzure_VaultOnly(t *testing.T) {
 	t.Setenv("AZURE_KEYVAULT_NAME", "env-vault")
 	t.Setenv("AZURE_APPCONFIG_NAME", "")
 
-	app := NewApp(provider.Scope{Provider: provider.ProviderAzure})
+	app := NewApp(provider.Scope{Provider: provider.ProviderAzure}, "")
 
 	got := app.GetCurrentScope()
 	require.NotNil(t, got)
@@ -225,7 +225,7 @@ func TestApp_GetCurrentScope_EnvDerivedAzure_StoreOnly(t *testing.T) {
 	t.Setenv("AZURE_KEYVAULT_NAME", "")
 	t.Setenv("AZURE_APPCONFIG_NAME", "env-store")
 
-	app := NewApp(provider.Scope{Provider: provider.ProviderAzure})
+	app := NewApp(provider.Scope{Provider: provider.ProviderAzure}, "")
 
 	got := app.GetCurrentScope()
 	require.NotNil(t, got)

--- a/internal/gui/staging_integration_internal_test.go
+++ b/internal/gui/staging_integration_internal_test.go
@@ -24,7 +24,7 @@ import (
 func setupTestApp(t *testing.T) *App {
 	t.Helper()
 
-	app := NewApp(provider.Scope{Provider: provider.ProviderAWS})
+	app := NewApp(provider.Scope{Provider: provider.ProviderAWS}, "")
 	app.Startup(t.Context())
 	app.stagingStore = testutil.NewMockStore()
 

--- a/internal/gui/staging_multiprovider_internal_test.go
+++ b/internal/gui/staging_multiprovider_internal_test.go
@@ -86,7 +86,7 @@ func TestApp_getStagingStore_ScopeKeyed(t *testing.T) {
 	t.Setenv("SUVE_STAGING_KEY", base64.StdEncoding.EncodeToString(make([]byte, 32)))
 	t.Setenv("HOME", t.TempDir())
 
-	app := NewApp(provider.Scope{Provider: provider.ProviderGoogleCloud})
+	app := NewApp(provider.Scope{Provider: provider.ProviderGoogleCloud}, "")
 	app.Startup(t.Context())
 	app.scope = provider.GoogleCloudScope("proj-a")
 


### PR DESCRIPTION
## Summary

Fixes two GUI launch-context (`--gui`) bugs on top of `gui-polish`.

### Bug 1 — launch scope was defeated by the localStorage cache
`App.svelte`'s `buildSelection(p)` preferred the localStorage-cached scope **wholesale** over the launch-derived backend scope (`GetCurrentScope`, built from `--gui` flags + env). A stale cache (e.g. empty namespace) therefore overrode `AZURE_APPCONFIG_NAMESPACE=dev` / `--namespace dev`, and likewise defeated `--vault-name` / `--store-name` / `--project`.

**Fix — launch wins, cache fills gaps (per field).** `buildSelection` now builds each field as `launchScope[field] || cachedScope[field]` (launch first, cache fallback) for `projectId` (gcloud) and `vaultName`/`storeName`/`namespace` (azure). A bare `suve --gui` (launch scope carries only the provider, empty resource fields) still restores the cache. localStorage persistence is unchanged.

**Namespace initial-seed:** the footer Namespace dropdown now defaults to the effective launch namespace. `resetNamespaceFilter` runs on the initial connect (via `applyScope`, after `GetCurrentScope`), so `AZURE_APPCONFIG_NAMESPACE=dev suve az param --gui` opens with the dropdown on `dev` (not `(NULL)`).

### Bug 2 — the launched service (param vs secret) was not carried
Only the provider was threaded (`InitialProvider`); the service was lost, so the GUI opened on its own default view.

**Fix — thread an initial service through the launch:**
- `cmd/suve/gui.go`: capture the subcommand's canonical service (`param`/`secret`) when `--gui` fires on an Azure `secret`/`param` subgroup; group-level (`suve azure --gui`) and bare (`suve --gui`) carry `""`. Aliases (`kv`/`keyvault`) resolve to the same subcommand, so keying off the subcommand identity is correct. Threaded through `launchGUI → gui.Run → NewApp`.
- `internal/gui/app.go`: store the initial service; expose `InitialService() string` (mirrors `InitialProvider`).
- `App.svelte` `onMount`: after the provider connects, navigate to the launched service's view; `effectiveView` clamps an empty/unsupported value back to the default.

## Tests
**Go unit** (`internal/gui/app_internal_test.go`, `cmd/suve/gui_test.go`):
- `hydrateScope` reads `AZURE_APPCONFIG_NAMESPACE` (namespace flag-wins-else-env).
- `NewApp`/`InitialService` returns the launched service.
- `guiScope` carries the namespace (+ gcloud project); `guiService` mapping; `registerGUIFlag` attaches `--gui` to Azure's `param`/`secret` subgroups.

**GUI Playwright** (`internal/gui/frontend/tests/launch-context.spec.ts`, 5 tests × 3 browsers = 15):
- launch namespace seeds the footer dropdown (no cache) → `dev`, not `(NULL)`;
- launch scope beats a stale cache, per field;
- bare launch (empty launch fields) restores the cached scope;
- `InitialService()` = `secret`/`param` → the Key Vault / App Configuration view is active on load.

The wails mock (`tests/fixtures/wails-mock.ts`) gains `initialService` + an `InitialService` binding.

## Verification
- `go build ./...`, `go build -tags production ./cmd/...` — pass.
- `go test ./...`; `go test -tags production ./internal/gui/... ./cmd/...` — pass.
- `golangci-lint run --allow-parallel-runners --build-tags=e2e,production ./internal/... ./cmd/...` — **0 issues**.
- Frontend: `npm run check` (0 errors), `npm run lint` (clean), `npm run test` (Playwright, 3 browsers). New `launch-context` spec 15/15. The formerly-flaky `Close`-button strict-mode specs (`version-history` close-diff-modal, `staging` apply-on-confirm, `ui-interaction`) now pass after rebasing onto the backdrop-`aria-label` fix (a3f411b). The pre-existing `[webkit] keyboard-focus.spec.ts` Tab-navigation flake may still appear intermittently (present on the base tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
