### PR TITLE
fix(gui): populate ParamListEntry.Secret/Type from the domain value type

### DIFF
--- a/internal/gui/param.go
+++ b/internal/gui/param.go
@@ -144,8 +144,10 @@ func (a *App) ParamList(prefix string, recursive bool, withValue bool, filter st
 	entries := make([]ParamListEntry, len(result.Entries))
 	for i, e := range result.Entries {
 		entries[i] = ParamListEntry{
-			Name:  e.Name,
-			Value: e.Value,
+			Name:   e.Name,
+			Type:   paramtype.Display(e.Type),
+			Secret: e.Type == domain.ValueTypeSecret,
+			Value:  e.Value,
 		}
 	}
 
@@ -186,7 +188,14 @@ func (a *App) paramListWithNamespaces(
 			continue
 		}
 
-		entry := ParamListEntry{Name: item.Key, Namespace: item.Namespace}
+		// App Configuration values are always plaintext (never a secret), so the
+		// domain value type is fixed; mirror it into Type/Secret like the SSM path.
+		entry := ParamListEntry{
+			Name:      item.Key,
+			Type:      paramtype.Display(domain.ValueTypePlaintext),
+			Secret:    false,
+			Namespace: item.Namespace,
+		}
 		if withValue {
 			entry.Value = lo.ToPtr(item.Value)
 		}

--- a/internal/gui/param_internal_test.go
+++ b/internal/gui/param_internal_test.go
@@ -9,10 +9,20 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mpyw/suve/internal/cli/commands/param/paramtype"
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/azure/appconfig"
 	"github.com/mpyw/suve/internal/provider/providermock"
 )
+
+// fakeFactory returns a fixed store for any scope/kind, so a test can inject a
+// providermock into the GUI's package-global registry.
+type fakeFactory struct{ store provider.Store }
+
+func (f fakeFactory) Store(context.Context, provider.Scope, provider.Kind) (provider.Store, error) {
+	return f.store, nil
+}
 
 // fakeNamespaceLister is a minimal appConfigNamespaceLister for testing the
 // Azure App Configuration all-namespaces list path without a real client.
