### PR TITLE
test(stage): cover per-namespace apply/diff + gather; qualify conflicts by service

### DIFF
--- a/internal/cli/commands/azure/stage.go
+++ b/internal/cli/commands/azure/stage.go
@@ -220,10 +220,12 @@ func StageCommand() *cli.Command {
 }
 
 // FlatStageCommand returns the Azure stage command as a standalone top-level
-// command named `name` (e.g. "stage"). The secret/param staging subgroups own
-// their --vault-name / --store-name flags and hooks, so it is self-contained.
-// Used for the flat `suve stage` alias when Azure is the uniquely active staging
-// provider.
+// command named `name` (e.g. "stage"). It carries the whole StageCommand tree:
+// the per-service secret/param subgroups (which own their own --vault-name /
+// --store-name flags and Before hooks) AND the provider-wide global commands
+// (status/diff/apply/reset), which rely on the parent command's global flags and
+// Before hook injecting both resource names into the context. Used for the flat
+// `suve stage` alias when Azure is the uniquely active staging provider.
 func FlatStageCommand(name string) *cli.Command {
 	c := StageCommand()
 	c.Name = name

--- a/internal/cli/commands/stage/apply/apply.go
+++ b/internal/cli/commands/stage/apply/apply.go
@@ -48,8 +48,19 @@ func (s ServiceApply) strategyForNamespace(namespace string) (staging.ApplyStrat
 
 // serviceConflictCheck holds entries and strategy for a single service's conflict checking.
 type serviceConflictCheck struct {
-	entries  map[staging.EntryKey]staging.Entry
-	strategy staging.ApplyStrategy
+	serviceName string
+	entries     map[staging.EntryKey]staging.Entry
+	strategy    staging.ApplyStrategy
+}
+
+// conflictItem identifies a conflicting staged entry, qualified by its service.
+// Conflicts are tracked per (service, key) rather than per key alone so two
+// services staging the same (name, namespace) — e.g. an SSM param and a Secrets
+// Manager secret both named "foo" — are counted and reported separately instead
+// of collapsing into one.
+type conflictItem struct {
+	serviceName string
+	key         staging.EntryKey
 }
 
 // Runner executes the apply command.
@@ -102,33 +113,39 @@ EXAMPLES:
 	}
 }
 
