### PR TITLE
feat(staging): add export/import envelope format (Step 1/6)

### DIFF
--- a/internal/staging/store/file/envelope.go
+++ b/internal/staging/store/file/envelope.go
@@ -1,0 +1,190 @@
+package file
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/staging"
+	"github.com/mpyw/suve/internal/staging/store/file/internal/crypt"
+)
+
+// EnvelopeVersion is the current export/import envelope schema version.
+const EnvelopeVersion = 1
+
+// Envelope is the on-disk format for `stage export` / `stage import` files.
+//
+// It is a plaintext JSON object; only Payload carries secret data (the staged
+// State, optionally encrypted, base64-encoded). Provider/Scope/Service stay in
+// the clear so a file can be identified and validated without a passphrase.
+//
+// Exactly one service lives in a single envelope file (per-service files mirror
+// the working store's param.json / secret.json split).
+type Envelope struct {
+	// Version is the envelope schema version (EnvelopeVersion).
+	Version int `json:"version"`
+	// Provider is the scope provider string, e.g. "aws"/"googlecloud"/"azure".
+	Provider string `json:"provider"`
+	// Scope is the scope key (provider.Scope.Key()), used to validate on import.
+	Scope string `json:"scope"`
+	// Service is the staging service the payload holds ("param" or "secret").
+	Service string `json:"service"`
+	// Payload is base64(std) of the marshaled single-service State. When the
+	// state was exported with a passphrase it is the encrypted (v1) blob;
+	// otherwise it is the plaintext state JSON.
+	//
+	// WARNING: base64 is NOT encryption. An empty passphrase stores the secret
+	// values in cleartext (base64 only). Callers exporting with an empty
+	// passphrase must warn the user before writing such a file.
+	Payload string `json:"payload"`
+}
+
+var (
+	// ErrInvalidEnvelope is returned when a file is not a valid export envelope
+	// (bad JSON, missing required fields, or corrupted base64 payload).
+	ErrInvalidEnvelope = errors.New("invalid export file")
+	// ErrUnsupportedEnvelopeVersion is returned for an unknown envelope version.
+	ErrUnsupportedEnvelopeVersion = errors.New("unsupported export file version")
+)
+
+// encodePayload marshals a single-service state into the base64 payload. With an
+// empty passphrase the state JSON is stored as plaintext (base64 only, no
+// encryption); otherwise it is encrypted with the passphrase-based (v1) format.
+func encodePayload(state *staging.State, passphrase string) (string, error) {
+	// staging.State implements json.Marshaler (MarshalJSON), emitting its
+	// EntryKey-keyed maps as arrays of (name, namespace) records, so the static
+	// errchkjson "unsupported map key" warning is a false positive here.
+	data, err := json.Marshal(state) //nolint:errchkjson // State has a custom MarshalJSON
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal state: %w", err)
+	}
+
+	if passphrase != "" {
+		data, err = crypt.Encrypt(data, passphrase)
+		if err != nil {
+			return "", fmt.Errorf("failed to encrypt payload: %w", err)
+		}
+	}
+
+	return base64.StdEncoding.EncodeToString(data), nil
+}
+
+// WriteEnvelopeFile writes state to path as an export envelope, overwriting any
+// existing file wholesale. Only svc's entries are written: the state is scoped
+// to svc defensively so a caller passing a multi-service state can never leak
+// another service's secrets into a file labeled for svc. The parent directory
+// is created if needed and the write is atomic.
+//
+// WARNING: an empty passphrase writes the secret values UNENCRYPTED (base64
+// only); callers must warn the user first.
+func WriteEnvelopeFile(path string, scope provider.Scope, svc staging.Service, state *staging.State, passphrase string) error {
+	payload, err := encodePayload(state.ExtractService(svc), passphrase)
+	if err != nil {
+		return err
+	}
+
+	env := Envelope{
+		Version:  EnvelopeVersion,
+		Provider: string(scope.Provider),
+		Scope:    scope.Key(),
+		Service:  string(svc),
+		Payload:  payload,
+	}
+
+	data, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal export envelope: %w", err)
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil { //nolint:mnd // owner-only directory permissions
+		return fmt.Errorf("failed to create export directory: %w", err)
+	}
+
+	if err := writeFileAtomic(path, data); err != nil {
+		return fmt.Errorf("failed to write export file: %w", err)
+	}
+
+	return nil
+}
+
+// ReadEnvelopeFile reads and validates the envelope at path without decoding the
+// payload, so scope/service can be checked before a passphrase is prompted.
+func ReadEnvelopeFile(path string) (*Envelope, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path is user-supplied import target
+	if err != nil {
+		return nil, fmt.Errorf("failed to read export file: %w", err)
+	}
+
+	var env Envelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidEnvelope, err.Error())
+	}
+
+	if env.Version != EnvelopeVersion {
+		return nil, fmt.Errorf("%w: %d", ErrUnsupportedEnvelopeVersion, env.Version)
+	}
+
+	if env.Provider == "" || env.Scope == "" || env.Service == "" || env.Payload == "" {
+		return nil, ErrInvalidEnvelope
+	}
+
+	return &env, nil
+}
+
+// decodedPayload base64-decodes the payload into its raw (possibly encrypted)
+// bytes.
+func (e *Envelope) decodedPayload() ([]byte, error) {
+	raw, err := base64.StdEncoding.DecodeString(e.Payload)
+	if err != nil {
+		return nil, fmt.Errorf("%w: corrupted payload encoding", ErrInvalidEnvelope)
+	}
+
+	return raw, nil
+}
+
+// IsEncryptedPayload reports whether the payload is passphrase-encrypted. It
+// only inspects the header, so no passphrase is required.
+func (e *Envelope) IsEncryptedPayload() (bool, error) {
+	raw, err := e.decodedPayload()
+	if err != nil {
+		return false, err
+	}
+
+	return crypt.IsEncrypted(raw), nil
+}
+
+// DecodeState decodes (and decrypts, when encrypted) the payload into a State.
+// An empty passphrase is valid only for a plaintext payload.
+func (e *Envelope) DecodeState(passphrase string) (*staging.State, error) {
+	raw, err := e.decodedPayload()
+	if err != nil {
+		return nil, err
+	}
+
+	if crypt.IsEncrypted(raw) {
+		if passphrase == "" {
+			return nil, crypt.ErrDecryptionFailed
+		}
+
+		raw, err = crypt.Decrypt(raw, passphrase)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var state staging.State
+	if err := json.Unmarshal(raw, &state); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidEnvelope, err.Error())
+	}
+
+	// The payload is untrusted input, so return only the entries for the
+	// service the (plaintext) header declares: a mismatched or hostile payload
+	// carrying another service's data is dropped rather than trusted.
+	// ExtractService returns a state with fully initialized maps.
+	return state.ExtractService(staging.Service(e.Service)), nil
+}

