### PR TITLE
feat(usecase): add export/import staging use cases

### DIFF
--- a/internal/usecase/staging/export.go
+++ b/internal/usecase/staging/export.go
@@ -1,0 +1,155 @@
+package staging
+
+import (
+	"context"
+	"errors"
+
+	"github.com/mpyw/suve/internal/staging"
+	"github.com/mpyw/suve/internal/staging/store"
+)
+
+// Export error Op codes.
+const (
+	exportOpLoad  = "load"
+	exportOpWrite = "write"
+	exportOpClear = "clear"
+)
+
+// EnvelopeWriter writes a single service's staged state to an export target
+// (typically a per-service envelope file). Adapters bind the destination path,
+// scope, and passphrase; the use case only supplies the service and its state.
+type EnvelopeWriter interface {
+	// WriteEnvelope serializes state (scoped to svc) to the export target.
+	WriteEnvelope(ctx context.Context, svc staging.Service, state *staging.State) error
+}
+
+// ExportInput holds input for the export use case.
+type ExportInput struct {
+	// Service filters the export to a specific service. Empty means all services
+	// that have staged changes.
+	Service staging.Service
+	// Keep preserves the working staging area after exporting.
+	Keep bool
+}
+
+// ExportOutput holds the result of the export use case.
+type ExportOutput struct {
+	// EntryCount is the number of entries exported.
+	EntryCount int
+	// TagCount is the number of tag entries exported.
+	TagCount int
+}
+
+// ExportUseCase writes the working staging area out to an export target
+// wholesale. Unlike the former stash push, export never merges with existing
+// destination data: writing state out is a serialization of the current working
+// area, not a reconciliation with whatever a file previously held.
+type ExportUseCase struct {
+	// Working is the working staging area (param.json/secret.json).
+	Working store.FileStore
+	// Target receives the exported per-service state.
+	Target EnvelopeWriter
+}
+
+// Execute runs the export use case.
+func (u *ExportUseCase) Execute(ctx context.Context, input ExportInput) (*ExportOutput, error) {
+	// Read the working staging area (keep=true; we clear it afterwards only when
+	// the write succeeded and --keep was not requested).
+	workingState, err := u.Working.Drain(ctx, "", true)
+	if err != nil {
+		return nil, &ExportError{Op: exportOpLoad, Err: err}
+	}
+
+	// Determine which services actually have data to export, along with their
+	// extracted per-service state. A service filter narrows to that one service;
+	// otherwise every non-empty service is written.
+	targets := exportTargets(input.Service, workingState)
+	if len(targets) == 0 {
+		return nil, ErrNothingToExport
+	}
+
+	output := &ExportOutput{}
+
+	for _, t := range targets {
+		if err := u.Target.WriteEnvelope(ctx, t.service, t.state); err != nil {
+			return nil, &ExportError{Op: exportOpWrite, Err: err}
+		}
+
+		output.EntryCount += t.state.EntryCount()
+		output.TagCount += t.state.TagCount()
+	}
+
+	// Clear the exported working area unless --keep is specified. The export has
+	// already succeeded, so a failure here is non-fatal.
+	if !input.Keep {
+		if input.Service != "" {
+			workingState.RemoveService(input.Service)
+		} else {
+			workingState = staging.NewEmptyState()
+		}
+
+		if err := u.Working.WriteState(ctx, "", workingState); err != nil {
+			return output, &ExportError{Op: exportOpClear, Err: err, NonFatal: true}
+		}
+	}
+
+	return output, nil
+}
+
+// exportTarget pairs a service with its extracted single-service state.
+type exportTarget struct {
+	service staging.Service
+	state   *staging.State
+}
+
+// exportTargets returns the services that should be exported together with their
+// extracted state. With a service filter it is that single service when it has
+// data; otherwise it is every service (param, secret) whose state is non-empty.
+func exportTargets(service staging.Service, state *staging.State) []exportTarget {
+	services := []staging.Service{staging.ServiceParam, staging.ServiceSecret}
+	if service != "" {
+		services = []staging.Service{service}
+	}
+
+	var targets []exportTarget
+
+	for _, svc := range services {
+		svcState := state.ExtractService(svc)
+		if svcState.IsEmpty() {
+			continue
+		}
+
+		targets = append(targets, exportTarget{service: svc, state: svcState})
+	}
+
+	return targets
+}
+
+var (
+	// ErrNothingToExport is returned when there are no staged changes to export.
+	ErrNothingToExport = errors.New("no staged changes to export")
+)
+
+// ExportError represents an error during an export operation.
+type ExportError struct {
+	Op       string // "load", "write", "clear"
+	Err      error
+	NonFatal bool // If true, the error is non-fatal (state was already written)
+}
+
+func (e *ExportError) Error() string {
+	switch e.Op {
+	case exportOpLoad:
+		return "failed to read the working staging area: " + e.Err.Error()
+	case exportOpWrite:
+		return "failed to write export file: " + e.Err.Error()
+	case exportOpClear:
+		return "failed to clear the working staging area: " + e.Err.Error()
+	default:
+		return e.Err.Error()
+	}
+}
+
+func (e *ExportError) Unwrap() error {
+	return e.Err
+}

