### PR TITLE
docs: fix documentation/comment divergences from implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ where ~SHIFT = ~ | ~N  (repeatable, cumulative)
 ### Azure App Configuration
 
 > [!NOTE]
-> Azure App Configuration is unversioned. Version specifiers (`#VERSION`, `~SHIFT`, `:LABEL`) are rejected, and `log` reports that history is unsupported.
+> Azure App Configuration is unversioned. `#`, `~`, and `:` are valid key characters — the whole argument is the literal key name, not a version spec — and `log` reports that history is unsupported.
 
 ## Providers
 
@@ -601,7 +601,7 @@ where ~SHIFT = ~ | ~N  (repeatable, cumulative)
 | [Azure Key Vault](docs/azure.md) | `azure secret` | ✅ opaque id | ✅ tags | ✅ | ✅ | DefaultAzureCredential |
 | [Azure App Configuration](docs/azure.md) | `azure param` | ❌ unversioned | ✅ tags¹ | ✅² | ✅ | DefaultAzureCredential |
 
-Read/write operations (`show`, `log`, `diff`, `list`, `create`, `update`, `delete`, `tag`, `untag`) are available on every backend, with these caveats: `restore` is AWS Secrets Manager only; on Azure App Configuration `log` reports history unsupported; version specifiers (`#VERSION`, `~SHIFT`, `:LABEL`) are rejected on App Configuration. Only AWS Secrets Manager has staging labels (`:AWSCURRENT` etc.).
+Read/write operations (`show`, `log`, `diff`, `list`, `create`, `update`, `delete`, `tag`, `untag`) are available on every backend, with these caveats: `restore` is available on AWS Secrets Manager and Azure Key Vault (soft-delete recovery); on Azure App Configuration `log` reports history unsupported and `#`/`~`/`:` are treated as literal key characters (not version specifiers). Only AWS Secrets Manager has staging labels (`:AWSCURRENT` etc.).
 
 ¹ App Configuration's PUT replaces the whole key-value, so tag writes are a **GET-merge-PUT** with an ETag precondition (`azappconfig/v2`): `tag`/`untag` preserve the value and other tags, and a value write (`update`) preserves existing tags.
 