--- a/internal/staging/store/file/envelope_test.go
+++ b/internal/staging/store/file/envelope_test.go
@@ -1,0 +1,429 @@
+package file_test
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/staging"
+	"github.com/mpyw/suve/internal/staging/store/file"
+	"github.com/mpyw/suve/internal/staging/store/file/internal/crypt"
+)
+
+// paramState builds a single-service (param) state with one create entry.
+func paramState(name, value string) *staging.State {
+	state := staging.NewEmptyState()
+	state.Entries[staging.ServiceParam][staging.EntryKey{Name: name}] = staging.Entry{
+		Operation: staging.OperationCreate,
+		Value:     lo.ToPtr(value),
+	}
+
+	return state
+}
+
+// secretState builds a single-service (secret) state with one create entry.
+func secretState(name, value string) *staging.State {
+	state := staging.NewEmptyState()
+	state.Entries[staging.ServiceSecret][staging.EntryKey{Name: name}] = staging.Entry{
+		Operation: staging.OperationCreate,
+		Value:     lo.ToPtr(value),
+	}
+
+	return state
+}
+
+func TestWriteAndReadEnvelope_Encrypted(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "param.json")
+	scope := provider.AWSScope("123456789012", "ap-northeast-1")
+	state := paramState("/app/config", "secret-value")
+
+	err := file.WriteEnvelopeFile(path, scope, staging.ServiceParam, state, "correct horse")
+	require.NoError(t, err)
+
+	env, err := file.ReadEnvelopeFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, file.EnvelopeVersion, env.Version)
+	assert.Equal(t, "aws", env.Provider)
+	assert.Equal(t, "aws/123456789012/ap-northeast-1", env.Scope)
+	assert.Equal(t, "param", env.Service)
+
+	encrypted, err := env.IsEncryptedPayload()
+	require.NoError(t, err)
+	assert.True(t, encrypted)
+
+	got, err := env.DecodeState("correct horse")
+	require.NoError(t, err)
+	assert.Equal(t, "secret-value",
+		lo.FromPtr(got.Entries[staging.ServiceParam][staging.EntryKey{Name: "/app/config"}].Value))
+}
+
+func TestWriteAndReadEnvelope_Plaintext(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "secret.json")
+	scope := provider.AWSScope("123456789012", "us-east-1")
+	state := secretState("my-secret", "plain-value")
+
+	// Empty passphrase => plaintext payload.
+	err := file.WriteEnvelopeFile(path, scope, staging.ServiceSecret, state, "")
+	require.NoError(t, err)
+
+	env, err := file.ReadEnvelopeFile(path)
+	require.NoError(t, err)
+	assert.Equal(t, "secret", env.Service)
+
+	encrypted, err := env.IsEncryptedPayload()
+	require.NoError(t, err)
+	assert.False(t, encrypted)
+
+	// A passphrase is ignored for a plaintext payload.
+	got, err := env.DecodeState("ignored")
+	require.NoError(t, err)
+	assert.Equal(t, "plain-value",
+		lo.FromPtr(got.Entries[staging.ServiceSecret][staging.EntryKey{Name: "my-secret"}].Value))
+}
+
+func TestWriteAndReadEnvelope_TagsAndNamespace(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "param.json")
+	scope := provider.AzureAppConfigScope("mystore")
+
+	state := staging.NewEmptyState()
+	key := staging.EntryKey{Name: "k", Namespace: "dev"}
+	state.Entries[staging.ServiceParam][key] = staging.Entry{
+		Operation: staging.OperationCreate,
+		Value:     lo.ToPtr("v"),
+	}
+	state.Tags[staging.ServiceParam][key] = staging.TagEntry{
+		Add: map[string]string{"env": "dev"},
+	}
+
+	err := file.WriteEnvelopeFile(path, scope, staging.ServiceParam, state, "pw")
+	require.NoError(t, err)
+
+	env, err := file.ReadEnvelopeFile(path)
+	require.NoError(t, err)
+
+	got, err := env.DecodeState("pw")
+	require.NoError(t, err)
+	assert.Equal(t, "v", lo.FromPtr(got.Entries[staging.ServiceParam][key].Value))
+	assert.Equal(t, "dev", got.Tags[staging.ServiceParam][key].Add["env"])
+}
+
+func TestDecodeState_WrongPassphrase(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "param.json")
+	scope := provider.AWSScope("123456789012", "ap-northeast-1")
+
+	err := file.WriteEnvelopeFile(path, scope, staging.ServiceParam, paramState("/k", "v"), "right")
+	require.NoError(t, err)
+
+	env, err := file.ReadEnvelopeFile(path)
+	require.NoError(t, err)
+
+	_, err = env.DecodeState("wrong")
+	require.ErrorIs(t, err, crypt.ErrDecryptionFailed)
+}
+
+func TestDecodeState_EncryptedButNoPassphrase(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "param.json")
+	scope := provider.AWSScope("123456789012", "ap-northeast-1")
+
+	err := file.WriteEnvelopeFile(path, scope, staging.ServiceParam, paramState("/k", "v"), "pw")
+	require.NoError(t, err)
+
+	env, err := file.ReadEnvelopeFile(path)
+	require.NoError(t, err)
+
+	_, err = env.DecodeState("")
+	require.ErrorIs(t, err, crypt.ErrDecryptionFailed)
+}
+
+func TestDecodeState_ServiceMismatchDropsForeignData(t *testing.T) {
+	t.Parallel()
+
+	// A plaintext payload holding a full multi-service state, but the header
+	// declares only "param": DecodeState must return only param entries.
+	full := staging.NewEmptyState()
+	full.Entries[staging.ServiceParam][staging.EntryKey{Name: "/p"}] = staging.Entry{
+		Operation: staging.OperationCreate, Value: lo.ToPtr("pv"),
+	}
+	full.Entries[staging.ServiceSecret][staging.EntryKey{Name: "s"}] = staging.Entry{
+		Operation: staging.OperationCreate, Value: lo.ToPtr("sv"),
+	}
+
+	raw, err := json.Marshal(full) //nolint:errchkjson // State has a custom MarshalJSON
+	require.NoError(t, err)
+
+	env := &file.Envelope{
+		Version:  file.EnvelopeVersion,
+		Provider: "aws",
+		Scope:    "aws/1/r",
+		Service:  "param",
+		Payload:  base64.StdEncoding.EncodeToString(raw),
+	}
+
+	got, err := env.DecodeState("")
+	require.NoError(t, err)
+	assert.Len(t, got.Entries[staging.ServiceParam], 1)
+	assert.Empty(t, got.Entries[staging.ServiceSecret], "foreign service must be dropped")
+}
+
+func TestWriteEnvelope_ScopesToService(t *testing.T) {
+	t.Parallel()
+
+	// A multi-service state written as "param" must not leak secret entries.
+	full := staging.NewEmptyState()
+	full.Entries[staging.ServiceParam][staging.EntryKey{Name: "/p"}] = staging.Entry{
+		Operation: staging.OperationCreate, Value: lo.ToPtr("pv"),
+	}
+	full.Entries[staging.ServiceSecret][staging.EntryKey{Name: "s"}] = staging.Entry{
+		Operation: staging.OperationCreate, Value: lo.ToPtr("super-secret"),
+	}
+
+	path := filepath.Join(t.TempDir(), "param.json")
+	err := file.WriteEnvelopeFile(path, provider.AWSScope("1", "r"), staging.ServiceParam, full, "")
+	require.NoError(t, err)
+
+	env, err := file.ReadEnvelopeFile(path)
+	require.NoError(t, err)
+
+	got, err := env.DecodeState("")
+	require.NoError(t, err)
+	assert.Len(t, got.Entries[staging.ServiceParam], 1)
+	assert.Empty(t, got.Entries[staging.ServiceSecret])
+
+	// The other service's secret must not be present anywhere in the file.
+	fileBytes, err := os.ReadFile(path) //nolint:gosec // path is a file just written to t.TempDir()
+	require.NoError(t, err)
+	decoded, err := base64.StdEncoding.DecodeString(env.Payload)
+	require.NoError(t, err)
+	assert.NotContains(t, string(decoded), "super-secret")
+	assert.NotContains(t, string(fileBytes), "super-secret")
+}
+
+func TestPayloadBytes_PlaintextVsEncrypted(t *testing.T) {
+	t.Parallel()
+
+	scope := provider.AWSScope("1", "r")
+
+	t.Run("plaintext payload contains the secret", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "param.json")
+		require.NoError(t, file.WriteEnvelopeFile(path, scope, staging.ServiceParam, paramState("/k", "cleartext-secret"), ""))
+
+		env, err := file.ReadEnvelopeFile(path)
+		require.NoError(t, err)
+		decoded, err := base64.StdEncoding.DecodeString(env.Payload)
+		require.NoError(t, err)
+		assert.Contains(t, string(decoded), "cleartext-secret")
+	})
+
+	t.Run("encrypted payload hides the secret", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "param.json")
+		require.NoError(t, file.WriteEnvelopeFile(path, scope, staging.ServiceParam, paramState("/k", "hidden-secret"), "pw"))
+
+		env, err := file.ReadEnvelopeFile(path)
+		require.NoError(t, err)
+		decoded, err := base64.StdEncoding.DecodeString(env.Payload)
+		require.NoError(t, err)
+		assert.NotContains(t, string(decoded), "hidden-secret")
+		assert.True(t, crypt.IsEncrypted(decoded))
+	})
+}
+
+func TestReadEnvelopeFile_Errors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing file", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := file.ReadEnvelopeFile(filepath.Join(t.TempDir(), "nope.json"))
+		require.Error(t, err)
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "bad.json")
+		require.NoError(t, os.WriteFile(path, []byte("not json"), 0o600))
+
+		_, err := file.ReadEnvelopeFile(path)
+		require.ErrorIs(t, err, file.ErrInvalidEnvelope)
+	})
+
+	t.Run("unsupported version", func(t *testing.T) {
+		t.Parallel()
+
+		path := filepath.Join(t.TempDir(), "v99.json")
+		data, err := json.Marshal(file.Envelope{
+			Version:  99,
+			Provider: "aws",
+			Scope:    "aws/1/r",
+			Service:  "param",
+			Payload:  base64.StdEncoding.EncodeToString([]byte("{}")),
+		})
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(path, data, 0o600))
+
+		_, err = file.ReadEnvelopeFile(path)
+		require.ErrorIs(t, err, file.ErrUnsupportedEnvelopeVersion)
+	})
+
+	t.Run("missing required fields", func(t *testing.T) {
+		t.Parallel()
+
+		cases := map[string]file.Envelope{
+			"all empty":       {Version: file.EnvelopeVersion},
+			"missing scope":   {Version: file.EnvelopeVersion, Provider: "aws", Service: "param", Payload: "eyJ9"},
+			"missing payload": {Version: file.EnvelopeVersion, Provider: "aws", Scope: "aws/1/r", Service: "param"},
+		}
+
+		for name, env := range cases {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				path := filepath.Join(t.TempDir(), "e.json")
+				data, err := json.Marshal(env)
+				require.NoError(t, err)
+				require.NoError(t, os.WriteFile(path, data, 0o600))
+
+				_, err = file.ReadEnvelopeFile(path)
+				require.ErrorIs(t, err, file.ErrInvalidEnvelope)
+			})
+		}
+	})
+}
+
+func TestDecodeState_CorruptedPayload(t *testing.T) {
+	t.Parallel()
+
+	base := file.Envelope{
+		Version:  file.EnvelopeVersion,
+		Provider: "aws",
+		Scope:    "aws/1/r",
+		Service:  "param",
+	}
+
+	t.Run("bad base64", func(t *testing.T) {
+		t.Parallel()
+
+		env := base
+		env.Payload = "!!!not-base64!!!"
+
+		_, err := env.DecodeState("")
+		require.ErrorIs(t, err, file.ErrInvalidEnvelope)
+	})
+
+	t.Run("plaintext payload with invalid json", func(t *testing.T) {
+		t.Parallel()
+
+		env := base
+		env.Payload = base64.StdEncoding.EncodeToString([]byte("not json"))
+
+		_, err := env.DecodeState("")
+		require.ErrorIs(t, err, file.ErrInvalidEnvelope)
+	})
+
+	t.Run("encrypted payload decrypts to invalid json", func(t *testing.T) {
+		t.Parallel()
+
+		blob, err := crypt.Encrypt([]byte("not json"), "pw")
+		require.NoError(t, err)
+
+		env := base
+		env.Payload = base64.StdEncoding.EncodeToString(blob)
+
+		_, err = env.DecodeState("pw")
+		require.ErrorIs(t, err, file.ErrInvalidEnvelope)
+	})
+}
+
+func TestIsEncryptedPayload_BadBase64(t *testing.T) {
+	t.Parallel()
+
+	env := &file.Envelope{Payload: "!!!not-base64!!!"}
+
+	_, err := env.IsEncryptedPayload()
+	require.ErrorIs(t, err, file.ErrInvalidEnvelope)
+}
+
+func TestWriteEnvelope_ProviderScopeFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		scope        provider.Scope
+		svc          staging.Service
+		wantProvider string
+		wantScope    string
+	}{
+		{
+			name:         "aws param",
+			scope:        provider.AWSScope("123456789012", "ap-northeast-1"),
+			svc:          staging.ServiceParam,
+			wantProvider: "aws",
+			wantScope:    "aws/123456789012/ap-northeast-1",
+		},
+		{
+			name:         "gcloud secret",
+			scope:        provider.GoogleCloudScope("my-project"),
+			svc:          staging.ServiceSecret,
+			wantProvider: "googlecloud",
+			wantScope:    "googlecloud/my-project",
+		},
+		{
+			name:         "azure keyvault secret",
+			scope:        provider.AzureKeyVaultScope("myvault"),
+			svc:          staging.ServiceSecret,
+			wantProvider: "azure",
+			wantScope:    "azure/keyvault/myvault",
+		},
+		{
+			name:         "azure appconfig param",
+			scope:        provider.AzureAppConfigScope("mystore"),
+			svc:          staging.ServiceParam,
+			wantProvider: "azure",
+			wantScope:    "azure/appconfig/mystore",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var state *staging.State
+			if tt.svc == staging.ServiceParam {
+				state = paramState("/k", "v")
+			} else {
+				state = secretState("k", "v")
+			}
+
+			path := filepath.Join(t.TempDir(), string(tt.svc)+".json")
+			err := file.WriteEnvelopeFile(path, tt.scope, tt.svc, state, "")
+			require.NoError(t, err)
+
+			env, err := file.ReadEnvelopeFile(path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantProvider, env.Provider)
+			assert.Equal(t, tt.wantScope, env.Scope)
+			assert.Equal(t, string(tt.svc), env.Service)
+		})
+	}
+}

