### PR TITLE
test(e2e): restore per-service export/import coverage

### DIFF
--- a/e2e/azure_stage_test.go
+++ b/e2e/azure_stage_test.go
@@ -5,6 +5,8 @@ package e2e_test
 
 import (
 	"bytes"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -464,5 +466,114 @@ func TestAzureAppConfigStage_NamespacedTags(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, devShow, "tier")
 		assert.Contains(t, devShow, "dev")
+	})
+}
+
+// TestAzureKeyVaultStage_ExportImport exercises the service-specific
+// `azure stage secret export <file>` / `import <file>` round-trip against the
+// Key Vault emulator. It uses an isolated temp HOME so the working staging area
+// starts empty.
+func TestAzureKeyVaultStage_ExportImport(t *testing.T) {
+	setupAzureKeyVault(t)
+	setupTempHome(t)
+
+	const name = "suve-e2e-az-kv-stage-export-import"
+
+	exportPath := filepath.Join(t.TempDir(), "secret.json")
+
+	// Stage a create in the working staging area.
+	_, err := runAzureStage(t, "secret", "add", name, "exported-value")
+	require.NoError(t, err)
+
+	t.Run("export", func(t *testing.T) {
+		stdout, err := runAzureStage(t, "secret", "export", exportPath)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "exported")
+
+		_, statErr := os.Stat(exportPath)
+		require.NoError(t, statErr)
+	})
+
+	t.Run("working-cleared", func(t *testing.T) {
+		stdout, err := runAzureStage(t, "secret", "status")
+		require.NoError(t, err)
+		assert.NotContains(t, stdout, name)
+	})
+
+	t.Run("import", func(t *testing.T) {
+		stdout, err := runAzureStage(t, "secret", "import", exportPath)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "imported")
+	})
+
+	t.Run("working-restored", func(t *testing.T) {
+		stdout, err := runAzureStage(t, "secret", "status")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "Key Vault")
+		assert.Contains(t, stdout, name)
+	})
+}
+
+// TestAzureAppConfigStage_ExportImport exercises the service-specific
+// `azure stage param export <file>` / `import <file>` round-trip against the App
+// Configuration emulator. Beyond restoring the working area, it applies the
+// re-imported staged param and reads the real setting back: this is the e2e
+// guard for #445 (a staged App Config param must survive export -> import in the
+// PARAM bucket, not be misrouted/dropped into the secret bucket).
+func TestAzureAppConfigStage_ExportImport(t *testing.T) {
+	setupAzureAppConfig(t)
+	setupTempHome(t)
+
+	const name = "suve/e2e/az/ac/stage/export-import"
+
+	exportPath := filepath.Join(t.TempDir(), "param.json")
+
+	cleanup := func() { _, _ = runAzureParam(t, "delete", "--yes", name) }
+	cleanup()
+	t.Cleanup(cleanup)
+
+	// Stage a create of an App Configuration setting.
+	_, err := runAzureStage(t, "param", "add", name, "exported-value")
+	require.NoError(t, err)
+
+	t.Run("export", func(t *testing.T) {
+		stdout, err := runAzureStage(t, "param", "export", exportPath)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "exported")
+
+		_, statErr := os.Stat(exportPath)
+		require.NoError(t, statErr)
+	})
+
+	t.Run("working-cleared", func(t *testing.T) {
+		stdout, err := runAzureStage(t, "param", "status")
+		require.NoError(t, err)
+		assert.NotContains(t, stdout, name)
+	})
+
+	t.Run("import", func(t *testing.T) {
+		stdout, err := runAzureStage(t, "param", "import", exportPath)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "imported")
+	})
+
+	// The re-imported staged param must land back in the param (App Config)
+	// bucket: status attributes it to App Configuration and shows the key.
+	t.Run("working-restored", func(t *testing.T) {
+		stdout, err := runAzureStage(t, "param", "status")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "App Configuration")
+		assert.Contains(t, stdout, name)
+	})
+
+	// Applying the re-imported staged param writes the real setting, proving the
+	// value and per-service bucket survived the round-trip end to end (#445).
+	t.Run("apply-after-roundtrip", func(t *testing.T) {
+		_, err := runAzureStage(t, "param", "apply", "--yes")
+		require.NoError(t, err)
+
+		stdout, err := runAzureParam(t, "show", "--raw", name)
+		require.NoError(t, err)
+		assert.Equal(t, "exported-value", stdout)
 	})
 }

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -28,9 +28,10 @@ import (
 
 // TestMain sets up the environment before running tests.
 func TestMain(m *testing.M) {
-	// Create an isolated temp directory. The staging area and stash files live
-	// under HOME (set per-test via setupTempHome), but keep the platform's
-	// runtime-dir env vars pinned to a short, isolated path for consistency.
+	// Create an isolated temp directory. The working staging area lives under
+	// HOME (set per-test via setupTempHome) and export/import files are written
+	// to per-test t.TempDir()s, but keep the platform's runtime-dir env vars
+	// pinned to a short, isolated path for consistency.
 	// Use /tmp directly to avoid path length limit issues on macOS.
 	tmpDir, err := os.MkdirTemp("/tmp", "suve-e2e-")
 	if err != nil {

--- a/e2e/gcloud_stage_test.go
+++ b/e2e/gcloud_stage_test.go
@@ -4,6 +4,8 @@
 package e2e_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -146,4 +148,49 @@ func TestGoogleCloudStage_FlatAliasReachesEmulator(t *testing.T) {
 	stdout, err := runGcloud(t, "stage", "status")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "suve-e2e-gcloud-flat/secret")
+}
+
+// TestGoogleCloudStage_ExportImport exercises the service-specific
+// `gcloud stage export <file>` / `import <file>` round-trip (Google Cloud is
+// secret-only, so the operation lives directly under `gcloud stage`). It uses an
+// isolated temp HOME so the working staging area starts empty.
+func TestGoogleCloudStage_ExportImport(t *testing.T) {
+	setupGoogleCloud(t)
+	setupTempHome(t)
+
+	const name = "suve-e2e-gcloud-stage-export-import/secret"
+
+	exportPath := filepath.Join(t.TempDir(), "secret.json")
+
+	// Stage a create in the working staging area.
+	_, err := runGcloud(t, "stage", "add", name, "exported-value")
+	require.NoError(t, err)
+
+	t.Run("export", func(t *testing.T) {
+		stdout, err := runGcloud(t, "stage", "export", exportPath)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "exported")
+
+		_, statErr := os.Stat(exportPath)
+		require.NoError(t, statErr)
+	})
+
+	t.Run("working-cleared", func(t *testing.T) {
+		stdout, err := runGcloud(t, "stage", "status")
+		require.NoError(t, err)
+		assert.NotContains(t, stdout, name)
+	})
+
+	t.Run("import", func(t *testing.T) {
+		stdout, err := runGcloud(t, "stage", "import", exportPath)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "imported")
+	})
+
+	t.Run("working-restored", func(t *testing.T) {
+		stdout, err := runGcloud(t, "stage", "status")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "Secret Manager")
+		assert.Contains(t, stdout, name)
+	})
 }

