### PR TITLE
export/import: final integration review (Step 6) + wire GUI export --keep

### DIFF
--- a/internal/gui/frontend/src/lib/PassphraseModal.svelte
+++ b/internal/gui/frontend/src/lib/PassphraseModal.svelte
@@ -12,9 +12,23 @@
     oncancel?: () => void;
     loading?: boolean;
     error?: string;
+    // keepOption renders a "keep in the working area" checkbox (export only).
+    keepOption?: boolean;
+    // keep is bound to the checkbox above; the parent reads it after onsubmit.
+    keep?: boolean;
   }
 
-  let { show = false, mode, title, onsubmit, oncancel, loading = false, error = '' }: Props = $props();
+  let {
+    show = false,
+    mode,
+    title,
+    onsubmit,
+    oncancel,
+    loading = false,
+    error = '',
+    keepOption = false,
+    keep = $bindable(false),
+  }: Props = $props();
 
   let passphrase = $state('');
   let confirmPassphrase = $state('');
@@ -150,6 +164,13 @@
         </div>
       {/if}
 
+      {#if keepOption}
+        <label class="keep-option">
+          <input type="checkbox" bind:checked={keep} disabled={loading} data-testid="export-keep" />
+          <span>Keep staged changes in the working area after exporting</span>
+        </label>
+      {/if}
+
       <div class="form-actions">
         <button type="button" class="btn-secondary" onclick={handleClose} disabled={loading}>
           Cancel
@@ -179,6 +200,19 @@
     font-size: 12px;
     color: #888;
     text-transform: uppercase;
+  }
+
+  .keep-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 13px;
+    color: #ccc;
+    cursor: pointer;
+  }
+
+  .keep-option input {
+    cursor: pointer;
   }
 
   .password-input-wrapper {

--- a/internal/gui/frontend/src/lib/StagingView.svelte
+++ b/internal/gui/frontend/src/lib/StagingView.svelte
@@ -70,6 +70,7 @@
   let showExportPassphrase = $state(false);
   let exportService = $state('');
   let exportPath = $state('');
+  let exportKeep = $state(false);
   let exportLoading = $state(false);
   let exportError = $state('');
   let exportResult: gui.StagingExportResult | null = $state(null);
@@ -339,6 +340,7 @@
     showTransferDropdown = false;
     exportError = '';
     exportResult = null;
+    exportKeep = false;
     exportService = service;
     try {
       const path = await PickExportPath(`${service}.json`);
@@ -354,7 +356,7 @@
     exportLoading = true;
     exportError = '';
     try {
-      const result = await StagingExport(exportPath, exportService, passphrase, false);
+      const result = await StagingExport(exportPath, exportService, passphrase, exportKeep);
       exportResult = result;
       showExportPassphrase = false;
       await loadStatus();
@@ -798,6 +800,8 @@
   show={showExportPassphrase}
   mode="encrypt"
   title="Export {serviceLabel(exportService)}"
+  keepOption={true}
+  bind:keep={exportKeep}
   onsubmit={handleExport}
   oncancel={closeExportModal}
   loading={exportLoading}

--- a/internal/gui/frontend/tests/staging-export-import.spec.ts
+++ b/internal/gui/frontend/tests/staging-export-import.spec.ts
@@ -100,6 +100,32 @@ test.describe('Export', () => {
     await expect(page.locator('.section').nth(1).locator('.entry-item')).toHaveCount(1);
   });
 
+  test('keeps the working area when the Keep option is checked', async ({ page }) => {
+    await setupWailsMocks(page, createStagedForExportState());
+    await page.goto('/');
+    await navigateTo(page, 'Staging');
+    await page.waitForSelector('.entry-item');
+
+    await openTransferMenu(page);
+    await page.getByTestId('export-param').click();
+
+    await expect(page.locator('.modal-title')).toHaveText(/Export Param/);
+    // Opt in to retaining the working area, then export as plaintext.
+    await page.getByTestId('export-keep').check();
+    await submitPlaintextExport(page);
+
+    await expect(page.locator('.modal-title')).toHaveText(/Export Complete/);
+
+    // The file was still written.
+    const files = await readExportFiles(page);
+    expect(files['/mock/exports/export.json'].service).toBe('param');
+
+    // Working param area was NOT cleared (Keep was checked); secret remains too.
+    await page.getByRole('button', { name: 'Close' }).click();
+    await expect(page.locator('.section').nth(0).locator('.entry-item')).toHaveCount(1);
+    await expect(page.locator('.section').nth(1).locator('.entry-item')).toHaveCount(1);
+  });
+
   test('encrypts the export when a passphrase is supplied', async ({ page }) => {
     await setupWailsMocks(page, createStagedForExportState());
     await page.goto('/');


### PR DESCRIPTION
**Step 6/6 of Epic #451** — final end-to-end integration & comprehensive review of the `stage export` / `stage import` migration that replaced `stage stash`. This step adds no new features; it reconciles cross-layer inconsistencies left by stacking the sub-issue PRs independently and runs the full validation matrix.

## Review scope

Re-read the merged feature across all layers and confirmed they fit together:
- **Storage** `internal/staging/store/file/envelope.go` — plaintext JSON envelope, encrypted+base64 payload, `crypt.IsEncrypted` gate, service extraction on read.
- **Usecase** `export.go` / `import.go` / `import_mode.go` — typed `ExportOp`/`ImportOp`, wholesale export + working-area clear (`--keep` retains), merge/overwrite reconciliation, partial-import safety (global overwrite only replaces services present in the source).
- **CLI** `internal/staging/cli/export.go` / `import.go` — flag surfaces match the epic (export: `--keep`/`--yes`/`--force`/`--passphrase-stdin`, no merge/overwrite; import: `--merge`/`--overwrite`/`--yes`/`--force`/`--passphrase-stdin`, no keep), scope refuse-by-default + `--force`, service mismatch hard error, plaintext warning, corruption → typed error.
- **GUI** `internal/gui/staging.go` + Svelte + Playwright — per-service scope resolution (#445), `InspectImportFile` header validation, scope-mismatch confirm (GUI equivalent of `--force`), service-mismatch hard error.
- **Docs** — README/CLAUDE/docs are present-tense and describe the correct flag surfaces (verified via a dedicated docs sweep).

## Inconsistency found and fixed

**GUI export `--keep` was unwired.** The Svelte export flow hard-coded `StagingExport(..., false)`, so the GUI could never retain the working area after export — despite the Wails binding, `App.StagingExport`, its Go integration test (`export --keep retains the working area`), and the CLI all supporting it. Wired an opt-in "Keep staged changes" checkbox into the shared `PassphraseModal` (encrypt/export mode only) and threaded it through, plus a new Playwright test asserting retention. A context-isolated critical review of the diff returned clean.

No other cross-layer divergences warranted a change (error wording differences between GUI and CLI are surface-appropriate; the plaintext-"secrets" wording matches the CLI's generic usage).

## Breaking change fully realized

`git grep -in stash` is clean apart from intentional non-code references (`.github/issue-labeler.yml` keyword, historical test comments, and unrelated "stashes the resolved …" prose). No `stash` code paths and no `stash.json` writer remain.

## Validation matrix

| Gate | Result |
|---|---|
| `mise test` | ✅ pass |
| `mise lint` (`default: all`) | ✅ 0 issues |
| `mise build-gui` | ✅ pass (bindings already 4-arg; no regeneration needed) |
| Playwright (chromium + firefox) | ✅ export/import spec + full suite pass, incl. the new keep test |
| `mise e2e` (AWS/localstack) | ✅ all export/import tests pass |

Notes left to CI:
- **Playwright webkit**: env-blocked on this macOS host (`page.goto('/')` → "server with the specified hostname could not be found" for every test, incl. untouched ones — webkit localhost-resolution quirk). Chromium + Firefox are green. 4 firefox-only `version-history` Compare/diff failures are pre-existing/flaky and unrelated to this feature.
- **`mise e2e-gcloud` / `e2e-azure-appconfig` / `e2e-azure-keyvault`**: compile-verified (whole `-tags e2e` package builds); left to CI (each needs its own emulator).
- **Pre-existing, feature-unrelated e2e caveat**: 3 unrelated staging-option tests (`TestParam_StagingResetWithVersion`, `TestParam_StagingAddWithOptions`, `TestSecret_StagingDeleteOptions`) fail locally *only* when `SUVE_STAGING_KEY` is set. Root cause: the e2e helper `newStore()` uses the keyless `file.NewStore`, which cannot decrypt a working store written by `NewWorkingStore` under a data key. In CI (no key/keychain → plaintext working store) the keyless read succeeds, so they pass. `NewWorkingStore` predates this epic (introduced in #218), so this is out of scope here — flagged for a separate follow-up.

Closes #457
Part of #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)