--- a/internal/staging/store/file/envelope_test.go
+++ b/internal/staging/store/file/envelope_test.go
@@ -182,6 +182,35 @@ func TestDecodeState_ServiceMismatchDropsForeignData(t *testing.T) {
 	assert.Empty(t, got.Entries[staging.ServiceSecret], "foreign service must be dropped")
 }
 
+func TestWriteEnvelopeFile_WriteErrors(t *testing.T) {
+	t.Parallel()
+
+	scope := provider.AWSScope("1", "r")
+	state := paramState("/k", "v")
+
+	t.Run("mkdir fails when a parent path component is a file", func(t *testing.T) {
+		t.Parallel()
+
+		blocker := filepath.Join(t.TempDir(), "blocker")
+		require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o600))
+
+		// The parent directory cannot be created because "blocker" is a file.
+		err := file.WriteEnvelopeFile(filepath.Join(blocker, "sub", "param.json"), scope, staging.ServiceParam, state, "")
+		require.Error(t, err)
+	})
+
+	t.Run("atomic write fails when the target path is a directory", func(t *testing.T) {
+		t.Parallel()
+
+		target := filepath.Join(t.TempDir(), "param.json")
+		require.NoError(t, os.Mkdir(target, 0o700))
+
+		// Renaming the temp file over an existing directory fails.
+		err := file.WriteEnvelopeFile(target, scope, staging.ServiceParam, state, "")
+		require.Error(t, err)
+	})
+}
+
 func TestWriteEnvelope_ScopesToService(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

**Step 1 of 6** replacing `stage stash` with `stage export` / `stage import` (Epic #451).

This PR is **additive only**: it adds the export/import on-disk format (a self-describing, per-service "envelope") to the file store. It intentionally does **not** remove the stash constructors — those are still used by the usecase/CLI/GUI layers, so removing them now would break the build. To keep every stacked PR independently green, the removal is deferred to the GUI step (#455), which migrates the last caller. See the ordering note on #451.

## What's added

`internal/staging/store/file/envelope.go`:
- `Envelope{version, provider, scope, service, payload}` — plaintext JSON; only `payload` carries secret data.
- `payload` = base64(std) of the marshaled **single-service** `State`; passphrase-encrypted (`crypt.Encrypt`, Argon2id v1 `SUVE_ENC` blob) or plaintext JSON when the passphrase is empty (`crypt.IsEncrypted` decides on read, mirroring `store.go`'s working-store behavior).
- `WriteEnvelopeFile` / `ReadEnvelopeFile` / `DecodeState` / `IsEncryptedPayload` (atomic write via the existing `writeFileAtomic`).

### Hardening applied after an independent critical review
- **Write is scoped to the service** (`ExtractService(svc)`), so a caller passing a multi-service state can't leak another service's secrets into a file labeled for one service.
- **Decode returns only the declared service's entries** — an untrusted/hostile payload cannot smuggle another service's data past the plaintext header label.
- **`scope` is a required field** on read (it's used for import validation).
- **Empty passphrase = plaintext** is documented as a hazard in the godoc; the CLI/GUI layers (later steps) will warn the user before writing an unencrypted file.

## Tests

`envelope_test.go` covers: encrypted + plaintext round-trips, tags & namespace round-trip, wrong passphrase, encrypted-without-passphrase, service-mismatch drop, write-scoping, plaintext-vs-encrypted payload byte inspection (secret hidden when encrypted), base64/JSON/encrypted-invalid-JSON corruption, `IsEncryptedPayload` error path, and provider/scope/service fields for aws / gcloud / azure-keyvault / azure-appconfig.

`mise test` and `mise lint` pass on the whole repo. New-file logic is fully exercised (package coverage 77.8%, dominated by pre-existing `store.go` branches).

Closes #452
Part of #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)