### PR TITLE
fix(staging): make conflict detection namespace-aware

### DIFF
--- a/e2e/azure_keyvault_test.go
+++ b/e2e/azure_keyvault_test.go
@@ -5,6 +5,7 @@ package e2e_test
 
 import (
 	"bytes"
+	"encoding/base64"
 	"os"
 	"strings"
 	"testing"
@@ -55,6 +56,154 @@ func runAzureSecret(t *testing.T, args ...string) (string, error) {
 	err := app.Run(t.Context(), full)
 
 	return outBuf.String(), err
+}
+
+// setAzureKeyVaultStagingKey pins a deterministic staging encryption key for the
+// working store that `stage edit`/`stage apply` use, so those commands resolve a
+// key from the env instead of the OS keychain (which would block the test on an
+// interactive macOS prompt). Any valid base64-standard 32-byte value works; it
+// only has to be stable within the test.
+func setAzureKeyVaultStagingKey(t *testing.T) {
+	t.Helper()
+	// EnvStagingKey ("SUVE_STAGING_KEY") is defined in an internal keyprovider
+	// package the e2e module cannot import; use the literal name.
+	t.Setenv("SUVE_STAGING_KEY", base64.StdEncoding.EncodeToString(make([]byte, 32)))
+}
+
+// runAzureStageCapture is like runAzureStage but also returns stderr, where the
+// apply runner prints per-entry conflict warnings.
+func runAzureStageCapture(t *testing.T, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+
+	var outBuf, errBuf bytes.Buffer
+
+	app := &cli.Command{
+		Name:      "suve",
+		Writer:    &outBuf,
+		ErrWriter: &errBuf,
+		Commands:  []*cli.Command{azure.Command()},
+	}
+
+	full := append([]string{"suve", "azure", "stage"}, args...)
+	err = app.Run(t.Context(), full)
+
+	return outBuf.String(), errBuf.String(), err
+}
+
+// TestAzureKeyVaultStage_ConflictDetected exercises live conflict detection on
+// Key Vault (whose FetchLastModified is real, unlike App Configuration's no-op).
+// Staging an edit records the current version's LastModified as the conflict
+// base; an out-of-band write then makes the remote newer, so apply must reject
+// the write and report the conflict under the bare name (empty namespace -> no
+// [namespace] badge, via EntryKey.Label()). This is the end-to-end guard for the
+// resolver-based CheckConflicts path from #441 on a namespaced-capable provider.
+func TestAzureKeyVaultStage_ConflictDetected(t *testing.T) {
+	setupAzureKeyVault(t)
+	setAzureKeyVaultStagingKey(t)
+	setupTempHome(t)
+
+	const name = "suve-e2e-kv-conflict-detected"
+
+	cleanup := func() { _, _ = runAzureSecret(t, "delete", "--yes", name) }
+	cleanup()
+	t.Cleanup(cleanup)
+
+	_, err := runAzureSecret(t, "create", name, "original")
+	require.NoError(t, err)
+
+	// Stage an edit: the edit use case fetches the current version and records its
+	// LastModified as the conflict base.
+	_, err = runAzureStage(t, "secret", "edit", name, "staged-value")
+	require.NoError(t, err)
+
+	// Key Vault LastModified is second-granular; sleep past a second boundary so
+	// the out-of-band write lands strictly after the recorded base.
+	time.Sleep(1100 * time.Millisecond)
+
+	// Modify the secret out-of-band (a new version created directly, bypassing
+	// staging) so the remote is now newer than the staged base.
+	_, err = runAzureSecret(t, "update", "--yes", name, "external-value")
+	require.NoError(t, err)
+
+	// Apply must detect the conflict, block the write, and report the bare name.
+	_, stderr, err := runAzureStageCapture(t, "secret", "apply", "--yes")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflict")
+	// The bare name immediately followed by ':' proves EntryKey.Label() rendered
+	// no namespace badge for the empty-namespace Key Vault entry.
+	assert.Contains(t, stderr, "conflict detected for "+name+":")
+
+	// The write was blocked: the value is still the out-of-band one, not staged.
+	got, err := runAzureSecret(t, "show", "--raw", name)
+	require.NoError(t, err)
+	assert.Equal(t, "external-value", got)
+}
+
+// TestAzureKeyVaultStage_IgnoreConflictsOverrides is the conflict scenario with
+// --ignore-conflicts: the same out-of-band modification is present, but apply
+// must skip the conflict check and force the staged value through.
+func TestAzureKeyVaultStage_IgnoreConflictsOverrides(t *testing.T) {
+	setupAzureKeyVault(t)
+	setAzureKeyVaultStagingKey(t)
+	setupTempHome(t)
+
+	const name = "suve-e2e-kv-conflict-ignore"
+
+	cleanup := func() { _, _ = runAzureSecret(t, "delete", "--yes", name) }
+	cleanup()
+	t.Cleanup(cleanup)
+
+	_, err := runAzureSecret(t, "create", name, "original")
+	require.NoError(t, err)
+
+	_, err = runAzureStage(t, "secret", "edit", name, "staged-value")
+	require.NoError(t, err)
+
+	time.Sleep(1100 * time.Millisecond)
+
+	_, err = runAzureSecret(t, "update", "--yes", name, "external-value")
+	require.NoError(t, err)
+
+	// --ignore-conflicts bypasses the check: the apply succeeds despite the newer
+	// remote.
+	stdout, _, err := runAzureStageCapture(t, "secret", "apply", "--yes", "--ignore-conflicts")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, name)
+
+	got, err := runAzureSecret(t, "show", "--raw", name)
+	require.NoError(t, err)
+	assert.Equal(t, "staged-value", got)
+}
+
+// TestAzureKeyVaultStage_NoFalseConflict guards the other direction: staging an
+// edit and applying WITHOUT any out-of-band modification must not raise a false
+// conflict — the remote's LastModified still equals the recorded base.
+func TestAzureKeyVaultStage_NoFalseConflict(t *testing.T) {
+	setupAzureKeyVault(t)
+	setAzureKeyVaultStagingKey(t)
+	setupTempHome(t)
+
+	const name = "suve-e2e-kv-no-false-conflict"
+
+	cleanup := func() { _, _ = runAzureSecret(t, "delete", "--yes", name) }
+	cleanup()
+	t.Cleanup(cleanup)
+
+	_, err := runAzureSecret(t, "create", name, "original")
+	require.NoError(t, err)
+
+	_, err = runAzureStage(t, "secret", "edit", name, "staged-value")
+	require.NoError(t, err)
+
+	// No out-of-band modification between staging and apply.
+	stdout, stderr, err := runAzureStageCapture(t, "secret", "apply", "--yes")
+	require.NoError(t, err)
+	assert.NotContains(t, stderr, "conflict")
+	assert.Contains(t, stdout, name)
+
+	got, err := runAzureSecret(t, "show", "--raw", name)
+	require.NoError(t, err)
+	assert.Equal(t, "staged-value", got)
 }
 
 // TestAzureKeyVault_FullWorkflow exercises the azure secret commands against a