--- a/e2e/param_test.go
+++ b/e2e/param_test.go
@@ -4,6 +4,8 @@
 package e2e_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -2110,4 +2112,174 @@ func TestParam_ListJSON(t *testing.T) {
 	stdout, _, err := runCommand(t, cmdparam.ListCommand(), "--output", "json", basePath)
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(strings.TrimSpace(stdout), "[") || strings.HasPrefix(strings.TrimSpace(stdout), "{"))
+}
+
+// =============================================================================
+// Service-Specific Export / Import Tests
+//
+// These restore the round-trip coverage that the removed service-specific stash
+// tests (TestParam_StashPushAndPop / StashPushWithKeep / StashPopWithMerge)
+// provided, expressed through `stage param export <file>` / `import <file>`.
+// Each test runs against an isolated temp HOME, so the on-disk working staging
+// area is empty at the start and no cross-test cleanup is required.
+// =============================================================================
+
+// TestParam_ExportImport tests the service-specific export -> clear -> import
+// round-trip for parameters.
+func TestParam_ExportImport(t *testing.T) {
+	setupEnv(t)
+	setupTempHome(t)
+
+	paramName := "/suve-e2e-param-export-import/test"
+	exportPath := filepath.Join(t.TempDir(), "param.json")
+
+	// Stage a parameter in the working staging area.
+	_, _, err := runSubCommand(t, paramstage.Command(), "add", paramName, "test-value")
+	require.NoError(t, err)
+
+	// Export writes the file and clears the working area.
+	t.Run("export", func(t *testing.T) {
+		stdout, _, err := runSubCommand(t, paramstage.Command(), "export", exportPath)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "exported")
+
+		_, statErr := os.Stat(exportPath)
+		require.NoError(t, statErr)
+	})
+
+	// The working area is now empty.
+	t.Run("working-cleared", func(t *testing.T) {
+		stdout, _, err := runSubCommand(t, paramstage.Command(), "status")
+		require.NoError(t, err)
+		assert.NotContains(t, stdout, paramName)
+	})
+
+	// Import restores the working area.
+	t.Run("import", func(t *testing.T) {
+		stdout, _, err := runSubCommand(t, paramstage.Command(), "import", exportPath)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "imported")
+	})
+
+	t.Run("working-restored", func(t *testing.T) {
+		stdout, _, err := runSubCommand(t, paramstage.Command(), "status")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, paramName)
+	})
+}
+
+// TestParam_ExportKeep tests that `export --keep` retains the working area.
+func TestParam_ExportKeep(t *testing.T) {
+	setupEnv(t)
+	setupTempHome(t)
+
+	paramName := "/suve-e2e-param-export-keep/test"
+	exportPath := filepath.Join(t.TempDir(), "param.json")
+
+	_, _, err := runSubCommand(t, paramstage.Command(), "add", paramName, "keep-value")
+	require.NoError(t, err)
+
+	stdout, _, err := runSubCommand(t, paramstage.Command(), "export", exportPath, "--keep")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "kept in the working staging area")
+
+	// The file was written...
+	_, statErr := os.Stat(exportPath)
+	require.NoError(t, statErr)
+
+	// ...and the parameter is still staged.
+	stdout, _, err = runSubCommand(t, paramstage.Command(), "status")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, paramName)
+}
+
+// TestParam_ImportMerge tests that `import --merge` combines the imported file
+// with an existing working entry.
+func TestParam_ImportMerge(t *testing.T) {
+	setupEnv(t)
+	setupTempHome(t)
+
+	paramName1 := "/suve-e2e-param-import-merge/param1"
+	paramName2 := "/suve-e2e-param-import-merge/param2"
+	exportPath := filepath.Join(t.TempDir(), "param.json")
+
+	// Stage param1 and export it (this clears the working area).
+	_, _, err := runSubCommand(t, paramstage.Command(), "add", paramName1, "value1")
+	require.NoError(t, err)
+	_, _, err = runSubCommand(t, paramstage.Command(), "export", exportPath)
+	require.NoError(t, err)
+
+	// Stage param2 in the working area.
+	_, _, err = runSubCommand(t, paramstage.Command(), "add", paramName2, "value2")
+	require.NoError(t, err)
+
+	// Import merges param1 back in alongside param2.
+	stdout, _, err := runSubCommand(t, paramstage.Command(), "import", exportPath, "--merge")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "merged")
+
+	stdout, _, err = runSubCommand(t, paramstage.Command(), "status")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, paramName1)
+	assert.Contains(t, stdout, paramName2)
+}
+
+// TestParam_ExportImportEncrypted tests a service-level encrypted round-trip via
+// --passphrase-stdin: the payload is encrypted on export and decrypted with the
+// same passphrase on import.
+func TestParam_ExportImportEncrypted(t *testing.T) {
+	setupEnv(t)
+	setupTempHome(t)
+
+	paramName := "/suve-e2e-param-export-encrypted/test"
+	exportPath := filepath.Join(t.TempDir(), "param.json")
+
+	// Cleanup: the round-trip is proven end to end by applying to localstack.
+	_, _, _ = runCommand(t, paramdelete.Command(), "--yes", paramName)
+	t.Cleanup(func() {
+		_, _, _ = runCommand(t, paramdelete.Command(), "--yes", paramName)
+	})
+
+	_, _, err := runSubCommand(t, paramstage.Command(), "add", paramName, "secret-value")
+	require.NoError(t, err)
+
+	// Export encrypted.
+	stdout, stderr, err := runSubCommandWithStdin(
+		t, paramstage.Command(), strings.NewReader("testpass\n"), "export", exportPath, "--passphrase-stdin",
+	)
+	require.NoError(t, err, "export failed: stdout=%s stderr=%s", stdout, stderr)
+	assert.Contains(t, stdout, "encrypted")
+
+	// Import back with the same passphrase.
+	stdout, stderr, err = runSubCommandWithStdin(
+		t, paramstage.Command(), strings.NewReader("testpass\n"), "import", exportPath, "--passphrase-stdin",
+	)
+	require.NoError(t, err, "import failed: stdout=%s stderr=%s", stdout, stderr)
+	assert.Contains(t, stdout, "imported")
+
+	stdout, _, err = runSubCommand(t, paramstage.Command(), "status")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, paramName)
+
+	// Prove the VALUE (not just the key) survived the encrypt -> decrypt
+	// round-trip: apply the re-imported staged create and read it back.
+	_, _, err = runSubCommand(t, paramstage.Command(), "apply", "--yes")
+	require.NoError(t, err)
+
+	stdout, _, err = runCommand(t, cmdparam.ShowCommand(), "--raw", paramName)
+	require.NoError(t, err)
+	assert.Equal(t, "secret-value", strings.TrimSpace(stdout))
+}
+
+// TestParam_ImportMissingFile tests that a service-specific import of a
+// non-existent file is a hard error.
+func TestParam_ImportMissingFile(t *testing.T) {
+	setupEnv(t)
+	setupTempHome(t)
+
+	_, _, err := runSubCommand(
+		t, paramstage.Command(), "import", filepath.Join(t.TempDir(), "does-not-exist.json"),
+	)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
 }