-func runAction(ctx context.Context, cmd *cli.Command, cfg stgcli.GlobalConfig) error {
-	var (
-		svcs        []ServiceApply
-		targets     []string
-		totalStaged int
-	)
+// workingStoreResolver resolves a service's staging store and scope. It matches
+// stgcli.WorkingStore; tests substitute a fake to exercise skip-unconfigured and
+// store-error paths without touching disk.
+type workingStoreResolver func(
+	ctx context.Context, resolver staging.ScopeResolver,
+) (store.ReadWriteOperator, staging.ResolvedScope, error)
 
-	// Gather each CONFIGURED service's staged changes from its OWN store. A
-	// service whose scope is not configured is skipped (it can hold no state).
+// gatherServices lists each CONFIGURED service's staged changes from its OWN
+// store, skipping any service whose scope is not configured (it can hold no
+// staged state). It returns the services that actually have staged changes,
+// their confirmation targets, and the total staged count. resolve is injected so
+// tests can drive skip-unconfigured and store-error propagation.
+func gatherServices(
+	ctx context.Context, cfg stgcli.GlobalConfig, resolve workingStoreResolver,
+) (svcs []ServiceApply, targets []string, totalStaged int, err error) {
 	for _, spec := range cfg.Services {
-		st, resolved, err := stgcli.WorkingStore(ctx, spec.ScopeResolver)
+		st, resolved, err := resolve(ctx, spec.ScopeResolver)
 		if errors.Is(err, staging.ErrServiceNotConfigured) {
 			continue
 		}
 
 		if err != nil {
-			return err
+			return nil, nil, 0, err
 		}
 
 		entries, err := st.ListEntries(ctx, spec.Service)
 		if err != nil {
-			return err
+			return nil, nil, 0, err
 		}
 
 		tags, err := st.ListTags(ctx, spec.Service)
 		if err != nil {
-			return err
+			return nil, nil, 0, err
 		}
 
 		svcEntries := entries[spec.Service]
@@ -141,7 +158,7 @@ func runAction(ctx context.Context, cmd *cli.Command, cfg stgcli.GlobalConfig) e
 
 		strategy, err := spec.Factory(ctx)
 		if err != nil {
-			return err
+			return nil, nil, 0, err
 		}
 
 		targets = append(targets, resolved.Target)
@@ -153,6 +170,21 @@ func runAction(ctx context.Context, cmd *cli.Command, cfg stgcli.GlobalConfig) e
 			Entries:     svcEntries,
 			Tags:        svcTags,
 		})
+	}
+
+	return svcs, targets, totalStaged, nil
+}
+
+func runAction(ctx context.Context, cmd *cli.Command, cfg stgcli.GlobalConfig) error {
+	resolve := func(
+		ctx context.Context, resolver staging.ScopeResolver,
+	) (store.ReadWriteOperator, staging.ResolvedScope, error) {
+		return stgcli.WorkingStore(ctx, resolver)
+	}
+
+	svcs, targets, totalStaged, err := gatherServices(ctx, cfg, resolve)
+	if err != nil {
+		return err
 	}
 
 	if totalStaged == 0 {
@@ -211,14 +243,19 @@ func (r *Runner) Run(ctx context.Context) error {
 
 		for _, svc := range r.Services {
 			if len(svc.Entries) > 0 {
-				checks = append(checks, serviceConflictCheck{entries: svc.Entries, strategy: svc.Strategy})
+				checks = append(checks, serviceConflictCheck{
+					serviceName: svc.Strategy.ServiceName(),
+					entries:     svc.Entries,
+					strategy:    svc.Strategy,
+				})
 			}
 		}
 
 		allConflicts := r.checkAllConflicts(ctx, checks)
 		if len(allConflicts) > 0 {
-			for _, key := range staging.SortedEntryKeys(allConflicts) {
-				output.Warning(r.Stderr, "conflict detected for %s: %s was modified after staging", key.Name, r.ProviderLabel)
+			for _, c := range allConflicts {
+				output.Warning(r.Stderr, "conflict detected for %s (%s): %s was modified after staging",
+					keyLabel(c.key), c.serviceName, r.ProviderLabel)
 			}
 
 			return fmt.Errorf("apply rejected: %d conflict(s) detected (use --ignore-conflicts to force)", len(allConflicts))
@@ -353,16 +390,28 @@ func formatTagApplySummary(tagEntry staging.TagEntry) string {
 	return " [" + strings.Join(parts, ", ") + "]"
 }
 
-// checkAllConflicts checks all services for conflicts and returns a combined map of conflicting keys.
-func (r *Runner) checkAllConflicts(ctx context.Context, checks []serviceConflictCheck) map[staging.EntryKey]struct{} {
-	allConflicts := make(map[staging.EntryKey]struct{})
+// checkAllConflicts checks all services for conflicts and returns them qualified
+// by service, in a stable (service order, then sorted key) order. Two services
+// with a conflict on the same (name, namespace) yield two distinct items.
+func (r *Runner) checkAllConflicts(ctx context.Context, checks []serviceConflictCheck) []conflictItem {
+	var all []conflictItem
 
 	for _, check := range checks {
 		conflicts := staging.CheckConflicts(ctx, check.strategy, check.entries)
-		for key := range conflicts {
-			allConflicts[key] = struct{}{}
+		for _, key := range staging.SortedEntryKeys(conflicts) {
+			all = append(all, conflictItem{serviceName: check.serviceName, key: key})
 		}
 	}
 
-	return allConflicts
+	return all
+}
+
+// keyLabel renders an entry key for display, appending the namespace when
+// present (empty is the null/default namespace, shown bare).
+func keyLabel(key staging.EntryKey) string {
+	if key.Namespace == "" {
+		return key.Name
+	}
+
+	return fmt.Sprintf("%s [%s]", key.Name, key.Namespace)
 }

--- a/internal/cli/commands/stage/apply/apply_perns_test.go
+++ b/internal/cli/commands/stage/apply/apply_perns_test.go
@@ -1,0 +1,82 @@
+package apply_test
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/cli/commands/stage/apply"
+	"github.com/mpyw/suve/internal/staging"
+	"github.com/mpyw/suve/internal/staging/store/testutil"
+)
+
+// TestRun_AppliesEntriesUnderTheirNamespace is the core guard for the
+// per-namespace path: the SAME key staged under two namespaces must apply through
+// the strategy scoped to EACH entry's own namespace (App Configuration keeps all
+// namespaces in one staging store). Without correct threading, both entries would
+// go through one namespace's strategy.
+func TestRun_AppliesEntriesUnderTheirNamespace(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	st := testutil.NewMockStore()
+	require.NoError(t, st.StageEntry(ctx, staging.ServiceParam, staging.EntryKey{Name: "k"}, staging.Entry{
+		Operation: staging.OperationCreate, Value: lo.ToPtr("va"), StagedAt: time.Now(),
+	}))
+	require.NoError(t, st.StageEntry(ctx, staging.ServiceParam, staging.EntryKey{Name: "k", Namespace: "dev"}, staging.Entry{
+		Operation: staging.OperationCreate, Value: lo.ToPtr("vb"), StagedAt: time.Now(),
+	}))
+
+	var mu sync.Mutex
+
+	appliedByNS := map[string]string{}
+
+	// StrategyFor returns a strategy bound to the requested namespace; its Apply
+	// records which value it received, so we can prove each entry was routed to
+	// its own namespace's strategy.
+	strategyFor := func(ns string) (staging.ApplyStrategy, error) {
+		s := newParamStrategy()
+		s.applyFunc = func(_ context.Context, _ string, entry staging.Entry) error {
+			mu.Lock()
+			defer mu.Unlock()
+
+			appliedByNS[ns] = lo.FromPtr(entry.Value)
+
+			return nil
+		}
+
+		return s, nil
+	}
+
+	entries, _ := st.ListEntries(ctx, staging.ServiceParam)
+	svc := apply.ServiceApply{
+		Service:     staging.ServiceParam,
+		Store:       st,
+		Strategy:    newParamStrategy(),
+		StrategyFor: strategyFor,
+		Entries:     entries[staging.ServiceParam],
+	}
+
+	r := &apply.Runner{
+		Services:        []apply.ServiceApply{svc},
+		ProviderLabel:   "Azure",
+		Stdout:          &bytes.Buffer{},
+		Stderr:          &bytes.Buffer{},
+		IgnoreConflicts: true, // this test is about namespace routing, not conflicts
+	}
+
+	require.NoError(t, r.Run(ctx))
+
+	// Each entry reached the strategy scoped to ITS namespace.
+	assert.Equal(t, map[string]string{"": "va", "dev": "vb"}, appliedByNS)
+
+	// Both entries were unstaged under their own (name, namespace) key.
+	remaining, _ := st.ListEntries(ctx, staging.ServiceParam)
+	assert.Empty(t, remaining[staging.ServiceParam])
+}

--- a/internal/cli/commands/stage/apply/gather_internal_test.go
+++ b/internal/cli/commands/stage/apply/gather_internal_test.go
@@ -1,0 +1,169 @@
+package apply
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/staging"
+	stgcli "github.com/mpyw/suve/internal/staging/cli"
+	"github.com/mpyw/suve/internal/staging/store"
+	"github.com/mpyw/suve/internal/staging/store/testutil"
+)
+
+// White-box tests for gatherServices — the per-service listing + skip-unconfigured
+// + store-error path that used to live inline in runAction and was therefore
+// unreachable from the (external) Runner tests. The store resolver is injected so
+// these run without touching disk or a real provider.
+
+// notConfiguredResolver mimics an Azure scope resolver whose resource is not
+// named (e.g. no --vault-name): the service must be skipped.
+func notConfiguredResolver(_ context.Context) (staging.ResolvedScope, error) {
+	return staging.ResolvedScope{}, fmt.Errorf("%w: no resource", staging.ErrServiceNotConfigured)
+}
+
+// targetResolver returns a scope whose Target is the given string, so the
+// injected working-store resolver can map it back to a specific mock store.
+func targetResolver(target string) staging.ScopeResolver {
+	return func(_ context.Context) (staging.ResolvedScope, error) {
+		return staging.ResolvedScope{Target: target}, nil
+	}
+}
+
+// resolveFrom builds a workingStoreResolver that runs the spec's ScopeResolver
+// (so skip/error semantics match WorkingStore) and, on success, returns the mock
+// store registered under the resolved Target.
+func resolveFrom(stores map[string]store.ReadWriteOperator) workingStoreResolver {
+	return func(ctx context.Context, resolver staging.ScopeResolver) (store.ReadWriteOperator, staging.ResolvedScope, error) {
+		rs, err := resolver(ctx)
+		if err != nil {
+			return nil, staging.ResolvedScope{}, err
+		}
+
+		return stores[rs.Target], rs, nil
+	}
+}
+
+// nilFactory returns a nil strategy: gatherServices stores it but never calls it,
+// so it is enough for the listing/skip paths under test.
+func nilFactory(_ context.Context) (staging.FullStrategy, error) {
+	return nil, nil //nolint:nilnil // test stub; gatherServices never invokes the strategy
+}
+
+func TestGatherServices_SkipsUnconfigured(t *testing.T) {
+	t.Parallel()
+
+	cfg := stgcli.GlobalConfig{
+		ProviderLabel: "Azure",
+		Services: []stgcli.GlobalServiceSpec{
+			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: notConfiguredResolver},
+			{Service: staging.ServiceSecret, ParserFactory: staging.SecretParserFactory, ScopeResolver: notConfiguredResolver},
+		},
+	}
+
+	svcs, targets, total, err := gatherServices(t.Context(), cfg, resolveFrom(nil))
+	require.NoError(t, err)
+	assert.Empty(t, svcs, "an unconfigured service holds no staged state and must be skipped")
+	assert.Empty(t, targets)
+	assert.Zero(t, total)
+}
+
+func TestGatherServices_ResolverErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("boom")
+	cfg := stgcli.GlobalConfig{
+		Services: []stgcli.GlobalServiceSpec{
+			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: func(_ context.Context) (staging.ResolvedScope, error) {
+				return staging.ResolvedScope{}, wantErr
+			}},
+		},
+	}
+
+	svcs, _, _, err := gatherServices(t.Context(), cfg, resolveFrom(nil))
+	require.ErrorIs(t, err, wantErr, "a non-sentinel resolver error must not be swallowed by the skip path")
+	assert.Empty(t, svcs)
+}
+
+func TestGatherServices_ListEntriesErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("list entries boom")
+	st := testutil.NewMockStore()
+	st.ListEntriesErr = wantErr
+
+	cfg := stgcli.GlobalConfig{
+		Services: []stgcli.GlobalServiceSpec{
+			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: targetResolver("t")},
+		},
+	}
+
+	svcs, _, _, err := gatherServices(t.Context(), cfg, resolveFrom(map[string]store.ReadWriteOperator{"t": st}))
+	require.ErrorIs(t, err, wantErr)
+	assert.Empty(t, svcs)
+}
+
+func TestGatherServices_ListTagsErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("list tags boom")
+	st := testutil.NewMockStore()
+	st.ListTagsErr = wantErr
+
+	cfg := stgcli.GlobalConfig{
+		Services: []stgcli.GlobalServiceSpec{
+			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: targetResolver("t")},
+		},
+	}
+
+	svcs, _, _, err := gatherServices(t.Context(), cfg, resolveFrom(map[string]store.ReadWriteOperator{"t": st}))
+	require.ErrorIs(t, err, wantErr)
+	assert.Empty(t, svcs)
+}
+
+// TestGatherServices_PerServiceStores proves each service is listed from and
+// bound to its OWN store — the whole Azure premise (App Configuration and Key
+// Vault live in separate staging buckets), which the AWS Runner tests (shared
+// store) never exercise.
+func TestGatherServices_PerServiceStores(t *testing.T) {
+	t.Parallel()
+
+	paramStore := testutil.NewMockStore()
+	require.NoError(t, paramStore.StageEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "app/cfg"}, staging.Entry{
+		Operation: staging.OperationCreate, Value: lo.ToPtr("pv"), StagedAt: time.Now(),
+	}))
+
+	secretStore := testutil.NewMockStore()
+	require.NoError(t, secretStore.StageEntry(t.Context(), staging.ServiceSecret, staging.EntryKey{Name: "kv-secret"}, staging.Entry{
+		Operation: staging.OperationCreate, Value: lo.ToPtr("sv"), StagedAt: time.Now(),
+	}))
+
+	cfg := stgcli.GlobalConfig{
+		Services: []stgcli.GlobalServiceSpec{
+			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: targetResolver("store"), Factory: nilFactory},
+			{Service: staging.ServiceSecret, ParserFactory: staging.SecretParserFactory, ScopeResolver: targetResolver("vault"), Factory: nilFactory},
+		},
+	}
+
+	svcs, targets, total, err := gatherServices(t.Context(), cfg, resolveFrom(map[string]store.ReadWriteOperator{
+		"store": paramStore,
+		"vault": secretStore,
+	}))
+	require.NoError(t, err)
+	require.Len(t, svcs, 2)
+	assert.Equal(t, 2, total)
+	assert.Equal(t, []string{"store", "vault"}, targets)
+
+	// Each ServiceApply is bound to ITS service's store and entries — no bleed.
+	assert.Same(t, paramStore, svcs[0].Store)
+	assert.Same(t, secretStore, svcs[1].Store)
+	assert.Contains(t, svcs[0].Entries, staging.EntryKey{Name: "app/cfg"})
+	assert.NotContains(t, svcs[0].Entries, staging.EntryKey{Name: "kv-secret"})
+	assert.Contains(t, svcs[1].Entries, staging.EntryKey{Name: "kv-secret"})
+}