--- a/internal/usecase/staging/export_test.go
+++ b/internal/usecase/staging/export_test.go
@@ -1,0 +1,294 @@
+package staging_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/staging"
+	"github.com/mpyw/suve/internal/staging/store/testutil"
+	stagingusecase "github.com/mpyw/suve/internal/usecase/staging"
+)
+
+// recordingWriter is a fake EnvelopeWriter that records the states it is asked
+// to write, keyed by service. An optional err forces a write failure.
+type recordingWriter struct {
+	written map[staging.Service]*staging.State
+	err     error
+}
+
+func (w *recordingWriter) WriteEnvelope(_ context.Context, svc staging.Service, state *staging.State) error {
+	if w.err != nil {
+		return w.err
+	}
+
+	if w.written == nil {
+		w.written = make(map[staging.Service]*staging.State)
+	}
+
+	w.written[svc] = state
+
+	return nil
+}
+
+func stageEntry(t *testing.T, s *testutil.MockStore, svc staging.Service, name, value string) {
+	t.Helper()
+
+	require.NoError(t, s.StageEntry(t.Context(), svc, staging.EntryKey{Name: name}, staging.Entry{
+		Operation: staging.OperationUpdate,
+		Value:     lo.ToPtr(value),
+		StagedAt:  time.Now(),
+	}))
+}
+
+func TestExportUseCase_Execute(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nothing to export when working is empty", func(t *testing.T) {
+		t.Parallel()
+
+		working := testutil.NewMockStore()
+		writer := &recordingWriter{}
+
+		usecase := &stagingusecase.ExportUseCase{Working: working, Target: writer}
+
+		_, err := usecase.Execute(t.Context(), stagingusecase.ExportInput{})
+		require.ErrorIs(t, err, stagingusecase.ErrNothingToExport)
+		assert.Empty(t, writer.written)
+	})
+
+	t.Run("nothing to export when filtered service is empty", func(t *testing.T) {
+		t.Parallel()
+
+		working := testutil.NewMockStore()
+		stageEntry(t, working, staging.ServiceSecret, "my-secret", "v")
+
+		writer := &recordingWriter{}
+		usecase := &stagingusecase.ExportUseCase{Working: working, Target: writer}
+
+		_, err := usecase.Execute(t.Context(), stagingusecase.ExportInput{Service: staging.ServiceParam})
+		require.ErrorIs(t, err, stagingusecase.ErrNothingToExport)
+		assert.Empty(t, writer.written)
+	})
+
+	t.Run("global export writes each non-empty service and clears working", func(t *testing.T) {
+		t.Parallel()
+
+		working := testutil.NewMockStore()
+		stageEntry(t, working, staging.ServiceParam, "/app/config", "p")
+		stageEntry(t, working, staging.ServiceSecret, "my-secret", "s")
+
+		writer := &recordingWriter{}
+		usecase := &stagingusecase.ExportUseCase{Working: working, Target: writer}
+
+		output, err := usecase.Execute(t.Context(), stagingusecase.ExportInput{})
+		require.NoError(t, err)
+		assert.Equal(t, 2, output.EntryCount)
+		assert.Equal(t, 0, output.TagCount)
+
+		// Both services written, each scoped to its own service only.
+		require.Contains(t, writer.written, staging.ServiceParam)
+		require.Contains(t, writer.written, staging.ServiceSecret)
+		assert.Equal(t, 1, writer.written[staging.ServiceParam].EntryCount())
+		assert.Empty(t, writer.written[staging.ServiceParam].Entries[staging.ServiceSecret])
+
+		// The secret envelope carries only the secret entry, never the param one.
+		assert.Equal(t, 1, writer.written[staging.ServiceSecret].EntryCount())
+		assert.Len(t, writer.written[staging.ServiceSecret].Entries[staging.ServiceSecret], 1)
+		assert.Empty(t, writer.written[staging.ServiceSecret].Entries[staging.ServiceParam])
+
+		// Working cleared.
+		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
+		require.ErrorIs(t, err, staging.ErrNotStaged)
+		_, err = working.GetEntry(t.Context(), staging.ServiceSecret, staging.EntryKey{Name: "my-secret"})
+		assert.ErrorIs(t, err, staging.ErrNotStaged)
+	})
+
+	t.Run("global export skips empty service", func(t *testing.T) {
+		t.Parallel()
+
+		working := testutil.NewMockStore()
+		stageEntry(t, working, staging.ServiceParam, "/app/config", "p")
+
+		writer := &recordingWriter{}
+		usecase := &stagingusecase.ExportUseCase{Working: working, Target: writer}
+
+		_, err := usecase.Execute(t.Context(), stagingusecase.ExportInput{})
+		require.NoError(t, err)
+
+		assert.Contains(t, writer.written, staging.ServiceParam)
+		assert.NotContains(t, writer.written, staging.ServiceSecret)
+	})
+
+	t.Run("keep preserves the working area", func(t *testing.T) {
+		t.Parallel()
+
+		working := testutil.NewMockStore()
+		stageEntry(t, working, staging.ServiceParam, "/app/config", "p")
+
+		writer := &recordingWriter{}
+		usecase := &stagingusecase.ExportUseCase{Working: working, Target: writer}
+
+		_, err := usecase.Execute(t.Context(), stagingusecase.ExportInput{Keep: true})
+		require.NoError(t, err)
+
+		// Working still holds the entry.
+		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
+		require.NoError(t, err)
+	})
+
+	t.Run("service filter clears only that service", func(t *testing.T) {
+		t.Parallel()
+
+		working := testutil.NewMockStore()
+		stageEntry(t, working, staging.ServiceParam, "/app/config", "p")
+		stageEntry(t, working, staging.ServiceSecret, "my-secret", "s")
+
+		writer := &recordingWriter{}
+		usecase := &stagingusecase.ExportUseCase{Working: working, Target: writer}
+
+		output, err := usecase.Execute(t.Context(), stagingusecase.ExportInput{Service: staging.ServiceParam})
+		require.NoError(t, err)
+		assert.Equal(t, 1, output.EntryCount)
+
+		assert.Contains(t, writer.written, staging.ServiceParam)
+		assert.NotContains(t, writer.written, staging.ServiceSecret)
+
+		// Param cleared, secret preserved.
+		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
+		require.ErrorIs(t, err, staging.ErrNotStaged)
+		_, err = working.GetEntry(t.Context(), staging.ServiceSecret, staging.EntryKey{Name: "my-secret"})
+		require.NoError(t, err)
+	})
+
+	t.Run("counts entries and tags", func(t *testing.T) {
+		t.Parallel()
+
+		working := testutil.NewMockStore()
+		stageEntry(t, working, staging.ServiceParam, "/app/config", "p")
+
+		require.NoError(t, working.StageTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"}, staging.TagEntry{
+			Add:      map[string]string{"env": "prod"},
+			StagedAt: time.Now(),
+		}))
+
+		writer := &recordingWriter{}
+		usecase := &stagingusecase.ExportUseCase{Working: working, Target: writer}
+
+		output, err := usecase.Execute(t.Context(), stagingusecase.ExportInput{Keep: true})
+		require.NoError(t, err)
+		assert.Equal(t, 1, output.EntryCount)
+		assert.Equal(t, 1, output.TagCount)
+	})
+}
+
+func TestExportUseCase_Execute_Errors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("error on working load", func(t *testing.T) {
+		t.Parallel()
+
+		working := testutil.NewMockStore()
+		working.DrainErr = errors.New("read error")
+
+		usecase := &stagingusecase.ExportUseCase{Working: working, Target: &recordingWriter{}}
+
+		_, err := usecase.Execute(t.Context(), stagingusecase.ExportInput{})
+
+		var exportErr *stagingusecase.ExportError
+		require.ErrorAs(t, err, &exportErr)
+		assert.Equal(t, "load", exportErr.Op)
+	})
+
+	t.Run("error on target write", func(t *testing.T) {
+		t.Parallel()
+
+		working := testutil.NewMockStore()
+		stageEntry(t, working, staging.ServiceParam, "/app/config", "p")
+
+		writer := &recordingWriter{err: errors.New("write error")}
+		usecase := &stagingusecase.ExportUseCase{Working: working, Target: writer}
+
+		_, err := usecase.Execute(t.Context(), stagingusecase.ExportInput{})
+
+		var exportErr *stagingusecase.ExportError
+		require.ErrorAs(t, err, &exportErr)
+		assert.Equal(t, "write", exportErr.Op)
+
+		// Working must not have been cleared: the export failed.
+		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
+		require.NoError(t, err)
+	})
+
+	t.Run("clear error is non-fatal and output is returned", func(t *testing.T) {
+		t.Parallel()
+
+		working := testutil.NewMockStore()
+		stageEntry(t, working, staging.ServiceParam, "/app/config", "p")
+
+		writer := &recordingWriter{}
+		usecase := &stagingusecase.ExportUseCase{Working: working, Target: writer}
+
+		// The export write succeeds; only the working-area clear fails.
+		working.WriteStateErr = errors.New("clear error")
+
+		output, err := usecase.Execute(t.Context(), stagingusecase.ExportInput{})
+		require.NotNil(t, output)
+		assert.Equal(t, 1, output.EntryCount)
+
+		var exportErr *stagingusecase.ExportError
+		require.ErrorAs(t, err, &exportErr)
+		assert.Equal(t, "clear", exportErr.Op)
+		assert.True(t, exportErr.NonFatal)
+
+		// The state was still exported.
+		assert.Contains(t, writer.written, staging.ServiceParam)
+	})
+}
+
+func TestExportError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("error message - load", func(t *testing.T) {
+		t.Parallel()
+
+		err := &stagingusecase.ExportError{Op: "load", Err: errors.New("boom")}
+		assert.Contains(t, err.Error(), "failed to read the working staging area")
+		assert.Contains(t, err.Error(), "boom")
+	})
+
+	t.Run("error message - write", func(t *testing.T) {
+		t.Parallel()
+
+		err := &stagingusecase.ExportError{Op: "write", Err: errors.New("boom")}
+		assert.Contains(t, err.Error(), "failed to write export file")
+	})
+
+	t.Run("error message - clear", func(t *testing.T) {
+		t.Parallel()
+
+		err := &stagingusecase.ExportError{Op: "clear", Err: errors.New("boom")}
+		assert.Contains(t, err.Error(), "failed to clear the working staging area")
+	})
+
+	t.Run("error message - unknown op", func(t *testing.T) {
+		t.Parallel()
+
+		inner := errors.New("something went wrong")
+		err := &stagingusecase.ExportError{Op: "unknown", Err: inner}
+		assert.Equal(t, "something went wrong", err.Error())
+	})
+
+	t.Run("unwrap", func(t *testing.T) {
+		t.Parallel()
+
+		inner := errors.New("inner")
+		err := &stagingusecase.ExportError{Op: "load", Err: inner}
+		assert.ErrorIs(t, err, inner)
+	})
+}

