### PR TITLE
fix(aws): map SDK not-found to provider.ErrNotFound in Resolve listing paths

### DIFF
--- a/internal/provider/aws/param/param.go
+++ b/internal/provider/aws/param/param.go
@@ -196,6 +196,11 @@ func (s *Store) getFullHistory(ctx context.Context, name string) ([]types.Parame
 			NextToken:      token,
 		})
 		if err != nil {
+			var notFound *types.ParameterNotFound
+			if errors.As(err, &notFound) {
+				return nil, fmt.Errorf("%w: %s", provider.ErrNotFound, name)
+			}
+
 			return nil, err
 		}
 

--- a/internal/provider/aws/param/param_test.go
+++ b/internal/provider/aws/param/param_test.go
@@ -467,6 +467,24 @@ func TestGet_VersionNotFoundMapsSentinel(t *testing.T) {
 	assert.ErrorIs(t, err, provider.ErrNotFound)
 }
 
+// TestResolve_ShiftNotFoundMapsSentinel guards #481: a ~shift spec drives
+// resolution through GetParameterHistory instead of GetParameter. A missing
+// parameter must still map to provider.ErrNotFound so callers see the same
+// sentinel they get on the no-shift path (Get).
+func TestResolve_ShiftNotFoundMapsSentinel(t *testing.T) {
+	t.Parallel()
+
+	store := param.New(&mockClient{
+		getHistory: func(*ssm.GetParameterHistoryInput) (*ssm.GetParameterHistoryOutput, error) {
+			return nil, &types.ParameterNotFound{Message: aws.String("nope")}
+		},
+	})
+
+	_, err := store.Resolve(t.Context(), "/missing", "~1")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, provider.ErrNotFound)
+}
+
 // paginatedHistoryClient returns history across two pages: page 1 (versions 1,2)
 // with a NextToken, page 2 (version 3) without. Exercises the NextToken loop.
 func paginatedHistoryClient() *mockClient {

--- a/internal/provider/aws/secret/secret.go
+++ b/internal/provider/aws/secret/secret.go
@@ -148,6 +148,11 @@ func (s *Store) listAllVersions(ctx context.Context, name string) ([]types.Secre
 			NextToken:         token,
 		})
 		if err != nil {
+			var notFound *types.ResourceNotFoundException
+			if errors.As(err, &notFound) {
+				return nil, fmt.Errorf("%w: %s", provider.ErrNotFound, name)
+			}
+
 			return nil, err
 		}
 

--- a/internal/provider/aws/secret/secret_test.go
+++ b/internal/provider/aws/secret/secret_test.go
@@ -744,6 +744,24 @@ func TestDescribe_NotFoundMapsSentinel(t *testing.T) {
 	assert.ErrorIs(t, err, provider.ErrNotFound)
 }
 
+// TestResolve_ShiftNotFoundMapsSentinel guards #481: a ~shift (or label) spec
+// drives resolution through ListSecretVersionIds instead of GetSecretValue. A
+// missing secret must still map to provider.ErrNotFound so callers see the same
+// sentinel they get on the no-shift path (Get).
+func TestResolve_ShiftNotFoundMapsSentinel(t *testing.T) {
+	t.Parallel()
+
+	store := secret.New(&mockClient{
+		listVersion: func(*secretsmanager.ListSecretVersionIdsInput) (*secretsmanager.ListSecretVersionIdsOutput, error) {
+			return nil, &types.ResourceNotFoundException{Message: aws.String("nope")}
+		},
+	})
+
+	_, err := store.Resolve(t.Context(), "missing-secret", "~1")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, provider.ErrNotFound)
+}
+
 // TestHistory_DeterministicOnEqualTimestamps guards #314: versions with equal
 // CreatedDate must sort deterministically (version-id descending tie-break),
 // independent of the arbitrary API/list order.


### PR DESCRIPTION
## What

`Resolve` on AWS param/secret takes a listing path (`getFullHistory` / `listAllVersions`) whenever the spec needs it — a `~N` shift, or a Secrets Manager `:LABEL`. On a missing resource those paths returned the raw SDK-flavored error (`failed to get parameter history: ParameterNotFound…` / `failed to list versions: ResourceNotFoundException…`) instead of the `provider.ErrNotFound` sentinel that the no-shift path (`Get`) already returns.

This wraps the AWS not-found types (`*ssm/types.ParameterNotFound`, `*secretsmanager/types.ResourceNotFoundException`) via `errors.As` in `getFullHistory` and `listAllVersions`, mirroring `Get`/`Delete`/`Describe` and the other providers.

## Why

Consistent not-found surfacing: `suve param show /missing~1` now maps to the same clean sentinel as `suve param show /missing`, so `errors.Is(err, provider.ErrNotFound)` holds on every path. Message/UX consistency (issue is Low severity — no control-flow impact).

## Tests

Added provider-neutral unit tests `TestResolve_ShiftNotFoundMapsSentinel` in both the param and secret packages, asserting `errors.Is(Resolve err, provider.ErrNotFound)` when the listing call returns the SDK not-found error.

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)