--- a/internal/cli/commands/stage/diff/diff.go
+++ b/internal/cli/commands/stage/diff/diff.go
@@ -102,35 +102,41 @@ EXAMPLES:
 	}
 }
 
-func runAction(ctx context.Context, cmd *cli.Command, cfg stgcli.GlobalConfig) error {
-	opts := Options{
-		ParseJSON: cmd.Bool("parse-json"),
-		NoPager:   cmd.Bool("no-pager"),
-	}
+// workingStoreResolver resolves a service's staging store and scope. It matches
+// stgcli.WorkingStore; tests substitute a fake to exercise skip-unconfigured and
+// store-error paths without touching disk.
+type workingStoreResolver func(
+	ctx context.Context, resolver staging.ScopeResolver,
+) (store.ReadWriteOperator, staging.ResolvedScope, error)
 
-	// Gather each CONFIGURED service's staged changes from its OWN store. A
-	// service whose scope is not configured is skipped (it can hold no state).
+// gatherServices lists each CONFIGURED service's staged changes from its OWN
+// store, skipping any service whose scope is not configured (it can hold no
+// staged state). It returns only services that actually have staged changes.
+// resolve is injected so tests can drive skip-unconfigured and store-error
+// propagation.
+func gatherServices(
+	ctx context.Context, cfg stgcli.GlobalConfig, resolve workingStoreResolver,
+) ([]ServiceStrategy, error) {
 	services := make([]ServiceStrategy, 0, len(cfg.Services))
-	anyChanges := false
 
 	for _, spec := range cfg.Services {
-		st, _, err := stgcli.WorkingStore(ctx, spec.ScopeResolver)
+		st, _, err := resolve(ctx, spec.ScopeResolver)
 		if errors.Is(err, staging.ErrServiceNotConfigured) {
 			continue
 		}
 
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		entries, err := st.ListEntries(ctx, spec.Service)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		tags, err := st.ListTags(ctx, spec.Service)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		svcEntries := entries[spec.Service]
@@ -140,11 +146,9 @@ func runAction(ctx context.Context, cmd *cli.Command, cfg stgcli.GlobalConfig) e
 			continue
 		}
 
-		anyChanges = true
-
 		strategy, err := spec.Factory(ctx)
 		if err != nil {
-			return fmt.Errorf("failed to initialize %s client: %w", spec.ParserFactory().ServiceName(), err)
+			return nil, fmt.Errorf("failed to initialize %s client: %w", spec.ParserFactory().ServiceName(), err)
 		}
 
 		services = append(services, ServiceStrategy{
@@ -157,7 +161,27 @@ func runAction(ctx context.Context, cmd *cli.Command, cfg stgcli.GlobalConfig) e
 		})
 	}
 
-	if !anyChanges {
+	return services, nil
+}
+
+func runAction(ctx context.Context, cmd *cli.Command, cfg stgcli.GlobalConfig) error {
+	opts := Options{
+		ParseJSON: cmd.Bool("parse-json"),
+		NoPager:   cmd.Bool("no-pager"),
+	}
+
+	resolve := func(
+		ctx context.Context, resolver staging.ScopeResolver,
+	) (store.ReadWriteOperator, staging.ResolvedScope, error) {
+		return stgcli.WorkingStore(ctx, resolver)
+	}
+
+	services, err := gatherServices(ctx, cfg, resolve)
+	if err != nil {
+		return err
+	}
+
+	if len(services) == 0 {
 		output.Warning(cmd.Root().ErrWriter, "nothing staged")
 
 		return nil

--- a/internal/cli/commands/stage/diff/diff_perns_test.go
+++ b/internal/cli/commands/stage/diff/diff_perns_test.go
@@ -1,0 +1,66 @@
+package diff_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	stagediff "github.com/mpyw/suve/internal/cli/commands/stage/diff"
+	"github.com/mpyw/suve/internal/staging"
+	"github.com/mpyw/suve/internal/staging/store/testutil"
+)
+
+// TestRun_DiffsEntriesUnderTheirNamespace guards the per-namespace diff path: the
+// SAME key staged under two namespaces must be diffed against the CURRENT value
+// fetched under EACH entry's own namespace. The dev entry's strategy reports a
+// different current value ("cur-b"), so if namespace threading were broken the
+// dev entry would diff against the null-namespace current ("cur-a") and "cur-b"
+// would never appear.
+func TestRun_DiffsEntriesUnderTheirNamespace(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	st := testutil.NewMockStore()
+	require.NoError(t, st.StageEntry(ctx, staging.ServiceParam, staging.EntryKey{Name: "k"}, staging.Entry{
+		Operation: staging.OperationUpdate, Value: lo.ToPtr("new-a"), StagedAt: time.Now(),
+	}))
+	require.NoError(t, st.StageEntry(ctx, staging.ServiceParam, staging.EntryKey{Name: "k", Namespace: "dev"}, staging.Entry{
+		Operation: staging.OperationUpdate, Value: lo.ToPtr("new-b"), StagedAt: time.Now(),
+	}))
+
+	// Current value differs per namespace, so a mis-routed fetch is observable.
+	nsCurrent := map[string]string{"": "cur-a", "dev": "cur-b"}
+
+	entries, _ := st.ListEntries(ctx, staging.ServiceParam)
+	svc := stagediff.ServiceStrategy{
+		Service:  staging.ServiceParam,
+		Store:    st,
+		Strategy: staging.NewParamStrategy(storeReturning("cur-a", "1")),
+		StrategyFor: func(ns string) (staging.DiffStrategy, error) {
+			return staging.NewParamStrategy(storeReturning(nsCurrent[ns], "1")), nil
+		},
+		Entries: entries[staging.ServiceParam],
+	}
+
+	var buf bytes.Buffer
+
+	r := &stagediff.Runner{
+		Services:      []stagediff.ServiceStrategy{svc},
+		ProviderLabel: "Azure",
+		Stdout:        &buf,
+		Stderr:        &bytes.Buffer{},
+	}
+
+	require.NoError(t, r.Run(ctx, stagediff.Options{}))
+
+	out := buf.String()
+	assert.Contains(t, out, "cur-a")
+	assert.Contains(t, out, "new-a")
+	assert.Contains(t, out, "cur-b", "the dev entry must be diffed against the value fetched under the dev namespace")
+	assert.Contains(t, out, "new-b")
+	assert.Contains(t, out, "[dev]", "the dev-namespaced entry must be labelled with its namespace")
+}

--- a/internal/cli/commands/stage/diff/gather_internal_test.go
+++ b/internal/cli/commands/stage/diff/gather_internal_test.go
@@ -1,0 +1,148 @@
+package diff
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/staging"
+	stgcli "github.com/mpyw/suve/internal/staging/cli"
+	"github.com/mpyw/suve/internal/staging/store"
+	"github.com/mpyw/suve/internal/staging/store/testutil"
+)
+
+// White-box tests for gatherServices — the per-service listing + skip-unconfigured
+// + store-error path extracted from runAction so it is unit-reachable. The store
+// resolver is injected so these run without disk or a real provider.
+
+func notConfiguredResolver(_ context.Context) (staging.ResolvedScope, error) {
+	return staging.ResolvedScope{}, fmt.Errorf("%w: no resource", staging.ErrServiceNotConfigured)
+}
+
+func targetResolver(target string) staging.ScopeResolver {
+	return func(_ context.Context) (staging.ResolvedScope, error) {
+		return staging.ResolvedScope{Target: target}, nil
+	}
+}
+
+func resolveFrom(stores map[string]store.ReadWriteOperator) workingStoreResolver {
+	return func(ctx context.Context, resolver staging.ScopeResolver) (store.ReadWriteOperator, staging.ResolvedScope, error) {
+		rs, err := resolver(ctx)
+		if err != nil {
+			return nil, staging.ResolvedScope{}, err
+		}
+
+		return stores[rs.Target], rs, nil
+	}
+}
+
+func nilFactory(_ context.Context) (staging.FullStrategy, error) {
+	return nil, nil //nolint:nilnil // test stub; gatherServices never invokes the strategy
+}
+
+func TestGatherServices_SkipsUnconfigured(t *testing.T) {
+	t.Parallel()
+
+	cfg := stgcli.GlobalConfig{
+		Services: []stgcli.GlobalServiceSpec{
+			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: notConfiguredResolver},
+			{Service: staging.ServiceSecret, ParserFactory: staging.SecretParserFactory, ScopeResolver: notConfiguredResolver},
+		},
+	}
+
+	svcs, err := gatherServices(t.Context(), cfg, resolveFrom(nil))
+	require.NoError(t, err)
+	assert.Empty(t, svcs, "an unconfigured service holds no staged state and must be skipped")
+}
+
+func TestGatherServices_ResolverErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("boom")
+	cfg := stgcli.GlobalConfig{
+		Services: []stgcli.GlobalServiceSpec{
+			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: func(_ context.Context) (staging.ResolvedScope, error) {
+				return staging.ResolvedScope{}, wantErr
+			}},
+		},
+	}
+
+	_, err := gatherServices(t.Context(), cfg, resolveFrom(nil))
+	require.ErrorIs(t, err, wantErr, "a non-sentinel resolver error must not be swallowed by the skip path")
+}
+
+func TestGatherServices_ListEntriesErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("list entries boom")
+	st := testutil.NewMockStore()
+	st.ListEntriesErr = wantErr
+
+	cfg := stgcli.GlobalConfig{
+		Services: []stgcli.GlobalServiceSpec{
+			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: targetResolver("t")},
+		},
+	}
+
+	_, err := gatherServices(t.Context(), cfg, resolveFrom(map[string]store.ReadWriteOperator{"t": st}))
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestGatherServices_ListTagsErrorPropagates(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("list tags boom")
+	st := testutil.NewMockStore()
+	st.ListTagsErr = wantErr
+
+	cfg := stgcli.GlobalConfig{
+		Services: []stgcli.GlobalServiceSpec{
+			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: targetResolver("t")},
+		},
+	}
+
+	_, err := gatherServices(t.Context(), cfg, resolveFrom(map[string]store.ReadWriteOperator{"t": st}))
+	require.ErrorIs(t, err, wantErr)
+}
+
+// TestGatherServices_PerServiceStores proves each service is diffed from its OWN
+// store (App Configuration and Key Vault live in separate staging buckets).
+func TestGatherServices_PerServiceStores(t *testing.T) {
+	t.Parallel()
+
+	paramStore := testutil.NewMockStore()
+	require.NoError(t, paramStore.StageEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "app/cfg"}, staging.Entry{
+		Operation: staging.OperationCreate, Value: lo.ToPtr("pv"), StagedAt: time.Now(),
+	}))
+
+	secretStore := testutil.NewMockStore()
+	require.NoError(t, secretStore.StageEntry(t.Context(), staging.ServiceSecret, staging.EntryKey{Name: "kv-secret"}, staging.Entry{
+		Operation: staging.OperationCreate, Value: lo.ToPtr("sv"), StagedAt: time.Now(),
+	}))
+
+	cfg := stgcli.GlobalConfig{
+		Services: []stgcli.GlobalServiceSpec{
+			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: targetResolver("store"), Factory: nilFactory},
+			{Service: staging.ServiceSecret, ParserFactory: staging.SecretParserFactory, ScopeResolver: targetResolver("vault"), Factory: nilFactory},
+		},
+	}
+
+	svcs, err := gatherServices(t.Context(), cfg, resolveFrom(map[string]store.ReadWriteOperator{
+		"store": paramStore,
+		"vault": secretStore,
+	}))
+	require.NoError(t, err)
+	require.Len(t, svcs, 2)
+
+	assert.Same(t, paramStore, svcs[0].Store)
+	assert.Same(t, secretStore, svcs[1].Store)
+	assert.Contains(t, svcs[0].Entries, staging.EntryKey{Name: "app/cfg"})
+	assert.NotContains(t, svcs[0].Entries, staging.EntryKey{Name: "kv-secret"})
+	assert.Contains(t, svcs[1].Entries, staging.EntryKey{Name: "kv-secret"})
+}


