### PR TITLE
fix(staging): refuse to mint a replacement key when encrypted state exists (#475)

### DIFF
--- a/internal/staging/store/file/internal/keyprovider/keyprovider.go
+++ b/internal/staging/store/file/internal/keyprovider/keyprovider.go
@@ -5,8 +5,11 @@
 //
 //  1. SUVE_STAGING_KEY env var, if set: base64-standard of exactly 32 bytes.
 //     If set but invalid, a clear error is returned (no silent fall-through).
-//  2. Otherwise the OS keychain (get-or-create): fetch the stored key, or
-//     generate 32 random bytes, store them, and use them.
+//  2. Otherwise the OS keychain: fetch the stored key. When the keychain is
+//     reachable but empty, Resolve reports needsMint instead of generating a
+//     key itself, so the caller can refuse to mint a replacement when encrypted
+//     working state already exists (a fresh key could not decrypt it). Minting
+//     the 32 random bytes and storing them happens in Mint.
 //  3. Otherwise (no keyring backend on this platform): plaintext, with the
 //     caller expected to warn the user once.
 //
@@ -58,6 +61,12 @@ var (
 	randReader     = rand.Reader
 )
 
+// ErrKeychainKeyNotFound signals that the OS keychain is reachable but holds no
+// stored staging data key. It is the cause reported when a lost keychain entry
+// is detected alongside encrypted working state.
+var ErrKeychainKeyNotFound = errors.New(
+	"no staging data key found in the OS keychain (it may have been deleted or reset)")
+
 // KeychainUnavailableError wraps a hard OS-keychain failure — a locked
 // keychain, an unreachable dbus, a corrupted stored key, or a failed store.
 //
@@ -76,33 +85,41 @@ func (e *KeychainUnavailableError) Unwrap() error { return e.Err }
 
 // Resolve returns the data key for the working staging store.
 //
-// The returned key is 32 bytes when plaintext is false. When plaintext is
-// true, key is nil and the caller should operate without encryption (and warn
-// the user once). err is non-nil for an invalid SUVE_STAGING_KEY value or for a
+// The returned key is 32 bytes when plaintext and needsMint are both false.
+// When plaintext is true, key is nil and the caller should operate without
+// encryption (and warn the user once). When needsMint is true, the keychain is
+// reachable but has no stored key yet: key is nil and the caller must decide
+// whether to mint one (safe only when no encrypted working state exists) by
+// calling Mint. err is non-nil for an invalid SUVE_STAGING_KEY value or for a
 // hard keychain failure (as a *KeychainUnavailableError).
-func Resolve() (key []byte, plaintext bool, err error) {
+func Resolve() (key []byte, plaintext, needsMint bool, err error) {
 	// 1. Environment variable override.
 	if raw, ok := lookupEnvFunc(EnvStagingKey); ok {
 		envKey, decErr := decodeEnvKey(raw)
 		if decErr != nil {
-			return nil, false, decErr
+			return nil, false, false, decErr
 		}
 
-		return envKey, false, nil
+		return envKey, false, false, nil
 	}
 
-	// 2. OS keychain get-or-create.
-	k, kcErr := getOrCreateKeychainKey()
+	// 2. OS keychain lookup (minting is deferred to Mint so the caller can gate
+	// it on the absence of encrypted state).
+	k, found, kcErr := getKeychainKey()
 
 	switch {
-	case kcErr == nil:
-		return k, false, nil
+	case kcErr == nil && found:
+		return k, false, false, nil
+	case kcErr == nil && !found:
+		// Keychain reachable but empty: genuine first run OR the entry was lost
+		// while state persists. The caller gates minting accordingly.
+		return nil, false, true, nil
 	case errors.Is(kcErr, keyring.ErrUnsupportedPlatform):
 		// 3. No keyring backend on this platform: documented plaintext fallback.
-		return nil, true, nil
+		return nil, true, false, nil
 	default:
 		// Hard keychain failure: surfaced, never silently downgraded.
-		return nil, false, &KeychainUnavailableError{Err: kcErr}
+		return nil, false, false, &KeychainUnavailableError{Err: kcErr}
 	}
 }
 
@@ -120,29 +137,37 @@ func decodeEnvKey(raw string) ([]byte, error) {
 	return decoded, nil
 }
 
-// getOrCreateKeychainKey fetches the stored key from the OS keychain, or
-// generates, stores, and returns a new 32-byte key if none exists.
-func getOrCreateKeychainKey() ([]byte, error) {
+// getKeychainKey fetches the stored key from the OS keychain. found is false
+// with a nil error when the keychain is reachable but holds no key yet
+// (keyring.ErrNotFound); minting is deferred to Mint.
+func getKeychainKey() (key []byte, found bool, err error) {
 	stored, err := keyringGetFunc(keychainService, keychainAccount)
 	switch {
 	case err == nil:
-		key, decErr := base64.StdEncoding.DecodeString(stored)
+		decoded, decErr := base64.StdEncoding.DecodeString(stored)
 		if decErr != nil {
-			return nil, fmt.Errorf("stored keychain key is corrupted: %w", decErr)
+			return nil, false, fmt.Errorf("stored keychain key is corrupted: %w", decErr)
 		}
 
-		if len(key) != keyLen {
-			return nil, fmt.Errorf("stored keychain key has wrong length %d", len(key))
+		if len(decoded) != keyLen {
+			return nil, false, fmt.Errorf("stored keychain key has wrong length %d", len(decoded))
 		}
 
-		return key, nil
+		return decoded, true, nil
 
 	case errors.Is(err, keyring.ErrNotFound):
-		return generateAndStoreKey()
+		return nil, false, nil
 
 	default:
-		return nil, fmt.Errorf("failed to read key from keychain: %w", err)
+		return nil, false, fmt.Errorf("failed to read key from keychain: %w", err)
 	}
+}
+
+// Mint generates a new random 32-byte data key, stores it in the OS keychain,
+// and returns it. Callers must confirm no encrypted working state exists before
+// minting: a fresh key cannot decrypt state written with a previous key.
+func Mint() ([]byte, error) {
+	return generateAndStoreKey()
 }
 
 // generateAndStoreKey creates a new random 32-byte key and stores it in the

--- a/internal/staging/store/file/internal/keyprovider/keyprovider_test.go
+++ b/internal/staging/store/file/internal/keyprovider/keyprovider_test.go
@@ -45,9 +45,10 @@ func TestResolve_EnvVar_Valid(t *testing.T) {
 			return "", false
 		}
 
-		key, plaintext, err := Resolve()
+		key, plaintext, needsMint, err := Resolve()
 		require.NoError(t, err)
 		assert.False(t, plaintext)
+		assert.False(t, needsMint)
 		assert.Equal(t, want, key)
 	})
 }
@@ -59,7 +60,7 @@ func TestResolve_EnvVar_InvalidBase64(t *testing.T) {
 			return "not!valid!base64!", true
 		}
 
-		_, _, err := Resolve()
+		_, _, _, err := Resolve()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "base64")
 	})