--- a/internal/usecase/staging/import.go
+++ b/internal/usecase/staging/import.go
@@ -1,0 +1,183 @@
+package staging
+
+import (
+	"context"
+	"errors"
+
+	"github.com/mpyw/suve/internal/staging"
+	"github.com/mpyw/suve/internal/staging/store"
+)
+
+// Import error Op codes.
+const (
+	importOpLoad        = "load"
+	importOpWrite       = "write"
+	importOpReadWorking = "read-working"
+)
+
+// EnvelopeReader reads a single service's staged state from an import source
+// (typically a per-service envelope file). Adapters bind the source path, scope
+// validation, and passphrase; the use case only supplies the service. For a
+// missing file in the directory/global case the adapter returns an empty state
+// with a nil error (an absent service is skipped, not an error).
+type EnvelopeReader interface {
+	// ReadState returns the decoded state for svc.
+	ReadState(ctx context.Context, svc staging.Service) (*staging.State, error)
+}
+
+// ImportInput holds input for the import use case.
+type ImportInput struct {
+	// Service filters the import to a specific service. Empty means all services.
+	Service staging.Service
+	// Mode determines how to reconcile with an existing working staging area.
+	// ImportModeMerge combines the imported state with the working area.
+	// ImportModeOverwrite replaces the working area with the imported state.
+	Mode ImportMode
+}
+
+// ImportOutput holds the result of the import use case.
+type ImportOutput struct {
+	// Merged indicates whether the imported state was merged with pre-existing
+	// working state.
+	Merged bool
+	// EntryCount is the number of entries in the final working state.
+	EntryCount int
+	// TagCount is the number of tag entries in the final working state.
+	TagCount int
+}
+
+// ImportUseCase reads an export source into the working staging area. It keeps
+// the merge/overwrite reconciliation of the former stash pop for the working
+// area (a legitimate conflict), but is read-only on the source: nothing is
+// consumed or deleted, so there is no Keep concept.
+type ImportUseCase struct {
+	// Source provides the imported per-service state.
+	Source EnvelopeReader
+	// Working is the working staging area (param.json/secret.json).
+	Working store.FileStore
+}
+
+// Execute runs the import use case.
+func (u *ImportUseCase) Execute(ctx context.Context, input ImportInput) (*ImportOutput, error) {
+	// Read the imported state from the source (read-only; never mutated).
+	sourceState, err := u.readSource(ctx, input.Service)
+	if err != nil {
+		return nil, &ImportError{Op: importOpLoad, Err: err}
+	}
+
+	if sourceState.IsEmpty() {
+		return nil, ErrNothingToImport
+	}
+
+	// Read the working staging area (keep=true; we never clear the source). A
+	// missing file yields an empty state with a nil error, so any error here is a
+	// real failure (wrong key, corrupt/unreadable file): propagate it before the
+	// WriteState below would replace the working files with a partial view.
+	workingState, err := u.Working.Drain(ctx, "", true)
+	if err != nil {
+		return nil, &ImportError{Op: importOpReadWorking, Err: err}
+	}
+
+	// Capture whether the working area already held data BEFORE any mutation, for
+	// the Merged output flag.
+	hasExistingData := !workingState.ExtractService(input.Service).IsEmpty()
+	workingWasEmpty := workingState.IsEmpty()
+
+	var finalState *staging.State
+
+	merged := false
+
+	switch {
+	case input.Service != "":
+		// Service-specific: always preserve other services from the working area.
+		finalState = workingState
+		if input.Mode == ImportModeOverwrite {
+			finalState.RemoveService(input.Service)
+			finalState.Merge(sourceState)
+		} else {
+			finalState.Merge(sourceState)
+
+			merged = hasExistingData
+		}
+	case input.Mode == ImportModeMerge:
+		// Global merge: combine working state with imported state.
+		finalState = workingState
+		finalState.Merge(sourceState)
+
+		merged = !workingWasEmpty
+	default:
+		// Global overwrite: replace only the services actually present in the
+		// source. A partial import (e.g. a directory holding only param.json,
+		// with secret.json skipped) must not wipe an untouched working service,
+		// so services absent from the source are left intact.
+		finalState = workingState
+
+		for _, svc := range []staging.Service{staging.ServiceParam, staging.ServiceSecret} {
+			if !sourceState.ExtractService(svc).IsEmpty() {
+				finalState.RemoveService(svc)
+			}
+		}
+
+		finalState.Merge(sourceState)
+	}
+
+	if err := u.Working.WriteState(ctx, "", finalState); err != nil {
+		return nil, &ImportError{Op: importOpWrite, Err: err}
+	}
+
+	return &ImportOutput{
+		Merged:     merged,
+		EntryCount: finalState.EntryCount(),
+		TagCount:   finalState.TagCount(),
+	}, nil
+}
+
+// readSource reads the imported state. With a service filter it reads that one
+// service; otherwise it reads each service (param, secret) and merges them
+// (a missing per-service file yields an empty state, so it is simply skipped).
+func (u *ImportUseCase) readSource(ctx context.Context, service staging.Service) (*staging.State, error) {
+	if service != "" {
+		return u.Source.ReadState(ctx, service)
+	}
+
+	result := staging.NewEmptyState()
+
+	for _, svc := range []staging.Service{staging.ServiceParam, staging.ServiceSecret} {
+		state, err := u.Source.ReadState(ctx, svc)
+		if err != nil {
+			return nil, err
+		}
+
+		result.Merge(state)
+	}
+
+	return result, nil
+}
+
+var (
+	// ErrNothingToImport is returned when the source holds no staged changes.
+	ErrNothingToImport = errors.New("no staged changes to import")
+)
+
+// ImportError represents an error during an import operation.
+type ImportError struct {
+	Op  string // "load", "write", "read-working"
+	Err error
+}
+
+func (e *ImportError) Error() string {
+	switch e.Op {
+	case importOpLoad:
+		return "failed to read export file: " + e.Err.Error()
+	case importOpWrite:
+		return "failed to write the working staging area: " + e.Err.Error()
+	case importOpReadWorking:
+		return "failed to read the working staging area: " + e.Err.Error()
+	default:
+		return e.Err.Error()
+	}
+}
+
+func (e *ImportError) Unwrap() error {
+	return e.Err
+}

