### PR TITLE
fix(staging): discard orphan tags on delete/reset so apply can't wedge

### DIFF
--- a/e2e/param_test.go
+++ b/e2e/param_test.go
@@ -373,6 +373,60 @@ func TestParam_StagingWorkflow(t *testing.T) {
 	})
 }
 
+// TestParam_StagingTagThenDeleteApply reproduces the #470 wedge: staging a tag
+// on an existing parameter and then staging its deletion must NOT leave an
+// orphan tag change. Applying must delete the parameter and finish clean rather
+// than persistently failing when ApplyTags runs against the deleted resource.
+func TestParam_StagingTagThenDeleteApply(t *testing.T) {
+	setupEnv(t)
+	setupTempHome(t)
+
+	paramName := "/suve-e2e-staging/tag-delete/param"
+
+	// Cleanup
+	_, _, _ = runCommand(t, paramdelete.Command(), "--yes", paramName)
+	t.Cleanup(func() {
+		_, _, _ = runCommand(t, paramdelete.Command(), "--yes", paramName)
+	})
+
+	// 1. Create the parameter.
+	t.Run("setup", func(t *testing.T) {
+		_, _, err := runCommand(t, paramcreate.Command(), paramName, "original-value")
+		require.NoError(t, err)
+	})
+
+	// 2. Stage a tag against the existing parameter.
+	t.Run("stage-tag", func(t *testing.T) {
+		_, _, err := runSubCommand(t, paramstage.Command(), "tag", paramName, "env=prod")
+		require.NoError(t, err)
+	})
+
+	// 3. Stage the parameter for deletion - this must discard the staged tag.
+	t.Run("stage-delete", func(t *testing.T) {
+		_, _, err := runSubCommand(t, paramstage.Command(), "delete", paramName)
+		require.NoError(t, err)
+	})
+
+	// 4. Apply - must succeed (not wedge on the orphan tag) and delete the param.
+	t.Run("apply", func(t *testing.T) {
+		_, _, err := runSubCommand(t, paramstage.Command(), "apply", "--yes", "--ignore-conflicts")
+		require.NoError(t, err)
+	})
+
+	// 5. Status must be empty - nothing left staged.
+	t.Run("status-after-apply", func(t *testing.T) {
+		stdout, _, err := runSubCommand(t, paramstage.Command(), "status")
+		require.NoError(t, err)
+		assert.NotContains(t, stdout, paramName)
+	})
+
+	// 6. Parameter must be gone.
+	t.Run("verify-deleted", func(t *testing.T) {
+		_, _, err := runCommand(t, cmdparam.ShowCommand(), paramName)
+		assert.Error(t, err, "expected error after deletion")
+	})
+}
+
 // TestParam_StagingAdd tests staging a new parameter (create operation).
 func TestParam_StagingAdd(t *testing.T) {
 	setupEnv(t)

--- a/internal/staging/transition/reducer.go
+++ b/internal/staging/transition/reducer.go
@@ -129,10 +129,14 @@ func reduceEdit(state EntryState, action EntryActionEdit) EntryTransitionResult 
 //   - CurrentValue=nil + Create    → NotStaged  (unstage, also unstage tags)
 //   - CurrentValue=nil + Update    → ERROR      (should not happen)
 //   - CurrentValue=nil + Delete    → ERROR      (should not happen)
-//   - CurrentValue!=nil + NotStaged → Delete    (stage for deletion)
+//   - CurrentValue!=nil + NotStaged → Delete    (stage for deletion, also unstage tags)
 //   - CurrentValue!=nil + Create    → NotStaged (unstage, also unstage tags) - should not happen
-//   - CurrentValue!=nil + Update    → Delete    (convert to delete)
+//   - CurrentValue!=nil + Update    → Delete    (convert to delete, also unstage tags)
 //   - CurrentValue!=nil + Delete    → Delete    (no-op)
+//
+// Tags are always discarded when the resource ends up gone (Create unstaged, or
+// staged for deletion): a staged tag change against an absent resource would
+// orphan and permanently wedge apply.
 func reduceDelete(state EntryState) EntryTransitionResult {
 	var discardTags bool
 
@@ -144,7 +148,10 @@ func reduceDelete(state EntryState) EntryTransitionResult {
 
 	switch state.StagedState.(type) {
 	case EntryStagedStateNotStaged, EntryStagedStateUpdate:
+		// Discard tags too - the resource is being deleted, so staged tags would
+		// orphan and fail at apply time.
 		state.StagedState = EntryStagedStateDelete{}
+		discardTags = true
 	case EntryStagedStateCreate:
 		// Discard tags too - resource was never created
 		state.StagedState = EntryStagedStateNotStaged{}
@@ -159,11 +166,16 @@ func reduceDelete(state EntryState) EntryTransitionResult {
 // reduceReset handles the RESET action.
 //
 // Transition rules:
-//   - Any → NotStaged  (unstage entry only, tags preserved)
+//   - Create → NotStaged  (unstage entry, also unstage tags - resource was never created)
+//   - Any    → NotStaged  (unstage entry only, tags preserved)
 func reduceReset(state EntryState) EntryTransitionResult {
+	// Discard tags when resetting a staged CREATE: the resource never existed, so
+	// any staged tag change would orphan and wedge apply.
+	_, isCreate := state.StagedState.(EntryStagedStateCreate)
+
 	state.StagedState = EntryStagedStateNotStaged{}
 
-	return EntryTransitionResult{NewState: state}
+	return EntryTransitionResult{NewState: state, DiscardTags: isCreate}
 }
 
 // reduceTag handles the TAG action.

--- a/internal/staging/transition/reducer_internal_test.go
+++ b/internal/staging/transition/reducer_internal_test.go
@@ -183,12 +183,13 @@ func TestReduceEntry_Delete(t *testing.T) {
 		wantDiscardTags bool
 	}{
 		{
-			name: "NotStaged -> Delete",
+			name: "NotStaged -> Delete (also unstage tags)",
 			state: EntryState{
 				CurrentValue: lo.ToPtr("current"),
 				StagedState:  EntryStagedStateNotStaged{},
 			},
-			wantState: EntryStagedStateDelete{},
+			wantState:       EntryStagedStateDelete{},
+			wantDiscardTags: true,
 		},
 		{
 			name: "Create -> NotStaged (unstage, also unstage tags)",
@@ -200,12 +201,13 @@ func TestReduceEntry_Delete(t *testing.T) {
 			wantDiscardTags: true,
 		},
 		{
-			name: "Update -> Delete",
+			name: "Update -> Delete (also unstage tags)",
 			state: EntryState{
 				CurrentValue: lo.ToPtr("current"),
 				StagedState:  EntryStagedStateUpdate{DraftValue: "updated"},
 			},
-			wantState: EntryStagedStateDelete{},
+			wantState:       EntryStagedStateDelete{},
+			wantDiscardTags: true,
 		},
 		{
 			name: "Delete -> Delete (no-op)",
@@ -233,9 +235,10 @@ func TestReduceEntry_Reset(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		state     EntryState
-		wantState EntryStagedState
+		name            string
+		state           EntryState
+		wantState       EntryStagedState
+		wantDiscardTags bool
 	}{
 		{
 			name: "NotStaged -> NotStaged",
@@ -246,12 +249,13 @@ func TestReduceEntry_Reset(t *testing.T) {
 			wantState: EntryStagedStateNotStaged{},
 		},
 		{
-			name: "Create -> NotStaged",
+			name: "Create -> NotStaged (also unstage tags)",
 			state: EntryState{
 				CurrentValue: nil,
 				StagedState:  EntryStagedStateCreate{DraftValue: "draft"},
 			},
-			wantState: EntryStagedStateNotStaged{},
+			wantState:       EntryStagedStateNotStaged{},
+			wantDiscardTags: true,
 		},
 		{
 			name: "Update -> NotStaged",
@@ -277,7 +281,7 @@ func TestReduceEntry_Reset(t *testing.T) {
 
 			result := ReduceEntry(tt.state, EntryActionReset{})
 			assert.Equal(t, tt.wantState, result.NewState.StagedState)
-			assert.False(t, result.DiscardTags)
+			assert.Equal(t, tt.wantDiscardTags, result.DiscardTags)
 			assert.NoError(t, result.Error)
 		})
 	}

--- a/internal/usecase/staging/delete.go
+++ b/internal/usecase/staging/delete.go
@@ -88,28 +88,37 @@ func (u *DeleteUseCase) Execute(ctx context.Context, input DeleteInput) (*Delete
 		return nil, result.Error
 	}
 
-	// Check if we should unstage a CREATE
-	if result.DiscardTags {
-		// CREATE -> NotStaged: unstage entry and tags
+	// A CREATE reduces to NotStaged (nothing to delete on AWS); anything else
+	// stages a DELETE. In both cases DiscardTags may be set, and the resource
+	// ends up gone, so orphan staged tags must be unstaged too.
+	_, unstaged := result.NewState.StagedState.(transition.EntryStagedStateNotStaged)
+
+	if unstaged {
+		// CREATE -> NotStaged: unstage the entry.
 		if err := u.Store.UnstageEntry(ctx, service, key); err != nil {
 			return nil, err
 		}
-		// Unstage tags too (ignore ErrNotStaged)
+	} else {
+		// Stage delete with options (single persist)
+		if err := u.stageDeleteWithOptions(
+			ctx, service, key, lastModified, hasDeleteOptions, input.Force, input.RecoveryWindow,
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	// Discard orphan staged tags (ignore ErrNotStaged) - the resource is gone.
+	if result.DiscardTags {
 		if err := u.Store.UnstageTag(ctx, service, key); err != nil && !errors.Is(err, staging.ErrNotStaged) {
 			return nil, err
 		}
+	}
 
+	if unstaged {
 		return &DeleteOutput{
 			Name:     input.Key.Name,
 			Unstaged: true,
 		}, nil
-	}
-
-	// Stage delete with options (single persist)
-	if err := u.stageDeleteWithOptions(
-		ctx, service, key, lastModified, hasDeleteOptions, input.Force, input.RecoveryWindow,
-	); err != nil {
-		return nil, err
 	}
 
 	output := &DeleteOutput{

--- a/internal/usecase/staging/delete_test.go
+++ b/internal/usecase/staging/delete_test.go
@@ -357,6 +357,38 @@ func TestDeleteUseCase_Execute_DeleteOnUpdate(t *testing.T) {
 	assert.Equal(t, staging.OperationDelete, entry.Operation)
 }
 
+func TestDeleteUseCase_Execute_ExistingWithStagedTags_UnstagesTags(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	// A tag was staged against an existing resource (entry NotStaged, tag staged).
+	require.NoError(t, store.StageTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/to-delete"}, staging.TagEntry{
+		Add:      map[string]string{"env": "prod"},
+		StagedAt: time.Now(),
+	}))
+
+	uc := &usecasestaging.DeleteUseCase{
+		Strategy: newMockDeleteStrategy(false),
+		Store:    store,
+	}
+
+	// Deleting the resource must stage a DELETE and discard the orphan tags so
+	// they don't fail against a resource that no longer exists (#470).
+	output, err := uc.Execute(t.Context(), usecasestaging.DeleteInput{
+		Key: staging.EntryKey{Name: "/app/to-delete"},
+	})
+	require.NoError(t, err)
+	assert.False(t, output.Unstaged)
+
+	entry, err := store.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/to-delete", Namespace: ""})
+	require.NoError(t, err)
+	assert.Equal(t, staging.OperationDelete, entry.Operation)
+
+	// Tags must be gone.
+	_, err = store.GetTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/to-delete", Namespace: ""})
+	assert.ErrorIs(t, err, staging.ErrNotStaged)
+}
+
 func TestDeleteUseCase_Execute_UnstageTagError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/usecase/staging/reset_test.go
+++ b/internal/usecase/staging/reset_test.go
@@ -95,6 +95,41 @@ func TestResetUseCase_Execute_NotStaged(t *testing.T) {
 	assert.Equal(t, usecasestaging.ResetResultNotStaged, output.Type)
 }
 
+func TestResetUseCase_Execute_UnstageCreate_DiscardsTags(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	// A CREATE was staged for a not-yet-existing resource, then tagged.
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/new"}, staging.Entry{
+		Operation: staging.OperationCreate,
+		Value:     lo.ToPtr("value"),
+		StagedAt:  time.Now(),
+	}))
+	require.NoError(t, store.StageTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/new"}, staging.TagEntry{
+		Add:      map[string]string{"env": "prod"},
+		StagedAt: time.Now(),
+	}))
+
+	uc := &usecasestaging.ResetUseCase{
+		Parser: newMockParser(),
+		Store:  store,
+	}
+
+	// Resetting the CREATE must discard the orphan tags too - the resource never
+	// existed, so a tag-only change would wedge apply (#470).
+	output, err := uc.Execute(t.Context(), usecasestaging.ResetInput{
+		Spec: "/app/new",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, usecasestaging.ResetResultUnstaged, output.Type)
+
+	// Both entry and tags must be gone.
+	_, err = store.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/new", Namespace: ""})
+	assert.ErrorIs(t, err, staging.ErrNotStaged)
+	_, err = store.GetTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/new", Namespace: ""})
+	assert.ErrorIs(t, err, staging.ErrNotStaged)
+}
+
 func TestResetUseCase_Execute_UnstageAll(t *testing.T) {
 	t.Parallel()
 

--- a/internal/usecase/staging/reset_test.go
+++ b/internal/usecase/staging/reset_test.go
@@ -125,7 +125,7 @@ func TestResetUseCase_Execute_UnstageCreate_DiscardsTags(t *testing.T) {
 
 	// Both entry and tags must be gone.
 	_, err = store.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/new", Namespace: ""})
-	assert.ErrorIs(t, err, staging.ErrNotStaged)
+	require.ErrorIs(t, err, staging.ErrNotStaged)
 	_, err = store.GetTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/new", Namespace: ""})
 	assert.ErrorIs(t, err, staging.ErrNotStaged)
 }


### PR DESCRIPTION
## What

Two staging transitions left a staged tag change pointing at a resource that would not exist at apply time. Entries apply before tags, so `ApplyTags` failed against the deleted/absent resource; the failed `TagEntry` is only unstaged on success, so **every subsequent `stage apply` re-failed** and only `stage reset --all` could recover (nuking all other staged work).

- `reduceDelete`: now sets `DiscardTags=true` for `NotStaged/Update → Delete` (previously only the `Create` case), so deleting a resource also drops its staged tags.
- `reduceReset`: now create-aware — discards staged tags when the prior state was `Create` (the resource never existed).
- `delete` usecase: honors `DiscardTags` on the stage-delete path too (it bypasses the executor), unstaging orphan tags after staging the delete.

## Why

Prevents `stage apply` from wedging on orphan tags after the tag+delete (Path A) and add+tag+reset (Path B) flows described in #470.

## Tests

- Reducer unit tests: `Delete`/`Reset` now assert `DiscardTags` for the affected transitions.
- Usecase tests: `tag → delete` unstages the tag while staging the delete; `create + tag → reset` discards both.
- E2E: `TestParam_StagingTagThenDeleteApply` exercises tag+delete+apply on a param via localstack.

## Notes

Scope limited to the forward fix per the issue's suggested fix. The optional "let untag/reset clear already-orphaned tags to recover pre-existing wedged states" recovery path was intentionally not included: it would change reset/untag semantics for legitimate tag-only staging (a normal state) and widen scope/risk beyond a minimal fix.

Closes #470

🤖 Generated with [Claude Code](https://claude.com/claude-code)