@@ -73,14 +74,14 @@ func TestResolve_EnvVar_WrongLength(t *testing.T) {
 			return base64.StdEncoding.EncodeToString(make([]byte, 16)), true
 		}
 
-		_, _, err := Resolve()
+		_, _, _, err := Resolve()
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "32 bytes")
 	})
 }
 
 //nolint:paralleltest // uses global keyring.MockInit and overrides hook vars.
-func TestResolve_Keychain_GetOrCreate(t *testing.T) {
+func TestResolve_Keychain_MintThenReuse(t *testing.T) {
 	keyring.MockInit()
 
 	withHooks(t, func() {
@@ -88,16 +89,24 @@ func TestResolve_Keychain_GetOrCreate(t *testing.T) {
 		keyringGetFunc = keyring.Get
 		keyringSetFunc = keyring.Set
 
-		// First call: no key stored -> generate and store.
-		key1, plaintext, err := Resolve()
+		// First call: no key stored yet -> caller is told to mint (Resolve does
+		// not mint or store on its own).
+		key0, plaintext, needsMint, err := Resolve()
 		require.NoError(t, err)
 		assert.False(t, plaintext)
+		assert.True(t, needsMint)
+		assert.Nil(t, key0)
+
+		// Mint stores a fresh key.
+		key1, err := Mint()
+		require.NoError(t, err)
 		assert.Len(t, key1, 32)
 
-		// Second call: must return the same stored key.
-		key2, plaintext, err := Resolve()
+		// Second call: must return the same stored key, no longer needing a mint.
+		key2, plaintext, needsMint, err := Resolve()
 		require.NoError(t, err)
 		assert.False(t, plaintext)
+		assert.False(t, needsMint)
 		assert.Equal(t, key1, key2)
 	})
 }
@@ -114,9 +123,10 @@ func TestResolve_UnsupportedPlatform_Plaintext(t *testing.T) {
 			return "", keyring.ErrUnsupportedPlatform
 		}
 
-		key, plaintext, err := Resolve()
+		key, plaintext, needsMint, err := Resolve()
 		require.NoError(t, err)
 		assert.True(t, plaintext)
+		assert.False(t, needsMint)
 		assert.Nil(t, key)
 	})
 }