--- a/internal/cli/commands/stage/apply/apply.go
+++ b/internal/cli/commands/stage/apply/apply.go
@@ -46,11 +46,13 @@ func (s ServiceApply) strategyForNamespace(namespace string) (staging.ApplyStrat
 	return s.StrategyFor(namespace)
 }
 
-// serviceConflictCheck holds entries and strategy for a single service's conflict checking.
+// serviceConflictCheck holds entries and the per-namespace strategy resolver for
+// a single service's conflict checking. resolve mirrors the apply path so each
+// entry is probed against its own namespace's remote state.
 type serviceConflictCheck struct {
 	serviceName string
 	entries     map[staging.EntryKey]staging.Entry
-	strategy    staging.ApplyStrategy
+	resolve     staging.ApplyStrategyResolver
 }
 
 // conflictItem identifies a conflicting staged entry, qualified by its service.
@@ -246,7 +248,7 @@ func (r *Runner) Run(ctx context.Context) error {
 				checks = append(checks, serviceConflictCheck{
 					serviceName: svc.Strategy.ServiceName(),
 					entries:     svc.Entries,
-					strategy:    svc.Strategy,
+					resolve:     svc.strategyForNamespace,
 				})
 			}
 		}
@@ -255,7 +257,7 @@ func (r *Runner) Run(ctx context.Context) error {
 		if len(allConflicts) > 0 {
 			for _, c := range allConflicts {
 				output.Warning(r.Stderr, "conflict detected for %s (%s): %s was modified after staging",
-					keyLabel(c.key), c.serviceName, r.ProviderLabel)
+					c.key.Label(), c.serviceName, r.ProviderLabel)
 			}
 
 			return fmt.Errorf("apply rejected: %d conflict(s) detected (use --ignore-conflicts to force)", len(allConflicts))
@@ -397,21 +399,11 @@ func (r *Runner) checkAllConflicts(ctx context.Context, checks []serviceConflict
 	var all []conflictItem
 
 	for _, check := range checks {
-		conflicts := staging.CheckConflicts(ctx, check.strategy, check.entries)
+		conflicts := staging.CheckConflicts(ctx, check.resolve, check.entries)
 		for _, key := range staging.SortedEntryKeys(conflicts) {
 			all = append(all, conflictItem{serviceName: check.serviceName, key: key})
 		}
 	}
 
 	return all
-}
-
-// keyLabel renders an entry key for display, appending the namespace when
-// present (empty is the null/default namespace, shown bare).
-func keyLabel(key staging.EntryKey) string {
-	if key.Namespace == "" {
-		return key.Name
-	}
-
-	return fmt.Sprintf("%s [%s]", key.Name, key.Namespace)
 }

--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -327,9 +327,16 @@ func (a *App) StagingApply(service string, ignoreConflicts bool) (*StagingApplyR
 		return nil, err
 	}
 
+	// Render each conflict's EntryKey with its namespace badge (bare name for the
+	// empty/default namespace, so AWS/GCloud/Key Vault output is unchanged).
+	conflicts := make([]string, 0, len(result.Conflicts))
+	for _, key := range result.Conflicts {
+		conflicts = append(conflicts, key.Label())
+	}
+
 	output := &StagingApplyResult{
 		ServiceName:    result.ServiceName,
-		Conflicts:      result.Conflicts,
+		Conflicts:      conflicts,
 		EntrySucceeded: result.EntrySucceeded,
 		EntryFailed:    result.EntryFailed,
 		TagSucceeded:   result.TagSucceeded,

--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -9,6 +9,8 @@ import (
 
 	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 
+	"github.com/samber/lo"
+
 	"github.com/mpyw/suve/internal/maputil"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/staging"
@@ -329,10 +331,7 @@ func (a *App) StagingApply(service string, ignoreConflicts bool) (*StagingApplyR
 
 	// Render each conflict's EntryKey with its namespace badge (bare name for the
 	// empty/default namespace, so AWS/GCloud/Key Vault output is unchanged).
-	conflicts := make([]string, 0, len(result.Conflicts))
-	for _, key := range result.Conflicts {
-		conflicts = append(conflicts, key.Label())
-	}
+	conflicts := lo.Map(result.Conflicts, func(key staging.EntryKey, _ int) string { return key.Label() })
 
 	output := &StagingApplyResult{
 		ServiceName:    result.ServiceName,

--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -7,9 +7,8 @@ import (
 	"errors"
 	"fmt"
 
-	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
-
 	"github.com/samber/lo"
+	wailsruntime "github.com/wailsapp/wails/v2/pkg/runtime"
 
 	"github.com/mpyw/suve/internal/maputil"
 	"github.com/mpyw/suve/internal/provider"

--- a/internal/gui/staging_integration_internal_test.go
+++ b/internal/gui/staging_integration_internal_test.go
@@ -1316,3 +1316,20 @@ func TestApp_StagingApply_ExecuteError(t *testing.T) {
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "list boom")
 }
+
+// TestApp_StagingApply_NoStagedChanges covers the success return of StagingApply
+// (nothing staged -> the use case returns early with no error), which exercises
+// the EntryKey->label mapping for result.Conflicts on the happy path. With no
+// staged entries there are no conflicts, so the mapping yields an empty slice.
+func TestApp_StagingApply_NoStagedChanges(t *testing.T) {
+	t.Parallel()
+
+	app := setupTestApp(t)
+
+	result, err := app.StagingApply(string(staging.ServiceParam), false)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Empty(t, result.Conflicts)
+	assert.Zero(t, result.EntrySucceeded)
+	assert.Zero(t, result.EntryFailed)
+}

--- a/internal/staging/cli/apply.go
+++ b/internal/staging/cli/apply.go
@@ -6,8 +6,6 @@ import (
 	"io"
 	"strings"
 
-	"github.com/samber/lo"
-
 	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/maputil"
 	"github.com/mpyw/suve/internal/staging"
@@ -130,9 +128,10 @@ func (r *ApplyRunner) Run(ctx context.Context, opts ApplyOptions) error {
 		return err
 	}
 
-	// Output conflicts if any
-	for _, name := range maputil.SortedKeys(lo.SliceToMap(result.Conflicts, func(s string) (string, struct{}) { return s, struct{}{} })) {
-		output.Warning(r.Stderr, "conflict detected for %s: AWS was modified after staging", name)
+	// Output conflicts if any. result.Conflicts is already sorted by (name,
+	// namespace); render each with the namespace badge (bare name when empty).
+	for _, key := range result.Conflicts {
+		output.Warning(r.Stderr, "conflict detected for %s: AWS was modified after staging", key.Label())
 	}
 
 	// Handle "nothing staged" case

--- a/internal/staging/conflict.go
+++ b/internal/staging/conflict.go
@@ -8,12 +8,24 @@ import (
 	"github.com/mpyw/suve/internal/parallel"
 )
 
+// ApplyStrategyResolver resolves the ApplyStrategy for a given namespace. It
+// mirrors the per-namespace resolution the apply path uses so a namespaced
+// provider (Azure App Configuration) probes each entry against the remote state
+// of its OWN namespace rather than the default one.
+type ApplyStrategyResolver func(namespace string) (ApplyStrategy, error)
+
 // CheckConflicts checks if remote resources were modified after staging.
 // Returns the set of EntryKeys that have conflicts.
 //
+// Each entry is probed through the strategy resolved for its own namespace, so
+// the probe carries the full EntryKey (name + namespace) and never collapses
+// two same-named entries across namespaces onto one namespace's remote state.
+// For namespace-agnostic providers the resolver returns the single strategy and
+// the empty namespace, so behavior is unchanged.
+//
 // For Create operations: conflicts if resource now exists (someone else created it).
 // For Update/Delete operations with BaseModifiedAt: conflicts if the remote was modified after base.
-func CheckConflicts(ctx context.Context, strategy ApplyStrategy, entries map[EntryKey]Entry) map[EntryKey]struct{} {
+func CheckConflicts(ctx context.Context, resolve ApplyStrategyResolver, entries map[EntryKey]Entry) map[EntryKey]struct{} {
 	conflicts := make(map[EntryKey]struct{})
 
 	// Separate entries by check type:
@@ -41,8 +53,15 @@ func CheckConflicts(ctx context.Context, strategy ApplyStrategy, entries map[Ent
 	maps.Copy(allToCheck, toCheckCreate)
 	maps.Copy(allToCheck, toCheckModified)
 
-	// Fetch last modified times in parallel
+	// Fetch last modified times in parallel. Resolve the strategy per entry so the
+	// probe targets the entry's own namespace (App Configuration); other providers
+	// resolve the same single strategy under the empty namespace.
 	results := parallel.ExecuteMap(ctx, allToCheck, func(ctx context.Context, key EntryKey, _ Entry) (time.Time, error) {
+		strategy, err := resolve(key.Namespace)
+		if err != nil {
+			return time.Time{}, err
+		}
+
 		return strategy.FetchLastModified(ctx, key.Name)
 	})
 

--- a/internal/staging/conflict_test.go
+++ b/internal/staging/conflict_test.go
@@ -3,6 +3,7 @@ package staging_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -48,6 +49,15 @@ func (m *mockApplyStrategy) ApplyTags(_ context.Context, _ string, _ staging.Tag
 	return nil
 }
 
+// resolverFor wraps a single strategy as a namespace-agnostic resolver, matching
+// the behavior of a provider without a namespace axis (AWS/GCloud/Key Vault):
+// every namespace resolves to the same strategy.
+func resolverFor(s staging.ApplyStrategy) staging.ApplyStrategyResolver {
+	return func(string) (staging.ApplyStrategy, error) {
+		return s, nil
+	}
+}
+
 func TestCheckConflicts(t *testing.T) {
 	t.Parallel()
 
@@ -58,7 +68,7 @@ func TestCheckConflicts(t *testing.T) {
 		t.Parallel()
 
 		strategy := &mockApplyStrategy{}
-		conflicts := staging.CheckConflicts(t.Context(), strategy, map[staging.EntryKey]staging.Entry{})
+		conflicts := staging.CheckConflicts(t.Context(), resolverFor(strategy), map[staging.EntryKey]staging.Entry{})
 		assert.Empty(t, conflicts)
 	})
 
@@ -70,7 +80,7 @@ func TestCheckConflicts(t *testing.T) {
 			{Name: "item1"}: {Operation: staging.OperationUpdate},
 			{Name: "item2"}: {Operation: staging.OperationDelete},
 		}
-		conflicts := staging.CheckConflicts(t.Context(), strategy, entries)
+		conflicts := staging.CheckConflicts(t.Context(), resolverFor(strategy), entries)
 		assert.Empty(t, conflicts)
 	})
 
@@ -85,7 +95,7 @@ func TestCheckConflicts(t *testing.T) {
 		entries := map[staging.EntryKey]staging.Entry{
 			{Name: "new-item"}: {Operation: staging.OperationCreate, Value: lo.ToPtr("value")},
 		}
-		conflicts := staging.CheckConflicts(t.Context(), strategy, entries)
+		conflicts := staging.CheckConflicts(t.Context(), resolverFor(strategy), entries)
 		assert.Contains(t, conflicts, staging.EntryKey{Name: "new-item"})
 	})
 
@@ -101,7 +111,7 @@ func TestCheckConflicts(t *testing.T) {
 		entries := map[staging.EntryKey]staging.Entry{
 			{Name: "new-item"}: {Operation: staging.OperationCreate, Value: lo.ToPtr("value")},
 		}
-		conflicts := staging.CheckConflicts(t.Context(), strategy, entries)
+		conflicts := staging.CheckConflicts(t.Context(), resolverFor(strategy), entries)
 		assert.Empty(t, conflicts)
 	})
 
@@ -116,7 +126,7 @@ func TestCheckConflicts(t *testing.T) {
 		entries := map[staging.EntryKey]staging.Entry{
 			{Name: "new-item"}: {Operation: staging.OperationCreate, Value: lo.ToPtr("value")},
 		}
-		conflicts := staging.CheckConflicts(t.Context(), strategy, entries)
+		conflicts := staging.CheckConflicts(t.Context(), resolverFor(strategy), entries)
 		assert.Empty(t, conflicts)
 	})
 
@@ -135,7 +145,7 @@ func TestCheckConflicts(t *testing.T) {
 				BaseModifiedAt: &baseTime,
 			},
 		}
-		conflicts := staging.CheckConflicts(t.Context(), strategy, entries)
+		conflicts := staging.CheckConflicts(t.Context(), resolverFor(strategy), entries)
 		assert.Contains(t, conflicts, staging.EntryKey{Name: "existing-item"})
 	})
 
@@ -154,7 +164,7 @@ func TestCheckConflicts(t *testing.T) {
 				BaseModifiedAt: &baseTime,
 			},
 		}
-		conflicts := staging.CheckConflicts(t.Context(), strategy, entries)
+		conflicts := staging.CheckConflicts(t.Context(), resolverFor(strategy), entries)
 		assert.Empty(t, conflicts)
 	})
 
