### PR TITLE
fix(cli): honor TZ in log --oneline date column

### DIFF
--- a/internal/cli/commands/azure/secret/log.go
+++ b/internal/cli/commands/azure/secret/log.go
@@ -102,7 +102,7 @@ func (p *logPresenter) RenderOneline(stdout io.Writer, i, _ int) {
 
 	dateStr := ""
 	if entry.CreatedDate != nil {
-		dateStr = entry.CreatedDate.Format("2006-01-02")
+		dateStr = timeutil.FormatDate(*entry.CreatedDate)
 	}
 
 	stateStr := ""

--- a/internal/cli/commands/gcloud/log.go
+++ b/internal/cli/commands/gcloud/log.go
@@ -93,7 +93,7 @@ func (p *logPresenter) RenderOneline(stdout io.Writer, i, _ int) {
 
 	dateStr := ""
 	if entry.CreatedDate != nil {
-		dateStr = entry.CreatedDate.Format("2006-01-02")
+		dateStr = timeutil.FormatDate(*entry.CreatedDate)
 	}
 
 	stateStr := ""

--- a/internal/cli/commands/param/log.go
+++ b/internal/cli/commands/param/log.go
@@ -85,7 +85,7 @@ func (p *logPresenter) RenderOneline(stdout io.Writer, i, maxValueLength int) {
 	// Compact one-line format: VERSION  DATE  VALUE_PREVIEW
 	dateStr := ""
 	if entry.LastModified != nil {
-		dateStr = entry.LastModified.Format("2006-01-02")
+		dateStr = timeutil.FormatDate(*entry.LastModified)
 	}
 
 	value := entry.Value

--- a/internal/cli/commands/param/log_internal_test.go
+++ b/internal/cli/commands/param/log_internal_test.go
@@ -1,10 +1,15 @@
 package param
 
 import (
+	"bytes"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/mpyw/suve/internal/timeutil"
+	"github.com/mpyw/suve/internal/usecase/param"
 )
 
 func TestTruncateRunes(t *testing.T) {
@@ -36,6 +41,32 @@ func TestTruncateRunes(t *testing.T) {
 			assert.True(t, utf8.ValidString(got), "result must be valid UTF-8")
 		})
 	}
+}
+
+// TestRenderOnelineDateHonorsTZ ensures the oneline date column is converted
+// into the TZ location like every other date, rather than formatting the raw
+// UTC instant. Near a UTC midnight boundary these disagree by a full day (#492).
+func TestRenderOnelineDateHonorsTZ(t *testing.T) {
+	// 2024-01-15T21:30:45Z is still 2024-01-15 in UTC but 2024-01-16 in Tokyo.
+	modified := time.Date(2024, 1, 15, 21, 30, 45, 0, time.UTC)
+
+	timeutil.ResetLocationCache()
+	t.Setenv("TZ", "Asia/Tokyo")
+	t.Cleanup(timeutil.ResetLocationCache)
+
+	p := &logPresenter{
+		result: &param.LogOutput{
+			Entries: []param.LogEntry{
+				{Version: 1, Value: "v", LastModified: &modified},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	p.RenderOneline(&buf, 0, 0)
+
+	assert.Contains(t, buf.String(), "2024-01-16")
+	assert.NotContains(t, buf.String(), "2024-01-15")
 }
 
 func TestSanitizeControl(t *testing.T) {

--- a/internal/cli/commands/secret/log.go
+++ b/internal/cli/commands/secret/log.go
@@ -103,7 +103,7 @@ func (p *logPresenter) RenderOneline(stdout io.Writer, i, _ int) {
 	// Compact one-line format: VERSION_ID  DATE  [LABELS]
 	dateStr := ""
 	if entry.CreatedDate != nil {
-		dateStr = entry.CreatedDate.Format("2006-01-02")
+		dateStr = timeutil.FormatDate(*entry.CreatedDate)
 	}
 
 	labelsStr := ""

--- a/internal/timeutil/timeutil.go
+++ b/internal/timeutil/timeutil.go
@@ -49,6 +49,12 @@ func FormatRFC3339(t time.Time) string {
 	return t.In(GetLocation()).Format(time.RFC3339)
 }
 
+// FormatDate formats the given time as a YYYY-MM-DD date using the
+// timezone from TZ environment variable.
+func FormatDate(t time.Time) string {
+	return t.In(GetLocation()).Format("2006-01-02")
+}
+
 // ResetLocationCache resets the cached location.
 // This is intended for testing purposes only.
 func ResetLocationCache() {


### PR DESCRIPTION
## What
The `log --oneline` date column formatted the raw UTC provider timestamp with `.Format("2006-01-02")`, ignoring `TZ`. Every other date in suve honors `TZ` via `timeutil.GetLocation()`, so near a UTC midnight boundary the oneline date disagreed with the header/JSON date of the same version by a full day (e.g. `TZ=Asia/Tokyo`, instant `2024-01-15T21:30:45Z` → oneline `2024-01-15` vs header `2024-01-16T06:30:45+09:00`).

## Why / How
Added a `timeutil.FormatDate` helper that converts into `GetLocation()` before formatting `YYYY-MM-DD`, and used it at the four affected `RenderOneline` sites (param, secret, gcloud, azure-secret). App Config's oneline is a no-op (unversioned), so those are exactly the four sites.

Added a Go unit test that sets `TZ=Asia/Tokyo` and asserts the oneline date of a near-midnight-UTC instant is the TZ-adjusted date.

Closes #492

🤖 Generated with [Claude Code](https://claude.com/claude-code)