### PR TITLE
feat(azure): Key Vault soft-delete restore (GUI+CLI)

### DIFF
--- a/e2e/azure_keyvault_test.go
+++ b/e2e/azure_keyvault_test.go
@@ -179,15 +179,18 @@ func TestAzureKeyVault_FullWorkflow(t *testing.T) {
 }
 
 // TestAzureKeyVault_SoftDelete exercises soft-delete recovery: delete (soft) →
-// restore → the secret is readable again; then delete --force → purge, and it is
-// gone for good. Mirrors AWS Secrets Manager's delete/restore semantics.
+// restore → the secret is readable again. Mirrors AWS Secrets Manager's
+// delete/restore semantics. Force-delete/purge is intentionally unsupported for
+// Key Vault, so there is nothing to exercise here.
 func TestAzureKeyVault_SoftDelete(t *testing.T) {
 	setupAzureKeyVault(t)
 	setupTempHome(t)
 
 	const name = "suve-e2e-kv-softdelete"
 
-	cleanup := func() { _, _ = runAzureSecret(t, "delete", "--yes", "--force", name) }
+	// Best-effort cleanup: delete (soft) then restore-and-delete is unnecessary; a
+	// plain delete is enough to reset for the next run.
+	cleanup := func() { _, _ = runAzureSecret(t, "delete", "--yes", name) }
 	cleanup()
 	t.Cleanup(cleanup)
 
@@ -208,24 +211,5 @@ func TestAzureKeyVault_SoftDelete(t *testing.T) {
 		stdout, err := runAzureSecret(t, "show", "--raw", name)
 		require.NoError(t, err)
 		assert.Equal(t, "v1", stdout)
-	})
-
-	t.Run("force-delete-purges", func(t *testing.T) {
-		_, err := runAzureSecret(t, "delete", "--yes", "--force", name)
-		if err != nil && strings.Contains(err.Error(), "cannot be purged") {
-			// lowkey-vault rejects immediate purge (purge-protection-like). The
-			// delete+purge sequence is correct for real Azure and is covered by the
-			// keyvault adapter unit test; skip the emulator assertion.
-			t.Skip("emulator does not support purge; force-delete/purge covered by unit tests")
-		}
-
-		require.NoError(t, err)
-
-		// Purged: gone, and NOT restorable.
-		_, err = runAzureSecret(t, "show", "--raw", name)
-		require.Error(t, err)
-
-		_, err = runAzureSecret(t, "restore", name)
-		require.Error(t, err, "a purged secret cannot be restored")
 	})
 }

--- a/e2e/azure_keyvault_test.go
+++ b/e2e/azure_keyvault_test.go
@@ -177,3 +177,55 @@ func TestAzureKeyVault_FullWorkflow(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// TestAzureKeyVault_SoftDelete exercises soft-delete recovery: delete (soft) →
+// restore → the secret is readable again; then delete --force → purge, and it is
+// gone for good. Mirrors AWS Secrets Manager's delete/restore semantics.
+func TestAzureKeyVault_SoftDelete(t *testing.T) {
+	setupAzureKeyVault(t)
+	setupTempHome(t)
+
+	const name = "suve-e2e-kv-softdelete"
+
+	cleanup := func() { _, _ = runAzureSecret(t, "delete", "--yes", "--force", name) }
+	cleanup()
+	t.Cleanup(cleanup)
+
+	_, err := runAzureSecret(t, "create", name, "v1")
+	require.NoError(t, err)
+
+	t.Run("soft-delete-then-restore", func(t *testing.T) {
+		_, err := runAzureSecret(t, "delete", "--yes", name)
+		require.NoError(t, err)
+
+		// Soft-deleted: not readable until restored.
+		_, err = runAzureSecret(t, "show", "--raw", name)
+		require.Error(t, err)
+
+		_, err = runAzureSecret(t, "restore", name)
+		require.NoError(t, err)
+
+		stdout, err := runAzureSecret(t, "show", "--raw", name)
+		require.NoError(t, err)
+		assert.Equal(t, "v1", stdout)
+	})
+
+	t.Run("force-delete-purges", func(t *testing.T) {
+		_, err := runAzureSecret(t, "delete", "--yes", "--force", name)
+		if err != nil && strings.Contains(err.Error(), "cannot be purged") {
+			// lowkey-vault rejects immediate purge (purge-protection-like). The
+			// delete+purge sequence is correct for real Azure and is covered by the
+			// keyvault adapter unit test; skip the emulator assertion.
+			t.Skip("emulator does not support purge; force-delete/purge covered by unit tests")
+		}
+
+		require.NoError(t, err)
+
+		// Purged: gone, and NOT restorable.
+		_, err = runAzureSecret(t, "show", "--raw", name)
+		require.Error(t, err)
+
+		_, err = runAzureSecret(t, "restore", name)
+		require.Error(t, err, "a purged secret cannot be restored")
+	})
+}

--- a/internal/cli/commands/azure/secret/command.go
+++ b/internal/cli/commands/azure/secret/command.go
@@ -21,6 +21,9 @@ import (
 // nounSecret is the command name / noun used across the Key Vault secret commands.
 const nounSecret = "secret"
 
+// argsUsageName is the shared ArgsUsage for single-secret commands.
+const argsUsageName = "<name>"
+
 // Command returns the "azure secret" subcommand group.
 func Command() *cli.Command {
 	return &cli.Command{
@@ -53,6 +56,7 @@ AZURE_KEYVAULT_NAME environment variable.`,
 			CreateCommand(),
 			UpdateCommand(),
 			DeleteCommand(),
+			RestoreCommand(),
 			TagCommand(),
 			UntagCommand(),
 		},

--- a/internal/cli/commands/azure/secret/delete.go
+++ b/internal/cli/commands/azure/secret/delete.go
@@ -11,6 +11,7 @@ import (
 	cliinternal "github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/confirm"
 	"github.com/mpyw/suve/internal/cli/output"
+	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/usecase/azure"
 )
 
@@ -23,7 +24,8 @@ type DeleteRunner struct {
 
 // DeleteOptions holds the options for the delete command.
 type DeleteOptions struct {
-	Name string
+	Name  string
+	Force bool
 }
 
 // DeleteCommand returns the Azure Key Vault delete command.
@@ -32,20 +34,25 @@ func DeleteCommand() *cli.Command {
 		Name:      "delete",
 		Aliases:   []string{"rm"},
 		Usage:     "Delete a secret",
-		ArgsUsage: "<name>",
+		ArgsUsage: argsUsageName,
 		Description: `Delete a secret and all its versions from Azure Key Vault.
 
 When the vault has soft-delete enabled, the secret is recoverable within the
-vault's retention window via the Azure portal/CLI; otherwise deletion is
-permanent.
+vault's retention window (use 'suve azure secret restore'); otherwise deletion
+is permanent. --force purges immediately, skipping the recovery window.
 
 EXAMPLES:
-   suve azure secret delete my-secret        Delete (with confirmation)
-   suve azure secret delete --yes my-secret  Delete without confirmation`,
+   suve azure secret delete my-secret          Soft-delete (with confirmation)
+   suve azure secret delete --yes my-secret    Soft-delete without confirmation
+   suve azure secret delete --force my-secret  Delete and purge (no recovery)`,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "yes",
 				Usage: "Skip confirmation prompt",
+			},
+			&cli.BoolFlag{
+				Name:  "force",
+				Usage: "Purge immediately, skipping the recovery window (no recovery)",
 			},
 		},
 		Action: deleteAction,
@@ -98,17 +105,27 @@ func deleteAction(ctx context.Context, cmd *cli.Command) error {
 		Stderr:  cmd.Root().ErrWriter,
 	}
 
-	return r.Run(ctx, DeleteOptions{Name: name})
+	return r.Run(ctx, DeleteOptions{Name: name, Force: cmd.Bool("force")})
 }
 
 // Run executes the delete command.
 func (r *DeleteRunner) Run(ctx context.Context, opts DeleteOptions) error {
-	result, err := r.UseCase.Execute(ctx, azure.DeleteInput{Name: opts.Name})
+	var options []provider.DeleteOption
+	if opts.Force {
+		// Key Vault soft-deletes then purges; the recovery window is skipped.
+		options = append(options, provider.ForceDelete{})
+	}
+
+	result, err := r.UseCase.Execute(ctx, azure.DeleteInput{Name: opts.Name, Options: options})
 	if err != nil {
 		return err
 	}
 
-	output.Success(r.Stdout, "Deleted secret %s", result.Name)
+	if opts.Force {
+		output.Success(r.Stdout, "Deleted and purged secret %s", result.Name)
+	} else {
+		output.Success(r.Stdout, "Deleted secret %s", result.Name)
+	}
 
 	return nil
 }

--- a/internal/cli/commands/azure/secret/delete.go
+++ b/internal/cli/commands/azure/secret/delete.go
@@ -11,7 +11,6 @@ import (
 	cliinternal "github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/confirm"
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/usecase/azure"
 )
 
@@ -24,8 +23,7 @@ type DeleteRunner struct {
 
 // DeleteOptions holds the options for the delete command.
 type DeleteOptions struct {
-	Name  string
-	Force bool
+	Name string
 }
 
 // DeleteCommand returns the Azure Key Vault delete command.
@@ -39,20 +37,15 @@ func DeleteCommand() *cli.Command {
 
 When the vault has soft-delete enabled, the secret is recoverable within the
 vault's retention window (use 'suve azure secret restore'); otherwise deletion
-is permanent. --force purges immediately, skipping the recovery window.
+is permanent.
 
 EXAMPLES:
    suve azure secret delete my-secret          Soft-delete (with confirmation)
-   suve azure secret delete --yes my-secret    Soft-delete without confirmation
-   suve azure secret delete --force my-secret  Delete and purge (no recovery)`,
+   suve azure secret delete --yes my-secret    Soft-delete without confirmation`,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "yes",
 				Usage: "Skip confirmation prompt",
-			},
-			&cli.BoolFlag{
-				Name:  "force",
-				Usage: "Purge immediately, skipping the recovery window (no recovery)",
 			},
 		},
 		Action: deleteAction,
@@ -105,27 +98,17 @@ func deleteAction(ctx context.Context, cmd *cli.Command) error {
 		Stderr:  cmd.Root().ErrWriter,
 	}
 
-	return r.Run(ctx, DeleteOptions{Name: name, Force: cmd.Bool("force")})
+	return r.Run(ctx, DeleteOptions{Name: name})
 }
 
 // Run executes the delete command.
 func (r *DeleteRunner) Run(ctx context.Context, opts DeleteOptions) error {
-	var options []provider.DeleteOption
-	if opts.Force {
-		// Key Vault soft-deletes then purges; the recovery window is skipped.
-		options = append(options, provider.ForceDelete{})
-	}
-
-	result, err := r.UseCase.Execute(ctx, azure.DeleteInput{Name: opts.Name, Options: options})
+	result, err := r.UseCase.Execute(ctx, azure.DeleteInput{Name: opts.Name})
 	if err != nil {
 		return err
 	}
 
-	if opts.Force {
-		output.Success(r.Stdout, "Deleted and purged secret %s", result.Name)
-	} else {
-		output.Success(r.Stdout, "Deleted secret %s", result.Name)
-	}
+	output.Success(r.Stdout, "Deleted secret %s", result.Name)
 
 	return nil
 }

