### PR TITLE
fix(cli): trim trailing CR in interactive passphrase fallback

### DIFF
--- a/internal/cli/passphrase/passphrase.go
+++ b/internal/cli/passphrase/passphrase.go
@@ -148,5 +148,5 @@ func (p *Prompter) readPassword() (string, error) {
 		return "", err
 	}
 
-	return strings.TrimSuffix(line, "\n"), nil
+	return strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r"), nil
 }

--- a/internal/cli/passphrase/passphrase_test.go
+++ b/internal/cli/passphrase/passphrase_test.go
@@ -104,6 +104,26 @@ func TestPrompter_PromptForDecrypt(t *testing.T) {
 	assert.Equal(t, "mypassword", pass)
 }
 
+func TestPrompter_PromptForDecrypt_CRLF(t *testing.T) {
+	t.Parallel()
+
+	// strings.NewReader is not a terminal.Fder, so readPassword takes the
+	// non-TTY fallback. CRLF input must be normalized the same as ReadFromStdin.
+	stdin := strings.NewReader("pass\r\n")
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	p := &passphrase.Prompter{
+		Stdin:  stdin,
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+
+	pass, err := p.PromptForDecrypt()
+	require.NoError(t, err)
+	assert.Equal(t, "pass", pass)
+}
+
 func TestPrompter_WarnNonTTY(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

`readPassword`'s non-TTY fallback trimmed only `\n`, while `ReadFromStdin` trims `\r\n`. Trim a trailing `\r` in the fallback too, so all non-TTY input paths normalize line endings identically.

## Why

The fallback is reached when stderr is a TTY but stdin is a pipe/file that is not a `terminal.Fder` (e.g. `suve stage import ./dir < creds.txt`). With CRLF input, the interactive path yielded `"pass\r"` while `--passphrase-stdin` yielded `"pass"`, producing different Argon2 keys for the same passphrase and a spurious "wrong passphrase" across paths.

Added a unit test: a `Prompter` with a non-`Fder` stdin containing `"pass\r\n"` now yields `"pass"`.

Closes #479

🤖 Generated with [Claude Code](https://claude.com/claude-code)