--- a/e2e/secret_test.go
+++ b/e2e/secret_test.go
@@ -4,6 +4,8 @@
 package e2e_test
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -795,4 +797,54 @@ func TestSecret_ListJSON(t *testing.T) {
 	stdout, _, err := runCommand(t, cmdsecret.ListCommand(), "--output", "json")
 	require.NoError(t, err)
 	assert.True(t, strings.HasPrefix(strings.TrimSpace(stdout), "[") || strings.HasPrefix(strings.TrimSpace(stdout), "{"))
+}
+
+// =============================================================================
+// Service-Specific Export / Import Tests
+// =============================================================================
+
+// TestSecret_ExportImport restores the round-trip coverage previously provided
+// by TestSecret_StashPushAndPop, expressed through `stage secret export <file>`
+// / `import <file>`. It runs against an isolated temp HOME so the working
+// staging area starts empty.
+func TestSecret_ExportImport(t *testing.T) {
+	setupEnv(t)
+	setupTempHome(t)
+
+	secretName := "suve-e2e-secret-export-import/test"
+	exportPath := filepath.Join(t.TempDir(), "secret.json")
+
+	// Stage a secret in the working staging area.
+	_, _, err := runSubCommand(t, secretstage.Command(), "add", secretName, "secret-value")
+	require.NoError(t, err)
+
+	// Export writes the file and clears the working area.
+	t.Run("export", func(t *testing.T) {
+		stdout, _, err := runSubCommand(t, secretstage.Command(), "export", exportPath)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "exported")
+
+		_, statErr := os.Stat(exportPath)
+		require.NoError(t, statErr)
+	})
+
+	// The working area is now empty.
+	t.Run("working-cleared", func(t *testing.T) {
+		stdout, _, err := runSubCommand(t, secretstage.Command(), "status")
+		require.NoError(t, err)
+		assert.NotContains(t, stdout, secretName)
+	})
+
+	// Import restores the working area.
+	t.Run("import", func(t *testing.T) {
+		stdout, _, err := runSubCommand(t, secretstage.Command(), "import", exportPath)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "imported")
+	})
+
+	t.Run("working-restored", func(t *testing.T) {
+		stdout, _, err := runSubCommand(t, secretstage.Command(), "status")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, secretName)
+	})
 }