@@ -173,7 +183,7 @@ func TestCheckConflicts(t *testing.T) {
 				BaseModifiedAt: &baseTime,
 			},
 		}
-		conflicts := staging.CheckConflicts(t.Context(), strategy, entries)
+		conflicts := staging.CheckConflicts(t.Context(), resolverFor(strategy), entries)
 		assert.Empty(t, conflicts)
 	})
 
@@ -191,7 +201,7 @@ func TestCheckConflicts(t *testing.T) {
 				BaseModifiedAt: &baseTime,
 			},
 		}
-		conflicts := staging.CheckConflicts(t.Context(), strategy, entries)
+		conflicts := staging.CheckConflicts(t.Context(), resolverFor(strategy), entries)
 		assert.Contains(t, conflicts, staging.EntryKey{Name: "delete-item"})
 	})
 
@@ -209,7 +219,7 @@ func TestCheckConflicts(t *testing.T) {
 				BaseModifiedAt: &baseTime,
 			},
 		}
-		conflicts := staging.CheckConflicts(t.Context(), strategy, entries)
+		conflicts := staging.CheckConflicts(t.Context(), resolverFor(strategy), entries)
 		assert.Empty(t, conflicts)
 	})
 
@@ -238,9 +248,71 @@ func TestCheckConflicts(t *testing.T) {
 			{Name: "delete-item"}:        {Operation: staging.OperationDelete, BaseModifiedAt: &baseTime},
 			{Name: "update-no-conflict"}: {Operation: staging.OperationUpdate, Value: lo.ToPtr("v"), BaseModifiedAt: &baseTime},
 		}