@@ -23,6 +33,68 @@ type fakeNamespaceLister struct {
 
 func (f *fakeNamespaceLister) ListWithNamespaces(_ context.Context) ([]appconfig.KeyNamespace, error) {
 	return f.items, f.err
+}
+
+// TestParamList_PopulatesSecretAndType covers the generic (non-App-Config) list
+// path: Secret/Type must mirror the domain value type of each entry so a future
+// list-mode masking that trusts entry.secret masks SecureString params (#491).
+func TestParamList_PopulatesSecretAndType(t *testing.T) {
+	// Not parallel: overrides the package-global registry.
+	store := &providermock.Store{
+		ListFunc: func(context.Context) ([]string, error) {
+			return []string{"/my/plain", "/my/secure"}, nil
+		},
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			if name == "/my/secure" {
+				return &domain.Entry{Name: name, Value: "s", Type: domain.ValueTypeSecret}, nil
+			}
+
+			return &domain.Entry{Name: name, Value: "p", Type: domain.ValueTypePlaintext}, nil
+		},
+	}
+
+	orig := registry
+	registry = provider.NewRegistry()
+	registry.Register(provider.ProviderAWS, fakeFactory{store: store})
+
+	t.Cleanup(func() { registry = orig })
+
+	app := &App{ctx: t.Context(), scope: provider.Scope{Provider: provider.ProviderAWS}}
+
+	// withValue=true so each entry's value (and thus its type) is fetched.
+	res, err := app.ParamList("", false, true, "", 0, "")
+	require.NoError(t, err)
+	require.Len(t, res.Entries, 2)
+
+	byName := make(map[string]ParamListEntry, len(res.Entries))
+	for _, e := range res.Entries {
+		byName[e.Name] = e
+	}
+
+	assert.False(t, byName["/my/plain"].Secret, "plaintext param must not be a secret")
+	assert.Equal(t, paramtype.String, byName["/my/plain"].Type)
+
+	assert.True(t, byName["/my/secure"].Secret, "SecureString param must be flagged secret")
+	assert.Equal(t, paramtype.SecureString, byName["/my/secure"].Type)
+}
+
+// TestParamListWithNamespaces_PopulatesSecretAndType covers the App
+// Configuration list path: its values are always plaintext, so Secret stays
+// false and Type is the plaintext display, matching the detail path (#491).
+func TestParamListWithNamespaces_PopulatesSecretAndType(t *testing.T) {
+	t.Parallel()
+
+	lister := &fakeNamespaceLister{
+		items: []appconfig.KeyNamespace{{Key: "app/config", Namespace: "dev", Value: "v"}},
+	}
+	app := &App{ctx: t.Context()}
+
+	res, err := app.paramListWithNamespaces(lister, "", true, true, "")
+	require.NoError(t, err)
+	require.Len(t, res.Entries, 1)
+
+	assert.False(t, res.Entries[0].Secret, "App Configuration values are never secrets")
+	assert.Equal(t, paramtype.String, res.Entries[0].Type)
 }
 
 func TestParamListWithNamespaces_PopulatesNamespace(t *testing.T) {

--- a/internal/gui/param_internal_test.go
+++ b/internal/gui/param_internal_test.go
@@ -38,6 +38,7 @@ func (f *fakeNamespaceLister) ListWithNamespaces(_ context.Context) ([]appconfig
 // TestParamList_PopulatesSecretAndType covers the generic (non-App-Config) list
 // path: Secret/Type must mirror the domain value type of each entry so a future
 // list-mode masking that trusts entry.secret masks SecureString params (#491).
+//
 //nolint:paralleltest // overrides the package-global registry.
 func TestParamList_PopulatesSecretAndType(t *testing.T) {
 	store := &providermock.Store{

--- a/internal/gui/param_internal_test.go
+++ b/internal/gui/param_internal_test.go
@@ -38,8 +38,8 @@ func (f *fakeNamespaceLister) ListWithNamespaces(_ context.Context) ([]appconfig
 // TestParamList_PopulatesSecretAndType covers the generic (non-App-Config) list
 // path: Secret/Type must mirror the domain value type of each entry so a future
 // list-mode masking that trusts entry.secret masks SecureString params (#491).
+//nolint:paralleltest // overrides the package-global registry.
 func TestParamList_PopulatesSecretAndType(t *testing.T) {
-	// Not parallel: overrides the package-global registry.
 	store := &providermock.Store{
 		ListFunc: func(context.Context) ([]string, error) {
 			return []string{"/my/plain", "/my/secure"}, nil

--- a/internal/usecase/param/list.go
+++ b/internal/usecase/param/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/mpyw/suve/internal/debug"
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/parallel"
 	"github.com/mpyw/suve/internal/provider"
 )
@@ -25,6 +26,9 @@ type ListInput struct {
 type ListEntry struct {
 	Name  string
 	Value *string // nil when error or not requested
+	// Type is the provider-neutral value type. It is only known when values are
+	// fetched (WithValue); for name-only listings it stays the zero value.
+	Type  domain.ValueType
 	Error error
 }
 
@@ -130,15 +134,16 @@ func (u *ListUseCase) buildOutput(ctx context.Context, withValue bool, names []s
 		return output
 	}
 
-	values, errs := u.fetchValues(ctx, names)
+	entries, errs := u.fetchEntries(ctx, names)
 
 	for _, name := range names {
 		entry := ListEntry{Name: name}
 
 		if err, hasErr := errs[name]; hasErr {
 			entry.Error = err
-		} else if val, hasVal := values[name]; hasVal {
-			entry.Value = lo.ToPtr(val)
+		} else if e, hasEntry := entries[name]; hasEntry {
+			entry.Value = lo.ToPtr(e.Value)
+			entry.Type = e.Type
 		}
 
 		output.Entries = append(output.Entries, entry)
@@ -147,25 +152,25 @@ func (u *ListUseCase) buildOutput(ctx context.Context, withValue bool, names []s
 	return output
 }
 
-// fetchValues retrieves each parameter's latest value in parallel, returning
-// maps of name->value and name->error.
-func (u *ListUseCase) fetchValues(ctx context.Context, names []string) (map[string]string, map[string]error) {
+// fetchEntries retrieves each parameter's latest entry in parallel, returning
+// maps of name->entry and name->error.
+func (u *ListUseCase) fetchEntries(ctx context.Context, names []string) (map[string]domain.Entry, map[string]error) {
 	if len(names) == 0 {
 		return nil, nil
 	}
 
 	nameMap := lo.SliceToMap(names, func(name string) (string, string) { return name, name })
 
-	results := parallel.ExecuteMap(ctx, nameMap, func(ctx context.Context, _ string, name string) (string, error) {
+	results := parallel.ExecuteMap(ctx, nameMap, func(ctx context.Context, _ string, name string) (domain.Entry, error) {
 		entry, err := u.Reader.Get(ctx, name, provider.VersionRef{})
 		if err != nil {
-			return "", err
+			return domain.Entry{}, err
 		}
 
-		return entry.Value, nil
+		return *entry, nil
 	})
 
-	values := make(map[string]string)
+	entries := make(map[string]domain.Entry)
 	errs := make(map[string]error)
 
 	for name, result := range results {
@@ -175,8 +180,8 @@ func (u *ListUseCase) fetchValues(ctx context.Context, names []string) (map[stri
 			continue
 		}
 
-		values[name] = result.Value
+		entries[name] = result.Value
 	}
 
-	return values, errs
+	return entries, errs
 }


### PR DESCRIPTION
## What
Populate `ParamListEntry.Secret` and `.Type` in both GUI `ParamList` loops (the generic/non-App-Config path and the Azure App Configuration path) from the domain value type, mirroring the detail path (`ParamShow`).

To make the value type available in the list, the domain value type is now plumbed through `param.ListUseCase` — captured from the `Get` already performed when values are fetched (`WithValue`). App Configuration values are always plaintext, so that path sets `Secret=false` / `Type=String`.

## Why
`ParamListEntry` declared `Type`/`Secret` — the latter's doc comment says it drives UI masking — but neither list path ever set them, so they were always `""`/`false`. This was a latent DTO trap (#491): a future list-mode masking that trusts `entry.secret` would silently never mask SecureString params.

## Tests
- Added `TestParamList_PopulatesSecretAndType` (generic path, via a providermock injected into the registry): SecureString → `Secret=true`/`Type=SecureString`, String → `Secret=false`/`Type=String`.
- Added `TestParamListWithNamespaces_PopulatesSecretAndType` (App Configuration path): `Secret=false`/`Type=String`.
- Go-side only with no currently visible GUI behavior, so no Playwright test.

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)