### PR TITLE
feat(cli): namespace column in App Config `param list` + --hide-namespace (#430)

### DIFF
--- a/e2e/azure_appconfig_test.go
+++ b/e2e/azure_appconfig_test.go
@@ -275,6 +275,29 @@ func TestAzureAppConfig_Namespace(t *testing.T) {
 		assert.Contains(t, allList, devOnly)
 	})
 
+	// The NAMESPACE column is on by default (#430): every row is prefixed with
+	// its namespace, "(NULL)" for the null namespace; --namespace "*" reveals the
+	// dev rows too; --hide-ns drops the column for the neutral key-only output.
+	t.Run("namespace-column", func(t *testing.T) {
+		// Default (null scope): the shared key is prefixed with "(NULL)".
+		nullList, err := runAzureParam(t, "list")
+		require.NoError(t, err)
+		assert.Contains(t, nullList, "(NULL)\t"+shared)
+
+		// --namespace "*" spans namespaces, so both the null and dev rows show,
+		// each carrying its own namespace label.
+		allList, err := runAzureParam(t, "list", "--namespace", "*")
+		require.NoError(t, err)
+		assert.Contains(t, allList, "(NULL)\t"+shared)
+		assert.Contains(t, allList, "dev\t"+devOnly)
+
+		// --hide-ns drops the column: no "(NULL)" prefix, just the bare key.
+		hidden, err := runAzureParam(t, "list", "--namespace", "*", "--hide-ns")
+		require.NoError(t, err)
+		assert.NotContains(t, hidden, "(NULL)")
+		assert.Contains(t, hidden, devOnly)
+	})
+
 	// A filter value (all/multiple) is rejected on a single-item op.
 	t.Run("wildcard-rejected-on-single-item", func(t *testing.T) {
 		_, err := runAzureParam(t, "show", "--raw", "--namespace", "*", shared)

--- a/internal/cli/commands/azure/param/list.go
+++ b/internal/cli/commands/azure/param/list.go
@@ -2,22 +2,145 @@ package param
 
 import (
 	"context"
+	"io"
 
+	"github.com/samber/lo"
 	"github.com/urfave/cli/v3"
 
 	genericlist "github.com/mpyw/suve/internal/cli/commands/generic/list"
 	cliinternal "github.com/mpyw/suve/internal/cli/commands/internal"
+	"github.com/mpyw/suve/internal/cli/output"
+	"github.com/mpyw/suve/internal/provider/azure/appconfig/aznamespace"
 	"github.com/mpyw/suve/internal/usecase/azure"
 )
 
+// namespaceJSONItem is one row of `--output=json` for the namespace-aware
+// listing. Namespace is the raw label ("" for the null namespace, matching the
+// GUI's per-entry namespace), NOT the "(NULL)" display form used in text.
+type namespaceJSONItem struct {
+	Namespace string  `json:"namespace"`
+	Name      string  `json:"name"`
+	Value     *string `json:"value,omitempty"`
+}
+
+// ListOptions holds the parsed flags for the App Configuration list command.
+type ListOptions struct {
+	Prefix string
+	Filter string
+	Show   bool
+	HideNS bool
+	Output output.Format
+}
+
+// ListRunner renders the Azure App Configuration listing. When Namespace is set
+// (the App Configuration default) it prepends a NAMESPACE column; --hide-namespace
+// — or the absence of the App-Config extension — falls through to KeyOnly, the
+// neutral key-only listing shared with every other provider.
+type ListRunner struct {
+	// Namespace produces per-(key, namespace) rows for the NAMESPACE column. Nil
+	// when the resolved store is not Azure App Configuration.
+	Namespace *azure.ListNamespacesUseCase
+	// KeyOnly produces the neutral, deduped key-only listing (the --hide-namespace
+	// fallback), honoring the store's namespace filter via Reader.List.
+	KeyOnly *azure.ListUseCase
+	Stdout  io.Writer
+	Stderr  io.Writer
+}
+
+// Run executes the listing in the mode selected by opts.
+func (r *ListRunner) Run(ctx context.Context, opts ListOptions) error {
+	if opts.HideNS || r.Namespace == nil {
+		return r.runKeyOnly(ctx, opts)
+	}
+
+	return r.runNamespaced(ctx, opts)
+}
+
+// runKeyOnly reuses the shared generic list renderer so --hide-namespace output
+// is byte-for-byte the neutral listing.
+func (r *ListRunner) runKeyOnly(ctx context.Context, opts ListOptions) error {
+	input := azure.ListInput{Prefix: opts.Prefix, Filter: opts.Filter, WithValue: opts.Show}
+
+	runner := &genericlist.Runner{
+		List: func(ctx context.Context) ([]genericlist.Entry, error) {
+			result, err := r.KeyOnly.Execute(ctx, input)
+			if err != nil {
+				return nil, err
+			}
+
+			entries := make([]genericlist.Entry, len(result.Entries))
+			for i, e := range result.Entries {
+				entries[i] = genericlist.Entry{Name: e.Name, Value: e.Value, Error: e.Error}
+			}
+
+			return entries, nil
+		},
+		Options: genericlist.Options{Show: opts.Show, Output: opts.Output},
+		Stdout:  r.Stdout,
+		Stderr:  r.Stderr,
+	}
+
+	return runner.Run(ctx)
+}
+
+// runNamespaced renders the NAMESPACE column (text: <namespace>TAB<key>[TAB<value>];
+// json: {namespace, name, value?}). The null namespace shows as "(NULL)" in text
+// but stays "" in JSON so machine consumers see the raw label.
+func (r *ListRunner) runNamespaced(ctx context.Context, opts ListOptions) error {
+	result, err := r.Namespace.Execute(ctx, azure.ListNamespacesInput{
+		Prefix: opts.Prefix, Filter: opts.Filter, WithValue: opts.Show,
+	})
+	if err != nil {
+		return err
+	}
+
+	if opts.Output == output.FormatJSON {
+		items := make([]namespaceJSONItem, len(result.Entries))
+		for i, e := range result.Entries {
+			items[i] = namespaceJSONItem{Namespace: e.Namespace, Name: e.Name, Value: e.Value}
+		}
+
+		return output.WriteJSON(r.Stdout, items)
+	}
+
+	for _, e := range result.Entries {
+		ns := e.Namespace
+		if ns == "" {
+			ns = aznamespace.NullDisplay
+		}
+
+		if opts.Show {
+			output.Printf(r.Stdout, "%s\t%s\t%s\n", ns, e.Name, lo.FromPtr(e.Value))
+		} else {
+			output.Printf(r.Stdout, "%s\t%s\n", ns, e.Name)
+		}
+	}
+
+	return nil
+}
+
 // ListCommand returns the Azure App Configuration list command.
+//
+// Unlike the other providers it does NOT use the generic list scaffold: App
+// Configuration keys live in namespaces (the label axis), so by default the
+// listing prepends a NAMESPACE column (#430). The default scope is the null
+// namespace — matching the GUI's default filter — so every row reads "(NULL)"
+// until `--namespace "*"` (or a specific/OR filter) widens it. `--hide-namespace`
+// drops the column and falls back to the neutral key-only listing.
 func ListCommand() *cli.Command {
-	return genericlist.Command(genericlist.Config{
+	return &cli.Command{
+		Name:      "list",
+		Aliases:   []string{"ls"},
 		Usage:     "List settings",
 		ArgsUsage: "[filter-prefix]",
 		Description: `List settings (key-values) in Azure App Configuration.
 
-Without a filter prefix, lists all keys in the store.
+Each row is prefixed with the setting's NAMESPACE (the label axis; Azure calls
+it a "label"); "(NULL)" is the null/default namespace. The listing is scoped by
+--namespace: with no flag it shows the null namespace only (so every row reads
+"(NULL)"), "*" shows all namespaces, and "dev,prd"/"dev*" filter by OR/prefix.
+
+Without a filter prefix, lists all keys in the (namespace-)scoped store.
 With a filter prefix, lists only keys that start with that prefix.
 
 FILTERING:
@@ -25,13 +148,18 @@ FILTERING:
 
 VALUE DISPLAY:
    Use --show to display setting values alongside keys.
-   Output format: <key><TAB><value>
+   Output format: <namespace><TAB><key><TAB><value>
+
+NAMESPACE COLUMN:
+   Use --hide-namespace (--hide-ns) to drop the NAMESPACE column and list keys
+   only (the neutral, pipe-friendly output).
 
 EXAMPLES:
-   suve azure param list                     List all settings
-   suve azure param list app/                List settings starting with "app/"
-   suve azure param list --show app/         List with values
-   suve azure param list --output=json app/  List as JSON`,
+   suve azure param list                      List the null namespace
+   suve azure param list --namespace '*'      List across all namespaces
+   suve azure param list --hide-ns app/       List keys only, no namespace column
+   suve azure param list --show app/          List with values
+   suve azure param list --output=json app/   List as JSON (namespace field)`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "filter",
@@ -45,35 +173,41 @@ EXAMPLES:
 				Name:  "output",
 				Usage: "Output format: text (default) or json",
 			},
+			&cli.BoolFlag{
+				Name:    "hide-namespace",
+				Aliases: []string{"hide-ns"},
+				Usage:   "Drop the NAMESPACE column and list keys only",
+			},
 		},
-		NewList: func(
-			ctx context.Context, cmd *cli.Command, withValue bool,
-		) (func(context.Context) ([]genericlist.Entry, error), error) {
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			outputFormat, err := output.ParseFormat(cmd.String("output"))
+			if err != nil {
+				return err
+			}
+
 			store, err := cliinternal.AzureAppConfigStore(ctx)
 			if err != nil {
-				return nil, err
+				return err
 			}
 
-			uc := &azure.ListUseCase{Reader: store}
-			input := azure.ListInput{
-				Prefix:    cmd.Args().First(),
-				Filter:    cmd.String("filter"),
-				WithValue: withValue,
+			runner := &ListRunner{
+				KeyOnly: &azure.ListUseCase{Reader: store},
+				Stdout:  cmd.Root().Writer,
+				Stderr:  cmd.Root().ErrWriter,
+			}
+			// Only the App Configuration store implements the namespace extension;
+			// a store that does not keep the NAMESPACE column off entirely.
+			if lister, ok := store.(azure.NamespaceLister); ok {
+				runner.Namespace = &azure.ListNamespacesUseCase{Lister: lister}
 			}
 
-			return func(ctx context.Context) ([]genericlist.Entry, error) {
-				result, err := uc.Execute(ctx, input)
-				if err != nil {
-					return nil, err
-				}
-
-				entries := make([]genericlist.Entry, len(result.Entries))
-				for i, e := range result.Entries {
-					entries[i] = genericlist.Entry{Name: e.Name, Value: e.Value, Error: e.Error}
-				}
-
-				return entries, nil
-			}, nil
+			return runner.Run(ctx, ListOptions{
+				Prefix: cmd.Args().First(),
+				Filter: cmd.String("filter"),
+				Show:   cmd.Bool("show"),
+				HideNS: cmd.Bool("hide-namespace"),
+				Output: outputFormat,
+			})
 		},
-	})
+	}
 }

--- a/internal/cli/commands/azure/param/param_test.go
+++ b/internal/cli/commands/azure/param/param_test.go
@@ -11,8 +11,10 @@ import (
 	appcli "github.com/mpyw/suve/internal/cli/commands"
 	"github.com/mpyw/suve/internal/cli/commands/azure/param"
 	genericlog "github.com/mpyw/suve/internal/cli/commands/generic/log"
+	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/azure/appconfig"
 	"github.com/mpyw/suve/internal/provider/providermock"
 	"github.com/mpyw/suve/internal/usecase/azure"
 	"github.com/mpyw/suve/internal/version/azureappconfigversion"
@@ -186,4 +188,102 @@ func TestDeleteRunner(t *testing.T) {
 	require.NoError(t, r.Run(t.Context(), param.DeleteOptions{Name: "app/timeout"}))
 	assert.Equal(t, "app/timeout", deleted)
 	assert.Contains(t, buf.String(), "Deleted setting app/timeout")
+}
+
+// namespaceListerStub is the App-Config-specific lister the namespaced list
+// path depends on.
+type namespaceListerStub struct {
+	rows []appconfig.KeyNamespace
+}
+
+func (s *namespaceListerStub) ListWithNamespacesScoped(_ context.Context) ([]appconfig.KeyNamespace, error) {
+	return s.rows, nil
+}
+
+func nsListRunner(rows []appconfig.KeyNamespace, keyOnlyReader provider.Reader, out, errOut *bytes.Buffer) *param.ListRunner {
+	return &param.ListRunner{
+		Namespace: &azure.ListNamespacesUseCase{Lister: &namespaceListerStub{rows: rows}},
+		KeyOnly:   &azure.ListUseCase{Reader: keyOnlyReader},
+		Stdout:    out,
+		Stderr:    errOut,
+	}
+}
+
+func TestListRunner_NamespaceColumn(t *testing.T) {
+	t.Parallel()
+
+	rows := []appconfig.KeyNamespace{
+		{Key: "app/a", Namespace: "", Value: "a-null"},
+		{Key: "app/a", Namespace: "dev", Value: "a-dev"},
+	}
+
+	t.Run("default prepends NAMESPACE column and renders null as (NULL)", func(t *testing.T) {
+		t.Parallel()
+
+		var buf, errBuf bytes.Buffer
+
+		r := nsListRunner(rows, nil, &buf, &errBuf)
+		require.NoError(t, r.Run(t.Context(), param.ListOptions{}))
+		assert.Equal(t, "(NULL)\tapp/a\ndev\tapp/a\n", buf.String())
+	})
+
+	t.Run("--show appends the value column", func(t *testing.T) {
+		t.Parallel()
+
+		var buf, errBuf bytes.Buffer
+
+		r := nsListRunner(rows, nil, &buf, &errBuf)
+		require.NoError(t, r.Run(t.Context(), param.ListOptions{Show: true}))
+		assert.Equal(t, "(NULL)\tapp/a\ta-null\ndev\tapp/a\ta-dev\n", buf.String())
+	})
+
+	t.Run("json carries the raw namespace (empty, not (NULL))", func(t *testing.T) {
+		t.Parallel()
+
+		var buf, errBuf bytes.Buffer
+
+		r := nsListRunner(rows, nil, &buf, &errBuf)
+		require.NoError(t, r.Run(t.Context(), param.ListOptions{Output: output.FormatJSON}))
+		assert.JSONEq(t, `[{"namespace":"","name":"app/a"},{"namespace":"dev","name":"app/a"}]`, buf.String())
+	})
+}
+
+func TestListRunner_HideNamespace(t *testing.T) {
+	t.Parallel()
+
+	// --hide-namespace falls back to the neutral key-only listing (Reader.List),
+	// so no NAMESPACE column appears and keys are deduped by the provider.
+	reader := &providermock.Store{
+		ListFunc: func(_ context.Context) ([]string, error) {
+			return []string{"app/a", "app/b"}, nil
+		},
+	}
+
+	var buf, errBuf bytes.Buffer
+
+	r := nsListRunner(nil, reader, &buf, &errBuf)
+	require.NoError(t, r.Run(t.Context(), param.ListOptions{HideNS: true}))
+	assert.Equal(t, "app/a\napp/b\n", buf.String())
+}
+
+func TestListRunner_NonAppConfigNoColumn(t *testing.T) {
+	t.Parallel()
+
+	// A store without the App-Config extension leaves Namespace nil, so the
+	// NAMESPACE column never appears even without --hide-namespace.
+	reader := &providermock.Store{
+		ListFunc: func(_ context.Context) ([]string, error) {
+			return []string{"k1", "k2"}, nil
+		},
+	}
+
+	var buf, errBuf bytes.Buffer
+
+	r := &param.ListRunner{
+		KeyOnly: &azure.ListUseCase{Reader: reader},
+		Stdout:  &buf,
+		Stderr:  &errBuf,
+	}
+	require.NoError(t, r.Run(t.Context(), param.ListOptions{}))
+	assert.Equal(t, "k1\nk2\n", buf.String())
 }

--- a/internal/provider/azure/appconfig/appconfig.go
+++ b/internal/provider/azure/appconfig/appconfig.go
@@ -193,9 +193,25 @@ type KeyNamespace struct {
 // provider.Reader.List contract untouched. A key that exists under several
 // namespaces yields one entry per (key, namespace) pair.
 func (s *Store) ListWithNamespaces(ctx context.Context) ([]KeyNamespace, error) {
-	settings, err := s.client.ListSettings(ctx, aznamespace.AllNamespacesFilter)
+	return s.listWithNamespaces(ctx, aznamespace.AllNamespacesFilter, "across namespaces")
+}
+
+// ListWithNamespacesScoped returns per-(key, namespace) rows HONORING the
+// store's configured --namespace filter (empty -> the null namespace only, "*"
+// -> all, "dev,prd" -> OR, "dev*" -> prefix), sorted by key then namespace. It
+// is the filter-respecting sibling of ListWithNamespaces (which forces "*"):
+// the CLI `param list` NAMESPACE column (#430) uses it so `param list` defaults
+// to the null namespace, matching the GUI's default filter, while `--namespace
+// "*"` widens to every namespace. Like ListWithNamespaces it is an
+// App-Config-specific extension, not part of the neutral provider seam.
+func (s *Store) ListWithNamespacesScoped(ctx context.Context) ([]KeyNamespace, error) {
+	return s.listWithNamespaces(ctx, aznamespace.Filter(s.namespace), "with namespaces")
+}
+
+func (s *Store) listWithNamespaces(ctx context.Context, filter, what string) ([]KeyNamespace, error) {
+	settings, err := s.client.ListSettings(ctx, filter)
 	if err != nil {
-		return nil, fmt.Errorf("failed to list settings across namespaces: %w", err)
+		return nil, fmt.Errorf("failed to list settings %s: %w", what, err)
 	}
 
 	out := make([]KeyNamespace, 0, len(settings))
@@ -215,7 +231,7 @@ func (s *Store) ListWithNamespaces(ctx context.Context) ([]KeyNamespace, error) 
 		return out[i].Namespace < out[j].Namespace
 	})
 
-	debug.From(ctx).Logf("azure appconfig: ListWithNamespaces -> %d settings across all namespaces\n", len(out))
+	debug.From(ctx).Logf("azure appconfig: listWithNamespaces(filter=%q) -> %d settings\n", filter, len(out))
 
 	return out, nil
 }

--- a/internal/provider/azure/appconfig/appconfig_test.go
+++ b/internal/provider/azure/appconfig/appconfig_test.go
@@ -362,6 +362,72 @@ func TestListWithNamespaces_Error(t *testing.T) {
 	assert.Contains(t, err.Error(), "list settings across namespaces")
 }
 
+func TestListWithNamespacesScoped(t *testing.T) {
+	t.Parallel()
+
+	settings := []azappconfig.Setting{
+		{Key: lo.ToPtr("beta"), Label: lo.ToPtr("prd"), Value: lo.ToPtr("bp")},
+		{Key: lo.ToPtr("alpha"), Value: lo.ToPtr("a-null")},
+		{Key: lo.ToPtr("alpha"), Label: lo.ToPtr("dev"), Value: lo.ToPtr("ad")},
+		{Key: lo.ToPtr("beta"), Value: lo.ToPtr("b-null")},
+	}
+
+	// The store namespace becomes the label filter verbatim, EXCEPT empty, which
+	// maps to the reserved null-label filter — this is what makes the default
+	// `param list` scope to the null namespace rather than "*".
+	for name, tc := range map[string]struct {
+		namespace  string
+		wantFilter string
+	}{
+		"null namespace uses the null-label filter": {namespace: "", wantFilter: "\x00"},
+		"single namespace forwarded":                {namespace: "dev", wantFilter: "dev"},
+		"all-namespaces wildcard forwarded":         {namespace: "*", wantFilter: "*"},
+		"OR-list forwarded":                         {namespace: "dev,prd", wantFilter: "dev,prd"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			var gotFilter string
+
+			m := &mockClient{
+				listFunc: func(_ context.Context, filter string) ([]azappconfig.Setting, error) {
+					gotFilter = filter
+
+					return settings, nil
+				},
+			}
+			store := appconfig.New(m, tc.namespace)
+
+			items, err := store.ListWithNamespacesScoped(t.Context())
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantFilter, gotFilter, "the store namespace must drive the label filter")
+			// The service applies the filter; the store only sorts by (key, namespace).
+			assert.Equal(t, []appconfig.KeyNamespace{
+				{Key: "alpha", Namespace: "", Value: "a-null"},
+				{Key: "alpha", Namespace: "dev", Value: "ad"},
+				{Key: "beta", Namespace: "", Value: "b-null"},
+				{Key: "beta", Namespace: "prd", Value: "bp"},
+			}, items)
+		})
+	}
+}
+
+func TestListWithNamespacesScoped_Error(t *testing.T) {
+	t.Parallel()
+
+	m := &mockClient{
+		listFunc: func(_ context.Context, _ string) ([]azappconfig.Setting, error) {
+			return nil, serverError()
+		},
+	}
+	store := appconfig.New(m, "")
+
+	_, err := store.ListWithNamespacesScoped(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "list settings with namespaces")
+}
+
 func TestCreate_AlreadyExists(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/azure/appconfig/aznamespace/aznamespace.go
+++ b/internal/provider/azure/appconfig/aznamespace/aznamespace.go
@@ -33,6 +33,12 @@ const NullLabelFilter = "\x00"
 // store's configured namespace.
 const AllNamespacesFilter = "*"
 
+// NullDisplay is the human-readable rendering of the null (default) namespace,
+// used wherever a namespace is shown to a user (the CLI `param list` NAMESPACE
+// column, #430) so it is visible rather than a blank. It mirrors the GUI's
+// NS_NULL (frontend viewUtils.ts).
+const NullDisplay = "(NULL)"
+
 // Filter maps a raw --namespace value to an App Configuration LabelFilter for
 // list/read enumeration. An empty value maps to the null-label filter (the
 // default namespace); any other value is forwarded verbatim so the service's

--- a/internal/usecase/azure/azure_test.go
+++ b/internal/usecase/azure/azure_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/azure/appconfig"
 	"github.com/mpyw/suve/internal/provider/providermock"
 	"github.com/mpyw/suve/internal/usecase/azure"
 )
@@ -138,4 +139,85 @@ func TestUpdateUseCase_NotFound(t *testing.T) {
 	uc := &azure.UpdateUseCase{Store: store}
 	_, err := uc.Execute(t.Context(), azure.UpdateInput{Name: "missing", Value: "v", ValueType: domain.ValueTypePlaintext})
 	require.ErrorIs(t, err, azure.ErrEntryNotFound)
+}
+
+// namespaceListerMock is a minimal fake for the App-Config-specific
+// NamespaceLister the namespace-aware list use case depends on.
+type namespaceListerMock struct {
+	rows []appconfig.KeyNamespace
+	err  error
+}
+
+func (m *namespaceListerMock) ListWithNamespacesScoped(_ context.Context) ([]appconfig.KeyNamespace, error) {
+	return m.rows, m.err
+}
+
+func TestListNamespacesUseCase(t *testing.T) {
+	t.Parallel()
+
+	// The store (service) already sorts by (key, namespace); the use case only
+	// layers the client-side key filters on top and preserves order.
+	rows := []appconfig.KeyNamespace{
+		{Key: "app/a", Namespace: "", Value: "a-null"},
+		{Key: "app/a", Namespace: "dev", Value: "a-dev"},
+		{Key: "app/b", Namespace: "prd", Value: "b-prd"},
+		{Key: "other", Namespace: "", Value: "o"},
+	}
+
+	t.Run("without value carries namespace and drops value", func(t *testing.T) {
+		t.Parallel()
+
+		uc := &azure.ListNamespacesUseCase{Lister: &namespaceListerMock{rows: rows}}
+		out, err := uc.Execute(t.Context(), azure.ListNamespacesInput{})
+		require.NoError(t, err)
+
+		assert.Equal(t, []azure.ListNamespacesEntry{
+			{Namespace: "", Name: "app/a"},
+			{Namespace: "dev", Name: "app/a"},
+			{Namespace: "prd", Name: "app/b"},
+			{Namespace: "", Name: "other"},
+		}, out.Entries)
+	})
+
+	t.Run("prefix filters on the key, keeping every namespace of a match", func(t *testing.T) {
+		t.Parallel()
+
+		uc := &azure.ListNamespacesUseCase{Lister: &namespaceListerMock{rows: rows}}
+		out, err := uc.Execute(t.Context(), azure.ListNamespacesInput{Prefix: "app/", WithValue: true})
+		require.NoError(t, err)
+
+		assert.Equal(t, []azure.ListNamespacesEntry{
+			{Namespace: "", Name: "app/a", Value: lo.ToPtr("a-null")},
+			{Namespace: "dev", Name: "app/a", Value: lo.ToPtr("a-dev")},
+			{Namespace: "prd", Name: "app/b", Value: lo.ToPtr("b-prd")},
+		}, out.Entries)
+	})
+
+	t.Run("regex filters on the key", func(t *testing.T) {
+		t.Parallel()
+
+		uc := &azure.ListNamespacesUseCase{Lister: &namespaceListerMock{rows: rows}}
+		out, err := uc.Execute(t.Context(), azure.ListNamespacesInput{Filter: "^other$"})
+		require.NoError(t, err)
+
+		assert.Equal(t, []azure.ListNamespacesEntry{{Namespace: "", Name: "other"}}, out.Entries)
+	})
+
+	t.Run("invalid regex is a usage error", func(t *testing.T) {
+		t.Parallel()
+
+		uc := &azure.ListNamespacesUseCase{Lister: &namespaceListerMock{rows: rows}}
+		_, err := uc.Execute(t.Context(), azure.ListNamespacesInput{Filter: "["})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid filter regex")
+	})
+
+	t.Run("lister error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		uc := &azure.ListNamespacesUseCase{Lister: &namespaceListerMock{err: errors.New("boom")}}
+		_, err := uc.Execute(t.Context(), azure.ListNamespacesInput{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to list entries")
+	})
 }

--- a/internal/usecase/azure/list_namespaces.go
+++ b/internal/usecase/azure/list_namespaces.go
@@ -1,0 +1,95 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/samber/lo"
+
+	"github.com/mpyw/suve/internal/debug"
+	"github.com/mpyw/suve/internal/provider/azure/appconfig"
+)
+
+// NamespaceLister is the App-Config-specific extension that lists per-(key,
+// namespace) rows honoring the store's configured --namespace filter. Only the
+// Azure App Configuration store implements it (via ListWithNamespacesScoped);
+// callers type-assert the resolved store to reach it. The neutral
+// provider.Reader.List contract is untouched.
+type NamespaceLister interface {
+	ListWithNamespacesScoped(ctx context.Context) ([]appconfig.KeyNamespace, error)
+}
+
+// ListNamespacesInput holds input for the namespace-aware list use case. The
+// namespace filter itself lives on the store (resolved from --namespace); here
+// only the client-side key filters apply.
+type ListNamespacesInput struct {
+	Prefix    string // Name prefix filter (case-sensitive)
+	Filter    string // Regex filter pattern (client-side)
+	WithValue bool   // Include values (App Config's list response already carries them)
+}
+
+// ListNamespacesEntry is one (key, namespace) row. Value is nil when not
+// requested. App Configuration's list response always carries the value, so no
+// per-entry error path exists (unlike the value-fetching neutral list).
+type ListNamespacesEntry struct {
+	Namespace string
+	Name      string
+	Value     *string
+}
+
+// ListNamespacesOutput holds the result of the namespace-aware list use case.
+type ListNamespacesOutput struct {
+	Entries []ListNamespacesEntry
+}
+
+// ListNamespacesUseCase lists App Configuration settings with their namespaces.
+type ListNamespacesUseCase struct {
+	Lister NamespaceLister
+}
+
+// Execute runs the namespace-aware list use case. The store applies the
+// namespace (label) filter; the name prefix and client-side regex filter are
+// applied here, on the key.
+func (u *ListNamespacesUseCase) Execute(ctx context.Context, input ListNamespacesInput) (*ListNamespacesOutput, error) {
+	var filterRegex *regexp.Regexp
+
+	if input.Filter != "" {
+		var err error
+
+		filterRegex, err = regexp.Compile(input.Filter)
+		if err != nil {
+			return nil, fmt.Errorf("invalid filter regex: %w", err)
+		}
+	}
+
+	rows, err := u.Lister.ListWithNamespacesScoped(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list entries: %w", err)
+	}
+
+	out := &ListNamespacesOutput{}
+
+	for _, row := range rows {
+		if input.Prefix != "" && !strings.HasPrefix(row.Key, input.Prefix) {
+			continue
+		}
+
+		if filterRegex != nil && !filterRegex.MatchString(row.Key) {
+			continue
+		}
+
+		entry := ListNamespacesEntry{Namespace: row.Namespace, Name: row.Key}
+		if input.WithValue {
+			entry.Value = lo.ToPtr(row.Value)
+		}
+
+		out.Entries = append(out.Entries, entry)
+	}
+
+	debug.From(ctx).Logf("azure list (namespaces): provider returned %d rows, %d after filters (prefix=%q, filter=%q)\n",
+		len(rows), len(out.Entries), input.Prefix, input.Filter)
+
+	return out, nil
+}


### PR DESCRIPTION
## Summary

Closes #430. Azure App Configuration keys live in namespaces (the label axis), so `suve azure param list` / `ls` now prepends a **NAMESPACE column** by default — CLI catching up to the GUI (#427), which already shows a per-entry namespace badge.

The **default scope is the null namespace**, matching the GUI's default filter (`NS_NULL`), so every row reads `(NULL)` until `--namespace "*"` (or a specific/OR/prefix filter) widens it. The column is **always shown** (even for a single namespace) — `(NULL)` makes "this belongs to the null namespace" legible at a glance. `--hide-namespace` (`--hide-ns`) drops the column and falls back to the neutral, pipe-friendly key-only listing.

```
$ suve azure param list --namespace '*'
(NULL)	Logging:LogLevel
(NULL)	suve/e2e/azure/ns/shared
dev	suve/e2e/azure/ns/dev-only
prd	FeatureFlags:Beta
```

## Design notes

- **GUI/CLI alignment.** The GUI loads all namespaces but defaults its filter to `NS_NULL` (`App.svelte`), so its default view is the null namespace. The CLI now matches: default `param list` → null scope; `--namespace "*"` → all (the GUI's `*` dropdown selection).
- **Rendering.** Tab-separated, no header — consistent with the existing `key<TAB>value` convention and pipe-friendly. (The issue's illustrative example used aligned columns; the codebase has no aligned-table precedent, and a header/padding would break piping by default.) JSON gains a raw `namespace` field (`""` for null, matching the GUI's per-entry namespace).
- **Not the generic scaffold.** A dedicated `ListRunner` renders the column; `--hide-namespace` and non-App-Config stores reuse the shared generic key-only renderer, so that output is byte-for-byte the neutral listing.

## Layers

- **Go unit**: `ListWithNamespacesScoped` (filter mapping incl. null-label), `ListNamespacesUseCase` (prefix/regex key filters), `ListRunner` (column, `--show`, JSON, `--hide-ns` fallback, non-App-Config no-op).
- **CLI e2e** (`azure_appconfig_test.go`): NAMESPACE column on by default (`(NULL)` prefix), revealed across namespaces with `--namespace "*"`, hidden with `--hide-ns`.

No GUI surface here (per the issue), so no Playwright layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