-		conflicts := staging.CheckConflicts(t.Context(), strategy, entries)
+		conflicts := staging.CheckConflicts(t.Context(), resolverFor(strategy), entries)
 		assert.Len(t, conflicts, 2)
 		assert.Contains(t, conflicts, staging.EntryKey{Name: "create-item"})
 		assert.Contains(t, conflicts, staging.EntryKey{Name: "update-item"})
 	})
+}
+
+// TestCheckConflicts_PerNamespace is a regression for #441: two same-named
+// entries under different namespaces must each be probed against their OWN
+// namespace's remote state, and the reported conflict must carry the namespace.
+// With the namespace dropped, a single bare-name probe would compare both
+// entries against one namespace's time and falsely flag or clear the other.
+func TestCheckConflicts_PerNamespace(t *testing.T) {
+	t.Parallel()
+
+	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	laterTime := time.Date(2024, 1, 1, 13, 0, 0, 0, time.UTC)
+
+	// The "dev" namespace was modified after base (conflict); the default
+	// namespace was not (no conflict). Same name "k" in both.
+	remoteByNamespace := map[string]time.Time{
+		"":    baseTime,  // unchanged since base -> no conflict
+		"dev": laterTime, // modified after base -> conflict
+	}
+
+	var mu sync.Mutex
+
+	probed := map[string]string{} // namespace -> name probed against its strategy
+
+	resolve := func(namespace string) (staging.ApplyStrategy, error) {
+		return &mockApplyStrategy{
+			fetchLastModifiedFunc: func(_ context.Context, name string) (time.Time, error) {
+				mu.Lock()
+				probed[namespace] = name
+				mu.Unlock()
+
+				return remoteByNamespace[namespace], nil
+			},
+		}, nil
+	}
+
+	entries := map[staging.EntryKey]staging.Entry{
+		{Name: "k", Namespace: ""}: {
+			Operation:      staging.OperationUpdate,
+			Value:          lo.ToPtr("v"),
+			BaseModifiedAt: &baseTime,
+		},
+		{Name: "k", Namespace: "dev"}: {
+			Operation:      staging.OperationUpdate,
+			Value:          lo.ToPtr("v"),
+			BaseModifiedAt: &baseTime,
+		},
+	}
+
+	conflicts := staging.CheckConflicts(t.Context(), resolve, entries)
+
+	// Only the "dev" entry conflicts, and the report carries its namespace.
+	assert.Len(t, conflicts, 1)
+	assert.Contains(t, conflicts, staging.EntryKey{Name: "k", Namespace: "dev"})
+	assert.NotContains(t, conflicts, staging.EntryKey{Name: "k", Namespace: ""})
+
+	// Each namespace's strategy was probed with the entry's own name — proving
+	// the namespace is threaded through to the probe, not dropped.
+	mu.Lock()
+	defer mu.Unlock()
+
+	assert.Equal(t, map[string]string{"": "k", "dev": "k"}, probed)
 }

