### PR TITLE
fix(jsonutil): skip TryFormat for invalid UTF-8 to avoid U+FFFD coercion

### DIFF
--- a/internal/jsonutil/json.go
+++ b/internal/jsonutil/json.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"unicode/utf8"
 
 	"github.com/mpyw/suve/internal/cli/output"
 )
@@ -25,7 +26,15 @@ import (
 // decoding into float64 (the default) silently loses integer precision beyond
 // 2^53 and collapses 1.0/1, which would make genuinely different values format
 // identically (and diff as "identical").
+//
+// Values carrying invalid UTF-8 are left unformatted: Go's json encoder coerces
+// invalid bytes to the replacement character (U+FFFD), which would silently
+// mutate the displayed value, so we fall back to the raw string instead.
 func TryFormat(value string) (string, bool) {
+	if !utf8.ValidString(value) {
+		return value, false
+	}
+
 	dec := json.NewDecoder(bytes.NewReader([]byte(value)))
 	dec.UseNumber()
 

--- a/internal/jsonutil/json_test.go
+++ b/internal/jsonutil/json_test.go
@@ -72,6 +72,12 @@ func TestTryFormat(t *testing.T) {
 			wantStr:  `{"a":1} garbage`,
 			wantBool: false,
 		},
+		{
+			name:     "invalid UTF-8 is left unformatted to avoid U+FFFD coercion",
+			input:    "{\"k\":\"\xff\"}",
+			wantStr:  "{\"k\":\"\xff\"}",
+			wantBool: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## What
`jsonutil.TryFormat` now returns `ok=false` (falling back to the raw value) when the input is not valid UTF-8, instead of formatting it.

## Why
Go's `json` encoder coerces invalid-UTF-8 bytes to the Unicode replacement character (U+FFFD). A secret/parameter value carrying e.g. a `0xff` byte was therefore silently mutated when displayed under `--parse-json` (`show` / `log` / `diff`), showing a user data that differs from what is stored. This is the minimal fix from the issue's "Suggested fix": skip formatting when `utf8.ValidString(value)` is false. The verified-clean large-integer (`UseNumber`) behavior is unchanged.

Added a unit test asserting `TryFormat` on a JSON string carrying a `0xff` byte returns `ok=false` and preserves the raw bytes.

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)