### PR TITLE
fix(gui): Reset All resets every service; badge counts tag-only; debounce filter input

### DIFF
--- a/internal/gui/frontend/src/App.svelte
+++ b/internal/gui/frontend/src/App.svelte
@@ -330,7 +330,14 @@
     // Steady-state, AWS-only: no retry wrapping (a real failure must not hammer).
     try {
       const staged = await StagingStatus();
-      stagingCount = (staged?.param?.length ?? 0) + (staged?.secret?.length ?? 0);
+      // Include tag-only staged changes (paramTags/secretTags) so the badge
+      // matches the Staging tab's total; otherwise a tag-only stage shows 0
+      // until the Staging view recomputes.
+      stagingCount =
+        (staged?.param?.length ?? 0) +
+        (staged?.secret?.length ?? 0) +
+        (staged?.paramTags?.length ?? 0) +
+        (staged?.secretTags?.length ?? 0);
     } catch {
       stagingCount = 0;
     }

--- a/internal/gui/frontend/src/lib/ParamView.svelte
+++ b/internal/gui/frontend/src/lib/ParamView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, onMount } from 'svelte';
+  import { onDestroy, onMount, untrack } from 'svelte';
   import { ParamAddTag, ParamDelete, ParamDiff, ParamList, ParamLog, ParamRemoveTag, ParamSet, ParamShow, ParamTypeOptions, StagingAdd, StagingAddTag, StagingCheckStatus, StagingDelete, StagingEdit, StagingRemoveTag } from '../../wailsjs/go/gui/App';
   import type { gui } from '../../wailsjs/go/models';
   import DiffDisplay from './DiffDisplay.svelte';
@@ -159,11 +159,15 @@
     withValue: boolean;
   }
 
-  // Reload when filter options change
+  // Reload when the checkboxes change. prefix/filter are intentionally NOT
+  // dependencies — the debounced oninput handlers own text-input reloads, so
+  // typing doesn't fire a backend list on every keystroke (AWS lists everything
+  // then filters client-side).
   $effect(() => {
-    const opts = { prefix, filter, recursive, withValue }; // read values to create dependencies
+    const trackedRecursive = recursive;
+    const trackedWithValue = withValue;
     if (initialLoadDone) {
-      loadParams(opts);
+      loadParams(untrack(() => ({ prefix, filter, recursive: trackedRecursive, withValue: trackedWithValue })));
     }
   });
 

--- a/internal/gui/frontend/src/lib/SecretView.svelte
+++ b/internal/gui/frontend/src/lib/SecretView.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, onMount } from 'svelte';
+  import { onDestroy, onMount, untrack } from 'svelte';
   import { SecretAddTag, SecretCreate, SecretDelete, SecretDiff, SecretList, SecretLog, SecretRemoveTag, SecretRestore, SecretShow, SecretUpdate, StagingAdd, StagingAddTag, StagingCheckStatus, StagingDelete, StagingEdit, StagingRemoveTag } from '../../wailsjs/go/gui/App';
   import type { gui } from '../../wailsjs/go/models';
   import DiffDisplay from './DiffDisplay.svelte';
@@ -63,11 +63,13 @@
     withValue: boolean;
   }
 
-  // Reload when filter options change
+  // Reload when the checkbox changes. prefix/filter are intentionally NOT
+  // dependencies — the debounced oninput handlers own text-input reloads, so
+  // typing doesn't fire a backend list on every keystroke.
   $effect(() => {
-    const opts = { prefix, filter, withValue }; // read values to create dependencies
+    const trackedWithValue = withValue;
     if (initialLoadDone) {
-      loadSecrets(opts);
+      loadSecrets(untrack(() => ({ prefix, filter, withValue: trackedWithValue })));
     }
   });
 