@@ -786,7 +786,8 @@ Secrets are versioned by opaque IDs and have no staging labels. Select the vault
 | [`suve azure secret list`](docs/azure.md#suve-azure-secret-list) | `--filter=<REGEX>`<br>`--show`<br>`--output=<FORMAT>` | List secrets |
 | [`suve azure secret create`](docs/azure.md#suve-azure-secret-create) | | Create new secret |
 | [`suve azure secret update`](docs/azure.md#suve-azure-secret-update) | `--yes` | Update existing secret |
-| [`suve azure secret delete`](docs/azure.md#suve-azure-secret-delete) | `--yes` | Delete secret |
+| [`suve azure secret delete`](docs/azure.md#suve-azure-secret-delete) | `--yes` | Delete secret (soft-delete) |
+| [`suve azure secret restore`](docs/azure.md#suve-azure-secret-restore) | | Recover a soft-deleted secret |
 | [`suve azure secret tag`](docs/azure.md#suve-azure-secret-tag) | `<KEY>=<VALUE>...` | Add or update tags |
 | [`suve azure secret untag`](docs/azure.md#suve-azure-secret-untag) | `<KEY>...` | Remove tags |
 
@@ -807,7 +808,7 @@ Secrets are versioned by opaque IDs and have no staging labels. Select the vault
 
 ### Azure App Configuration
 
-Unversioned key-value store. Version specifiers (`#VERSION`, `~SHIFT`, `:LABEL`) are rejected, `log` reports that history is unsupported, and `tag` / `untag` are unsupported (SDK limitation). Select the store with `--store-name` or the `AZURE_APPCONFIG_NAME` environment variable — the store name is a globally-unique endpoint, so no subscription or resource group is needed. See [docs/azure.md](docs/azure.md) for details.
+Unversioned key-value store. `#`, `~`, and `:` are valid key characters — the whole argument is the literal key name, not a version spec — and `log` reports that history is unsupported. `tag` / `untag` are supported via a GET-merge-PUT (see footnote ¹). Select the store with `--store-name` or the `AZURE_APPCONFIG_NAME` environment variable — the store name is a globally-unique endpoint, so no subscription or resource group is needed. See [docs/azure.md](docs/azure.md) for details.
 
 | Command | Options | Description |
 |---------|---------|-------------|
@@ -816,6 +817,8 @@ Unversioned key-value store. Version specifiers (`#VERSION`, `~SHIFT`, `:LABEL`)
 | [`suve azure param create`](docs/azure.md#suve-azure-param-create) | `--namespace`/`--ns` | Create a new key |
 | [`suve azure param update`](docs/azure.md#suve-azure-param-update) | `--namespace`/`--ns`<br>`--yes` | Update an existing key |
 | [`suve azure param delete`](docs/azure.md#suve-azure-param-delete) | `--namespace`/`--ns`<br>`--yes` | Delete a key |
+| [`suve azure param tag`](docs/azure.md#suve-azure-param-tag) | `--namespace`/`--ns` | Add or update tags (GET-merge-PUT) |
+| [`suve azure param untag`](docs/azure.md#suve-azure-param-untag) | `--namespace`/`--ns` | Remove tags |
 
 #### Namespaces
 
@@ -852,7 +855,7 @@ The value is interpreted by context:
 | `suve azure stage param stash` | `push`/`pop`/`show`/`drop` | Save/restore staged changes |
 
 > [!NOTE]
-> Azure staging is **per-service**: `suve azure stage secret` (Key Vault) and `suve azure stage param` (App Configuration) keep separate staging state, so there is no cross-service `azure stage status`/`apply` aggregate (unlike `aws stage`).
+> Azure staging is **per-service** under the hood: `suve azure stage secret` (Key Vault) and `suve azure stage param` (App Configuration) keep separate staging state. Provider-wide `azure stage status`/`diff`/`apply`/`reset` span both services, skipping whichever one is not configured.
 
 ### Global Stage Commands (AWS)
 

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -1461,7 +1461,7 @@ Created secret my-api-key (version: abc12345-1234-1234-1234-123456789012)
 With JSON value and description:
 
 ```ShellSession
-user@host:~$ suve aws secret create -d "Production database credentials" my-database-credentials '{"username":"admin","password":"secret"}'
+user@host:~$ suve aws secret create --description "Production database credentials" my-database-credentials '{"username":"admin","password":"secret"}'
 Created secret my-database-credentials (version: def67890-1234-1234-1234-123456789012)
 ```
 
@@ -1541,7 +1541,7 @@ suve aws secret delete [options] <name>
 | Option | Alias | Default | Description |
 |--------|-------|---------|-------------|
 | `--force` | - | `false` | Delete immediately without recovery window |
-| `--recovery-window` | - | `30` | Days before permanent deletion (7-30). Ignored if `--force` is set. |
+| `--recovery-window` | - | `30` | Days before permanent deletion (7-30). Cannot be combined with `--force`. |
 | `--yes` | - | `false` | Skip confirmation prompt |
 
 **Examples:**
@@ -2128,4 +2128,4 @@ suve aws stage secret untag my-secret deprecated old-tag
 
 ## Staging (`suve aws stage`)
 
-Staging (`stage add`/`edit`/`delete`/`status`/`diff`/`apply`/`reset`/`stash`) is currently AWS-only. See [Staging State Transitions](staging-state-transitions.md) for the underlying state model; the per-command staging docs live in the README staging section. Full multi-provider staging support is tracked in [#247](https://github.com/mpyw/suve/issues/247).
+Staging (`stage add`/`edit`/`delete`/`status`/`diff`/`apply`/`reset`/`stash`) is available on AWS, Google Cloud, and Azure — each provider keys its on-disk staging state by its own scope. See [Staging State Transitions](staging-state-transitions.md) for the underlying state model; the per-command staging docs live in the README staging section.

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -17,7 +17,7 @@ Azure also supports the local **staging workflow** via `suve azure stage` (or th
 - `suve azure stage secret` — Key Vault secrets. Full workflow (`add`/`edit`/`delete`/`status`/`diff`/`apply`/`reset`/`tag`/`untag`/`stash`). Versions are immutable, so a staged `edit` applies as a new version.
 - `suve azure stage param` — App Configuration settings. Because App Configuration is **unversioned**, staging uses **last-write-wins** (no modified-after conflict check). Tags are writable via a GET-merge-PUT, so `tag`/`untag` are available. Workflow: `add`/`edit`/`delete`/`status`/`diff`/`apply`/`reset`/`tag`/`untag`/`stash`.
 
-Unlike `aws stage`, there is no cross-service `azure stage status`/`apply` aggregate — the two services have distinct staging scopes. See the [staging workflow](../README.md#staging-workflow) overview for the general flow.
+The two services keep distinct staging scopes, but provider-wide `azure stage status`/`diff`/`apply`/`reset` span both — each resolves its own scope and any service that is not configured (no `--store-name`/`--vault-name`) is skipped. See the [staging workflow](../README.md#staging-workflow) overview for the general flow.
 
 ## Authentication and Configuration
 
@@ -359,7 +359,20 @@ suve azure secret delete --yes my-secret --vault-name my-vault
 ```
 
 > [!NOTE]
-> When the vault has soft-delete enabled, the secret is recoverable within the vault's retention window via the Azure portal/CLI; otherwise deletion is permanent.
+> When the vault has soft-delete enabled, the secret is recoverable within the vault's retention window with `suve azure secret restore` (see below); otherwise deletion is permanent.
+
+---
+
+## suve azure secret restore
+
+Recover a soft-deleted Key Vault secret while it is still within the vault's soft-delete retention window (`RecoverDeletedSecret`), mirroring AWS Secrets Manager's `restore`.
+
+```ShellSession
+user@host:~$ suve azure secret restore my-secret --vault-name my-vault
+Restored secret my-secret
+```
+
+Deletes stay soft — suve does not expose force-delete/purge for Key Vault (retention is a vault-level property, not a per-delete option), so a recently deleted secret can always be restored until the retention window elapses.
 
 ---
 

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -441,7 +441,7 @@ suve azure secret untag my-api-key env team --vault-name my-vault
 Access to Azure App Configuration key-values.
 
 > [!IMPORTANT]
-> App Configuration is **UNVERSIONED**: each key (with the default label) holds a single current value with **no history**. Version specifiers (`#VERSION`, `~SHIFT`, `:LABEL`) are **rejected with a clear error**. Set the store with `--store-name` or `AZURE_APPCONFIG_NAME`.
+> App Configuration is **UNVERSIONED**: each key (with the default label) holds a single current value with **no history**. `#`, `~`, and `:` are valid key characters — the whole argument is the literal key name, not a version specifier — so nothing is rejected at parse time; only `log` reports that history is unsupported. Set the store with `--store-name` or `AZURE_APPCONFIG_NAME`.
 
 Because App Configuration has no versions, several commands behave differently from their AWS / Key Vault / Google Cloud counterparts:
 
@@ -466,7 +466,7 @@ suve azure param show [options] <key>
 
 | Argument | Description |
 |----------|-------------|
-| `key` | Setting key (no version specifier -- specifiers are rejected) |
+| `key` | Setting key (the literal key name; `#`/`~`/`:` are valid key characters, not version specifiers) |
 
 **Options:**
 
@@ -491,7 +491,7 @@ suve azure param show --output=json my-key --store-name my-store
 ```
 
 > [!NOTE]
-> Version specifiers (`#VERSION`, `~SHIFT`, `:LABEL`) are rejected with a clear error because App Configuration is unversioned.
+> `#`, `~`, and `:` are valid key characters — the whole argument is the literal key name, not a version specifier — because App Configuration is unversioned.
 
 ---
 
@@ -525,7 +525,7 @@ suve azure param diff [options] <key1> [key2]
 ```
 
 > [!NOTE]
-> App Configuration is unversioned, so `diff` compares **two distinct keys** rather than two versions of one key. Version specifiers (`#VERSION`, `~SHIFT`, `:LABEL`) are rejected with a clear error.
+> App Configuration is unversioned, so `diff` compares **two distinct keys** rather than two versions of one key. `#`/`~`/`:` in a key are literal characters, not version specifiers.
 
 **Arguments:**
 

--- a/docs/gcloud.md
+++ b/docs/gcloud.md
@@ -48,8 +48,8 @@ Google Cloud secrets are integer-versioned. The version spec is:
 | Specifier | Description | Example |
 |-----------|-------------|---------|
 | `#VERSION` | Specific version by integer number | `#3` = version 3 |
-| `~` | One enabled version ago | `~` = latest - 1 |
-| `~N` | N enabled versions ago | `~2` = latest - 2 |
+| `~` | One version ago | `~` = latest - 1 |
+| `~N` | N versions ago | `~2` = latest - 2 |
 
 Specifiers can be combined: `my-secret#5~2` means "version 5, then 2 back".
 
@@ -57,7 +57,7 @@ Specifiers can be combined: `my-secret#5~2` means "version 5, then 2 back".
 > Unlike AWS Secrets Manager, Google Cloud Secret Manager has **no `:LABEL` syntax**. Versions are addressed only by integer number, `latest`, or shift.
 
 > [!TIP]
-> `~` without a number means `~1`. You can chain shifts: `~~` = `~1~1` = `~2`. Shift counts only **enabled** versions; disabled and destroyed versions are skipped.
+> `~` without a number means `~1`. You can chain shifts: `~~` = `~1~1` = `~2`. Shift counts **all** versions (any state, newest first) — the same anchor `latest` uses — so a `~N` never skips disabled or destroyed versions.
 
 ---
 

--- a/docs/provider-selection.md
+++ b/docs/provider-selection.md
@@ -51,9 +51,11 @@ The returned `provider.Store` is handed to the generic show / diff / list / log
 / tag / untag commands and the create / update / delete / restore commands. No
 command or usecase constructs a cloud SDK client or adapter directly.
 
-Staging is AWS-only. The AWS scope keys on-disk staging state (see
-`provider.Scope.Key`), so staged changes are partitioned per account/region
-under `~/.suve/staging/aws/<account>/<region>/`.
+Staging is available on AWS, Google Cloud, and Azure. Each provider's scope keys
+its on-disk staging state (see `provider.Scope.Key`), so staged changes are
+partitioned per scope — e.g. AWS by account/region under
+`~/.suve/staging/aws/<account>/<region>/`, Google Cloud by project, and Azure by
+App Configuration store / Key Vault vault.
 
 ## Enforced boundary
 

--- a/internal/cli/commands/azure/command.go
+++ b/internal/cli/commands/azure/command.go
@@ -34,9 +34,9 @@ Azure splits the two services:
   - "suve azure secret" targets Key Vault (opaque-id-versioned, no labels).
   - "suve azure param"   targets App Configuration (UNVERSIONED).
 
-App Configuration has no version history: version specifiers (#VERSION, ~SHIFT,
-:LABEL) are rejected with a clear error, and "log" reports that history is
-unsupported.
+App Configuration has no version history: #, ~, and : are valid key characters
+(the whole argument is the literal key name, not a version specifier), and "log"
+reports that history is unsupported.
 
 Authentication uses the DefaultAzureCredential chain (environment, managed
 identity, Azure CLI via 'az login', ...). The target resource is addressed by

--- a/internal/cli/commands/azure/param/command.go
+++ b/internal/cli/commands/azure/param/command.go
@@ -1,10 +1,11 @@
 // Package param provides CLI commands for Azure App Configuration, exposed as
 // the "suve azure param <op>" command group.
 //
-// Azure App Configuration is UNVERSIONED — the abstraction's acid test. Version
-// specifiers (#VERSION, ~SHIFT, :LABEL) are rejected at parse time with a clear
-// error, and "log" reports that version history is unsupported instead of
-// crashing. The group otherwise reuses the generic command scaffolding (show,
+// Azure App Configuration is UNVERSIONED — the abstraction's acid test. #, ~,
+// and : are valid key characters (the whole argument is the literal key name,
+// not a version specifier), so nothing is rejected at parse time; "log" reports
+// that version history is unsupported instead of crashing. The group otherwise
+// reuses the generic command scaffolding (show,
 // list, diff, create, update, delete, tag, untag) via App Configuration
 // presenters and the shared internal/usecase/azure use cases.
 package param
@@ -29,9 +30,9 @@ func Command() *cli.Command {
 		Description: `Interact with Azure App Configuration key-values.
 
 App Configuration is UNVERSIONED: each key (with the default label) holds a
-single current value with no history. Version specifiers (#VERSION, ~SHIFT,
-:LABEL) are rejected with a clear error, and "log" reports that history is
-unsupported.
+single current value with no history. #, ~, and : are valid key characters (the
+whole argument is the literal key name, not a version specifier), and "log"
+reports that history is unsupported.
 
 Set the store with --store-name or the AZURE_APPCONFIG_NAME environment
 variable.`,

--- a/internal/cli/commands/azure/param/diff.go
+++ b/internal/cli/commands/azure/param/diff.go
@@ -88,8 +88,8 @@ func DiffCommand() *cli.Command {
 		Description: `Compare two App Configuration settings in unified diff format.
 
 App Configuration is UNVERSIONED, so diff compares two distinct keys rather than
-two versions of one key. Version specifiers (#VERSION, ~SHIFT, :LABEL) are
-rejected with a clear error.
+two versions of one key. #, ~, and : in a key are literal characters, not
+version specifiers.
 
 EXAMPLES:
   suve azure param diff key-a key-b                    Compare two settings

--- a/internal/cli/commands/azure/param/show.go
+++ b/internal/cli/commands/azure/param/show.go
@@ -108,8 +108,8 @@ func ShowCommand() *cli.Command {
 		ArgsUsage: argsUsageKey,
 		Description: `Display an App Configuration setting's value along with its metadata.
 
-App Configuration is UNVERSIONED: version specifiers (#VERSION, ~SHIFT, :LABEL)
-are rejected with a clear error.
+App Configuration is UNVERSIONED: #, ~, and : are valid key characters (the
+whole argument is the literal key name, not a version specifier).
 
 Use --raw to output only the value without metadata (for piping/scripting).
 Use --output=json for structured JSON output (cannot be used with --raw).

--- a/internal/cli/commands/gcloud/diff.go
+++ b/internal/cli/commands/gcloud/diff.go
@@ -88,7 +88,7 @@ If only one version/spec is specified, compares against the latest version.
 
 VERSION SPECIFIERS:
   #VERSION  Specific version by integer number
-  ~SHIFT    N enabled versions ago; ~ alone means ~1
+  ~SHIFT    N versions ago (any state); ~ alone means ~1
 
 EXAMPLES:
   suve gcloud secret diff my-secret~                   Compare previous with latest

--- a/internal/cli/commands/gcloud/show.go
+++ b/internal/cli/commands/gcloud/show.go
@@ -121,7 +121,7 @@ Use --output=json for structured JSON output (cannot be used with --raw).
 
 VERSION SPECIFIERS:
   #VERSION  Specific version by integer number
-  ~SHIFT    N enabled versions ago; ~ alone means ~1
+  ~SHIFT    N versions ago (any state); ~ alone means ~1
 
 EXAMPLES:
   suve gcloud secret show my-secret                        Show latest version

--- a/internal/cli/commands/param/log.go
+++ b/internal/cli/commands/param/log.go
@@ -230,7 +230,7 @@ number, modification date, and a preview of the value.
 Output is sorted with the most recent version first (use --reverse to flip).
 Value preview truncation depends on the mode:
   - Normal mode: Full value is shown (no truncation)
-  - Oneline mode: Truncated to fit terminal width (default 50 if width unavailable)
+  - Oneline mode: Truncated to roughly (terminal width - 30); about 20 chars when width is unavailable
 
 Use --max-value-length to override the automatic truncation.
 Use --patch to show the diff between consecutive versions (like git log -p).

--- a/internal/gui/secret.go
+++ b/internal/gui/secret.go
@@ -279,7 +279,9 @@ func (a *App) SecretUpdate(name, value string) (*SecretUpdateResult, error) {
 	}, nil
 }
 
-// SecretDelete deletes a secret (with recovery window).
+// SecretDelete deletes a secret (soft delete; a recovery-window date is
+// surfaced only for AWS Secrets Manager — Google Cloud deletes immediately and
+// Azure Key Vault retention is governed by vault policy).
 func (a *App) SecretDelete(name string, force bool) (*SecretDeleteResult, error) {
 	store, err := a.secretStore()
 	if err != nil {

--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -728,7 +728,7 @@ func (a *App) StagingCheckStatus(service, name, namespace string) (*StagingCheck
 	return result, nil
 }
 
-// StagingDiff shows diff between staged changes and AWS.
+// StagingDiff shows diff between staged changes and the provider's current values.
 func (a *App) StagingDiff(service string, name string) (*StagingDiffResult, error) {
 	store, err := a.getStagingStore(kindForService(service))
 	if err != nil {

--- a/internal/provider/detect/detect.go
+++ b/internal/provider/detect/detect.go
@@ -62,7 +62,7 @@ type Result struct {
 	ParamActive  []provider.Provider
 	SecretActive []provider.Provider
 	// StageActive lists every staging-capable provider active, in stable order
-	// (AWS, GoogleCloud).
+	// (AWS, GoogleCloud, Azure).
 	StageActive []provider.Provider
 
 	// AWSViaFallback is true when AWS became active only through the

--- a/internal/provider/gcloud/secret/secret.go
+++ b/internal/provider/gcloud/secret/secret.go
@@ -102,8 +102,10 @@ func (s *Store) versionPath(name, version string) string {
 
 // Resolve parses the version spec (generic) and resolves it to an opaque
 // VersionRef holding the integer version string (or "" for latest). A ~shift is
-// applied by walking the ENABLED versions newest-first; a "#<int>" without a
-// shift needs no listing. A ":LABEL" spec is rejected by gcloudversion.Parse.
+// applied by walking ALL versions (any state) newest-first — the same anchor a
+// bare name resolves to, so a `~N` never skips disabled/destroyed versions; a
+// "#<int>" without a shift needs no listing. A ":LABEL" spec is rejected by
+// gcloudversion.Parse.
 func (s *Store) Resolve(ctx context.Context, name, spec string) (provider.VersionRef, error) {
 	parsed, err := gcloudversion.Parse(name + spec)
 	if err != nil {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -64,9 +64,10 @@ type DeleteOptionMarker struct{}
 func (DeleteOptionMarker) deleteOption() {}
 
 // ForceDelete requests immediate, unrecoverable deletion, skipping any recovery
-// window. It is provider-neutral because the concept is shared: AWS Secrets
-// Manager maps it to ForceDeleteWithoutRecovery, and Azure Key Vault soft-deletes
-// then purges. Providers without the concept ignore it.
+// window. Only AWS Secrets Manager honors it (mapped to
+// ForceDeleteWithoutRecovery). Azure Key Vault ignores it — its retention is a
+// vault-level property, not a per-delete option, so deletes stay soft (use
+// Restore to recover). Providers without the concept ignore it.
 type ForceDelete struct{ DeleteOptionMarker }
 
 // Reader provides read access to a provider's entries.

--- a/internal/staging/cli/stash_pop.go
+++ b/internal/staging/cli/stash_pop.go
@@ -247,7 +247,7 @@ This command loads the staging state from the stash file
 (~/.suve/staging/aws/{accountID}/{region}/{param,secret}.json).
 
 By default, the stash file is deleted after restoring.
-Use --keep to retain the stash file after popping (same as 'stash apply').
+Use --keep to retain the stash file after popping (like 'git stash apply').
 
 EXAMPLES:
    suve stage stash pop                            Restore from stash and delete the stash file

--- a/internal/staging/conflict.go
+++ b/internal/staging/conflict.go
@@ -8,11 +8,11 @@ import (
 	"github.com/mpyw/suve/internal/parallel"
 )
 
-// CheckConflicts checks if AWS resources were modified after staging.
-// Returns a map of names that have conflicts.
+// CheckConflicts checks if remote resources were modified after staging.
+// Returns the set of EntryKeys that have conflicts.
 //
 // For Create operations: conflicts if resource now exists (someone else created it).
-// For Update/Delete operations with BaseModifiedAt: conflicts if AWS was modified after base.
+// For Update/Delete operations with BaseModifiedAt: conflicts if the remote was modified after base.
 func CheckConflicts(ctx context.Context, strategy ApplyStrategy, entries map[EntryKey]Entry) map[EntryKey]struct{} {
 	conflicts := make(map[EntryKey]struct{})
 

--- a/internal/staging/stage.go
+++ b/internal/staging/stage.go
@@ -183,9 +183,10 @@ func (s *State) MarshalJSON() ([]byte, error) {
 	return json.Marshal(out)
 }
 
-// UnmarshalJSON reads a v3 (structured-record) state, migrating v1/v2 states
-// (NUL-composite string map keys) transparently on read so existing staged and
-// stashed state is never lost.
+// UnmarshalJSON reads a v3 (structured-record) state. Pre-v3 layouts
+// (NUL-composite string map keys) are intentionally NOT migrated: they are
+// treated as empty (see stateVersion) so a format bump never crashes commands —
+// stale local working state is dropped rather than converted.
 func (s *State) UnmarshalJSON(data []byte) error {
 	var head struct {
 		Version int `json:"version"`


### PR DESCRIPTION
Fixes #448.

Doc- and comment-vs-implementation divergences found by a subagent audit of the whole repo (README, `docs/`, code doc-comments, and CLI `--help` text against the actual code). **Doc/comment-only — no behavior change.** Verified against source before editing.

## User-facing docs that were wrong or stale

| # | Where | Was | Now |
|---|-------|-----|-----|
| 1 | README, docs/azure.md | `restore` is "AWS Secrets Manager only" | AWS SM **and** Azure Key Vault; added an `azure secret restore` section + Key Vault table row; delete note points at `suve azure secret restore` (not the portal) |
| 2 | README, docs/azure.md | App Config `tag`/`untag` "unsupported (SDK limitation)" | Supported via GET-merge-PUT (matches the existing footnote that already said so) |
| 3 | README, docs/azure.md | App Config version specifiers "rejected" | Unversioned, so `#`/`~`/`:` are **literal key characters** (whole arg is the key), not rejected specifiers |
| 4 | docs/gcloud.md, gcloud `show`/`diff` `--help` | `~SHIFT` counts "enabled versions only" | Counts **all** versions (any state) — the enabled-only filter was a removed bug (would make `~N` skip disabled/destroyed versions that `latest` counts) |
| 5 | docs/aws.md | `secret create -d "..."` example | `-d` doesn't exist → `--description` |
| 6 | docs/aws.md | `--recovery-window` "ignored if `--force`" | The combination **errors** → "cannot be combined with `--force`" |
| 7 | README, docs/azure.md | "no cross-service `azure stage` aggregate" | Provider-wide `azure stage status/diff/apply/reset` exist (span both services) |
| 8 | docs/aws.md, docs/provider-selection.md | "Staging is AWS-only" (+ closed #247) | Staging is AWS + Google Cloud + Azure, each scope-keyed |
| 9 | stash pop `--help` | "(same as 'stash apply')" | No `stash apply` subcommand → "(like 'git stash apply')" |

## Code comments describing removed/old behavior

- `provider.ForceDelete` doc claimed "Azure Key Vault soft-deletes then purges" — Azure ignores it (purge was removed); only AWS SM honors it.
- gcloud `Resolve` doc said it walks "ENABLED versions" — it walks ALL versions (the rest of the file and the #313 fix comment already say so).
- `staging.State.UnmarshalJSON` doc claimed it migrates v1/v2 state — pre-v3 is intentionally NOT migrated (treated as empty).
- `CheckConflicts` doc said "map of names" — returns a set of `EntryKey`s.
- `detect.Result.StageActive` order comment omitted Azure.

## Not fixed here

The audit found **one latent code bug** (not doc): staging conflict detection resolves entries with the unscoped strategy and probes by bare name, dropping the namespace — inert today (only App Config has a namespace axis and its conflict check is a no-op). Tracked in #441 rather than fixed inline, since it needs a `CheckConflicts` signature change + tests across two callers.

`go build ./...`, `go test ./...`, and `mise lint` (0 issues) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