--- a/internal/usecase/staging/import_mode.go
+++ b/internal/usecase/staging/import_mode.go
@@ -1,0 +1,14 @@
+package staging
+
+// ImportMode determines how to reconcile imported state with the existing
+// working staging area.
+type ImportMode int
+
+const (
+	// ImportModeMerge combines the imported state with the existing working
+	// staging area. Later entries win on key conflicts.
+	ImportModeMerge ImportMode = iota
+	// ImportModeOverwrite replaces the existing working staging area with the
+	// imported state.
+	ImportModeOverwrite
+)

--- a/internal/usecase/staging/import_test.go
+++ b/internal/usecase/staging/import_test.go
@@ -1,0 +1,394 @@
+package staging_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/staging"
+	"github.com/mpyw/suve/internal/staging/store/testutil"
+	stagingusecase "github.com/mpyw/suve/internal/usecase/staging"
+)
+
+// cannedReader is a fake EnvelopeReader returning pre-seeded per-service states.
+// A missing service returns an empty state with a nil error (mirroring an absent
+// per-service file in the directory case). An optional err forces a read failure.
+type cannedReader struct {
+	states map[staging.Service]*staging.State
+	err    error
+}
+
+func (r *cannedReader) ReadState(_ context.Context, svc staging.Service) (*staging.State, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	if s, ok := r.states[svc]; ok {
+		return s, nil
+	}
+
+	return staging.NewEmptyState(), nil
+}
+
+// sourceState builds a single-service state carrying one entry, for seeding a
+// cannedReader.
+func sourceState(svc staging.Service, name, value string) *staging.State {
+	s := staging.NewEmptyState()
+	s.Entries[svc][staging.EntryKey{Name: name}] = staging.Entry{
+		Operation: staging.OperationUpdate,
+		Value:     lo.ToPtr(value),
+		StagedAt:  time.Now(),
+	}
+
+	return s
+}
+
+//nolint:funlen // Many subtests covering merge/overwrite and service/global cases
+func TestImportUseCase_Execute(t *testing.T) {
+	t.Parallel()
+
+	t.Run("import into empty working - not merged", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &cannedReader{states: map[staging.Service]*staging.State{
+			staging.ServiceParam: sourceState(staging.ServiceParam, "/app/config", "v"),
+		}}
+		working := testutil.NewMockStore()
+
+		usecase := &stagingusecase.ImportUseCase{Source: reader, Working: working}
+
+		output, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{})
+		require.NoError(t, err)
+		assert.Equal(t, 1, output.EntryCount)
+		assert.False(t, output.Merged)
+
+		entry, err := working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
+		require.NoError(t, err)
+		assert.Equal(t, "v", lo.FromPtr(entry.Value))
+	})
+
+	t.Run("import merge into non-empty working - merged", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &cannedReader{states: map[staging.Service]*staging.State{
+			staging.ServiceParam: sourceState(staging.ServiceParam, "/app/new", "file"),
+		}}
+		working := testutil.NewMockStore()
+		stageEntry(t, working, staging.ServiceParam, "/app/existing", "work")
+
+		usecase := &stagingusecase.ImportUseCase{Source: reader, Working: working}
+
+		output, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{Mode: stagingusecase.ImportModeMerge})
+		require.NoError(t, err)
+		assert.True(t, output.Merged)
+
+		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/existing"})
+		require.NoError(t, err)
+		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/new"})
+		require.NoError(t, err)
+	})
+
+	t.Run("import overwrite replaces working", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &cannedReader{states: map[staging.Service]*staging.State{
+			staging.ServiceParam: sourceState(staging.ServiceParam, "/app/config", "file"),
+		}}
+		working := testutil.NewMockStore()
+		stageEntry(t, working, staging.ServiceParam, "/app/existing", "work")
+
+		usecase := &stagingusecase.ImportUseCase{Source: reader, Working: working}
+
+		output, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{Mode: stagingusecase.ImportModeOverwrite})
+		require.NoError(t, err)
+		assert.False(t, output.Merged)
+
+		// Imported entry present, prior working entry gone.
+		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
+		require.NoError(t, err)
+		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/existing"})
+		require.ErrorIs(t, err, staging.ErrNotStaged)
+	})
+
+	t.Run("global overwrite with partial source preserves untouched service", func(t *testing.T) {
+		t.Parallel()
+
+		// Source has only param (e.g. a directory where secret.json is absent).
+		reader := &cannedReader{states: map[staging.Service]*staging.State{
+			staging.ServiceParam: sourceState(staging.ServiceParam, "/app/config", "file"),
+		}}
+		working := testutil.NewMockStore()
+		stageEntry(t, working, staging.ServiceParam, "/app/existing", "old-param")
+		stageEntry(t, working, staging.ServiceSecret, "my-secret", "keep-me")
+
+		usecase := &stagingusecase.ImportUseCase{Source: reader, Working: working}
+
+		_, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{Mode: stagingusecase.ImportModeOverwrite})
+		require.NoError(t, err)
+
+		// Param replaced by source.
+		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
+		require.NoError(t, err)
+		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/existing"})
+		require.ErrorIs(t, err, staging.ErrNotStaged)
+
+		// Secret was NOT in the source, so it must survive the global overwrite.
+		_, err = working.GetEntry(t.Context(), staging.ServiceSecret, staging.EntryKey{Name: "my-secret"})
+		require.NoError(t, err)
+	})
+
+	t.Run("import merge conflict - source wins", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &cannedReader{states: map[staging.Service]*staging.State{
+			staging.ServiceParam: sourceState(staging.ServiceParam, "/app/config", "file"),
+		}}
+		working := testutil.NewMockStore()
+		stageEntry(t, working, staging.ServiceParam, "/app/config", "work")
+
+		usecase := &stagingusecase.ImportUseCase{Source: reader, Working: working}
+
+		_, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{Mode: stagingusecase.ImportModeMerge})
+		require.NoError(t, err)
+
+		entry, err := working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
+		require.NoError(t, err)
+		assert.Equal(t, "file", lo.FromPtr(entry.Value))
+	})
+
+	t.Run("nothing to import when source empty", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &cannedReader{}
+		working := testutil.NewMockStore()
+
+		usecase := &stagingusecase.ImportUseCase{Source: reader, Working: working}
+
+		_, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{})
+		require.ErrorIs(t, err, stagingusecase.ErrNothingToImport)
+	})
+
+	t.Run("nothing to import when filtered service empty", func(t *testing.T) {
+		t.Parallel()
+
+		// Source only holds secret, but we ask to import param.
+		reader := &cannedReader{states: map[staging.Service]*staging.State{
+			staging.ServiceSecret: sourceState(staging.ServiceSecret, "my-secret", "s"),
+		}}
+		working := testutil.NewMockStore()
+
+		usecase := &stagingusecase.ImportUseCase{Source: reader, Working: working}
+
+		_, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{Service: staging.ServiceParam})
+		require.ErrorIs(t, err, stagingusecase.ErrNothingToImport)
+	})
+
+	t.Run("global import merges both services", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &cannedReader{states: map[staging.Service]*staging.State{
+			staging.ServiceParam:  sourceState(staging.ServiceParam, "/app/config", "p"),
+			staging.ServiceSecret: sourceState(staging.ServiceSecret, "my-secret", "s"),
+		}}
+		working := testutil.NewMockStore()
+
+		usecase := &stagingusecase.ImportUseCase{Source: reader, Working: working}
+
+		output, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{})
+		require.NoError(t, err)
+		assert.Equal(t, 2, output.EntryCount)
+
+		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
+		require.NoError(t, err)
+		_, err = working.GetEntry(t.Context(), staging.ServiceSecret, staging.EntryKey{Name: "my-secret"})
+		require.NoError(t, err)
+	})
+
+	t.Run("service-specific import preserves other services in working", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &cannedReader{states: map[staging.Service]*staging.State{
+			staging.ServiceParam: sourceState(staging.ServiceParam, "/app/config", "p"),
+		}}
+		working := testutil.NewMockStore()
+		stageEntry(t, working, staging.ServiceSecret, "my-secret", "s")
+
+		usecase := &stagingusecase.ImportUseCase{Source: reader, Working: working}
+
+		output, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{Service: staging.ServiceParam})
+		require.NoError(t, err)
+		// Working had no param before, so this service-level import is not "merged".
+		assert.False(t, output.Merged)
+
+		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
+		require.NoError(t, err)
+		_, err = working.GetEntry(t.Context(), staging.ServiceSecret, staging.EntryKey{Name: "my-secret"})
+		require.NoError(t, err)
+	})
+
+	t.Run("service-specific import into non-empty service - merged", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &cannedReader{states: map[staging.Service]*staging.State{
+			staging.ServiceParam: sourceState(staging.ServiceParam, "/app/new", "p"),
+		}}
+		working := testutil.NewMockStore()
+		stageEntry(t, working, staging.ServiceParam, "/app/existing", "old")
+
+		usecase := &stagingusecase.ImportUseCase{Source: reader, Working: working}
+
+		output, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{Service: staging.ServiceParam})
+		require.NoError(t, err)
+		assert.True(t, output.Merged)
+	})
+
+	t.Run("service-specific overwrite replaces only that service", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &cannedReader{states: map[staging.Service]*staging.State{
+			staging.ServiceParam: sourceState(staging.ServiceParam, "/app/new", "p"),
+		}}
+		working := testutil.NewMockStore()
+		stageEntry(t, working, staging.ServiceParam, "/app/existing", "old")
+		stageEntry(t, working, staging.ServiceSecret, "my-secret", "s")
+
+		usecase := &stagingusecase.ImportUseCase{Source: reader, Working: working}
+
+		output, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{
+			Service: staging.ServiceParam,
+			Mode:    stagingusecase.ImportModeOverwrite,
+		})
+		require.NoError(t, err)
+		assert.False(t, output.Merged)
+
+		// Old param gone, new param present, secret preserved.
+		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/existing"})
+		require.ErrorIs(t, err, staging.ErrNotStaged)
+		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/new"})
+		require.NoError(t, err)
+		_, err = working.GetEntry(t.Context(), staging.ServiceSecret, staging.EntryKey{Name: "my-secret"})
+		require.NoError(t, err)
+	})
+}
+
+func TestImportUseCase_Execute_Errors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("error on source read", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &cannedReader{err: errors.New("corrupt file")}
+		working := testutil.NewMockStore()
+
+		usecase := &stagingusecase.ImportUseCase{Source: reader, Working: working}
+
+		_, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{Service: staging.ServiceParam})
+
+		var importErr *stagingusecase.ImportError
+		require.ErrorAs(t, err, &importErr)
+		assert.Equal(t, "load", importErr.Op)
+	})
+
+	t.Run("error on global source read", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &cannedReader{err: errors.New("corrupt file")}
+		working := testutil.NewMockStore()
+
+		usecase := &stagingusecase.ImportUseCase{Source: reader, Working: working}
+
+		// Global import reads each service; the loop must propagate the read error.
+		_, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{})
+
+		var importErr *stagingusecase.ImportError
+		require.ErrorAs(t, err, &importErr)
+		assert.Equal(t, "load", importErr.Op)
+	})
+
+	t.Run("error on working read", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &cannedReader{states: map[staging.Service]*staging.State{
+			staging.ServiceParam: sourceState(staging.ServiceParam, "/app/config", "v"),
+		}}
+		working := testutil.NewMockStore()
+		working.DrainErr = errors.New("read error")
+
+		usecase := &stagingusecase.ImportUseCase{Source: reader, Working: working}
+
+		_, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{})
+
+		var importErr *stagingusecase.ImportError
+		require.ErrorAs(t, err, &importErr)
+		assert.Equal(t, "read-working", importErr.Op)
+
+		// Working must not have been written.
+		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
+		assert.ErrorIs(t, err, staging.ErrNotStaged)
+	})
+
+	t.Run("error on working write", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &cannedReader{states: map[staging.Service]*staging.State{
+			staging.ServiceParam: sourceState(staging.ServiceParam, "/app/config", "v"),
+		}}
+		working := testutil.NewMockStore()
+		working.WriteStateErr = errors.New("write error")
+
+		usecase := &stagingusecase.ImportUseCase{Source: reader, Working: working}
+
+		_, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{})
+
+		var importErr *stagingusecase.ImportError
+		require.ErrorAs(t, err, &importErr)
+		assert.Equal(t, "write", importErr.Op)
+	})
+}
+
+func TestImportError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("error message - load", func(t *testing.T) {
+		t.Parallel()
+
+		err := &stagingusecase.ImportError{Op: "load", Err: errors.New("boom")}
+		assert.Contains(t, err.Error(), "failed to read export file")
+		assert.Contains(t, err.Error(), "boom")
+	})
+
+	t.Run("error message - write", func(t *testing.T) {
+		t.Parallel()
+
+		err := &stagingusecase.ImportError{Op: "write", Err: errors.New("boom")}
+		assert.Contains(t, err.Error(), "failed to write the working staging area")
+	})
+
+	t.Run("error message - read-working", func(t *testing.T) {
+		t.Parallel()
+
+		err := &stagingusecase.ImportError{Op: "read-working", Err: errors.New("boom")}
+		assert.Contains(t, err.Error(), "failed to read the working staging area")
+	})
+
+	t.Run("error message - unknown op", func(t *testing.T) {
+		t.Parallel()
+
+		inner := errors.New("something went wrong")
+		err := &stagingusecase.ImportError{Op: "unknown", Err: inner}
+		assert.Equal(t, "something went wrong", err.Error())
+	})
+
+	t.Run("unwrap", func(t *testing.T) {
+		t.Parallel()
+
+		inner := errors.New("inner")
+		err := &stagingusecase.ImportError{Op: "load", Err: inner}
+		assert.ErrorIs(t, err, inner)
+	})
+}