--- a/internal/cli/commands/azure/secret/log.go
+++ b/internal/cli/commands/azure/secret/log.go
@@ -203,7 +203,7 @@ func (p *logPresenter) RenderPatch(stdout, stderr io.Writer, i int, parseJSON, r
 func LogCommand() *cli.Command {
 	return genericlog.Command(genericlog.Config{
 		Usage:     "Show secret version history",
-		ArgsUsage: "<name>",
+		ArgsUsage: argsUsageName,
 		Description: `Display the version history of a secret, showing each version's
 opaque id, state (enabled/disabled), and creation date.
 

--- a/internal/cli/commands/azure/secret/restore.go
+++ b/internal/cli/commands/azure/secret/restore.go
@@ -1,0 +1,79 @@
+package secret
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/urfave/cli/v3"
+
+	cliinternal "github.com/mpyw/suve/internal/cli/commands/internal"
+	"github.com/mpyw/suve/internal/cli/output"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/usecase/azure"
+)
+
+// RestoreRunner executes the restore command.
+type RestoreRunner struct {
+	UseCase *azure.RestoreUseCase
+	Stdout  io.Writer
+	Stderr  io.Writer
+}
+
+// RestoreOptions holds the options for the restore command.
+type RestoreOptions struct {
+	Name string
+}
+
+// RestoreCommand returns the Azure Key Vault restore command.
+func RestoreCommand() *cli.Command {
+	return &cli.Command{
+		Name:      "restore",
+		Usage:     "Restore a soft-deleted secret",
+		ArgsUsage: argsUsageName,
+		Description: `Recover a soft-deleted Key Vault secret (RecoverDeletedSecret).
+
+Works while the secret is within the vault's soft-delete retention window and
+has not been purged. A secret deleted with --force (purged) cannot be restored.
+
+EXAMPLES:
+   suve azure secret restore my-secret    Recover a soft-deleted secret`,
+		Action: restoreAction,
+	}
+}
+
+func restoreAction(ctx context.Context, cmd *cli.Command) error {
+	if cmd.Args().Len() < 1 {
+		return fmt.Errorf("usage: suve azure secret restore <name>")
+	}
+
+	store, err := cliinternal.AzureKeyVaultStore(ctx)
+	if err != nil {
+		return err
+	}
+
+	restorer, ok := store.(provider.Restorer)
+	if !ok {
+		return fmt.Errorf("restore is not supported by this provider")
+	}
+
+	r := &RestoreRunner{
+		UseCase: &azure.RestoreUseCase{Restorer: restorer},
+		Stdout:  cmd.Root().Writer,
+		Stderr:  cmd.Root().ErrWriter,
+	}
+
+	return r.Run(ctx, RestoreOptions{Name: cmd.Args().First()})
+}
+
+// Run executes the restore command.
+func (r *RestoreRunner) Run(ctx context.Context, opts RestoreOptions) error {
+	result, err := r.UseCase.Execute(ctx, azure.RestoreInput{Name: opts.Name})
+	if err != nil {
+		return err
+	}
+
+	output.Success(r.Stdout, "Restored secret %s", result.Name)
+
+	return nil
+}

--- a/internal/cli/commands/azure/secret/restore.go
+++ b/internal/cli/commands/azure/secret/restore.go
@@ -34,7 +34,7 @@ func RestoreCommand() *cli.Command {
 		Description: `Recover a soft-deleted Key Vault secret (RecoverDeletedSecret).
 
 Works while the secret is within the vault's soft-delete retention window and
-has not been purged. A secret deleted with --force (purged) cannot be restored.
+has not been purged.
 
 EXAMPLES:
    suve azure secret restore my-secret    Recover a soft-deleted secret`,

--- a/internal/cli/commands/secret/delete/delete.go
+++ b/internal/cli/commands/secret/delete/delete.go
@@ -190,7 +190,7 @@ func (r *Runner) Run(ctx context.Context, opts Options) error {
 
 	switch {
 	case opts.Force:
-		options = append(options, awssecret.ForceDelete{})
+		options = append(options, provider.ForceDelete{})
 	case opts.RecoveryWindow > 0:
 		options = append(options, awssecret.RecoveryWindow{Days: int64(opts.RecoveryWindow)})
 	}

--- a/internal/cli/commands/secret/delete/delete_test.go
+++ b/internal/cli/commands/secret/delete/delete_test.go
@@ -81,7 +81,7 @@ func TestRun(t *testing.T) {
 			checkOpts: func(t *testing.T, opts []provider.DeleteOption) {
 				t.Helper()
 				require.Len(t, opts, 1)
-				assert.IsType(t, awssecret.ForceDelete{}, opts[0])
+				assert.IsType(t, provider.ForceDelete{}, opts[0])
 			},
 			check: func(t *testing.T, output string) {
 				t.Helper()

--- a/internal/gui/capabilities_internal_test.go
+++ b/internal/gui/capabilities_internal_test.go
@@ -50,13 +50,15 @@ func TestApp_Capabilities_StagingAndDeleteFlags(t *testing.T) {
 		hasRecoveryWindow bool
 		hasRestore        bool
 	}{
-		// Staging is now available for every provider service; force-delete
-		// and recovery-window stay AWS Secrets Manager only.
+		// Staging is available for every provider service. Force-delete and
+		// restore belong to the soft-delete providers — AWS Secrets Manager AND
+		// Azure Key Vault; only AWS SM has a per-delete recovery window (Key Vault
+		// retention is a vault property, so hasRecoveryWindow stays false there).
 		{string(provider.ProviderAWS), "param", true, false, false, false},
 		{string(provider.ProviderAWS), "secret", true, true, true, true},
 		{string(provider.ProviderGoogleCloud), "secret", true, false, false, false},
 		{string(provider.ProviderAzure), "param", true, false, false, false},
-		{string(provider.ProviderAzure), "secret", true, false, false, false},
+		{string(provider.ProviderAzure), "secret", true, true, false, true},
 	}
 
 	for _, tt := range tests {
@@ -72,17 +74,17 @@ func TestApp_Capabilities_StagingAndDeleteFlags(t *testing.T) {
 	}
 }
 
-// TestApp_Capabilities_DeleteOptionsAWSOnly pins the remaining AWS-only
-// invariant: force-delete and recovery-window are Secrets Manager features, so
-// no other provider/service may advertise them even though they now stage.
-func TestApp_Capabilities_DeleteOptionsAWSOnly(t *testing.T) {
+// TestApp_Capabilities_RecoveryWindowAWSOnly pins the AWS-only invariant: a
+// per-delete recovery window is a Secrets Manager feature. Force-delete is NOT
+// AWS-only anymore (Azure Key Vault purges), so only the recovery window is
+// pinned here. Key Vault's retention is a vault property, not a per-delete choice.
+func TestApp_Capabilities_RecoveryWindowAWSOnly(t *testing.T) {
 	t.Parallel()
 
 	for _, p := range (&App{}).Capabilities() {
 		for _, s := range p.Services {
 			isAWSSecret := p.Provider == string(provider.ProviderAWS) && s.Service == "secret"
 			if !isAWSSecret {
-				assert.False(t, s.HasForceDelete, "%s/%s must not have force-delete", p.Provider, s.Service)
 				assert.False(t, s.HasRecoveryWindow, "%s/%s must not have a recovery window", p.Provider, s.Service)
 			}
 		}

--- a/internal/gui/capabilities_internal_test.go
+++ b/internal/gui/capabilities_internal_test.go
@@ -50,15 +50,15 @@ func TestApp_Capabilities_StagingAndDeleteFlags(t *testing.T) {
 		hasRecoveryWindow bool
 		hasRestore        bool
 	}{
-		// Staging is available for every provider service. Force-delete and
-		// restore belong to the soft-delete providers — AWS Secrets Manager AND
-		// Azure Key Vault; only AWS SM has a per-delete recovery window (Key Vault
-		// retention is a vault property, so hasRecoveryWindow stays false there).
+		// Staging is available for every provider service. Restore belongs to the
+		// soft-delete providers — AWS Secrets Manager AND Azure Key Vault — but
+		// force-delete and the per-delete recovery window are AWS SM only: Key Vault
+		// retention is a vault property and force-delete/purge is unsupported there.
 		{string(provider.ProviderAWS), "param", true, false, false, false},
 		{string(provider.ProviderAWS), "secret", true, true, true, true},
 		{string(provider.ProviderGoogleCloud), "secret", true, false, false, false},
 		{string(provider.ProviderAzure), "param", true, false, false, false},
-		{string(provider.ProviderAzure), "secret", true, true, false, true},
+		{string(provider.ProviderAzure), "secret", true, false, false, true},
 	}
 
 	for _, tt := range tests {
@@ -74,17 +74,19 @@ func TestApp_Capabilities_StagingAndDeleteFlags(t *testing.T) {
 	}
 }
 
-// TestApp_Capabilities_RecoveryWindowAWSOnly pins the AWS-only invariant: a
-// per-delete recovery window is a Secrets Manager feature. Force-delete is NOT
-// AWS-only anymore (Azure Key Vault purges), so only the recovery window is
-// pinned here. Key Vault's retention is a vault property, not a per-delete choice.
-func TestApp_Capabilities_RecoveryWindowAWSOnly(t *testing.T) {
+// TestApp_Capabilities_ForceDeleteAndRecoveryWindowAWSOnly pins the AWS-only
+// invariant: both force-delete and the per-delete recovery window are Secrets
+// Manager features. Azure Key Vault soft-deletes (Restore recovers) but neither
+// purges on force nor exposes a per-delete recovery window (retention is a vault
+// property), so no other provider/service may report these.
+func TestApp_Capabilities_ForceDeleteAndRecoveryWindowAWSOnly(t *testing.T) {
 	t.Parallel()
 
 	for _, p := range (&App{}).Capabilities() {
 		for _, s := range p.Services {
 			isAWSSecret := p.Provider == string(provider.ProviderAWS) && s.Service == "secret"
 			if !isAWSSecret {
+				assert.False(t, s.HasForceDelete, "%s/%s must not offer force-delete", p.Provider, s.Service)
 				assert.False(t, s.HasRecoveryWindow, "%s/%s must not have a recovery window", p.Provider, s.Service)
 			}
 		}

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -275,7 +275,7 @@ export const defaultCapabilities: ProviderCapability[] = [
     scopeFields: [],
     services: [
       { service: 'param', displayName: 'App Configuration', hasVersionHistory: false, hasVersionSpecifiers: false, hasTags: true, tagsPerVersion: false, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: true },
-      { service: 'secret', displayName: 'Key Vault', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, tagsPerVersion: true, hasRestore: true, hasStaging: true, hasForceDelete: true, hasRecoveryWindow: false, hasNamespaces: false },
+      { service: 'secret', displayName: 'Key Vault', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, tagsPerVersion: true, hasRestore: true, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: false },
     ],
   },
 ];

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -275,7 +275,7 @@ export const defaultCapabilities: ProviderCapability[] = [
     scopeFields: [],
     services: [
       { service: 'param', displayName: 'App Configuration', hasVersionHistory: false, hasVersionSpecifiers: false, hasTags: true, tagsPerVersion: false, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: true },
-      { service: 'secret', displayName: 'Key Vault', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, tagsPerVersion: true, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: false },
+      { service: 'secret', displayName: 'Key Vault', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, tagsPerVersion: true, hasRestore: true, hasStaging: true, hasForceDelete: true, hasRecoveryWindow: false, hasNamespaces: false },
     ],
   },
 ];
@@ -1094,8 +1094,14 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
         if (existing) existing.value = value;
         return { name, versionId: 'v2', arn: '' };
       },
-      SecretDelete: async (name: string) => {
+      SecretDelete: async (name: string, force?: boolean) => {
+        const removed = state.secrets.filter((s: any) => s.name === name);
         state.secrets = state.secrets.filter((s: any) => s.name !== name);
+        // Soft-delete keeps the secret recoverable; force purges it for good.
+        if (!force) {
+          (window as any).__softDeleted = (window as any).__softDeleted ?? [];
+          (window as any).__softDeleted.push(...removed);
+        }
         return { name, deletionDate: new Date().toISOString(), arn: '' };
       },
       SecretDiff: async (spec1: string, spec2: string) => {
@@ -1120,7 +1126,15 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
         };
       },
       SecretRestore: async (name: string) => {
-        return { name, arn: `arn:aws:secretsmanager:us-east-1:123456789:secret:${name}` };
+        // Recover a soft-deleted secret back into the listing (purged ones stay
+        // gone). Mirrors RecoverDeletedSecret.
+        const soft = ((window as any).__softDeleted ?? []) as any[];
+        const idx = soft.findIndex((s) => s.name === name);
+        if (idx >= 0) {
+          state.secrets.push(soft[idx]);
+          soft.splice(idx, 1);
+        }
+        return { name, arn: '' };
       },
       SecretAddTag: async (name: string, key: string, value: string) => {
         if (!state.secretTags[name]) state.secretTags[name] = [];

--- a/internal/gui/frontend/tests/keyvault-restore.spec.ts
+++ b/internal/gui/frontend/tests/keyvault-restore.spec.ts
@@ -2,8 +2,10 @@ import { test, expect, type Page } from '@playwright/test';
 import { setupWailsMocks, createAzureState, navigateTo } from './fixtures/wails-mock';
 
 // Azure Key Vault soft-deletes secrets like AWS Secrets Manager, so the GUI must
-// offer Restore and a force-delete (purge) option — capability-gated on
-// hasRestore / hasForceDelete, which are true only for soft-delete providers.
+// offer Restore (capability-gated on hasRestore). Force-delete/purge is NOT
+// supported for Key Vault (hasForceDelete=false): retention is a vault property
+// and staged deletes can't carry a purge flag, so the delete modal must not show
+// a force-delete option there — deletes are always soft and recoverable.
 
 async function openKeyVault(page: Page) {
   await navigateTo(page, 'Key Vault');
@@ -11,7 +13,7 @@ async function openKeyVault(page: Page) {
 }
 
 test.describe('Key Vault soft-delete UI', () => {
-  test('offers Restore and a force-delete (purge) option', async ({ page }) => {
+  test('offers Restore but no force-delete (purge) option', async ({ page }) => {
     await setupWailsMocks(page, createAzureState());
     await page.goto('/');
     await openKeyVault(page);
@@ -19,26 +21,32 @@ test.describe('Key Vault soft-delete UI', () => {
     // Restore affordance is present for Key Vault.
     await expect(page.locator('.btn-restore')).toBeVisible();
 
-    // The delete modal offers force-delete (purge, skip recovery window).
+    // The delete modal has NO force-delete checkbox (purge unsupported).
     await page.locator('.item-button').filter({ hasText: 'kv-secret' }).click();
     await page.locator('.btn-action-sm.btn-danger').filter({ hasText: 'Delete' }).click();
-    await expect(page.locator('.force-delete')).toContainText('Force delete');
+    await expect(page.locator('.force-delete')).toHaveCount(0);
   });
 
-  test('force delete purges the secret from the list', async ({ page }) => {
+  test('soft-delete then restore round-trips the secret', async ({ page }) => {
     await setupWailsMocks(page, createAzureState());
     await page.goto('/');
     await openKeyVault(page);
 
+    // Delete immediately (soft-delete — no force option exists for Key Vault).
     await page.locator('.item-button').filter({ hasText: 'kv-secret' }).click();
     await page.locator('.btn-action-sm.btn-danger').filter({ hasText: 'Delete' }).click();
-
-    // Apply immediately (skip staging) so the purge hits the provider now, and
-    // force-delete to purge.
     await page.locator('.immediate-checkbox input[type="checkbox"]').check();
-    await page.locator('.force-delete input[type="checkbox"]').check();
     await page.locator('.form-actions .btn-danger').click();
 
+    // Soft-deleted: gone from the listing.
     await expect(page.locator('.item-button').filter({ hasText: 'kv-secret' })).toHaveCount(0);
+
+    // Restore it by name — it is still within the recovery window.
+    await page.locator('.btn-restore').click();
+    await page.locator('#restore-name').fill('kv-secret');
+    await page.locator('.btn-restore-confirm').click();
+
+    // Recovered: back in the listing.
+    await expect(page.locator('.item-button').filter({ hasText: 'kv-secret' })).toBeVisible();
   });
 });

--- a/internal/gui/frontend/tests/keyvault-restore.spec.ts
+++ b/internal/gui/frontend/tests/keyvault-restore.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect, type Page } from '@playwright/test';
+import { setupWailsMocks, createAzureState, navigateTo } from './fixtures/wails-mock';
+
+// Azure Key Vault soft-deletes secrets like AWS Secrets Manager, so the GUI must
+// offer Restore and a force-delete (purge) option — capability-gated on
+// hasRestore / hasForceDelete, which are true only for soft-delete providers.
+
+async function openKeyVault(page: Page) {
+  await navigateTo(page, 'Key Vault');
+  await expect(page.locator('.item-button').filter({ hasText: 'kv-secret' })).toBeVisible();
+}
+
+test.describe('Key Vault soft-delete UI', () => {
+  test('offers Restore and a force-delete (purge) option', async ({ page }) => {
+    await setupWailsMocks(page, createAzureState());
+    await page.goto('/');
+    await openKeyVault(page);
+
+    // Restore affordance is present for Key Vault.
+    await expect(page.locator('.btn-restore')).toBeVisible();
+
+    // The delete modal offers force-delete (purge, skip recovery window).
+    await page.locator('.item-button').filter({ hasText: 'kv-secret' }).click();
+    await page.locator('.btn-action-sm.btn-danger').filter({ hasText: 'Delete' }).click();
+    await expect(page.locator('.force-delete')).toContainText('Force delete');
+  });
+
+  test('force delete purges the secret from the list', async ({ page }) => {
+    await setupWailsMocks(page, createAzureState());
+    await page.goto('/');
+    await openKeyVault(page);
+
+    await page.locator('.item-button').filter({ hasText: 'kv-secret' }).click();
+    await page.locator('.btn-action-sm.btn-danger').filter({ hasText: 'Delete' }).click();
+
+    // Apply immediately (skip staging) so the purge hits the provider now, and
+    // force-delete to purge.
+    await page.locator('.immediate-checkbox input[type="checkbox"]').check();
+    await page.locator('.force-delete input[type="checkbox"]').check();
+    await page.locator('.form-actions .btn-danger').click();
+
+    await expect(page.locator('.item-button').filter({ hasText: 'kv-secret' })).toHaveCount(0);
+  });
+});

--- a/internal/gui/frontend/tests/provider-selection.spec.ts
+++ b/internal/gui/frontend/tests/provider-selection.spec.ts
@@ -138,14 +138,15 @@ test.describe('Provider selection', () => {
       await expect(page.locator('.error-banner')).toHaveCount(0);
     });
 
-    test('Key Vault (secret): version history yes, Restore no', async ({ page }) => {
+    test('Key Vault (secret): version history yes, Restore yes (soft-delete)', async ({ page }) => {
       await setupWailsMocks(page, createAzureState());
       await page.goto('/');
       await waitForItemList(page);
       await navigateTo(page, 'Key Vault');
       await waitForItemList(page);
 
-      await expect(page.locator('.btn-restore')).toHaveCount(0);
+      // Key Vault soft-deletes secrets, so Restore is offered (hasRestore=true).
+      await expect(page.locator('.btn-restore')).toBeVisible();
       await clickItemByName(page, 'kv-secret');
       await expect(page.locator('.detail-panel')).toBeVisible();
     });

--- a/internal/gui/providers.go
+++ b/internal/gui/providers.go
@@ -202,10 +202,11 @@ func (a *App) Capabilities() []ProviderCapability {
 				{
 					Service: serviceSecret, DisplayName: "Key Vault",
 					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, TagsPerVersion: true, HasRestore: true,
-					// HasForceDelete: purge (PurgeDeletedSecret) skips the recovery
-					// window. HasRecoveryWindow stays false: Key Vault's retention is a
-					// vault property (softDeleteRetentionInDays), not chosen per delete.
-					HasStaging: true, HasForceDelete: true, HasRecoveryWindow: false,
+					// Force-delete (purge) is unsupported: Key Vault retention is a vault
+					// property (softDeleteRetentionInDays), not a per-delete choice, and
+					// staged deletes can't carry it — so deletes are always soft (Restore
+					// recovers them). HasForceDelete/HasRecoveryWindow both stay false.
+					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false,
 				},
 			},
 		},

--- a/internal/gui/providers.go
+++ b/internal/gui/providers.go
@@ -201,8 +201,11 @@ func (a *App) Capabilities() []ProviderCapability {
 				},
 				{
 					Service: serviceSecret, DisplayName: "Key Vault",
-					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, TagsPerVersion: true, HasRestore: false,
-					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false,
+					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, TagsPerVersion: true, HasRestore: true,
+					// HasForceDelete: purge (PurgeDeletedSecret) skips the recovery
+					// window. HasRecoveryWindow stays false: Key Vault's retention is a
+					// vault property (softDeleteRetentionInDays), not chosen per delete.
+					HasStaging: true, HasForceDelete: true, HasRecoveryWindow: false,
 				},
 			},
 		},

--- a/internal/gui/secret.go
+++ b/internal/gui/secret.go
@@ -290,8 +290,10 @@ func (a *App) SecretDelete(name string, force bool) (*SecretDeleteResult, error)
 
 	var options []provider.DeleteOption
 	if force {
-		// Neutral force-delete: AWS maps it to ForceDeleteWithoutRecovery, Azure
-		// Key Vault soft-deletes then purges. One option works for both.
+		// Force-delete is AWS Secrets Manager only (mapped to
+		// ForceDeleteWithoutRecovery); the frontend hides the checkbox elsewhere
+		// (hasForceDelete=false), so force is never set for Key Vault or Google
+		// Cloud, which soft-delete/retain by policy instead.
 		options = append(options, provider.ForceDelete{})
 	}
 

--- a/internal/gui/secret.go
+++ b/internal/gui/secret.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/mpyw/suve/internal/provider"
-	awssecret "github.com/mpyw/suve/internal/provider/aws/secret"
 	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/usecase/secret"
 )
@@ -291,7 +290,9 @@ func (a *App) SecretDelete(name string, force bool) (*SecretDeleteResult, error)
 
 	var options []provider.DeleteOption
 	if force {
-		options = append(options, awssecret.ForceDelete{})
+		// Neutral force-delete: AWS maps it to ForceDeleteWithoutRecovery, Azure
+		// Key Vault soft-deletes then purges. One option works for both.
+		options = append(options, provider.ForceDelete{})
 	}
 
 	result, err := uc.Execute(a.ctx, secret.DeleteInput{

--- a/internal/provider/aws/secret/options.go
+++ b/internal/provider/aws/secret/options.go
@@ -26,12 +26,6 @@ type RotationRules struct {
 	AutomaticallyAfterDays int64
 }
 
-// ForceDelete deletes the secret immediately, without a recovery window
-// (ForceDeleteWithoutRecovery). It implements provider.DeleteOption.
-type ForceDelete struct {
-	provider.DeleteOptionMarker
-}
-
 // RecoveryWindow sets the number of days AWS retains the secret before
 // permanent deletion. It implements provider.DeleteOption.
 type RecoveryWindow struct {
@@ -44,7 +38,6 @@ type RecoveryWindow struct {
 var (
 	_ provider.WriteOption  = KMSKeyID{}
 	_ provider.WriteOption  = RotationRules{}
-	_ provider.DeleteOption = ForceDelete{}
 	_ provider.DeleteOption = RecoveryWindow{}
 )
 
@@ -82,7 +75,7 @@ func rotationOption(opts []provider.WriteOption) (RotationRules, bool) {
 func applyDeleteOptions(input *secretsmanager.DeleteSecretInput, opts []provider.DeleteOption) {
 	for _, opt := range opts {
 		switch o := opt.(type) {
-		case ForceDelete:
+		case provider.ForceDelete:
 			input.ForceDeleteWithoutRecovery = aws.Bool(true)
 		case RecoveryWindow:
 			if o.Days > 0 {

--- a/internal/provider/aws/secret/secret_test.go
+++ b/internal/provider/aws/secret/secret_test.go
@@ -508,7 +508,7 @@ func TestDelete_ForceDelete(t *testing.T) {
 		},
 	})
 
-	require.NoError(t, store.Delete(t.Context(), "my-secret", secret.ForceDelete{}))
+	require.NoError(t, store.Delete(t.Context(), "my-secret", provider.ForceDelete{}))
 	require.NotNil(t, in)
 	assert.True(t, aws.ToBool(in.ForceDeleteWithoutRecovery))
 	assert.Nil(t, in.RecoveryWindowInDays)

--- a/internal/provider/azure/keyvault/client.go
+++ b/internal/provider/azure/keyvault/client.go
@@ -39,6 +39,18 @@ func (a *apiClient) DeleteSecret(
 	return a.c.DeleteSecret(ctx, name, nil)
 }
 
+func (a *apiClient) RecoverDeletedSecret(
+	ctx context.Context, name string,
+) (azsecrets.RecoverDeletedSecretResponse, error) {
+	return a.c.RecoverDeletedSecret(ctx, name, nil)
+}
+
+func (a *apiClient) PurgeDeletedSecret(
+	ctx context.Context, name string,
+) (azsecrets.PurgeDeletedSecretResponse, error) {
+	return a.c.PurgeDeletedSecret(ctx, name, nil)
+}
+
 func (a *apiClient) UpdateSecretProperties(
 	ctx context.Context, name, version string, params azsecrets.UpdateSecretPropertiesParameters,
 ) (azsecrets.UpdateSecretPropertiesResponse, error) {

--- a/internal/provider/azure/keyvault/client.go
+++ b/internal/provider/azure/keyvault/client.go
@@ -45,12 +45,6 @@ func (a *apiClient) RecoverDeletedSecret(
 	return a.c.RecoverDeletedSecret(ctx, name, nil)
 }
 
-func (a *apiClient) PurgeDeletedSecret(
-	ctx context.Context, name string,
-) (azsecrets.PurgeDeletedSecretResponse, error) {
-	return a.c.PurgeDeletedSecret(ctx, name, nil)
-}
-
 func (a *apiClient) UpdateSecretProperties(
 	ctx context.Context, name, version string, params azsecrets.UpdateSecretPropertiesParameters,
 ) (azsecrets.UpdateSecretPropertiesResponse, error) {

--- a/internal/provider/azure/keyvault/keyvault.go
+++ b/internal/provider/azure/keyvault/keyvault.go
@@ -47,6 +47,8 @@ type Client interface {
 		ctx context.Context, name string, params azsecrets.SetSecretParameters,
 	) (azsecrets.SetSecretResponse, error)
 	DeleteSecret(ctx context.Context, name string) (azsecrets.DeleteSecretResponse, error)
+	RecoverDeletedSecret(ctx context.Context, name string) (azsecrets.RecoverDeletedSecretResponse, error)
+	PurgeDeletedSecret(ctx context.Context, name string) (azsecrets.PurgeDeletedSecretResponse, error)
 	UpdateSecretProperties(
 		ctx context.Context, name, version string, params azsecrets.UpdateSecretPropertiesParameters,
 	) (azsecrets.UpdateSecretPropertiesResponse, error)
@@ -60,8 +62,12 @@ type Store struct {
 	client Client
 }
 
-// Compile-time assertion that Store implements the provider contract.
-var _ provider.Store = (*Store)(nil)
+// Compile-time assertions that Store implements the provider contract and the
+// optional Restorer capability (soft-delete recovery).
+var (
+	_ provider.Store    = (*Store)(nil)
+	_ provider.Restorer = (*Store)(nil)
+)
 
 // New builds a Store backed by the given client.
 func New(client Client) *Store {
@@ -248,12 +254,40 @@ func (s *Store) setSecret(ctx context.Context, name, value string) (domain.Versi
 	return domain.Version{ID: versionID(resp.ID)}, nil
 }
 
+// Restore recovers a soft-deleted secret (RecoverDeletedSecret). It makes the
+// store satisfy provider.Restorer, mirroring AWS Secrets Manager's restore.
+func (s *Store) Restore(ctx context.Context, name string) error {
+	if _, err := s.client.RecoverDeletedSecret(ctx, name); err != nil {
+		return mapError(err, name, "restore secret")
+	}
+
+	return nil
+}
+
 // Delete deletes a secret. Key Vault delete is a soft-delete when the vault has
-// soft-delete enabled; provider.DeleteOptions (AWS-specific) are ignored.
-func (s *Store) Delete(ctx context.Context, name string, _ ...provider.DeleteOption) error {
+// soft-delete enabled. provider.ForceDelete makes it permanent immediately, the
+// way AWS Secrets Manager's ForceDeleteWithoutRecovery does: soft-delete, then
+// purge (PurgeDeletedSecret) so no recovery window remains. Other delete options
+// are ignored (Key Vault has no per-delete recovery window — that is a vault
+// property).
+func (s *Store) Delete(ctx context.Context, name string, opts ...provider.DeleteOption) error {
+	force := false
+
+	for _, opt := range opts {
+		if _, ok := opt.(provider.ForceDelete); ok {
+			force = true
+		}
+	}
+
 	_, err := s.client.DeleteSecret(ctx, name)
 	if err != nil {
 		return mapError(err, name, "delete secret")
+	}
+
+	if force {
+		if _, err := s.client.PurgeDeletedSecret(ctx, name); err != nil {
+			return mapError(err, name, "purge secret")
+		}
 	}
 
 	return nil

--- a/internal/provider/azure/keyvault/keyvault.go
+++ b/internal/provider/azure/keyvault/keyvault.go
@@ -48,7 +48,6 @@ type Client interface {
 	) (azsecrets.SetSecretResponse, error)
 	DeleteSecret(ctx context.Context, name string) (azsecrets.DeleteSecretResponse, error)
 	RecoverDeletedSecret(ctx context.Context, name string) (azsecrets.RecoverDeletedSecretResponse, error)
-	PurgeDeletedSecret(ctx context.Context, name string) (azsecrets.PurgeDeletedSecretResponse, error)
 	UpdateSecretProperties(
 		ctx context.Context, name, version string, params azsecrets.UpdateSecretPropertiesParameters,
 	) (azsecrets.UpdateSecretPropertiesResponse, error)
@@ -56,8 +55,9 @@ type Client interface {
 	ListSecretPropertiesVersions(ctx context.Context, name string) ([]*azsecrets.SecretProperties, error)
 }
 
-// Store is the Key Vault implementation of provider.Store. Like the Google
-// Cloud secret store it implements neither Restorer nor Describer.
+// Store is the Key Vault implementation of provider.Store. It also implements
+// the optional Restorer capability (soft-delete recovery); it does not
+// implement Describer.
 type Store struct {
 	client Client
 }
@@ -264,30 +264,13 @@ func (s *Store) Restore(ctx context.Context, name string) error {
 	return nil
 }
 
-// Delete deletes a secret. Key Vault delete is a soft-delete when the vault has
-// soft-delete enabled. provider.ForceDelete makes it permanent immediately, the
-// way AWS Secrets Manager's ForceDeleteWithoutRecovery does: soft-delete, then
-// purge (PurgeDeletedSecret) so no recovery window remains. Other delete options
-// are ignored (Key Vault has no per-delete recovery window — that is a vault
-// property).
-func (s *Store) Delete(ctx context.Context, name string, opts ...provider.DeleteOption) error {
-	force := false
-
-	for _, opt := range opts {
-		if _, ok := opt.(provider.ForceDelete); ok {
-			force = true
-		}
-	}
-
-	_, err := s.client.DeleteSecret(ctx, name)
-	if err != nil {
+// Delete soft-deletes a secret when the vault has soft-delete enabled (the
+// default); use Restore to recover it within the vault's retention window. All
+// delete options are ignored: Key Vault has no per-delete recovery window (that
+// is a vault property), and force-delete/purge is intentionally unsupported.
+func (s *Store) Delete(ctx context.Context, name string, _ ...provider.DeleteOption) error {
+	if _, err := s.client.DeleteSecret(ctx, name); err != nil {
 		return mapError(err, name, "delete secret")
-	}
-
-	if force {
-		if _, err := s.client.PurgeDeletedSecret(ctx, name); err != nil {
-			return mapError(err, name, "purge secret")
-		}
 	}
 
 	return nil

--- a/internal/provider/azure/keyvault/keyvault_test.go
+++ b/internal/provider/azure/keyvault/keyvault_test.go
@@ -45,7 +45,6 @@ type mockClient struct {
 	listFunc     func(ctx context.Context) ([]*azsecrets.SecretProperties, error)
 	listVersFunc func(ctx context.Context, name string) ([]*azsecrets.SecretProperties, error)
 	recoverFunc  func(ctx context.Context, name string) (azsecrets.RecoverDeletedSecretResponse, error)
-	purgeFunc    func(ctx context.Context, name string) (azsecrets.PurgeDeletedSecretResponse, error)
 }
 
 func (m *mockClient) GetSecret(ctx context.Context, name, version string) (azsecrets.GetSecretResponse, error) {
@@ -66,12 +65,6 @@ func (m *mockClient) RecoverDeletedSecret(
 	ctx context.Context, name string,
 ) (azsecrets.RecoverDeletedSecretResponse, error) {
 	return m.recoverFunc(ctx, name)
-}
-
-func (m *mockClient) PurgeDeletedSecret(
-	ctx context.Context, name string,
-) (azsecrets.PurgeDeletedSecretResponse, error) {
-	return m.purgeFunc(ctx, name)
 }
 
 func (m *mockClient) UpdateSecretProperties(
@@ -306,31 +299,6 @@ func TestDelete(t *testing.T) {
 
 	require.NoError(t, store.Delete(t.Context(), "my-secret"))
 	assert.Equal(t, "my-secret", deleted)
-}
-
-func TestDelete_Force_Purges(t *testing.T) {
-	t.Parallel()
-
-	var deleted, purged string
-
-	m := &mockClient{
-		deleteFunc: func(_ context.Context, name string) (azsecrets.DeleteSecretResponse, error) {
-			deleted = name
-
-			return azsecrets.DeleteSecretResponse{}, nil
-		},
-		purgeFunc: func(_ context.Context, name string) (azsecrets.PurgeDeletedSecretResponse, error) {
-			purged = name
-
-			return azsecrets.PurgeDeletedSecretResponse{}, nil
-		},
-	}
-	store := keyvault.New(m)
-
-	// provider.ForceDelete: soft-delete THEN purge (no recovery window left).
-	require.NoError(t, store.Delete(t.Context(), "my-secret", provider.ForceDelete{}))
-	assert.Equal(t, "my-secret", deleted)
-	assert.Equal(t, "my-secret", purged, "force delete must purge after the soft-delete")
 }
 
 func TestRestore(t *testing.T) {

--- a/internal/provider/azure/keyvault/keyvault_test.go
+++ b/internal/provider/azure/keyvault/keyvault_test.go
@@ -44,6 +44,8 @@ type mockClient struct {
 	updateFunc   func(ctx context.Context, name, version string, params updParams) (updResp, error)
 	listFunc     func(ctx context.Context) ([]*azsecrets.SecretProperties, error)
 	listVersFunc func(ctx context.Context, name string) ([]*azsecrets.SecretProperties, error)
+	recoverFunc  func(ctx context.Context, name string) (azsecrets.RecoverDeletedSecretResponse, error)
+	purgeFunc    func(ctx context.Context, name string) (azsecrets.PurgeDeletedSecretResponse, error)
 }
 
 func (m *mockClient) GetSecret(ctx context.Context, name, version string) (azsecrets.GetSecretResponse, error) {
@@ -58,6 +60,18 @@ func (m *mockClient) SetSecret(
 
 func (m *mockClient) DeleteSecret(ctx context.Context, name string) (azsecrets.DeleteSecretResponse, error) {
 	return m.deleteFunc(ctx, name)
+}
+
+func (m *mockClient) RecoverDeletedSecret(
+	ctx context.Context, name string,
+) (azsecrets.RecoverDeletedSecretResponse, error) {
+	return m.recoverFunc(ctx, name)
+}
+
+func (m *mockClient) PurgeDeletedSecret(
+	ctx context.Context, name string,
+) (azsecrets.PurgeDeletedSecretResponse, error) {
+	return m.purgeFunc(ctx, name)
 }
 
 func (m *mockClient) UpdateSecretProperties(
@@ -292,6 +306,49 @@ func TestDelete(t *testing.T) {
 
 	require.NoError(t, store.Delete(t.Context(), "my-secret"))
 	assert.Equal(t, "my-secret", deleted)
+}
+
+func TestDelete_Force_Purges(t *testing.T) {
+	t.Parallel()
+
+	var deleted, purged string
+
+	m := &mockClient{
+		deleteFunc: func(_ context.Context, name string) (azsecrets.DeleteSecretResponse, error) {
+			deleted = name
+
+			return azsecrets.DeleteSecretResponse{}, nil
+		},
+		purgeFunc: func(_ context.Context, name string) (azsecrets.PurgeDeletedSecretResponse, error) {
+			purged = name
+
+			return azsecrets.PurgeDeletedSecretResponse{}, nil
+		},
+	}
+	store := keyvault.New(m)
+
+	// provider.ForceDelete: soft-delete THEN purge (no recovery window left).
+	require.NoError(t, store.Delete(t.Context(), "my-secret", provider.ForceDelete{}))
+	assert.Equal(t, "my-secret", deleted)
+	assert.Equal(t, "my-secret", purged, "force delete must purge after the soft-delete")
+}
+
+func TestRestore(t *testing.T) {
+	t.Parallel()
+
+	var recovered string
+
+	m := &mockClient{
+		recoverFunc: func(_ context.Context, name string) (azsecrets.RecoverDeletedSecretResponse, error) {
+			recovered = name
+
+			return azsecrets.RecoverDeletedSecretResponse{}, nil
+		},
+	}
+	store := keyvault.New(m)
+
+	require.NoError(t, store.Restore(t.Context(), "my-secret"))
+	assert.Equal(t, "my-secret", recovered)
 }
 
 func TestTag(t *testing.T) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -63,6 +63,12 @@ type DeleteOptionMarker struct{}
 
 func (DeleteOptionMarker) deleteOption() {}
 
+// ForceDelete requests immediate, unrecoverable deletion, skipping any recovery
+// window. It is provider-neutral because the concept is shared: AWS Secrets
+// Manager maps it to ForceDeleteWithoutRecovery, and Azure Key Vault soft-deletes
+// then purges. Providers without the concept ignore it.
+type ForceDelete struct{ DeleteOptionMarker }
+
 // Reader provides read access to a provider's entries.
 type Reader interface {
 	// Resolve parses a provider-specific version spec string (e.g. "#3~1",

--- a/internal/staging/secret.go
+++ b/internal/staging/secret.go
@@ -108,7 +108,7 @@ func deleteOptions(o *DeleteOptions) []provider.DeleteOption {
 
 	switch {
 	case o.Force:
-		return []provider.DeleteOption{awssecret.ForceDelete{}}
+		return []provider.DeleteOption{provider.ForceDelete{}}
 	case o.RecoveryWindow > 0:
 		return []provider.DeleteOption{awssecret.RecoveryWindow{Days: int64(o.RecoveryWindow)}}
 	default:

--- a/internal/staging/secret_test.go
+++ b/internal/staging/secret_test.go
@@ -163,7 +163,7 @@ func TestSecretStrategy_Apply(t *testing.T) {
 		mock := &providermock.Store{
 			DeleteFunc: func(_ context.Context, _ string, opts ...provider.DeleteOption) error {
 				require.Len(t, opts, 1)
-				assert.IsType(t, awssecret.ForceDelete{}, opts[0])
+				assert.IsType(t, provider.ForceDelete{}, opts[0])
 
 				return nil
 			},

--- a/internal/usecase/azure/delete.go
+++ b/internal/usecase/azure/delete.go
@@ -11,9 +11,6 @@ import (
 // DeleteInput holds input for the delete use case.
 type DeleteInput struct {
 	Name string
-	// Options are passed through to the provider (e.g. provider.ForceDelete to
-	// purge a Key Vault secret immediately instead of soft-deleting).
-	Options []provider.DeleteOption
 }
 
 // DeleteOutput holds the result of the delete use case.
@@ -43,7 +40,7 @@ func (u *DeleteUseCase) GetCurrentValue(ctx context.Context, name string) (strin
 
 // Execute runs the delete use case.
 func (u *DeleteUseCase) Execute(ctx context.Context, input DeleteInput) (*DeleteOutput, error) {
-	if err := u.Store.Delete(ctx, input.Name, input.Options...); err != nil {
+	if err := u.Store.Delete(ctx, input.Name); err != nil {
 		return nil, fmt.Errorf("failed to delete entry: %w", err)
 	}
 

--- a/internal/usecase/azure/delete.go
+++ b/internal/usecase/azure/delete.go
@@ -11,6 +11,9 @@ import (
 // DeleteInput holds input for the delete use case.
 type DeleteInput struct {
 	Name string
+	// Options are passed through to the provider (e.g. provider.ForceDelete to
+	// purge a Key Vault secret immediately instead of soft-deleting).
+	Options []provider.DeleteOption
 }
 
 // DeleteOutput holds the result of the delete use case.
@@ -40,9 +43,34 @@ func (u *DeleteUseCase) GetCurrentValue(ctx context.Context, name string) (strin
 
 // Execute runs the delete use case.
 func (u *DeleteUseCase) Execute(ctx context.Context, input DeleteInput) (*DeleteOutput, error) {
-	if err := u.Store.Delete(ctx, input.Name); err != nil {
+	if err := u.Store.Delete(ctx, input.Name, input.Options...); err != nil {
 		return nil, fmt.Errorf("failed to delete entry: %w", err)
 	}
 
 	return &DeleteOutput{Name: input.Name}, nil
+}
+
+// RestoreInput holds input for the restore use case.
+type RestoreInput struct {
+	Name string
+}
+
+// RestoreOutput holds the result of the restore use case.
+type RestoreOutput struct {
+	Name string
+}
+
+// RestoreUseCase recovers a soft-deleted entry via a provider.Restorer (Azure
+// Key Vault's RecoverDeletedSecret).
+type RestoreUseCase struct {
+	Restorer provider.Restorer
+}
+
+// Execute runs the restore use case.
+func (u *RestoreUseCase) Execute(ctx context.Context, input RestoreInput) (*RestoreOutput, error) {
+	if err := u.Restorer.Restore(ctx, input.Name); err != nil {
+		return nil, fmt.Errorf("failed to restore entry: %w", err)
+	}
+
+	return &RestoreOutput{Name: input.Name}, nil
 }

--- a/internal/usecase/secret/delete_test.go
+++ b/internal/usecase/secret/delete_test.go
@@ -104,11 +104,11 @@ func TestDeleteUseCase_Execute_ForwardsForceDelete(t *testing.T) {
 
 	_, err := uc.Execute(t.Context(), secret.DeleteInput{
 		Name:    "my-secret",
-		Options: []provider.DeleteOption{awssecret.ForceDelete{}},
+		Options: []provider.DeleteOption{provider.ForceDelete{}},
 	})
 	require.NoError(t, err)
 	require.Len(t, gotOpts, 1)
-	assert.IsType(t, awssecret.ForceDelete{}, gotOpts[0])
+	assert.IsType(t, provider.ForceDelete{}, gotOpts[0])
 }
 
 // TestDeleteUseCase_Execute_ForwardsRecoveryWindow is a genuine anti-regression


### PR DESCRIPTION
Stacked on #438 (which stacks on #437). Merge #437 → #438 → this.

## Why

Azure Key Vault soft-deletes secrets, exactly like AWS Secrets Manager — a deleted secret is recoverable within the vault's retention window. suve didn't expose restore for Key Vault.

Force-delete/purge is **intentionally not** included: Key Vault retention is a **vault** property (`softDeleteRetentionInDays`, 7–90, default 90), not a per-delete choice, and the staging layer has no way to carry a purge flag (`HasDeleteOptions=false`), so a staged "force" delete would be silently downgraded to a soft-delete. The emulator (lowkey-vault) also rejects immediate purge. Rather than ship an inconsistent, half-testable feature, force-delete stays an AWS Secrets Manager capability.

## What

- **Provider**: `keyvault.Store.Restore` (`RecoverDeletedSecret`) makes Key Vault a `provider.Restorer`. `Delete` is soft-delete only.
- **CLI**: `suve azure secret restore <name>`. (No `--force` on `azure secret delete`.)
- **GUI**: capability-gated **Restore** button appears for Key Vault; the delete modal shows no force-delete checkbox there (`HasForceDelete=false`). `HasRecoveryWindow` also stays false — Key Vault retention is a vault property, not shown per delete.
- Per-version tags for Key Vault (from #438) are unchanged.

## Tests

- **Go unit** (`keyvault`): `TestRestore`.
- **CLI e2e** (`azure_keyvault`): soft-delete → restore round-trip.
- **GUI Playwright** (`keyvault-restore.spec`): Restore is offered, the delete modal has **no** force-delete option, and a soft-delete → restore round-trip re-lists the secret. The wails mock models soft-delete/recover faithfully.
- Capability tests pin force-delete + recovery-window as **AWS Secrets Manager only**.

`go test ./...`, `-tags production ./internal/gui/...`, `mise lint`, `svelte-check`, and the full Playwright suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