### PR DESCRIPTION
## Summary

PR #460 (Epic #451, Step 3) deleted the per-service stash e2e tests but did not revive them as export/import tests. Global `stage export/import <dir>` has e2e coverage (`e2e/staging_test.go`), but the **service-specific** `stage {param,secret} export/import <file>` path (and the gcloud/azure equivalents, which only expose the service-specific form) had **zero** e2e round-trip coverage. This restores it.

All tests are non-trivial round-trips: `require.NoError` gates before any success-string assertion, `working-cleared` proves the export actually drained the working area, and `working-restored` proves import repopulated it.

## Added coverage

**AWS param** (`e2e/param_test.go`):
- `TestParam_ExportImport` — export → working cleared → import → restored
- `TestParam_ExportKeep` — `--keep` retains the working area
- `TestParam_ImportMerge` — `--merge` combines the imported file with an existing working entry
- `TestParam_ExportImportEncrypted` — `--passphrase-stdin` encrypt/decrypt round-trip; applies to localstack and reads the value back to prove the value (not just the key) survived
- `TestParam_ImportMissingFile` — missing file is a hard error

**AWS secret** (`e2e/secret_test.go`):
- `TestSecret_ExportImport` — round-trip

**Google Cloud** (`e2e/gcloud_stage_test.go`):
- `TestGoogleCloudStage_ExportImport` — secret export/import round-trip

**Azure** (`e2e/azure_stage_test.go`):
- `TestAzureKeyVaultStage_ExportImport` — Key Vault (secret) round-trip
- `TestAzureAppConfigStage_ExportImport` — App Configuration (param) round-trip that applies the re-imported staged param and reads back the real value; this is the e2e guard for #445 (correct per-service bucket resolution — a misrouted param would not survive param-scoped apply)

**Misc**:
- Fixed the stale "stash files" comment at `e2e/e2e_test.go`

## Testing

Ran locally against emulators (each on a fresh isolated `$HOME` with `SUVE_STAGING_KEY` set):
- AWS (localstack): all 6 param/secret tests pass
- Google Cloud emulator: passes
- Azure App Configuration emulator: passes (incl. #445 apply guard)
- Azure Key Vault (lowkey-vault) emulator: passes

`golangci-lint` clean on the `e2e` package.

Closes #463
Part of #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)