### PR DESCRIPTION
## Summary

Step 2 of Epic #451 (replace `stage stash` with `stage export` / `stage import`): the usecase layer. This step is **additive only** — the existing stash use cases (`stash_push.go`, `stash_pop.go`, `stash_mode.go`) remain in place and are removed in a later step (#455).

### What's added (all in `internal/usecase/staging/`)

- **`export.go`** — `ExportUseCase` with the `EnvelopeWriter` port (`WriteEnvelope(ctx, svc, state)`). Export is a **wholesale write**: it never reads or merges the destination (the merge-on-write branching of the old stash push is gone). Supports `--keep`, global export of each non-empty service, and returns `ErrNothingToExport` for an empty selection. Post-write working-area clear failures are non-fatal. Typed `ExportError` (Op: `load`/`write`/`clear`).
- **`import.go`** — `ImportUseCase` with the `EnvelopeReader` port (`ReadState(ctx, svc)`). Import keeps the merge/overwrite reconciliation for the **working area** (the one legitimate conflict), mirroring the old stash pop's `Merged` computation. It is **read-only on the source** (no `Keep`, no mutation). Returns `ErrNothingToImport` for an empty source. Typed `ImportError` (Op: `load`/`write`/`read-working`).
  - Global overwrite only replaces the services actually present in the source, so a partial import (e.g. a directory holding only `param.json`) never wipes an untouched working service.
- **`import_mode.go`** — new `ImportMode` (`ImportModeMerge` default / `ImportModeOverwrite`), alongside the still-used `StashMode`.
- **`export_test.go` / `import_test.go`** — cover empty working → `ErrNothingToExport`, keep vs clear, global writes each non-empty service, per-service envelope isolation, merge vs overwrite, import into empty vs non-empty working (`Merged` flag), partial global-overwrite preservation, service-specific vs global, `ErrNothingToImport`, and the reachable error paths (drain/write/target errors).

The usecase layer depends only on `internal/staging/store` interfaces plus the two new local ports; it does **not** depend on the `store/file` envelope package (adapters wired in later CLI/GUI steps).

### Validation

- `mise test` — all packages pass (72 ok, no failures)
- `mise lint` — 0 issues (strict `default: all`)
- New files at 100% statement coverage; package at 97.7%

A context-isolated subagent critically reviewed the diff before this PR; its should-fix finding (global-overwrite wiping an untouched service on a partial import) was applied, along with the test-coverage suggestions.

Closes #453
Part of #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)