### PR TITLE
fix(gui): reconcile staging view after a mid-loop apply/reset failure

### DIFF
--- a/internal/gui/frontend/src/lib/StagingView.svelte
+++ b/internal/gui/frontend/src/lib/StagingView.svelte
@@ -161,13 +161,16 @@
       }
 
       applyResult = merged;
-      if (merged.entryFailed === 0 && merged.tagFailed === 0 && merged.conflicts?.length === 0) {
-        await loadStatus();
-      }
     } catch (e) {
       modalError = parseError(e);
     } finally {
+      // Reconcile the view with the backend regardless of a mid-loop rejection.
+      // "Apply All" applies each service in a separate call, and every success
+      // unstages that service's entries on disk. If a later service rejects
+      // (conflict / per-entry failure), the already-applied entries must not keep
+      // rendering as pending with a stale badge until a manual Refresh (#477).
       modalLoading = false;
+      await loadStatus();
     }
   }
 
@@ -198,11 +201,14 @@
         await StagingReset(svc);
       }
       showResetModal = false;
-      await loadStatus();
     } catch (e) {
       modalError = parseError(e);
     } finally {
+      // Reconcile with the backend regardless of a mid-loop rejection: a later
+      // service failing must not leave already-reset services rendering as
+      // pending with a stale badge (#477).
       modalLoading = false;
+      await loadStatus();
     }
   }
 

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -182,6 +182,12 @@ export interface MockState {
     operation: string;
     message: string;
   };
+  // Per-service StagingApply failure: when set, StagingApply rejects for exactly
+  // this service ('param'/'secret') BEFORE unstaging it, leaving its entries
+  // staged — while other services still apply+unstage. Mirrors the real backend
+  // turning any Execute error (conflict / per-entry failure) into a rejected
+  // Wails promise, so "Apply All" can succeed for one service and fail another.
+  stagingApplyFailService?: Service;
 }
 
 // ============================================================================
@@ -1184,6 +1190,11 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
         };
       },
       StagingApply: async (service: string) => {
+        // Reject for the designated service WITHOUT unstaging it, mirroring the
+        // backend turning any Execute error into a rejected promise (#477).
+        if (state.stagingApplyFailService === service) {
+          throw new Error(`staging apply failed for ${service}`);
+        }
         const staged = service === 'param' ? currentBucket().param : currentBucket().secret;
         const tagStaged = service === 'param' ? currentBucket().paramTags : currentBucket().secretTags;
         const entryCount = staged.length;

--- a/internal/gui/frontend/tests/staging-apply-partial-failure.spec.ts
+++ b/internal/gui/frontend/tests/staging-apply-partial-failure.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect, type Page } from '@playwright/test';
+import {
+  setupWailsMocks,
+  createStagedValue,
+  navigateTo,
+} from './fixtures/wails-mock';
+
+// Regression (#477): "Apply All" applies each service in a separate backend
+// call, and every success unstages that service's entries on disk. When a later
+// service rejects (conflict / per-entry failure) the GUI used to jump to catch
+// without reconciling, so the already-applied service kept rendering as pending
+// with a stale badge until a manual Refresh. handleApply/handleReset now run
+// loadStatus() in a finally block so the view always matches the backend.
+
+const applyAllButton = (page: Page) => page.getByRole('button', { name: 'Apply All' });
+const stagingBadge = (page: Page) => page.locator('.staging-count');
+const paramEntry = (page: Page) => page.locator('.entry-item').filter({ hasText: '/app/param-a' });
+const secretEntry = (page: Page) => page.locator('.entry-item').filter({ hasText: 'secret-a' });
+
+test.describe('Staging "Apply All" partial failure (#477)', () => {
+  test('applied service is reconciled after a later service rejects', async ({ page }) => {
+    // param applies first and unstages; secret rejects and stays staged.
+    await setupWailsMocks(page, {
+      stagedParam: [createStagedValue('/app/param-a', 'create', 'pv')],
+      stagedSecret: [createStagedValue('secret-a', 'create', 'sv')],
+      stagingApplyFailService: 'secret',
+    });
+    await page.goto('/');
+    await navigateTo(page, 'Staging');
+
+    // Both services staged before applying; badge shows the combined count of 2.
+    await expect(paramEntry(page)).toBeVisible();
+    await expect(secretEntry(page)).toBeVisible();
+    await expect(stagingBadge(page)).toHaveText('2');
+
+    await applyAllButton(page).click();
+    await page.locator('.form-actions').getByRole('button', { name: 'Apply', exact: true }).click();
+
+    // The secret failure surfaces as a modal error (the apply rejected).
+    await expect(page.locator('.modal-error')).toContainText('staging apply failed for secret');
+
+    // Despite the rejection, the finally-block loadStatus reconciled the view:
+    // the applied param entry is gone (before the fix it stayed pending), while
+    // the failed secret entry remains staged. The badge dropped 2 -> 1.
+    await expect(paramEntry(page)).toHaveCount(0);
+    await expect(secretEntry(page)).toHaveCount(1);
+    await expect(stagingBadge(page)).toHaveText('1');
+  });
+});


### PR DESCRIPTION
## What

Move `loadStatus()` into a `finally` block of `handleApply` / `handleReset` in `StagingView.svelte` so the staging view always reconciles with the backend, even when a per-service apply/reset rejects mid-loop.

## Why

"Apply All" / "Reset All" run one backend call per service, and each success unstages that service's entries on disk. When a later service failed (conflict or per-entry failure), the flow jumped to `catch` without reloading — so already-applied entries kept rendering as pending with a stale badge until a manual Refresh. The same staleness hit a single-service apply with a partial failure.

## Tests

Adds a Playwright regression test that mocks `StagingApply` to resolve for `param` and reject for `secret`, then asserts the applied param entry stops rendering as pending and the sidebar badge decrements 2 → 1. Verified the test fails without the fix and passes with it. The `staging-apply-all` / `staging-reset-all` suites still pass, and `mise build-gui` succeeds.

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)