### PR TITLE
test(staging): align MockStore with real store copy-on-read semantics

### DIFF
--- a/internal/staging/store/testutil/mock_store.go
+++ b/internal/staging/store/testutil/mock_store.go
@@ -4,6 +4,7 @@ package testutil
 import (
 	"context"
 	"maps"
+	"slices"
 
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store"
@@ -133,21 +134,23 @@ func (m *MockStore) UnstageAll(_ context.Context, service staging.Service) error
 		return m.UnstageAllErr
 	}
 
-	switch service {
-	case staging.ServiceParam:
-		m.entries[staging.ServiceParam] = make(map[staging.EntryKey]staging.Entry)
-		m.tags[staging.ServiceParam] = make(map[staging.EntryKey]staging.TagEntry)
-	case staging.ServiceSecret:
-		m.entries[staging.ServiceSecret] = make(map[staging.EntryKey]staging.Entry)
-		m.tags[staging.ServiceSecret] = make(map[staging.EntryKey]staging.TagEntry)
-	case "":
-		m.entries[staging.ServiceParam] = make(map[staging.EntryKey]staging.Entry)
-		m.entries[staging.ServiceSecret] = make(map[staging.EntryKey]staging.Entry)
-		m.tags[staging.ServiceParam] = make(map[staging.EntryKey]staging.TagEntry)
-		m.tags[staging.ServiceSecret] = make(map[staging.EntryKey]staging.TagEntry)
+	for _, svc := range m.servicesFor(service) {
+		m.entries[svc] = make(map[staging.EntryKey]staging.Entry)
+		m.tags[svc] = make(map[staging.EntryKey]staging.TagEntry)
 	}
 
 	return nil
+}
+
+// servicesFor returns the services to operate on for the given service filter.
+// An empty filter expands to the services the mock tracks, mirroring the real
+// store's scope-driven iteration instead of hardcoding {param, secret}.
+func (m *MockStore) servicesFor(service staging.Service) []staging.Service {
+	if service != "" {
+		return []staging.Service{service}
+	}
+
+	return slices.Sorted(maps.Keys(m.entries))
 }
 
 // ListEntries returns all staged entries for a service.