### PR DESCRIPTION
Stacked on #436 (`feat/azure-stage-global`). Merge #436 first.

Addresses the code-review findings on #436. All changes are **additive test coverage** plus two small robustness fixes — no happy-path behavior change.

## Findings addressed

- **#1 — per-namespace apply/diff was unit-untested.** The `StrategyFor` branch (the crux of spanning App Configuration's per-namespace staging) never ran in unit tests — every unit test used AWS specs where it's nil, and the e2e tests only stage the null namespace. Added apply/diff `Runner` tests that stage the SAME key under two namespaces and assert each entry is applied/diffed through the strategy scoped to ITS namespace (the `dev` entry diffs against the dev-namespace current value, so a mis-route is observable).
- **#2 — apply/diff skip-unconfigured + store-error propagation lost unit coverage.** That logic had moved from the `Runner` into the inline `runAction` gather loop, unreachable from the (external) Runner tests — an asymmetry vs `status`/`reset` which kept their seam + `StoreError`/`ListTagsError` tests. Extracted the loop into `gatherServices` with an injected working-store resolver, and added white-box tests: skip-unconfigured, non-sentinel resolver error propagates, `ListEntries` error propagates, `ListTags` error propagates.
- **#5 — distinct per-service stores never asserted.** Added a gather test proving each service is listed from and bound to its OWN store (the App Config / Key Vault separate-bucket premise the AWS shared-store tests never exercised).
- **#3 — conflict count/message collision.** `apply` tracked conflicts in one `map[EntryKey]`, so two services with a conflict on the same `(name, namespace)` (e.g. an SSM param and a Secrets Manager secret both named `foo`) collapsed into one — undercounting the message and dropping the namespace. Now tracked per `(service, key)`; the warning includes the namespace and service name. (Safety was never affected — apply was already rejected.)
- **#6 — stale doc comment.** `FlatStageCommand` said it's self-contained "because the subgroups own their flags"; the global subcommands actually rely on the parent command's global flags + `Before` hook. Comment corrected.

## Not changed, by design

- **#4 — `reset` shows zero-count services** (`Unstaged all changes (1 SSM..., 0 Secrets...)`). This is intended and locked by existing AWS reset tests: AWS keeps both services under one scope, so listing both with their counts (including 0) is the documented summary. Hiding zeros would regress that and break those tests. (Unconfigured Azure services are still skipped entirely, so no misleading `0` appears there.)

## Tests

12 new tests across `stage/apply` and `stage/diff` (5 gather white-box + 1 per-namespace each). `go test ./...`, `mise lint` (0 issues), and `mise build-gui` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
