### PR TITLE
feat(azure): show Key Vault tags per version (add/remove on latest)

### DIFF
--- a/e2e/azure_keyvault_test.go
+++ b/e2e/azure_keyvault_test.go
@@ -153,6 +153,11 @@ func TestAzureKeyVault_FullWorkflow(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, stdout, "env")
 		assert.Contains(t, stdout, "prod")
+
+		// log shows the tag on the (current) version — tags are per version.
+		logOut, err := runAzureSecret(t, "log", name)
+		require.NoError(t, err)
+		assert.Contains(t, logOut, "env=prod")
 	})
 
 	t.Run("untag", func(t *testing.T) {

--- a/internal/cli/commands/azure/secret/log.go
+++ b/internal/cli/commands/azure/secret/log.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/urfave/cli/v3"
 
@@ -19,11 +20,12 @@ import (
 
 // logJSONItem represents a single version entry in JSON output.
 type logJSONItem struct {
-	Version string  `json:"version"`
-	State   string  `json:"state,omitempty"`
-	Created string  `json:"created,omitempty"`
-	Value   *string `json:"value,omitempty"`
-	Error   string  `json:"error,omitempty"`
+	Version string            `json:"version"`
+	State   string            `json:"state,omitempty"`
+	Created string            `json:"created,omitempty"`
+	Value   *string           `json:"value,omitempty"`
+	Tags    map[string]string `json:"tags,omitempty"`
+	Error   string            `json:"error,omitempty"`
 }
 
 // logPresenter renders Azure Key Vault log output.
@@ -82,6 +84,13 @@ func (p *logPresenter) RenderJSON(stdout io.Writer) error {
 			item.Value = &entry.Value
 		}
 
+		if len(entry.Tags) > 0 {
+			item.Tags = make(map[string]string, len(entry.Tags))
+			for _, tag := range entry.Tags {
+				item.Tags[tag.Key] = tag.Value
+			}
+		}
+
 		items = append(items, item)
 	}
 
@@ -120,6 +129,16 @@ func (p *logPresenter) RenderHeader(stdout io.Writer, i int) {
 
 	if entry.CreatedDate != nil {
 		output.Printf(stdout, "%s %s\n", colors.For(stdout).FieldLabel("Date:"), timeutil.FormatRFC3339(*entry.CreatedDate))
+	}
+
+	// Key Vault tags are per version, so show this version's own tags.
+	if len(entry.Tags) > 0 {
+		pairs := make([]string, 0, len(entry.Tags))
+		for _, tag := range entry.Tags {
+			pairs = append(pairs, fmt.Sprintf("%s=%s", tag.Key, tag.Value))
+		}
+
+		output.Printf(stdout, "%s %s\n", colors.For(stdout).FieldLabel("Tags:"), strings.Join(pairs, ", "))
 	}
 }
 

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -53,6 +53,10 @@ type Version struct {
 	StagingLabels []string
 	// Created is the version creation time, if known.
 	Created *time.Time
+	// Tags are the labels attached to THIS version. Only Azure Key Vault scopes
+	// tags per version (each version has its own); every other provider keeps
+	// tags at the resource level (see Entry.Tags) and leaves this nil.
+	Tags []Tag
 }
 
 // Tag is a single key/value label attached to an entry.

--- a/internal/gui/frontend/src/lib/SecretView.svelte
+++ b/internal/gui/frontend/src/lib/SecretView.svelte
@@ -25,6 +25,10 @@
   // Capability-driven visibility. Absent capability defaults to AWS-like (true).
   const stagingEnabled = $derived(capability?.hasStaging ?? true);
   const tagsEnabled = $derived(capability?.hasTags ?? true);
+  // Azure Key Vault scopes tags per version: show them inside each Version
+  // History entry (add/remove only on the latest) instead of one resource-level
+  // list. Every other provider keeps the single top-level TagList.
+  const tagsPerVersion = $derived(capability?.tagsPerVersion ?? false);
   const historyEnabled = $derived(capability?.hasVersionHistory ?? true);
   const restoreEnabled = $derived(capability?.hasRestore ?? true);
   const forceDeleteEnabled = $derived(capability?.hasForceDelete ?? true);
@@ -589,7 +593,7 @@
               </div>
             {/if}
 
-            {#if tagsEnabled}
+            {#if tagsEnabled && !tagsPerVersion}
               <TagList tags={secretDetail.tags} serviceClass="secret" {provider} onadd={openTagModal} onremove={openRemoveTagModal} />
             {/if}
 
@@ -644,6 +648,28 @@
                           </div>
                         {/if}
                         <pre class="history-value" class:masked={!showValue}>{showValue ? formatJsonValue(logEntry.value) : maskValue(logEntry.value)}</pre>
+                        {#if tagsPerVersion && tagsEnabled}
+                          <div class="history-tags">
+                            <span class="history-tags-label">Tags</span>
+                            {#if (logEntry.tags || []).length > 0}
+                              {#each logEntry.tags as tag}
+                                <span class="tag-item">
+                                  <span class="tag-key secret">{tag.key}</span>
+                                  <span class="tag-separator">=</span>
+                                  <span class="tag-value">{tag.value}</span>
+                                  {#if logEntry.isCurrent}
+                                    <button class="btn-tag-remove" onclick={() => openRemoveTagModal(tag.key)} title="Remove tag">×</button>
+                                  {/if}
+                                </span>
+                              {/each}
+                            {:else}
+                              <span class="no-tags-inline">no tags</span>
+                            {/if}
+                            {#if logEntry.isCurrent}
+                              <button class="btn-tag-add-sm" onclick={openTagModal}>+ Add</button>
+                            {/if}
+                          </div>
+                        {/if}
                       </div>
                     </li>
                   {/each}

--- a/internal/gui/frontend/src/lib/Sidebar.svelte
+++ b/internal/gui/frontend/src/lib/Sidebar.svelte
@@ -195,7 +195,7 @@
       />
       <label class="scope-label" for="azure-store">App Configuration store</label>
       <input id="azure-store" class="scope-input" type="text" placeholder="my-store (params)" bind:value={storeInput} />
-      <label class="scope-label" for="azure-namespace">Namespace</label>
+      <label class="scope-label" for="azure-namespace">App Configuration NS</label>
       <input
         id="azure-namespace"
         class="scope-input"
@@ -203,7 +203,7 @@
         placeholder="(NULL)"
         bind:value={namespaceInput}
       />
-      <p class="scope-hint">Azure calls this a label; empty means (NULL). Applies to the App Configuration store only.</p>
+      <p class="scope-hint">Azure calls this a label; empty means (NULL).</p>
       {#if formError || scopeError}
         <div class="scope-error">{formError || scopeError}</div>
       {/if}

--- a/internal/gui/frontend/src/lib/common.css
+++ b/internal/gui/frontend/src/lib/common.css
@@ -345,6 +345,43 @@
   user-select: none;
 }
 
+/* Per-version tags inside a Version History entry (Azure Key Vault). */
+.history-tags {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.history-tags-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #777;
+}
+
+.no-tags-inline {
+  font-size: 12px;
+  color: #666;
+  font-style: italic;
+}
+
+.btn-tag-add-sm {
+  padding: 2px 8px;
+  font-size: 11px;
+  background: transparent;
+  color: #aaa;
+  border: 1px solid #3a3a52;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn-tag-add-sm:hover {
+  color: #fff;
+  border-color: #e94560;
+}
+
 /* Badges */
 .badge {
   font-size: 10px;

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -76,6 +76,8 @@ export interface SecretLogEntry {
   value: string;
   isCurrent: boolean;
   created: string;
+  // Per-version tags (Azure Key Vault only).
+  tags?: Tag[];
 }
 
 export interface AWSIdentity {
@@ -113,6 +115,7 @@ export interface ServiceCapability {
   hasVersionHistory: boolean;
   hasVersionSpecifiers: boolean;
   hasTags: boolean;
+  tagsPerVersion: boolean;
   hasRestore: boolean;
   hasStaging: boolean;
   hasForceDelete: boolean;
@@ -254,8 +257,8 @@ export const defaultCapabilities: ProviderCapability[] = [
     displayName: 'AWS',
     scopeFields: [],
     services: [
-      { service: 'param', displayName: 'Param', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: false },
-      { service: 'secret', displayName: 'Secret', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, hasRestore: true, hasStaging: true, hasForceDelete: true, hasRecoveryWindow: true, hasNamespaces: false },
+      { service: 'param', displayName: 'Param', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, tagsPerVersion: false, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: false },
+      { service: 'secret', displayName: 'Secret', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, tagsPerVersion: false, hasRestore: true, hasStaging: true, hasForceDelete: true, hasRecoveryWindow: true, hasNamespaces: false },
     ],
   },
   {
@@ -263,7 +266,7 @@ export const defaultCapabilities: ProviderCapability[] = [
     displayName: 'Google Cloud',
     scopeFields: ['project'],
     services: [
-      { service: 'secret', displayName: 'Secret', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: false },
+      { service: 'secret', displayName: 'Secret', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, tagsPerVersion: false, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: false },
     ],
   },
   {
@@ -271,8 +274,8 @@ export const defaultCapabilities: ProviderCapability[] = [
     displayName: 'Azure',
     scopeFields: [],
     services: [
-      { service: 'param', displayName: 'App Configuration', hasVersionHistory: false, hasVersionSpecifiers: false, hasTags: true, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: true },
-      { service: 'secret', displayName: 'Key Vault', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: false },
+      { service: 'param', displayName: 'App Configuration', hasVersionHistory: false, hasVersionSpecifiers: false, hasTags: true, tagsPerVersion: false, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: true },
+      { service: 'secret', displayName: 'Key Vault', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, tagsPerVersion: true, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: false },
     ],
   },
 ];
@@ -1073,7 +1076,9 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
         ];
         return {
           name,
-          entries: versions,
+          // Mirror the backend: every entry carries a tags array (empty, not
+          // undefined) so per-version tag rendering sees the real shape.
+          entries: versions.map((v) => ({ ...v, tags: v.tags ?? [] })),
         };
       },
       SecretCreate: async (name: string, value: string) => {

--- a/internal/gui/frontend/tests/keyvault-version-tags.spec.ts
+++ b/internal/gui/frontend/tests/keyvault-version-tags.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect, type Page } from '@playwright/test';
+import { setupWailsMocks, createAzureState, navigateTo } from './fixtures/wails-mock';
+
+// Azure Key Vault scopes tags PER VERSION (each version has its own tags). The
+// detail view must therefore show tags inside each Version History entry — not
+// one resource-level list — and offer add/remove only on the latest (current)
+// version, since writes target the current version.
+
+function kvWithVersionTags() {
+  return createAzureState({
+    secretVersions: {
+      'kv-secret': [
+        {
+          versionId: 'vLatest',
+          state: 'enabled',
+          value: 'v2',
+          isCurrent: true,
+          created: new Date().toISOString(),
+          tags: [{ key: 'env', value: 'prod' }],
+        },
+        {
+          versionId: 'vOld',
+          state: 'enabled',
+          value: 'v1',
+          isCurrent: false,
+          created: new Date().toISOString(),
+          tags: [],
+        },
+      ],
+    },
+  });
+}
+
+async function openKvSecret(page: Page) {
+  await navigateTo(page, 'Key Vault');
+  await page.locator('.item-button').filter({ hasText: 'kv-secret' }).click();
+  await expect(page.locator('.detail-panel, .secret-detail, .detail-content').first()).toBeVisible();
+}
+
+test.describe('Key Vault per-version tags', () => {
+  test('tags render inside each Version History entry, +Add only on latest', async ({ page }) => {
+    await setupWailsMocks(page, kvWithVersionTags());
+    await page.goto('/');
+    await openKvSecret(page);
+
+    // One per-version tags block per version.
+    await expect(page.locator('.history-tags')).toHaveCount(2);
+
+    const current = page.locator('.history-item.current-secret');
+    await expect(current.locator('.history-tags')).toContainText('env');
+    await expect(current.locator('.history-tags')).toContainText('prod');
+    // Latest version can add + remove.
+    await expect(current.locator('.btn-tag-add-sm')).toHaveCount(1);
+    await expect(current.locator('.btn-tag-remove')).toHaveCount(1);
+
+    // A non-current version shows its (empty) tags read-only: no add/remove.
+    const older = page.locator('.history-item:not(.current-secret)');
+    await expect(older.locator('.no-tags-inline')).toBeVisible();
+    await expect(older.locator('.btn-tag-add-sm')).toHaveCount(0);
+    await expect(older.locator('.btn-tag-remove')).toHaveCount(0);
+  });
+
+  test('the resource-level top-level TAGS list is folded for Key Vault', async ({ page }) => {
+    await setupWailsMocks(page, kvWithVersionTags());
+    await page.goto('/');
+    await openKvSecret(page);
+
+    // The standalone TagList renders an <h4>Tags</h4> section heading; for a
+    // per-version provider it must be gone (tags live in the history instead,
+    // labelled by a <span>, not a heading).
+    await expect(page.getByRole('heading', { name: 'Tags', exact: true })).toHaveCount(0);
+    // Version History heading is still there, and the per-version add control is
+    // the only tag-add button.
+    await expect(page.getByRole('heading', { name: 'Version History' })).toBeVisible();
+    await expect(page.locator('.btn-tag-add-sm')).toHaveCount(1);
+  });
+});

--- a/internal/gui/frontend/wailsjs/go/models.ts
+++ b/internal/gui/frontend/wailsjs/go/models.ts
@@ -255,6 +255,7 @@ export namespace gui {
 	    hasVersionHistory: boolean;
 	    hasVersionSpecifiers: boolean;
 	    hasTags: boolean;
+	    tagsPerVersion: boolean;
 	    hasRestore: boolean;
 	    hasStaging: boolean;
 	    hasNamespaces: boolean;
@@ -272,6 +273,7 @@ export namespace gui {
 	        this.hasVersionHistory = source["hasVersionHistory"];
 	        this.hasVersionSpecifiers = source["hasVersionSpecifiers"];
 	        this.hasTags = source["hasTags"];
+	        this.tagsPerVersion = source["tagsPerVersion"];
 	        this.hasRestore = source["hasRestore"];
 	        this.hasStaging = source["hasStaging"];
 	        this.hasNamespaces = source["hasNamespaces"];
@@ -435,6 +437,20 @@ export namespace gui {
 		    return a;
 		}
 	}
+	export class SecretShowTag {
+	    key: string;
+	    value: string;
+	
+	    static createFrom(source: any = {}) {
+	        return new SecretShowTag(source);
+	    }
+	
+	    constructor(source: any = {}) {
+	        if ('string' === typeof source) source = JSON.parse(source);
+	        this.key = source["key"];
+	        this.value = source["value"];
+	    }
+	}
 	export class SecretLogEntry {
 	    versionId: string;
 	    stagingLabels: string[];
@@ -442,6 +458,7 @@ export namespace gui {
 	    value: string;
 	    isCurrent: boolean;
 	    created?: string;
+	    tags: SecretShowTag[];
 	
 	    static createFrom(source: any = {}) {
 	        return new SecretLogEntry(source);
@@ -455,7 +472,26 @@ export namespace gui {
 	        this.value = source["value"];
 	        this.isCurrent = source["isCurrent"];
 	        this.created = source["created"];
+	        this.tags = this.convertValues(source["tags"], SecretShowTag);
 	    }
+	
+		convertValues(a: any, classs: any, asMap: boolean = false): any {
+		    if (!a) {
+		        return a;
+		    }
+		    if (a.slice && a.map) {
+		        return (a as any[]).map(elem => this.convertValues(elem, classs));
+		    } else if ("object" === typeof a) {
+		        if (asMap) {
+		            for (const key of Object.keys(a)) {
+		                a[key] = new classs(a[key]);
+		            }
+		            return a;
+		        }
+		        return new classs(a);
+		    }
+		    return a;
+		}
 	}
 	export class SecretLogResult {
 	    name: string;
@@ -501,20 +537,6 @@ export namespace gui {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.name = source["name"];
 	        this.arn = source["arn"];
-	    }
-	}
-	export class SecretShowTag {
-	    key: string;
-	    value: string;
-	
-	    static createFrom(source: any = {}) {
-	        return new SecretShowTag(source);
-	    }
-	
-	    constructor(source: any = {}) {
-	        if ('string' === typeof source) source = JSON.parse(source);
-	        this.key = source["key"];
-	        this.value = source["value"];
 	    }
 	}
 	export class SecretShowResult {

--- a/internal/gui/providers.go
+++ b/internal/gui/providers.go
@@ -109,6 +109,11 @@ type ServiceCapability struct {
 	// HasTags is true when tag/label read+write is supported (false for Azure
 	// App Configuration).
 	HasTags bool `json:"hasTags"`
+	// TagsPerVersion is true when tags are scoped to a specific version rather
+	// than the resource (Azure Key Vault only): each version has its own tags,
+	// so the GUI shows them per version in the history and writes target the
+	// latest version. Every other provider keeps tags at the resource level.
+	TagsPerVersion bool `json:"tagsPerVersion"`
 	// HasRestore is true when a soft-deleted item can be restored (AWS Secrets
 	// Manager only).
 	HasRestore bool `json:"hasRestore"`
@@ -196,7 +201,7 @@ func (a *App) Capabilities() []ProviderCapability {
 				},
 				{
 					Service: serviceSecret, DisplayName: "Key Vault",
-					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: false,
+					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, TagsPerVersion: true, HasRestore: false,
 					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false,
 				},
 			},

--- a/internal/gui/secret.go
+++ b/internal/gui/secret.go
@@ -76,6 +76,8 @@ type SecretLogEntry struct {
 	Value         string   `json:"value"`
 	IsCurrent     bool     `json:"isCurrent"`
 	Created       string   `json:"created,omitempty"`
+	// Tags attached to THIS version (Azure Key Vault only; empty otherwise).
+	Tags []SecretShowTag `json:"tags"`
 }
 
 // SecretCreateResult represents the result of creating a secret.
@@ -216,9 +218,14 @@ func (a *App) SecretLog(name string, maxResults int32) (*SecretLogResult, error)
 			State:         e.State,
 			Value:         e.Value,
 			IsCurrent:     e.IsCurrent,
+			Tags:          make([]SecretShowTag, 0, len(e.Tags)),
 		}
 		if e.CreatedDate != nil {
 			entry.Created = timeutil.FormatRFC3339(*e.CreatedDate)
+		}
+
+		for _, tag := range e.Tags {
+			entry.Tags = append(entry.Tags, SecretShowTag{Key: tag.Key, Value: tag.Value})
 		}
 
 		entries[i] = entry

--- a/internal/provider/azure/keyvault/keyvault.go
+++ b/internal/provider/azure/keyvault/keyvault.go
@@ -75,6 +75,7 @@ type secretVersion struct {
 	id      string
 	created *time.Time
 	enabled bool
+	tags    []domain.Tag
 }
 
 // Resolve parses the version spec (generic) and resolves it to an opaque
@@ -187,6 +188,7 @@ func (s *Store) History(ctx context.Context, name string) ([]domain.Version, err
 			ID:      v.id,
 			State:   boolLabel(v.enabled),
 			Created: v.created,
+			Tags:    v.tags,
 		}
 	}), nil
 }
@@ -332,7 +334,7 @@ func (s *Store) updateTags(ctx context.Context, name, version string, tags map[s
 
 // toSecretVersion maps SDK SecretProperties to the neutral secretVersion.
 func toSecretVersion(p *azsecrets.SecretProperties) secretVersion {
-	v := secretVersion{id: versionID(p.ID)}
+	v := secretVersion{id: versionID(p.ID), tags: mapTags(p.Tags)}
 
 	if attr := p.Attributes; attr != nil {
 		v.created = attr.Created

--- a/internal/usecase/azure/log.go
+++ b/internal/usecase/azure/log.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
 )
 
@@ -24,7 +25,10 @@ type LogEntry struct {
 	State       string // enabled/disabled, may be ""
 	Value       string
 	CreatedDate *time.Time
-	Error       error // Error from fetching value, if any (e.g. disabled versions)
+	// Tags attached to THIS version. Key Vault scopes tags per version, so each
+	// version carries its own set.
+	Tags  []domain.Tag
+	Error error // Error from fetching value, if any (e.g. disabled versions)
 }
 
 // LogOutput holds the result of the log use case.
@@ -106,6 +110,7 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 			State:       v.State,
 			Value:       value,
 			CreatedDate: v.Created,
+			Tags:        v.Tags,
 			Error:       fetchErr,
 		})
 	}

--- a/internal/usecase/secret/log.go
+++ b/internal/usecase/secret/log.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
 )
 
@@ -32,7 +33,10 @@ type LogEntry struct {
 	Value        string
 	CreatedDate  *time.Time
 	IsCurrent    bool
-	Error        error // Error from fetching value, if any
+	// Tags attached to THIS version. Only Azure Key Vault scopes tags per version;
+	// empty for providers whose tags live at the resource level.
+	Tags  []domain.Tag
+	Error error // Error from fetching value, if any
 }
 
 // LogOutput holds the result of the log use case.
@@ -70,6 +74,12 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 	// first version that ever existed. Remember it before truncation so we can
 	// tell whether the oldest shown version is genuinely the initial one.
 	initialVersion := versions[len(versions)-1].ID
+
+	// Determine the current version up front (over the FULL history, before any
+	// truncation/reverse): AWS Secrets Manager names it with the AWSCURRENT
+	// staging label; Google Cloud and Azure Key Vault have no such label, so the
+	// newest version is the current one.
+	currentVersion := currentVersionID(versions)
 
 	// Apply date filters BEFORE the count limit: -n must return up to N versions
 	// that match --since/--until, not N newest-then-filtered to fewer (#351).
@@ -116,11 +126,9 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 			State:        v.State,
 			Value:        value,
 			CreatedDate:  v.Created,
-			// A version is current when AWSCURRENT is among its staging labels;
-			// membership (not a "first stage" check) keeps this correct even when
-			// the version carries additional custom labels (#317).
-			IsCurrent: slices.Contains(v.StagingLabels, "AWSCURRENT"),
-			Error:     fetchErr,
+			IsCurrent:    v.ID == currentVersion,
+			Tags:         v.Tags,
+			Error:        fetchErr,
 		})
 	}
 
@@ -131,6 +139,21 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 			return e.VersionID == initialVersion
 		}),
 	}, nil
+}
+
+// currentVersionID returns the id of the current version. AWS Secrets Manager
+// marks it with the AWSCURRENT staging label (membership, not position, so it
+// stays correct even when the version carries extra custom labels, #317). Google
+// Cloud and Azure Key Vault have no staging labels, so the newest version (first
+// in the newest-first history) is the current one. versions must be non-empty.
+func currentVersionID(versions []domain.Version) string {
+	for _, v := range versions {
+		if slices.Contains(v.StagingLabels, "AWSCURRENT") {
+			return v.ID
+		}
+	}
+
+	return versions[0].ID
 }
 
 // getValue fetches the value for a specific version id, tolerating fetch

--- a/internal/usecase/secret/log_test.go
+++ b/internal/usecase/secret/log_test.go
@@ -75,7 +75,7 @@ func TestLogUseCase_Execute_State(t *testing.T) {
 
 	now := time.Now()
 	versions := []domain.Version{
-		{ID: "2", State: "enabled", Created: &now},
+		{ID: "2", State: "enabled", Created: &now, Tags: []domain.Tag{{Key: "env", Value: "prod"}}},
 		{ID: "1", State: "disabled", Created: tp(now, -time.Hour)},
 	}
 	values := map[string]string{"1": "value1", "2": "value2"}
@@ -89,6 +89,17 @@ func TestLogUseCase_Execute_State(t *testing.T) {
 	assert.Empty(t, output.Entries[0].VersionStage)
 	assert.Equal(t, "disabled", output.Entries[1].State)
 	assert.Empty(t, output.Entries[1].VersionStage)
+
+	// No AWSCURRENT staging label (Google Cloud / Azure Key Vault): the newest
+	// version is current. Regression guard — this used to be always-false for
+	// those providers, so nothing offered "current"/add-tag in the GUI history.
+	assert.True(t, output.Entries[0].IsCurrent, "newest version is current when there is no AWSCURRENT")
+	assert.False(t, output.Entries[1].IsCurrent)
+
+	// Per-version tags flow through (Azure Key Vault scopes tags per version).
+	require.Len(t, output.Entries[0].Tags, 1)
+	assert.Equal(t, "env", output.Entries[0].Tags[0].Key)
+	assert.Empty(t, output.Entries[1].Tags)
 }
 
 func TestLogUseCase_Execute_Empty(t *testing.T) {


### PR DESCRIPTION
Stacked on #437 (merge that first; this then shows only its own commit).

## Why

Azure Key Vault scopes tags to a secret **version** — each version has its own tags — unlike AWS Secrets Manager / SSM and Google Cloud, where tags/labels live at the **resource** level. The GUI showed a single top-level TAGS list (a resource-level mental model), which is wrong for Key Vault, and there was no per-version tag affordance.

## What

- **`domain.Version.Tags`**: the Key Vault provider populates each version's tags from `ListSecretPropertiesVersions` (`SecretProperties.Tags`). Resource-level-tag providers leave it empty (tags stay on `Entry.Tags`).
- **Secret log use case**: carries per-version `Tags`, and fixes `IsCurrent`. It was derived only from the `AWSCURRENT` staging label — which Key Vault / Google Cloud never carry — so **no version was ever marked current** (nothing offered "current"/add-tag). Now: the `AWSCURRENT` version (AWS) or the **newest** version (providers without staging labels).
- **CLI** (`azure secret log`): renders each version's tags — a `Tags: k=v` line in text output, a `tags` object in `--output=json`.
- **GUI**: a `tagsPerVersion` capability (Key Vault only) renders tags **inside each Version History entry** — read-only on older versions, **add/remove only on the current (latest)** version — and folds the single resource-level `TagList`. Writes target the current version (matches the Key Vault tag API).

## Tests

- **Go unit** (`secret/log_test`): newest-is-current when there is no `AWSCURRENT`; per-version tags flow through.
- **GUI Playwright** (`keyvault-version-tags.spec`): per-version tags render; +Add/remove only on the current version; top-level TAGS folded. The wails mock now mirrors the backend (`SecretLog` always emits a `tags` array) — the class of mock-vs-backend divergence that hid earlier bugs.

`go test ./...`, `-tags production ./internal/gui/...`, `mise lint`, `svelte-check`, and the full Playwright suite are green (one unrelated pre-existing webkit Tab-focus flake).

## Follow-ups (not in this PR)
- Azure Key Vault soft-delete **restore** (`RecoverDeletedSecret`) + **purge**/force-delete (`PurgeDeletedSecret`), GUI+CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)