### PR TITLE
fix(updatecheck): negative-cache failed probes to suppress retries

### DIFF
--- a/internal/updatecheck/updatecheck.go
+++ b/internal/updatecheck/updatecheck.go
@@ -129,7 +129,9 @@ func (c *checker) notice(ctx context.Context, current string) string {
 
 // resolveLatest returns the latest known version tag. It uses a fresh cache
 // entry (younger than cacheTTL) without any network access; otherwise it
-// fetches from GitHub and refreshes the cache. Any error yields "".
+// fetches from GitHub and refreshes the cache. On fetch failure it records a
+// short-lived negative marker so retries are suppressed within the TTL. Any
+// error yields "".
 func (c *checker) resolveLatest(ctx context.Context) string {
 	path, pathErr := c.cachePath()
 	if pathErr == nil {
@@ -142,8 +144,14 @@ func (c *checker) resolveLatest(ctx context.Context) string {
 
 	latest, err := c.fetchLatest(ctx)
 	if err != nil || latest == "" {
-		// On fetch failure we intentionally leave the cache untouched rather
-		// than nagging or recording an empty result.
+		// On fetch failure, record a short-lived negative marker (an empty
+		// LatestVersion, treated as "checked, nothing to report") so a failed
+		// probe suppresses retries within the TTL rather than paying the HTTP
+		// timeout on every invocation.
+		if pathErr == nil {
+			_ = writeCache(path, cacheEntry{CheckedAt: c.now()})
+		}
+
 		return ""
 	}
 

--- a/internal/updatecheck/updatecheck_test.go
+++ b/internal/updatecheck/updatecheck_test.go
@@ -182,9 +182,38 @@ func TestNotice_FetchError_NoCrash(t *testing.T) {
 
 	assert.Empty(t, c.notice(context.Background(), "v1.2.3"))
 
-	// A failed fetch must not create/refresh the cache.
-	_, ok := readCache(path)
-	assert.False(t, ok, "failed fetch must not write the cache")
+	// A failed fetch records a short-lived negative marker (empty
+	// LatestVersion) so subsequent invocations within the TTL do not retry.
+	entry, ok := readCache(path)
+	require.True(t, ok, "failed fetch must record a negative marker")
+	assert.Empty(t, entry.LatestVersion, "negative marker carries no version")
+	assert.WithinDuration(t, now, entry.CheckedAt, time.Second)
+}
+
+func TestNotice_FetchError_SuppressesRetriesWithinTTL(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "update-check.json")
+
+	fetches := 0
+	c := &checker{
+		now:       fixedNow(now),
+		lookupEnv: noEnv,
+		cachePath: func() (string, error) { return path, nil },
+		fetchLatest: func(context.Context) (string, error) {
+			fetches++
+
+			return "", errors.New("boom")
+		},
+	}
+
+	const calls = 5
+	for range calls {
+		assert.Empty(t, c.notice(context.Background(), "v1.2.3"))
+	}
+
+	assert.Equal(t, 1, fetches, "a failed probe must be attempted at most once within the TTL")
 }
 
 func TestNotice_CachePathError_StillFetches(t *testing.T) {


### PR DESCRIPTION
## What
On a failed release probe, `resolveLatest` now records a short-lived negative marker (bumps `CheckedAt` with an empty `LatestVersion`, treated as "checked, nothing to report") instead of leaving the cache untouched.

## Why
Previously the network was only skipped on a fresh cache hit. A failed fetch wrote nothing, so on an offline/proxied machine (or unwritable `~/.suve`) **every** suve invocation re-attempted the fetch and paid up to the 2s HTTP timeout synchronously at process exit. The negative marker makes a failed probe suppress retries for the rest of the TTL, matching the existing 24h caching contract. When the cache path itself is unusable, behavior is unchanged (there is nowhere to record the marker).

## Tests
- Updated `TestNotice_FetchError_NoCrash` to assert the negative marker is written (empty `LatestVersion`, current `CheckedAt`).
- Added `TestNotice_FetchError_SuppressesRetriesWithinTTL`: an always-erroring fetch with a working cache path is attempted exactly once across 5 `notice()` calls within the TTL.

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)