--- a/internal/staging/conflict_test.go
+++ b/internal/staging/conflict_test.go
@@ -255,6 +255,30 @@ func TestCheckConflicts(t *testing.T) {
 	})
 }
 
+// TestCheckConflicts_ResolverError verifies that a per-namespace resolver which
+// fails to resolve a strategy is treated like a fetch error: the entry is
+// skipped (no conflict) and the failure surfaces later on the apply attempt.
+func TestCheckConflicts_ResolverError(t *testing.T) {
+	t.Parallel()
+
+	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	resolve := func(string) (staging.ApplyStrategy, error) {
+		return nil, errors.New("cannot resolve strategy")
+	}
+	entries := map[staging.EntryKey]staging.Entry{
+		{Name: "create-item"}: {Operation: staging.OperationCreate, Value: lo.ToPtr("value")},
+		{Name: "update-item"}: {
+			Operation:      staging.OperationUpdate,
+			Value:          lo.ToPtr("value"),
+			BaseModifiedAt: &baseTime,
+		},
+	}
+
+	conflicts := staging.CheckConflicts(t.Context(), resolve, entries)
+	assert.Empty(t, conflicts)
+}
+
 // TestCheckConflicts_PerNamespace is a regression for #441: two same-named
 // entries under different namespaces must each be probed against their OWN
 // namespace's remote state, and the reported conflict must carry the namespace.