@@ -160,22 +163,9 @@ func (m *MockStore) ListEntries(_ context.Context, service staging.Service) (map
 
 	result := make(map[staging.Service]map[staging.EntryKey]staging.Entry)
 
-	switch service {
-	case staging.ServiceParam:
-		if len(m.entries[staging.ServiceParam]) > 0 {
-			result[staging.ServiceParam] = m.entries[staging.ServiceParam]
-		}
-	case staging.ServiceSecret:
-		if len(m.entries[staging.ServiceSecret]) > 0 {
-			result[staging.ServiceSecret] = m.entries[staging.ServiceSecret]
-		}
-	case "":
-		if len(m.entries[staging.ServiceParam]) > 0 {
-			result[staging.ServiceParam] = m.entries[staging.ServiceParam]
-		}
-
-		if len(m.entries[staging.ServiceSecret]) > 0 {
-			result[staging.ServiceSecret] = m.entries[staging.ServiceSecret]
+	for _, svc := range m.servicesFor(service) {
+		if len(m.entries[svc]) > 0 {
+			result[svc] = maps.Clone(m.entries[svc])
 		}
 	}
 
@@ -192,22 +182,9 @@ func (m *MockStore) ListTags(_ context.Context, service staging.Service) (map[st
 
 	result := make(map[staging.Service]map[staging.EntryKey]staging.TagEntry)
 
-	switch service {
-	case staging.ServiceParam:
-		if len(m.tags[staging.ServiceParam]) > 0 {
-			result[staging.ServiceParam] = m.tags[staging.ServiceParam]
-		}
-	case staging.ServiceSecret:
-		if len(m.tags[staging.ServiceSecret]) > 0 {
-			result[staging.ServiceSecret] = m.tags[staging.ServiceSecret]
-		}
-	case "":
-		if len(m.tags[staging.ServiceParam]) > 0 {
-			result[staging.ServiceParam] = m.tags[staging.ServiceParam]
-		}
-
-		if len(m.tags[staging.ServiceSecret]) > 0 {
-			result[staging.ServiceSecret] = m.tags[staging.ServiceSecret]
+	for _, svc := range m.servicesFor(service) {
+		if len(m.tags[svc]) > 0 {
+			result[svc] = maps.Clone(m.tags[svc])
 		}
 	}
 
@@ -248,13 +225,9 @@ func (m *MockStore) Drain(_ context.Context, service staging.Service, keep bool)
 
 	// Clear storage if not keeping
 	if !keep {
-		m.entries = map[staging.Service]map[staging.EntryKey]staging.Entry{
-			staging.ServiceParam:  make(map[staging.EntryKey]staging.Entry),
-			staging.ServiceSecret: make(map[staging.EntryKey]staging.Entry),
-		}
-		m.tags = map[staging.Service]map[staging.EntryKey]staging.TagEntry{
-			staging.ServiceParam:  make(map[staging.EntryKey]staging.TagEntry),
-			staging.ServiceSecret: make(map[staging.EntryKey]staging.TagEntry),
+		for _, svc := range m.servicesFor("") {
+			m.entries[svc] = make(map[staging.EntryKey]staging.Entry)
+			m.tags[svc] = make(map[staging.EntryKey]staging.TagEntry)
 		}
 	}
 
@@ -279,13 +252,9 @@ func (m *MockStore) WriteState(_ context.Context, service staging.Service, state
 	}
 
 	// Replace all entries and tags
-	m.entries = map[staging.Service]map[staging.EntryKey]staging.Entry{
-		staging.ServiceParam:  make(map[staging.EntryKey]staging.Entry),
-		staging.ServiceSecret: make(map[staging.EntryKey]staging.Entry),
-	}
-	m.tags = map[staging.Service]map[staging.EntryKey]staging.TagEntry{
-		staging.ServiceParam:  make(map[staging.EntryKey]staging.TagEntry),
-		staging.ServiceSecret: make(map[staging.EntryKey]staging.TagEntry),
+	for _, svc := range m.servicesFor("") {
+		m.entries[svc] = make(map[staging.EntryKey]staging.Entry)
+		m.tags[svc] = make(map[staging.EntryKey]staging.TagEntry)
 	}
 
 	if state == nil {

--- a/internal/staging/store/testutil/mock_store.go
+++ b/internal/staging/store/testutil/mock_store.go
@@ -154,8 +154,6 @@ func (m *MockStore) servicesFor(service staging.Service) []staging.Service {
 }
 
 // ListEntries returns all staged entries for a service.
-//
-//nolint:dupl // similar structure to ListTags but different types
 func (m *MockStore) ListEntries(_ context.Context, service staging.Service) (map[staging.Service]map[staging.EntryKey]staging.Entry, error) {
 	if m.ListEntriesErr != nil {
 		return nil, m.ListEntriesErr
@@ -173,8 +171,6 @@ func (m *MockStore) ListEntries(_ context.Context, service staging.Service) (map
 }
 
 // ListTags returns all staged tag changes for a service.
-//
-//nolint:dupl // similar structure to ListEntries but different types
 func (m *MockStore) ListTags(_ context.Context, service staging.Service) (map[staging.Service]map[staging.EntryKey]staging.TagEntry, error) {
 	if m.ListTagsErr != nil {
 		return nil, m.ListTagsErr

--- a/internal/staging/store/testutil/mock_store_test.go
+++ b/internal/staging/store/testutil/mock_store_test.go
@@ -1,0 +1,73 @@
+package testutil_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/staging"
+	"github.com/mpyw/suve/internal/staging/store"
+	"github.com/mpyw/suve/internal/staging/store/file"
+	"github.com/mpyw/suve/internal/staging/store/testutil"
+)
+
+// assertListCopyOnRead verifies that the store's List methods return brand-new
+// maps: mutating a returned map must not leak into subsequent reads. This is the
+// real file store's copy-on-read contract that MockStore must also honor.
+func assertListCopyOnRead(t *testing.T, rw store.ReadWriteOperator) {
+	t.Helper()
+
+	ctx := context.Background()
+	key := staging.EntryKey{Name: "/a"}
+
+	require.NoError(t, rw.StageEntry(ctx, staging.ServiceParam, key, staging.Entry{
+		Operation: staging.OperationUpdate,
+		Value:     lo.ToPtr("v1"),
+		StagedAt:  time.Now(),
+	}))
+	require.NoError(t, rw.StageTag(ctx, staging.ServiceParam, key, staging.TagEntry{
+		Add:      map[string]string{"env": "prod"},
+		StagedAt: time.Now(),
+	}))
+
+	// Mutating the map returned by ListEntries must not affect stored state.
+	entries, err := rw.ListEntries(ctx, staging.ServiceParam)
+	require.NoError(t, err)
+	require.Len(t, entries[staging.ServiceParam], 1)
+	delete(entries[staging.ServiceParam], key)
+
+	entries, err = rw.ListEntries(ctx, staging.ServiceParam)
+	require.NoError(t, err)
+	assert.Len(t, entries[staging.ServiceParam], 1, "ListEntries must return a copy, not the live map")
+
+	// Mutating the map returned by ListTags must not affect stored state.
+	tags, err := rw.ListTags(ctx, staging.ServiceParam)
+	require.NoError(t, err)
+	require.Len(t, tags[staging.ServiceParam], 1)
+	delete(tags[staging.ServiceParam], key)
+
+	tags, err = rw.ListTags(ctx, staging.ServiceParam)
+	require.NoError(t, err)
+	assert.Len(t, tags[staging.ServiceParam], 1, "ListTags must return a copy, not the live map")
+}
+
+// TestListCopyOnRead_Parity pins MockStore to the real file store's
+// copy-on-read semantics for the List methods.
+func TestListCopyOnRead_Parity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("mock", func(t *testing.T) {
+		t.Parallel()
+		assertListCopyOnRead(t, testutil.NewMockStore())
+	})
+
+	t.Run("file", func(t *testing.T) {
+		t.Parallel()
+		assertListCopyOnRead(t, file.NewStoreWithPath(filepath.Join(t.TempDir(), "stage.json")))
+	})
+}


### PR DESCRIPTION
## What
- `MockStore.ListEntries`/`ListTags` now return `maps.Clone` copies instead of the live internal maps, matching the real file store's copy-on-read contract.
- Replaced the hardcoded `{param, secret}` iteration in `ListEntries`, `ListTags`, `UnstageAll`, `Drain`, and `WriteState` with a `servicesFor` helper that iterates the services the mock tracks (mirroring the real store's scope-driven `servicesFor`).
- Added a parity unit test running the same copy-on-read assertions against both `MockStore` and the real file store.

## Why
The real `Store.ListEntries`/`ListTags` read the file fresh per call and return brand-new maps; the mock aliased its internal maps, so a test that mutates a returned map (or holds it across an Unstage) would pass against the mock while diverging against the real store. This is test-fidelity hardening with no production impact.

Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)