--- a/internal/gui/frontend/src/lib/StagingView.svelte
+++ b/internal/gui/frontend/src/lib/StagingView.svelte
@@ -193,7 +193,14 @@
     modalLoading = true;
     modalError = '';
     try {
-      await StagingReset(resetService);
+      // "Reset All" (resetService === 'all') resets every service with staged
+      // changes — each is a separate backend call (Azure App Configuration and
+      // Key Vault have independent scopes), mirroring "Apply All". Per-section
+      // reset passes a concrete service.
+      const targets = resetService === 'all' ? stagedServices() : [resetService];
+      for (const svc of targets) {
+        await StagingReset(svc);
+      }
       showResetModal = false;
       await loadStatus();
     } catch (e) {
@@ -557,10 +564,7 @@
       </button>
       <button
         class="btn-action btn-reset"
-        onclick={() => {
-          if (paramEntries.length > 0 || paramTagEntries.length > 0) openResetModal('param');
-          if (secretEntries.length > 0 || secretTagEntries.length > 0) openResetModal('secret');
-        }}
+        onclick={() => openResetModal('all')}
         disabled={paramEntries.length === 0 && secretEntries.length === 0 && paramTagEntries.length === 0 && secretTagEntries.length === 0}
       >
         Reset All

--- a/internal/gui/frontend/tests/staging-reset-all.spec.ts
+++ b/internal/gui/frontend/tests/staging-reset-all.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  setupWailsMocks,
+  createStagedValue,
+  navigateTo,
+} from './fixtures/wails-mock';
+
+// Regression: "Reset All" must reset EVERY service with staged changes in a
+// single confirm. It used to fire openResetModal('param') then
+// openResetModal('secret') back-to-back, so resetService ended up 'secret' and
+// only the secret service was reset — param changes silently remained staged.
+
+function bothStagedState() {
+  return {
+    stagedParam: [createStagedValue('/app/param-a', 'create', 'pv')],
+    stagedSecret: [createStagedValue('secret-a', 'create', 'sv')],
+  };
+}
+
+const resetAllButton = (page: Page) => page.getByRole('button', { name: 'Reset All' });
+
+test.describe('Staging "Reset All"', () => {
+  test('resets both Param and Secret in a single confirm', async ({ page }) => {
+    await setupWailsMocks(page, bothStagedState());
+    await page.goto('/');
+    await navigateTo(page, 'Staging');
+
+    // Both services are staged before resetting.
+    await expect(page.locator('.entry-item').filter({ hasText: '/app/param-a' })).toBeVisible();
+    await expect(page.locator('.entry-item').filter({ hasText: 'secret-a' })).toBeVisible();
+
+    await resetAllButton(page).click();
+
+    // The modal addresses ALL services, not just one.
+    await expect(page.locator('.modal')).toContainText('all services');
+
+    // Confirm (the modal's own danger button in .form-actions).
+    await page.locator('.form-actions').locator('.btn-danger').click();
+
+    // BOTH services are now empty — before the fix the param entry remained.
+    await expect(page.locator('.entry-item').filter({ hasText: '/app/param-a' })).toHaveCount(0);
+    await expect(page.locator('.entry-item').filter({ hasText: 'secret-a' })).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
Fixes #450.

Three GUI frontend bugs found by the round-3 subagent audit. All fixed; a Playwright regression test is added for the high-severity one.

## 1. (high) "Reset All" reset only the secret service

With **both** param and secret staged, the "Reset All" button ran `openResetModal('param')` then `openResetModal('secret')` back-to-back. The second call overwrote `resetService`, so the modal read "…for Secret" and `handleReset` called `StagingReset('secret')` alone — **param changes silently remained staged**. (Contrast "Apply All", which correctly loops `stagedServices()`.)

**Fix:** `openResetModal('all')` + an `'all'` path in `handleReset` that loops `stagedServices()`, mirroring "Apply All".

## 2. (medium) Filter input defeated its own debounce

`ParamView`/`SecretView` list-reload `$effect` listed `prefix`/`filter` as dependencies, so **every keystroke** fired a full backend list (AWS lists everything then filters client-side) on top of the 300 ms debounced call — the debounce was dead.

**Fix:** the effect now depends only on the checkboxes and reads `prefix`/`filter` via `untrack`; the debounced `oninput` handlers own text-input reloads.

## 3. (medium-low) Sidebar badge undercounted tag-only changes

`loadStagingCount` summed only `param`/`secret` entries, ignoring `paramTags`/`secretTags`, so a tag-only stage showed **0** in the sidebar until the Staging tab recomputed a higher number.

**Fix:** include the tag slices in the count.

## Tests

- New `staging-reset-all.spec.ts`: with both services staged, "Reset All" → one confirm → both empty (fails on the old code, which left param staged).
- `svelte-check` (0 errors), the staging/param/secret Playwright suites (255 passing), and `mise build-gui` are green.

Found alongside other audit items — see issues #441/#443/#445 and PRs #442/#444.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