--- a/internal/staging/stage.go
+++ b/internal/staging/stage.go
@@ -4,6 +4,7 @@ package staging
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"maps"
 	"slices"
 	"strings"
@@ -23,6 +24,17 @@ import (
 type EntryKey struct {
 	Name      string
 	Namespace string
+}
+
+// Label renders the key for display, appending the namespace as a [badge] when
+// present. The empty (default) namespace — the only value for AWS, Google Cloud
+// and Key Vault — renders as the bare name, matching status/diff output.
+func (k EntryKey) Label() string {
+	if k.Namespace == "" {
+		return k.Name
+	}
+
+	return fmt.Sprintf("%s [%s]", k.Name, k.Namespace)
 }
 
 // SortedEntryKeys returns the keys of m sorted by (name, namespace) for

--- a/internal/staging/stage_test.go
+++ b/internal/staging/stage_test.go
@@ -426,3 +426,21 @@ func TestEntryKey_NamespaceIdentity(t *testing.T) {
 		}, got)
 	})
 }
+
+func TestEntryKey_Label(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty namespace renders the bare name", func(t *testing.T) {
+		t.Parallel()
+
+		key := staging.EntryKey{Name: "/app/config"}
+		assert.Equal(t, "/app/config", key.Label())
+	})
+
+	t.Run("non-empty namespace appends a [namespace] badge", func(t *testing.T) {
+		t.Parallel()
+
+		key := staging.EntryKey{Name: "/app/config", Namespace: "dev"}
+		assert.Equal(t, "/app/config [dev]", key.Label())
+	})
+}