@@ -133,9 +143,10 @@ func TestResolve_HardKeychainError_Surfaced(t *testing.T) {
 			return "", errors.New("keychain locked")
 		}
 
-		key, plaintext, err := Resolve()
+		key, plaintext, needsMint, err := Resolve()
 		require.Error(t, err)
 		assert.False(t, plaintext)
+		assert.False(t, needsMint)
 		assert.Nil(t, key)
 
 		var kcErr *KeychainUnavailableError
@@ -143,26 +154,46 @@ func TestResolve_HardKeychainError_Surfaced(t *testing.T) {
 	})
 }
 
-// TestResolve_SetError_Surfaced: a failed store (Get says not-found, Set fails)
-// is a hard error, surfaced rather than silently downgraded.
+// TestResolve_KeyNotFound_NeedsMint: a reachable-but-empty keychain reports
+// needsMint (Resolve neither mints nor stores) so the caller can gate minting
+// on the absence of encrypted state.
 //
 //nolint:paralleltest // overrides package-level hook vars.
-func TestResolve_SetError_Surfaced(t *testing.T) {
+func TestResolve_KeyNotFound_NeedsMint(t *testing.T) {
 	withHooks(t, func() {
 		lookupEnvFunc = func(string) (string, bool) { return "", false }
 		keyringGetFunc = func(string, string) (string, error) {
 			return "", keyring.ErrNotFound
 		}
+
+		setCalled := false
+		keyringSetFunc = func(string, string, string) error {
+			setCalled = true
+
+			return nil
+		}
+
+		key, plaintext, needsMint, err := Resolve()
+		require.NoError(t, err)
+		assert.False(t, plaintext)
+		assert.True(t, needsMint)
+		assert.Nil(t, key)
+		assert.False(t, setCalled, "Resolve must not store a key")
+	})
+}
+
+// TestMint_SetError: a failed store surfaces from Mint as an error.
+//
+//nolint:paralleltest // overrides package-level hook vars.
+func TestMint_SetError(t *testing.T) {
+	withHooks(t, func() {
 		keyringSetFunc = func(string, string, string) error {
 			return errors.New("cannot write to keychain")
 		}
 
-		_, plaintext, err := Resolve()
+		_, err := Mint()
 		require.Error(t, err)
-		assert.False(t, plaintext)
-
-		var kcErr *KeychainUnavailableError
-		require.ErrorAs(t, err, &kcErr)
+		assert.Contains(t, err.Error(), "keychain")
 	})
 }
 
@@ -176,7 +207,7 @@ func TestResolve_CorruptStoredKey_Surfaced(t *testing.T) {
 			return "!!not-base64!!", nil
 		}
 
-		_, _, err := Resolve()
+		_, _, _, err := Resolve()
 		require.Error(t, err)
 
 		var kcErr *KeychainUnavailableError

--- a/internal/staging/store/file/store.go
+++ b/internal/staging/store/file/store.go
@@ -47,6 +47,12 @@ var userHomeDirFunc = os.UserHomeDir
 //nolint:gochecknoglobals // test hook for dependency injection
 var resolveKeyFunc = keyprovider.Resolve
 
+// mintKeyFunc mints and stores a new working-store data key. Overridable for
+// testing.
+//
+//nolint:gochecknoglobals // test hook for dependency injection
+var mintKeyFunc = keyprovider.Mint
+
 // plaintextWarnOnce ensures the plaintext fallback warning is emitted only once
 // per process.
 //
@@ -117,7 +123,7 @@ func NewWorkingStore(scope provider.Scope) (*Store, error) {
 		return nil, err
 	}
 
-	key, plaintext, err := resolveKeyFunc()
+	key, plaintext, needsMint, err := resolveKeyFunc()
 	if err != nil {
 		// A hard keychain failure (as opposed to a genuinely absent keyring
 		// backend or a bad SUVE_STAGING_KEY) is fatal ONLY when encrypted state
@@ -128,14 +134,13 @@ func NewWorkingStore(scope provider.Scope) (*Store, error) {
 		// headless CI without a keyring), warning the user once.
 		var kcErr *keyprovider.KeychainUnavailableError
 		if errors.As(err, &kcErr) {
-			encrypted, encErr := s.IsEncrypted()
-			if encErr != nil {
-				return nil, fmt.Errorf("failed to check staging state encryption: %w", encErr)
+			guardErr, checkErr := s.guardKeyLossWithEncryptedState(err)
+			if checkErr != nil {
+				return nil, checkErr
 			}
 
-			if encrypted {
-				return nil, fmt.Errorf(
-					"cannot access the staging encryption key while encrypted state exists: %w", err)
+			if guardErr != nil {
+				return nil, guardErr
 			}
 
 			warnPlaintextOnce(err)
@@ -144,6 +149,27 @@ func NewWorkingStore(scope provider.Scope) (*Store, error) {
 		}
 
 		return nil, fmt.Errorf("failed to resolve staging encryption key: %w", err)
+	}
+
+	if needsMint {
+		// The keychain is reachable but empty. Minting a replacement key when
+		// encrypted state already exists would leave that state undecryptable
+		// AND silently overwrite the (lost) key, masking the real cause behind a
+		// later "wrong passphrase or corrupted data" error. Refuse to mint in
+		// that case; otherwise this is a genuine first run.
+		guardErr, checkErr := s.guardKeyLossWithEncryptedState(keyprovider.ErrKeychainKeyNotFound)
+		if checkErr != nil {
+			return nil, checkErr
+		}
+
+		if guardErr != nil {
+			return nil, guardErr
+		}
+
+		key, err = mintKeyFunc()
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve staging encryption key: %w", err)
+		}
 	}
 
 	if plaintext {
@@ -155,6 +181,28 @@ func NewWorkingStore(scope provider.Scope) (*Store, error) {
 	s.key = key
 
 	return s, nil
+}
+
+// guardKeyLossWithEncryptedState reports whether the working store must hard-fail
+// because the encryption key is unavailable (a hard keychain failure or a lost
+// keychain entry, given by cause) while encrypted state already exists on disk.
+// When encrypted state exists it returns the explanatory error to surface (so
+// the real cause reaches the user instead of a later misleading decryption
+// failure); otherwise guardErr is nil and the caller may proceed (plaintext
+// fallback or a first-run mint). checkErr is non-nil only when the encryption
+// probe itself failed.
+func (s *Store) guardKeyLossWithEncryptedState(cause error) (guardErr, checkErr error) {
+	encrypted, err := s.IsEncrypted()
+	if err != nil {
+		return nil, fmt.Errorf("failed to check staging state encryption: %w", err)
+	}
+
+	if encrypted {
+		return fmt.Errorf(
+			"cannot access the staging encryption key while encrypted state exists: %w", cause), nil
+	}
+
+	return nil, nil
 }
 
 // warnPlaintextOnce emits the unencrypted-storage warning once per process. When

--- a/internal/staging/store/file/store_key_internal_test.go
+++ b/internal/staging/store/file/store_key_internal_test.go
@@ -115,7 +115,7 @@ func TestNewWorkingStore_KeyConfigured(t *testing.T) {
 	userHomeDirFunc = func() (string, error) { return t.TempDir(), nil }
 
 	key := newTestKey()
-	resolveKeyFunc = func() ([]byte, bool, error) { return key, false, nil }
+	resolveKeyFunc = func() ([]byte, bool, bool, error) { return key, false, false, nil }
 
 	s, err := NewWorkingStore(provider.AWSScope("123456789012", "ap-northeast-1"))
 	require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestNewWorkingStore_PlaintextFallback(t *testing.T) {
 
 	userHomeDirFunc = func() (string, error) { return t.TempDir(), nil }
 
-	resolveKeyFunc = func() ([]byte, bool, error) { return nil, true, nil }
+	resolveKeyFunc = func() ([]byte, bool, bool, error) { return nil, true, false, nil }
 
 	s, err := NewWorkingStore(provider.AWSScope("123456789012", "ap-northeast-1"))
 	require.NoError(t, err)
@@ -159,7 +159,7 @@ func TestNewWorkingStore_ResolveError(t *testing.T) {
 
 	userHomeDirFunc = func() (string, error) { return t.TempDir(), nil }
 
-	resolveKeyFunc = func() ([]byte, bool, error) { return nil, false, errors.New("bad key") }
+	resolveKeyFunc = func() ([]byte, bool, bool, error) { return nil, false, false, errors.New("bad key") }
 
 	s, err := NewWorkingStore(provider.AWSScope("123456789012", "ap-northeast-1"))
 	require.Error(t, err)
@@ -182,8 +182,8 @@ func TestNewWorkingStore_KeychainError_NoEncryptedState_Plaintext(t *testing.T) 
 	}()
 
 	userHomeDirFunc = func() (string, error) { return t.TempDir(), nil }
-	resolveKeyFunc = func() ([]byte, bool, error) {
-		return nil, false, &keyprovider.KeychainUnavailableError{Err: errors.New("dbus down")}
+	resolveKeyFunc = func() ([]byte, bool, bool, error) {
+		return nil, false, false, &keyprovider.KeychainUnavailableError{Err: errors.New("dbus down")}
 	}
 
 	s, err := NewWorkingStore(provider.AWSScope("123456789012", "ap-northeast-1"))
@@ -224,8 +224,8 @@ func TestNewWorkingStore_KeychainError_EncryptedStateExists_Fatal(t *testing.T) 
 	}
 	require.NoError(t, seed.WriteState(t.Context(), "", state))
 
-	resolveKeyFunc = func() ([]byte, bool, error) {
-		return nil, false, &keyprovider.KeychainUnavailableError{Err: errors.New("keychain locked")}
+	resolveKeyFunc = func() ([]byte, bool, bool, error) {
+		return nil, false, false, &keyprovider.KeychainUnavailableError{Err: errors.New("keychain locked")}
 	}
 
 	s, err := NewWorkingStore(scope)
@@ -233,6 +233,94 @@ func TestNewWorkingStore_KeychainError_EncryptedStateExists_Fatal(t *testing.T) 
 	assert.Nil(t, s)
 	assert.Contains(t, err.Error(), "keychain locked")
 	assert.Contains(t, err.Error(), "encrypted state exists")
+}
+
+// TestNewWorkingStore_NeedsMint_NoEncryptedState_Mints verifies that on a
+// genuine first run (keychain reachable but empty, no encrypted state) the
+// constructor mints a key and configures it.
+//
+//nolint:paralleltest // overrides package-level hook vars.
+func TestNewWorkingStore_NeedsMint_NoEncryptedState_Mints(t *testing.T) {
+	origResolve := resolveKeyFunc
+	origMint := mintKeyFunc
+	origHome := userHomeDirFunc
+
+	defer func() {
+		resolveKeyFunc = origResolve
+		mintKeyFunc = origMint
+		userHomeDirFunc = origHome
+	}()
+
+	userHomeDirFunc = func() (string, error) { return t.TempDir(), nil }
+	resolveKeyFunc = func() ([]byte, bool, bool, error) { return nil, false, true, nil }
+
+	key := newTestKey()
+
+	minted := false
+	mintKeyFunc = func() ([]byte, error) {
+		minted = true
+
+		return key, nil
+	}
+
+	s, err := NewWorkingStore(provider.AWSScope("123456789012", "ap-northeast-1"))
+	require.NoError(t, err)
+	assert.True(t, minted, "expected a key to be minted on first run")
+	assert.Equal(t, key, s.key)
+}
+
+// TestNewWorkingStore_NeedsMint_EncryptedStateExists_Fatal guards #475: if the
+// keychain entry is lost while encrypted working state persists, the next
+// constructor call must surface the real cause and MUST NOT mint (and thereby
+// silently store) a replacement key that could never decrypt that state.
+//
+//nolint:paralleltest // overrides package-level hook vars.
+func TestNewWorkingStore_NeedsMint_EncryptedStateExists_Fatal(t *testing.T) {
+	origResolve := resolveKeyFunc
+	origMint := mintKeyFunc
+	origHome := userHomeDirFunc
+
+	defer func() {
+		resolveKeyFunc = origResolve
+		mintKeyFunc = origMint
+		userHomeDirFunc = origHome
+	}()
+
+	home := t.TempDir()
+	userHomeDirFunc = func() (string, error) { return home, nil }
+
+	scope := provider.AWSScope("123456789012", "ap-northeast-1")
+
+	// Seed an ENCRYPTED param.json under the scope directory, as if written
+	// earlier with a now-lost key.
+	seed, err := NewStore(scope)
+	require.NoError(t, err)
+
+	seed.key = newTestKey()
+
+	state := staging.NewEmptyState()
+	state.Entries[staging.ServiceParam][staging.EntryKey{Name: "/app/secret"}] = staging.Entry{
+		Operation: staging.OperationCreate,
+		Value:     lo.ToPtr("v"),
+	}
+	require.NoError(t, seed.WriteState(t.Context(), "", state))
+
+	// The keychain now reports the key as absent (deleted/reset).
+	resolveKeyFunc = func() ([]byte, bool, bool, error) { return nil, false, true, nil }
+
+	minted := false
+	mintKeyFunc = func() ([]byte, error) {
+		minted = true
+
+		return newTestKey(), nil
+	}
+
+	s, err := NewWorkingStore(scope)
+	require.Error(t, err)
+	assert.Nil(t, s)
+	assert.False(t, minted, "must not mint a replacement key when encrypted state exists")
+	assert.Contains(t, err.Error(), "encrypted state exists")
+	assert.ErrorIs(t, err, keyprovider.ErrKeychainKeyNotFound)
 }
 
 // TestWriteFileAtomic guards #325: writes go through a temp file + rename, so


### PR DESCRIPTION
## What

On the keychain `ErrNotFound` path, key resolution used to silently mint and store a brand-new staging data key, and `NewWorkingStore` accepted it without the encrypted-state guard that the `KeychainUnavailableError` path already applied.

This change defers minting out of `keyprovider.Resolve` (which now reports a `needsMint` signal instead of minting itself) into a new `keyprovider.Mint`. `NewWorkingStore` now checks `IsEncrypted()` **before** minting, via a small guard helper shared by both the keychain-unavailable and key-not-found paths. When encrypted working state already exists, it returns the same explanatory hard error the keychain-unavailable path produces instead of minting.

## Why

If the keychain entry is lost (Keychain Access deletion, login-keychain reset, security tooling, OS migration) while `~/.suve/staging` files persist, the previous behavior minted a replacement key and every read failed with the generic `decryption failed: wrong passphrase or corrupted data` — misdiagnosing the cause and silently overwriting the (already lost) key. The data was already unrecoverable once the key was lost; the defect was the misleading diagnosis, the silent key replacement, and the stuck state.

## Tests

- Reworked `keyprovider` tests for the deferred-mint split (`Resolve` reports `needsMint`; `Mint` stores).
- Added `NewWorkingStore` tests: first-run mint succeeds; and — guarding #475 — a lost keychain entry with encrypted state on disk returns an explanatory hard error and does **not** mint/store a replacement key.
- `mise test` passes; touched packages lint clean (`mise lint` blocked only by an unrelated pre-existing `internal/gui/assets.go` embed that needs a built frontend — CI is the authoritative gate).

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)