### PR TITLE
refactor(usecase): defined type for export/import error Op codes

### DIFF
--- a/internal/usecase/staging/export.go
+++ b/internal/usecase/staging/export.go
@@ -8,11 +8,14 @@ import (
 	"github.com/mpyw/suve/internal/staging/store"
 )
 
+// ExportOp identifies the stage of an export operation that failed.
+type ExportOp string
+
 // Export error Op codes.
 const (
-	exportOpLoad  = "load"
-	exportOpWrite = "write"
-	exportOpClear = "clear"
+	ExportOpLoad  ExportOp = "load"
+	ExportOpWrite ExportOp = "write"
+	ExportOpClear ExportOp = "clear"
 )
 
 // EnvelopeWriter writes a single service's staged state to an export target
@@ -57,7 +60,7 @@ func (u *ExportUseCase) Execute(ctx context.Context, input ExportInput) (*Export
 	// the write succeeded and --keep was not requested).
 	workingState, err := u.Working.Drain(ctx, "", true)
 	if err != nil {
-		return nil, &ExportError{Op: exportOpLoad, Err: err}
+		return nil, &ExportError{Op: ExportOpLoad, Err: err}
 	}
 
 	// Determine which services actually have data to export, along with their
@@ -72,7 +75,7 @@ func (u *ExportUseCase) Execute(ctx context.Context, input ExportInput) (*Export
 
 	for _, t := range targets {
 		if err := u.Target.WriteEnvelope(ctx, t.service, t.state); err != nil {
-			return nil, &ExportError{Op: exportOpWrite, Err: err}
+			return nil, &ExportError{Op: ExportOpWrite, Err: err}
 		}
 
 		output.EntryCount += t.state.EntryCount()
@@ -89,7 +92,7 @@ func (u *ExportUseCase) Execute(ctx context.Context, input ExportInput) (*Export
 		}
 
 		if err := u.Working.WriteState(ctx, "", workingState); err != nil {
-			return output, &ExportError{Op: exportOpClear, Err: err, NonFatal: true}
+			return output, &ExportError{Op: ExportOpClear, Err: err, NonFatal: true}
 		}
 	}
 
@@ -132,18 +135,18 @@ var (
 
 // ExportError represents an error during an export operation.
 type ExportError struct {
-	Op       string // "load", "write", "clear"
+	Op       ExportOp
 	Err      error
 	NonFatal bool // If true, the error is non-fatal (state was already written)
 }
 
 func (e *ExportError) Error() string {
 	switch e.Op {
-	case exportOpLoad:
+	case ExportOpLoad:
 		return "failed to read the working staging area: " + e.Err.Error()
-	case exportOpWrite:
+	case ExportOpWrite:
 		return "failed to write export file: " + e.Err.Error()
-	case exportOpClear:
+	case ExportOpClear:
 		return "failed to clear the working staging area: " + e.Err.Error()
 	default:
 		return e.Err.Error()

--- a/internal/usecase/staging/export_test.go
+++ b/internal/usecase/staging/export_test.go
@@ -202,7 +202,7 @@ func TestExportUseCase_Execute_Errors(t *testing.T) {
 
 		var exportErr *stagingusecase.ExportError
 		require.ErrorAs(t, err, &exportErr)
-		assert.Equal(t, "load", exportErr.Op)
+		assert.Equal(t, stagingusecase.ExportOpLoad, exportErr.Op)
 	})
 
 	t.Run("error on target write", func(t *testing.T) {
@@ -218,7 +218,7 @@ func TestExportUseCase_Execute_Errors(t *testing.T) {
 
 		var exportErr *stagingusecase.ExportError
 		require.ErrorAs(t, err, &exportErr)
-		assert.Equal(t, "write", exportErr.Op)
+		assert.Equal(t, stagingusecase.ExportOpWrite, exportErr.Op)
 
 		// Working must not have been cleared: the export failed.
 		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
@@ -243,7 +243,7 @@ func TestExportUseCase_Execute_Errors(t *testing.T) {
 
 		var exportErr *stagingusecase.ExportError
 		require.ErrorAs(t, err, &exportErr)
-		assert.Equal(t, "clear", exportErr.Op)
+		assert.Equal(t, stagingusecase.ExportOpClear, exportErr.Op)
 		assert.True(t, exportErr.NonFatal)
 
 		// The state was still exported.
@@ -257,7 +257,7 @@ func TestExportError(t *testing.T) {
 	t.Run("error message - load", func(t *testing.T) {
 		t.Parallel()
 
-		err := &stagingusecase.ExportError{Op: "load", Err: errors.New("boom")}
+		err := &stagingusecase.ExportError{Op: stagingusecase.ExportOpLoad, Err: errors.New("boom")}
 		assert.Contains(t, err.Error(), "failed to read the working staging area")
 		assert.Contains(t, err.Error(), "boom")
 	})
@@ -265,14 +265,14 @@ func TestExportError(t *testing.T) {
 	t.Run("error message - write", func(t *testing.T) {
 		t.Parallel()
 
-		err := &stagingusecase.ExportError{Op: "write", Err: errors.New("boom")}
+		err := &stagingusecase.ExportError{Op: stagingusecase.ExportOpWrite, Err: errors.New("boom")}
 		assert.Contains(t, err.Error(), "failed to write export file")
 	})
 
 	t.Run("error message - clear", func(t *testing.T) {
 		t.Parallel()
 
-		err := &stagingusecase.ExportError{Op: "clear", Err: errors.New("boom")}
+		err := &stagingusecase.ExportError{Op: stagingusecase.ExportOpClear, Err: errors.New("boom")}
 		assert.Contains(t, err.Error(), "failed to clear the working staging area")
 	})
 
@@ -280,7 +280,7 @@ func TestExportError(t *testing.T) {
 		t.Parallel()
 
 		inner := errors.New("something went wrong")
-		err := &stagingusecase.ExportError{Op: "unknown", Err: inner}
+		err := &stagingusecase.ExportError{Op: stagingusecase.ExportOp("unknown"), Err: inner}
 		assert.Equal(t, "something went wrong", err.Error())
 	})
 
@@ -288,7 +288,7 @@ func TestExportError(t *testing.T) {
 		t.Parallel()
 
 		inner := errors.New("inner")
-		err := &stagingusecase.ExportError{Op: "load", Err: inner}
+		err := &stagingusecase.ExportError{Op: stagingusecase.ExportOpLoad, Err: inner}
 		assert.ErrorIs(t, err, inner)
 	})
 }

--- a/internal/usecase/staging/import.go
+++ b/internal/usecase/staging/import.go
@@ -8,11 +8,14 @@ import (
 	"github.com/mpyw/suve/internal/staging/store"
 )
 
+// ImportOp identifies the stage of an import operation that failed.
+type ImportOp string
+
 // Import error Op codes.
 const (
-	importOpLoad        = "load"
-	importOpWrite       = "write"
-	importOpReadWorking = "read-working"
+	ImportOpLoad        ImportOp = "load"
+	ImportOpWrite       ImportOp = "write"
+	ImportOpReadWorking ImportOp = "read-working"
 )
 
 // EnvelopeReader reads a single service's staged state from an import source
@@ -62,7 +65,7 @@ func (u *ImportUseCase) Execute(ctx context.Context, input ImportInput) (*Import
 	// Read the imported state from the source (read-only; never mutated).
 	sourceState, err := u.readSource(ctx, input.Service)
 	if err != nil {
-		return nil, &ImportError{Op: importOpLoad, Err: err}
+		return nil, &ImportError{Op: ImportOpLoad, Err: err}
 	}
 
 	if sourceState.IsEmpty() {
@@ -75,7 +78,7 @@ func (u *ImportUseCase) Execute(ctx context.Context, input ImportInput) (*Import
 	// WriteState below would replace the working files with a partial view.
 	workingState, err := u.Working.Drain(ctx, "", true)
 	if err != nil {
-		return nil, &ImportError{Op: importOpReadWorking, Err: err}
+		return nil, &ImportError{Op: ImportOpReadWorking, Err: err}
 	}
 
 	// Capture whether the working area already held data BEFORE any mutation, for
@@ -122,7 +125,7 @@ func (u *ImportUseCase) Execute(ctx context.Context, input ImportInput) (*Import
 	}
 
 	if err := u.Working.WriteState(ctx, "", finalState); err != nil {
-		return nil, &ImportError{Op: importOpWrite, Err: err}
+		return nil, &ImportError{Op: ImportOpWrite, Err: err}
 	}
 
 	return &ImportOutput{
@@ -161,17 +164,17 @@ var (
 
 // ImportError represents an error during an import operation.
 type ImportError struct {
-	Op  string // "load", "write", "read-working"
+	Op  ImportOp
 	Err error
 }
 
 func (e *ImportError) Error() string {
 	switch e.Op {
-	case importOpLoad:
+	case ImportOpLoad:
 		return "failed to read export file: " + e.Err.Error()
-	case importOpWrite:
+	case ImportOpWrite:
 		return "failed to write the working staging area: " + e.Err.Error()
-	case importOpReadWorking:
+	case ImportOpReadWorking:
 		return "failed to read the working staging area: " + e.Err.Error()
 	default:
 		return e.Err.Error()

--- a/internal/usecase/staging/import_test.go
+++ b/internal/usecase/staging/import_test.go
@@ -291,7 +291,7 @@ func TestImportUseCase_Execute_Errors(t *testing.T) {
 
 		var importErr *stagingusecase.ImportError
 		require.ErrorAs(t, err, &importErr)
-		assert.Equal(t, "load", importErr.Op)
+		assert.Equal(t, stagingusecase.ImportOpLoad, importErr.Op)
 	})
 
 	t.Run("error on global source read", func(t *testing.T) {
@@ -307,7 +307,7 @@ func TestImportUseCase_Execute_Errors(t *testing.T) {
 
 		var importErr *stagingusecase.ImportError
 		require.ErrorAs(t, err, &importErr)
-		assert.Equal(t, "load", importErr.Op)
+		assert.Equal(t, stagingusecase.ImportOpLoad, importErr.Op)
 	})
 
 	t.Run("error on working read", func(t *testing.T) {
@@ -325,7 +325,7 @@ func TestImportUseCase_Execute_Errors(t *testing.T) {
 
 		var importErr *stagingusecase.ImportError
 		require.ErrorAs(t, err, &importErr)
-		assert.Equal(t, "read-working", importErr.Op)
+		assert.Equal(t, stagingusecase.ImportOpReadWorking, importErr.Op)
 
 		// Working must not have been written.
 		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
@@ -347,7 +347,7 @@ func TestImportUseCase_Execute_Errors(t *testing.T) {
 
 		var importErr *stagingusecase.ImportError
 		require.ErrorAs(t, err, &importErr)
-		assert.Equal(t, "write", importErr.Op)
+		assert.Equal(t, stagingusecase.ImportOpWrite, importErr.Op)
 	})
 }
 
@@ -357,7 +357,7 @@ func TestImportError(t *testing.T) {
 	t.Run("error message - load", func(t *testing.T) {
 		t.Parallel()
 
-		err := &stagingusecase.ImportError{Op: "load", Err: errors.New("boom")}
+		err := &stagingusecase.ImportError{Op: stagingusecase.ImportOpLoad, Err: errors.New("boom")}
 		assert.Contains(t, err.Error(), "failed to read export file")
 		assert.Contains(t, err.Error(), "boom")
 	})
@@ -365,14 +365,14 @@ func TestImportError(t *testing.T) {
 	t.Run("error message - write", func(t *testing.T) {
 		t.Parallel()
 
-		err := &stagingusecase.ImportError{Op: "write", Err: errors.New("boom")}
+		err := &stagingusecase.ImportError{Op: stagingusecase.ImportOpWrite, Err: errors.New("boom")}
 		assert.Contains(t, err.Error(), "failed to write the working staging area")
 	})
 
 	t.Run("error message - read-working", func(t *testing.T) {
 		t.Parallel()
 
-		err := &stagingusecase.ImportError{Op: "read-working", Err: errors.New("boom")}
+		err := &stagingusecase.ImportError{Op: stagingusecase.ImportOpReadWorking, Err: errors.New("boom")}
 		assert.Contains(t, err.Error(), "failed to read the working staging area")
 	})
 
@@ -380,7 +380,7 @@ func TestImportError(t *testing.T) {
 		t.Parallel()
 
 		inner := errors.New("something went wrong")
-		err := &stagingusecase.ImportError{Op: "unknown", Err: inner}
+		err := &stagingusecase.ImportError{Op: stagingusecase.ImportOp("unknown"), Err: inner}
 		assert.Equal(t, "something went wrong", err.Error())
 	})
 
@@ -388,7 +388,7 @@ func TestImportError(t *testing.T) {
 		t.Parallel()
 
 		inner := errors.New("inner")
-		err := &stagingusecase.ImportError{Op: "load", Err: inner}
+		err := &stagingusecase.ImportError{Op: stagingusecase.ImportOpLoad, Err: inner}
 		assert.ErrorIs(t, err, inner)
 	})
 }


### PR DESCRIPTION
Small refactor requested during review of the export/import work.

`ExportError.Op` / `ImportError.Op` were bare `string` constants. Promote them to exported defined types `ExportOp` / `ImportOp` with typed constants (`ExportOpLoad/Write/Clear`, `ImportOpLoad/Write/ReadWorking`), so the field is type-safe and callers switch on named constants rather than magic strings. Tests updated to reference the exported constants.

`mise test` + `mise lint` green.

Part of #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)