--- a/internal/usecase/staging/apply.go
+++ b/internal/usecase/staging/apply.go
@@ -67,8 +67,10 @@ type ApplyOutput struct {
 	TagResults   []ApplyTagResult
 	TagSucceeded int
 	TagFailed    int
-	// Conflicts
-	Conflicts []string
+	// Conflicts carries the full EntryKey (name + namespace) of each conflicting
+	// entry so callers can render the namespace badge; empty namespace renders as
+	// the bare name.
+	Conflicts []staging.EntryKey
 }
 
 // ApplyUseCase executes apply operations.
@@ -151,11 +153,11 @@ func (u *ApplyUseCase) Execute(ctx context.Context, input ApplyInput) (*ApplyOut
 
 	// Check for conflicts (only for entries, as tags don't have value conflicts)
 	if !input.IgnoreConflicts && len(entries) > 0 {
-		conflicts := staging.CheckConflicts(ctx, u.Strategy, entries)
+		conflicts := staging.CheckConflicts(ctx, u.strategyForNamespace, entries)
 		if len(conflicts) > 0 {
-			for key := range conflicts {
-				output.Conflicts = append(output.Conflicts, key.Name)
-			}
+			// Report the full EntryKey (sorted for determinism) so callers can
+			// render the namespace badge.
+			output.Conflicts = append(output.Conflicts, staging.SortedEntryKeys(conflicts)...)
 
 			return output, fmt.Errorf("apply rejected: %d conflict(s) detected", len(conflicts))
 		}

--- a/internal/usecase/staging/apply_test.go
+++ b/internal/usecase/staging/apply_test.go
@@ -253,7 +253,7 @@ func TestApplyUseCase_Execute_ConflictDetection(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "conflict")
 	assert.Len(t, output.Conflicts, 1)
-	assert.Equal(t, "/app/conflict", output.Conflicts[0])
+	assert.Equal(t, staging.EntryKey{Name: "/app/conflict"}, output.Conflicts[0])
 }
 
 func TestApplyUseCase_Execute_ListError(t *testing.T) {


### PR DESCRIPTION
## The bug (#441, Priority:Critical, latent/inert today)

Staging **conflict detection** dropped `EntryKey.Namespace`. It resolved every staged entry through a single default (unscoped) strategy and probed the remote by bare `key.Name`:

- `internal/staging/conflict.go` — `CheckConflicts` fetched `strategy.FetchLastModified(ctx, key.Name)`, so the namespace was lost.
- `internal/usecase/staging/apply.go` — passed the **default** strategy (`u.Strategy`) into `CheckConflicts` even though entries span all namespaces, and appended only `key.Name` to `output.Conflicts` (namespace-ambiguous report).
- `internal/cli/commands/stage/apply/apply.go` — `checkAllConflicts` likewise passed the default strategy.

It is **inert today**: Azure App Configuration (the only provider with a namespace axis) deliberately disables conflict detection (`FetchLastModified` is a no-op, never records `BaseModifiedAt`); AWS/GCloud/Key Vault always have an empty namespace, so bare-name probing is currently equivalent. But the moment any namespaced provider gains real modified-after detection, two same-named settings under different namespaces would be compared against the **wrong** namespace's remote state -> false positive/negative, with an ambiguous bare-name warning.

## The fix

- **Namespace-aware probing**: thread a per-namespace `staging.ApplyStrategyResolver` into `CheckConflicts` and resolve the strategy per entry before probing — mirroring the apply path exactly (`strategyForNamespace(key.Namespace)` then `FetchLastModified(ctx, key.Name)`). Namespace-agnostic providers resolve the single strategy under the empty namespace, so their behavior is **byte-for-byte unchanged**.
- **Namespace in the report**: `ApplyOutput.Conflicts` now carries the full `EntryKey` instead of just the name. Added `EntryKey.Label()` to render the `[namespace]` badge like `status`/`diff` (empty namespace -> bare name). Updated the global CLI apply runner, the per-service CLI runner (`internal/staging/cli/apply.go`), and the GUI (`internal/gui/staging.go`). Conflicts are now reported sorted by `(name, namespace)` (deterministic; previously map-iteration order).
- **Both callers updated**: `internal/usecase/staging/apply.go` and `internal/cli/commands/stage/apply/apply.go`.

## Tests

### Unit
`TestCheckConflicts_PerNamespace` (`internal/staging/conflict_test.go`): two same-named entries `k`@"" and `k`@"dev", both staged as updates with a `BaseModifiedAt`, and a per-namespace resolver whose `FetchLastModified` returns different times per namespace (`""` -> base time = no conflict; `"dev"` -> later time = conflict). It asserts exactly one conflict carrying `Namespace:"dev"`, that the `""` entry is not flagged, and that each namespace's strategy was probed with its own key (`{"": "k", "dev": "k"}`). If the code reverted to single-strategy/bare-name probing, the `dev` key would be probed under the `""` strategy (base time) -> zero conflicts -> the test fails. So it genuinely distinguishes per-namespace probing.

### E2E — Azure Key Vault (live conflict detection)
Azure Key Vault's `FetchLastModified` is **real** (returns the secret's `LastModified`), so its staging conflict detection is live. Added three E2E tests in `e2e/azure_keyvault_test.go` that exercise the resolver-based `CheckConflicts` path end-to-end on this provider:

- **`TestAzureKeyVaultStage_ConflictDetected`** — stage an edit (records `BaseModifiedAt` from `FetchCurrent`), modify the secret out-of-band (new version, bypassing staging), then `apply` -> conflict is reported and the write is **blocked** (remote value unchanged). Asserts the conflict renders the **bare name** (empty namespace, via `EntryKey.Label()`).
- **`TestAzureKeyVaultStage_IgnoreConflictsOverrides`** — same setup with `--ignore-conflicts` -> applies anyway (staged value wins).
- **`TestAzureKeyVaultStage_NoFalseConflict`** — stage an edit, apply with no out-of-band change -> no conflict, applies cleanly.

Key Vault `LastModified` is second-granular, so the out-of-band write sleeps past a second boundary to land strictly after the recorded base. Tests set `SUVE_STAGING_KEY` so the working store used by `stage edit`/`apply` never blocks on the OS keychain, and each test uses its own temp `HOME` for staging isolation. Names match the `e2e-azure-keyvault` task's `-run` filter. Verified live against a fresh `lowkey-vault` emulator: all three pass.

### App Configuration limitation (documented, not e2e-observable)
Azure App Configuration's `FetchLastModified` is a deliberate **no-op** (returns zero time) and it never records `BaseModifiedAt`, so its conflict detection is **inert** (last-write-wins) — a real conflict cannot be triggered through it, so the namespace-aware conflict path is not observable via App Config E2E. The unit test above covers that plumbing directly. App Config namespace correctness is otherwise covered by `TestAzureAppConfigStage_Namespaces`.

## Verification
`mise test` and `mise lint` green (strict `default: all`, with `e2e` build tags). Fresh general-purpose review agents audited both the core `git diff main` and the new Key Vault E2E diff and found no bugs.

## Emulators run vs left to CI
- Ran locally against the `lowkey-vault` Key Vault emulator (port 8443): the three new conflict tests pass on a fresh emulator.
- The canonical fresh-emulator full run (`E2E Test (Azure)` / `mise e2e-azure-keyvault`) is left to CI. Note: like the existing Key Vault tests, these assume an ephemeral emulator (cleanup soft-deletes; re-create of a soft-deleted name fails on a persistent emulator) — not a regression.

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)