### PR TITLE
fix(staging): make export/import read-modify-write atomic under the file lock

### DIFF
--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -840,20 +840,22 @@ type EnvelopeInfoResult struct {
 // =============================================================================
 
 // errStoreNotFileStore is returned when the resolved staging store cannot serve
-// bulk drain/write operations (should never happen for the file/mock stores).
+// the working-area drain/unstage/update operations (should never happen for the
+// file/mock stores).
 var errStoreNotFileStore = stringError("staging store does not support import/export")
 
-// getWorkingFileStore resolves the per-service working store as a FileStore
-// (bulk Drain/WriteState). It goes through getStagingStore so the test seam and
-// the per-service scope resolution (the #445 fix: param → App Configuration
-// bucket, secret → Key Vault bucket) are shared with every other staging op.
-func (a *App) getWorkingFileStore(kind provider.Kind) (store.FileStore, error) {
+// getWorkingFileStore resolves the per-service working store as a WorkingStore
+// (bulk Drain plus the per-key unstage and atomic Update the export/import use
+// cases need). It goes through getStagingStore so the test seam and the
+// per-service scope resolution (the #445 fix: param → App Configuration bucket,
+// secret → Key Vault bucket) are shared with every other staging op.
+func (a *App) getWorkingFileStore(kind provider.Kind) (store.WorkingStore, error) {
 	s, err := a.getStagingStore(kind)
 	if err != nil {
 		return nil, err
 	}
 
-	fs, ok := s.(store.FileStore)
+	fs, ok := s.(store.WorkingStore)
 	if !ok {
 		return nil, errStoreNotFileStore
 	}

--- a/internal/staging/store/file/store.go
+++ b/internal/staging/store/file/store.go
@@ -442,6 +442,12 @@ func (s *Store) IsEncrypted() (bool, error) {
 func (s *Store) Drain(_ context.Context, service staging.Service, keep bool) (*staging.State, error) {
 	defer s.lock()()
 
+	return s.drainLocked(service, keep)
+}
+
+// drainLocked is the lock-free core of Drain. It must be called with the store
+// lock held (see Drain and Update).
+func (s *Store) drainLocked(service staging.Service, keep bool) (*staging.State, error) {
 	if !s.isSplit() {
 		return s.drainSingle(service, keep)
 	}
@@ -511,6 +517,12 @@ func (s *Store) drainServiceFile(service staging.Service, keep bool) (*staging.S
 func (s *Store) WriteState(_ context.Context, service staging.Service, state *staging.State) error {
 	defer s.lock()()
 
+	return s.writeStateLocked(service, state)
+}
+
+// writeStateLocked is the lock-free core of WriteState. It must be called with
+// the store lock held (see WriteState and Update).
+func (s *Store) writeStateLocked(service staging.Service, state *staging.State) error {
 	if !s.isSplit() {
 		if service != "" {
 			state = state.ExtractService(service)
@@ -530,6 +542,37 @@ func (s *Store) WriteState(_ context.Context, service staging.Service, state *st
 	}
 
 	return nil
+}
+
+// updateMidHook, when non-nil, is invoked inside Update while the store lock is
+// held — after the fresh read and before the write-back. Tests use it to prove
+// that no concurrent write can interleave within the atomic cycle. It is nil in
+// production.
+//
+//nolint:gochecknoglobals // test hook for dependency injection
+var updateMidHook func()
+
+// Update performs an atomic read-modify-write of the working state under a
+// single lock hold (see store.Updater). It re-reads the current state inside the
+// lock, so a concurrent StageEntry from another process is serialized either
+// fully before or fully after this cycle — never clobbered by a stale snapshot.
+func (s *Store) Update(_ context.Context, service staging.Service, fn func(*staging.State) error) error {
+	defer s.lock()()
+
+	state, err := s.drainLocked(service, true)
+	if err != nil {
+		return err
+	}
+
+	if updateMidHook != nil {
+		updateMidHook()
+	}
+
+	if err := fn(state); err != nil {
+		return err
+	}
+
+	return s.writeStateLocked(service, state)
 }
 
 // GetEntry retrieves the staged entry identified by key.
@@ -770,4 +813,5 @@ func (s *Store) Delete() error {
 var (
 	_ store.FileStore         = (*Store)(nil)
 	_ store.ReadWriteOperator = (*Store)(nil)
+	_ store.WorkingStore      = (*Store)(nil)
 )

--- a/internal/staging/store/file/store_internal_test.go
+++ b/internal/staging/store/file/store_internal_test.go
@@ -1,11 +1,15 @@
 package file
 
 import (
+	"context"
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -13,6 +17,121 @@ import (
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store/file/internal/crypt"
 )
+
+// updateTestEntry builds a minimal staged entry for the Update tests.
+func updateTestEntry(value string) staging.Entry {
+	return staging.Entry{
+		Operation: staging.OperationUpdate,
+		Value:     lo.ToPtr(value),
+		StagedAt:  time.Now(),
+	}
+}
+
+func TestStore_Update_ReadModifyWrite(t *testing.T) {
+	t.Parallel()
+
+	s := NewStoreWithPath(filepath.Join(t.TempDir(), "stage.json"))
+
+	keyA := staging.EntryKey{Name: "/a"}
+	require.NoError(t, s.StageEntry(t.Context(), staging.ServiceParam, keyA, updateTestEntry("a")))
+
+	keyB := staging.EntryKey{Name: "/b"}
+	require.NoError(t, s.Update(t.Context(), "", func(st *staging.State) error {
+		st.Entries[staging.ServiceParam][keyB] = updateTestEntry("b")
+
+		return nil
+	}))
+
+	final, err := s.Drain(t.Context(), "", true)
+	require.NoError(t, err)
+	assert.Contains(t, final.Entries[staging.ServiceParam], keyA)
+	assert.Contains(t, final.Entries[staging.ServiceParam], keyB)
+}
+
+func TestStore_Update_FnErrorLeavesStateUnchanged(t *testing.T) {
+	t.Parallel()
+
+	s := NewStoreWithPath(filepath.Join(t.TempDir(), "stage.json"))
+
+	keyA := staging.EntryKey{Name: "/a"}
+	require.NoError(t, s.StageEntry(t.Context(), staging.ServiceParam, keyA, updateTestEntry("a")))
+
+	sentinel := errors.New("boom")
+	err := s.Update(t.Context(), "", func(st *staging.State) error {
+		st.Entries[staging.ServiceParam][staging.EntryKey{Name: "/b"}] = updateTestEntry("b")
+
+		return sentinel
+	})
+	require.ErrorIs(t, err, sentinel)
+
+	// The failed mutation must not have been persisted.
+	final, err := s.Drain(t.Context(), "", true)
+	require.NoError(t, err)
+	assert.Len(t, final.Entries[staging.ServiceParam], 1)
+	assert.Contains(t, final.Entries[staging.ServiceParam], keyA)
+}
+
+// TestStore_Update_AtomicAgainstConcurrentStage proves the read-modify-write
+// cycle is atomic: a StageEntry from a second store handle (standing in for
+// another process) that fires while Update holds the lock cannot interleave, so
+// neither the Update's change nor the concurrent stage is lost. Under the old
+// Drain + WriteState(stale snapshot) pattern the concurrent entry was silently
+// clobbered.
+func TestStore_Update_AtomicAgainstConcurrentStage(t *testing.T) {
+	// Not parallel: it sets the package-level updateMidHook.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "stage.json")
+
+	writer := NewStoreWithPath(path) // the Update caller (import path)
+	stager := NewStoreWithPath(path) // a second handle standing in for another process
+
+	keyA := staging.EntryKey{Name: "/a"}
+	keyB := staging.EntryKey{Name: "/b"}
+	keyC := staging.EntryKey{Name: "/c"}
+
+	require.NoError(t, writer.StageEntry(t.Context(), staging.ServiceParam, keyA, updateTestEntry("a")))
+
+	stageStarted := make(chan struct{})
+	stageDone := make(chan struct{})
+
+	var stageErr error
+
+	updateMidHook = func() {
+		go func() {
+			close(stageStarted)
+			// Blocks on the store lock (held by Update) until the cycle completes.
+			stageErr = stager.StageEntry(context.Background(), staging.ServiceParam, keyC, updateTestEntry("c"))
+			close(stageDone)
+		}()
+
+		<-stageStarted
+
+		// The concurrent stage must NOT complete while Update holds the lock.
+		select {
+		case <-stageDone:
+			t.Error("concurrent StageEntry completed while Update held the store lock")
+		case <-time.After(50 * time.Millisecond): //nolint:mnd // generous wait for the blocked goroutine
+		}
+	}
+	t.Cleanup(func() { updateMidHook = nil })
+
+	require.NoError(t, writer.Update(t.Context(), "", func(st *staging.State) error {
+		st.Entries[staging.ServiceParam][keyB] = updateTestEntry("b")
+
+		return nil
+	}))
+
+	<-stageDone
+	require.NoError(t, stageErr)
+
+	final, err := writer.Drain(t.Context(), "", true)
+	require.NoError(t, err)
+
+	// Nothing lost: pre-existing A, the Update's B, and the concurrent C all survive.
+	assert.Contains(t, final.Entries[staging.ServiceParam], keyA)
+	assert.Contains(t, final.Entries[staging.ServiceParam], keyB)
+	assert.Contains(t, final.Entries[staging.ServiceParam], keyC)
+}
 
 func TestInitializeStateMaps(t *testing.T) {
 	t.Parallel()

--- a/internal/staging/store/file/store_internal_test.go
+++ b/internal/staging/store/file/store_internal_test.go
@@ -36,6 +36,7 @@ func TestStore_Update_ReadModifyWrite(t *testing.T) {
 	require.NoError(t, s.StageEntry(t.Context(), staging.ServiceParam, keyA, updateTestEntry("a")))
 
 	keyB := staging.EntryKey{Name: "/b"}
+
 	require.NoError(t, s.Update(t.Context(), "", func(st *staging.State) error {
 		st.Entries[staging.ServiceParam][keyB] = updateTestEntry("b")
 
@@ -77,6 +78,8 @@ func TestStore_Update_FnErrorLeavesStateUnchanged(t *testing.T) {
 // neither the Update's change nor the concurrent stage is lost. Under the old
 // Drain + WriteState(stale snapshot) pattern the concurrent entry was silently
 // clobbered.
+//
+//nolint:paralleltest // mutates the package-level updateMidHook; must run serially
 func TestStore_Update_AtomicAgainstConcurrentStage(t *testing.T) {
 	// Not parallel: it sets the package-level updateMidHook.
 	dir := t.TempDir()
@@ -101,6 +104,7 @@ func TestStore_Update_AtomicAgainstConcurrentStage(t *testing.T) {
 			close(stageStarted)
 			// Blocks on the store lock (held by Update) until the cycle completes.
 			stageErr = stager.StageEntry(context.Background(), staging.ServiceParam, keyC, updateTestEntry("c"))
+
 			close(stageDone)
 		}()
 
@@ -110,9 +114,10 @@ func TestStore_Update_AtomicAgainstConcurrentStage(t *testing.T) {
 		select {
 		case <-stageDone:
 			t.Error("concurrent StageEntry completed while Update held the store lock")
-		case <-time.After(50 * time.Millisecond): //nolint:mnd // generous wait for the blocked goroutine
+		case <-time.After(50 * time.Millisecond):
 		}
 	}
+
 	t.Cleanup(func() { updateMidHook = nil })
 
 	require.NoError(t, writer.Update(t.Context(), "", func(st *staging.State) error {

--- a/internal/staging/store/store.go
+++ b/internal/staging/store/store.go
@@ -58,8 +58,30 @@ type Writer interface {
 	WriteState(ctx context.Context, service staging.Service, state *staging.State) error
 }
 
+// Updater performs an atomic read-modify-write of the whole staging state under
+// a single lock hold: it reads the current state fresh, hands it to fn to mutate
+// in place, then writes it back — without releasing the lock in between. This
+// closes the read-then-write race a separate Drain + WriteState leaves open,
+// where a concurrent StageEntry landing between the two is clobbered by the
+// stale snapshot. fn must confine itself to mutating the passed state and must
+// not call back into the store (the lock is not reentrant).
+type Updater interface {
+	Update(ctx context.Context, service staging.Service, fn func(*staging.State) error) error
+}
+
 // FileStore combines drain and write operations for file storage.
 type FileStore interface {
 	Drainer
 	Writer
+}
+
+// WorkingStore is the working-area surface the export and import use cases rely
+// on: a bulk Drain for the export snapshot, per-key writes to clear exactly the
+// exported keys (each re-read under its own lock), and the atomic Update
+// read-modify-write used to reconcile an import without clobbering a concurrent
+// stage.
+type WorkingStore interface {
+	Drainer
+	WriteOperator
+	Updater
 }

--- a/internal/staging/store/testutil/mock_store.go
+++ b/internal/staging/store/testutil/mock_store.go
@@ -303,8 +303,27 @@ func (m *MockStore) WriteState(_ context.Context, service staging.Service, state
 	return nil
 }
 
+// Update performs an atomic read-modify-write, mirroring the file store's
+// Updater: it reads the current state (honoring DrainErr), hands it to fn to
+// mutate in place, then writes it back (honoring WriteStateErr). fn runs only
+// after a successful read, so callers can distinguish a read failure (fn never
+// ran) from a write failure.
+func (m *MockStore) Update(ctx context.Context, service staging.Service, fn func(*staging.State) error) error {
+	state, err := m.Drain(ctx, service, true)
+	if err != nil {
+		return err
+	}
+
+	if err := fn(state); err != nil {
+		return err
+	}
+
+	return m.WriteState(ctx, service, state)
+}
+
 // Compile-time checks that MockStore implements interfaces.
 var (
 	_ store.ReadWriteOperator = (*MockStore)(nil)
 	_ store.FileStore         = (*MockStore)(nil)
+	_ store.WorkingStore      = (*MockStore)(nil)
 )

--- a/internal/usecase/staging/export.go
+++ b/internal/usecase/staging/export.go
@@ -49,7 +49,7 @@ type ExportOutput struct {
 // area, not a reconciliation with whatever a file previously held.
 type ExportUseCase struct {
 	// Working is the working staging area (param.json/secret.json).
-	Working store.FileStore
+	Working store.WorkingStore
 	// Target receives the exported per-service state.
 	Target EnvelopeWriter
 }
@@ -82,17 +82,27 @@ func (u *ExportUseCase) Execute(ctx context.Context, input ExportInput) (*Export
 		output.TagCount += t.state.TagCount()
 	}
 
-	// Clear the exported working area unless --keep is specified. The export has
-	// already succeeded, so a failure here is non-fatal.
+	// Clear the exported working area unless --keep is specified. Each exported
+	// key is unstaged individually rather than rewriting the whole state from the
+	// stale snapshot: UnstageEntry/UnstageTag re-read the working state fresh
+	// under their own lock, so a concurrent stage of a *different* (unexported)
+	// key landing during the slow envelope write survives instead of being
+	// silently clobbered. The export has already succeeded, so a failure here is
+	// non-fatal; ErrNotStaged is ignored because the key we meant to clear is
+	// already gone.
 	if !input.Keep {
-		if input.Service != "" {
-			workingState.RemoveService(input.Service)
-		} else {
-			workingState = staging.NewEmptyState()
-		}
+		for _, t := range targets {
+			for key := range t.state.Entries[t.service] {
+				if err := u.Working.UnstageEntry(ctx, t.service, key); err != nil && !errors.Is(err, staging.ErrNotStaged) {
+					return output, &ExportError{Op: ExportOpClear, Err: err, NonFatal: true}
+				}
+			}
 
-		if err := u.Working.WriteState(ctx, "", workingState); err != nil {
-			return output, &ExportError{Op: ExportOpClear, Err: err, NonFatal: true}
+			for key := range t.state.Tags[t.service] {
+				if err := u.Working.UnstageTag(ctx, t.service, key); err != nil && !errors.Is(err, staging.ErrNotStaged) {
+					return output, &ExportError{Op: ExportOpClear, Err: err, NonFatal: true}
+				}
+			}
 		}
 	}
 

--- a/internal/usecase/staging/export_test.go
+++ b/internal/usecase/staging/export_test.go
@@ -46,8 +46,59 @@ func stageEntry(t *testing.T, s *testutil.MockStore, svc staging.Service, name, 
 	}))
 }
 
+// concurrentStager is an EnvelopeWriter that, on its first write, stages an
+// extra entry into the working store — standing in for another process staging
+// during the slow envelope encryption/write window (the export TOCTOU).
+type concurrentStager struct {
+	working *testutil.MockStore
+	svc     staging.Service
+	key     staging.EntryKey
+	staged  bool
+}
+
+func (w *concurrentStager) WriteEnvelope(ctx context.Context, _ staging.Service, _ *staging.State) error {
+	if w.staged {
+		return nil
+	}
+
+	w.staged = true
+
+	return w.working.StageEntry(ctx, w.svc, w.key, staging.Entry{
+		Operation: staging.OperationUpdate,
+		Value:     lo.ToPtr("concurrent"),
+		StagedAt:  time.Now(),
+	})
+}
+
 func TestExportUseCase_Execute(t *testing.T) {
 	t.Parallel()
+
+	t.Run("concurrent stage during envelope write survives the clear", func(t *testing.T) {
+		t.Parallel()
+
+		working := testutil.NewMockStore()
+		stageEntry(t, working, staging.ServiceParam, "/exported", "v")
+
+		// The concurrent entry is staged mid-export, inside WriteEnvelope.
+		writer := &concurrentStager{
+			working: working,
+			svc:     staging.ServiceParam,
+			key:     staging.EntryKey{Name: "/late"},
+		}
+		usecase := &stagingusecase.ExportUseCase{Working: working, Target: writer}
+
+		_, err := usecase.Execute(t.Context(), stagingusecase.ExportInput{Service: staging.ServiceParam})
+		require.NoError(t, err)
+
+		// The exported key is cleared (per-key unstage)...
+		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/exported"})
+		require.ErrorIs(t, err, staging.ErrNotStaged)
+
+		// ...but the entry staged concurrently during the envelope write survives.
+		// The former whole-state clear would have wiped it.
+		_, err = working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/late"})
+		require.NoError(t, err)
+	})
 
 	t.Run("nothing to export when working is empty", func(t *testing.T) {
 		t.Parallel()
@@ -234,8 +285,9 @@ func TestExportUseCase_Execute_Errors(t *testing.T) {
 		writer := &recordingWriter{}
 		usecase := &stagingusecase.ExportUseCase{Working: working, Target: writer}
 
-		// The export write succeeds; only the working-area clear fails.
-		working.WriteStateErr = errors.New("clear error")
+		// The export write succeeds; only the working-area clear fails. Clearing
+		// now unstages each exported key individually, so inject the failure there.
+		working.UnstageEntryErr = errors.New("clear error")
 
 		output, err := usecase.Execute(t.Context(), stagingusecase.ExportInput{})
 		require.NotNil(t, output)

--- a/internal/usecase/staging/import.go
+++ b/internal/usecase/staging/import.go
@@ -84,6 +84,7 @@ func (u *ImportUseCase) Execute(ctx context.Context, input ImportInput) (*Import
 
 	err = u.Working.Update(ctx, "", func(workingState *staging.State) error {
 		reconcileImport(workingState, sourceState, input, output)
+
 		reconciled = true
 
 		return nil

--- a/internal/usecase/staging/import.go
+++ b/internal/usecase/staging/import.go
@@ -57,7 +57,7 @@ type ImportUseCase struct {
 	// Source provides the imported per-service state.
 	Source EnvelopeReader
 	// Working is the working staging area (param.json/secret.json).
-	Working store.FileStore
+	Working store.WorkingStore
 }
 
 // Execute runs the import use case.
@@ -72,40 +72,60 @@ func (u *ImportUseCase) Execute(ctx context.Context, input ImportInput) (*Import
 		return nil, ErrNothingToImport
 	}
 
-	// Read the working staging area (keep=true; we never clear the source). A
-	// missing file yields an empty state with a nil error, so any error here is a
-	// real failure (wrong key, corrupt/unreadable file): propagate it before the
-	// WriteState below would replace the working files with a partial view.
-	workingState, err := u.Working.Drain(ctx, "", true)
+	output := &ImportOutput{}
+
+	// Reconcile the source into the working area as a single atomic
+	// read-modify-write. Update re-reads the working state fresh under the store
+	// lock and writes it back without releasing the lock, so a concurrent
+	// StageEntry can no longer land between a stale snapshot and the write-back
+	// and be silently clobbered. A missing working file yields an empty state
+	// with a nil error, so any error is a real failure (wrong key, corrupt file).
+	reconciled := false
+
+	err = u.Working.Update(ctx, "", func(workingState *staging.State) error {
+		reconcileImport(workingState, sourceState, input, output)
+		reconciled = true
+
+		return nil
+	})
 	if err != nil {
-		return nil, &ImportError{Op: ImportOpReadWorking, Err: err}
+		// fn (reconcileImport) runs only after a successful read, so if it never
+		// ran the read failed; otherwise the write-back did.
+		if !reconciled {
+			return nil, &ImportError{Op: ImportOpReadWorking, Err: err}
+		}
+
+		return nil, &ImportError{Op: ImportOpWrite, Err: err}
 	}
 
+	return output, nil
+}
+
+// reconcileImport merges sourceState into workingState in place per the import
+// mode, then records the resulting counts and merge flag in output. It is pure
+// (in-memory) so it can run inside the store's atomic Update callback.
+func reconcileImport(workingState, sourceState *staging.State, input ImportInput, output *ImportOutput) {
 	// Capture whether the working area already held data BEFORE any mutation, for
 	// the Merged output flag.
 	hasExistingData := !workingState.ExtractService(input.Service).IsEmpty()
 	workingWasEmpty := workingState.IsEmpty()
-
-	var finalState *staging.State
 
 	merged := false
 
 	switch {
 	case input.Service != "":
 		// Service-specific: always preserve other services from the working area.
-		finalState = workingState
 		if input.Mode == ImportModeOverwrite {
-			finalState.RemoveService(input.Service)
-			finalState.Merge(sourceState)
+			workingState.RemoveService(input.Service)
+			workingState.Merge(sourceState)
 		} else {
-			finalState.Merge(sourceState)
+			workingState.Merge(sourceState)
 
 			merged = hasExistingData
 		}
 	case input.Mode == ImportModeMerge:
 		// Global merge: combine working state with imported state.
-		finalState = workingState
-		finalState.Merge(sourceState)
+		workingState.Merge(sourceState)
 
 		merged = !workingWasEmpty
 	default:
@@ -113,26 +133,18 @@ func (u *ImportUseCase) Execute(ctx context.Context, input ImportInput) (*Import
 		// source. A partial import (e.g. a directory holding only param.json,
 		// with secret.json skipped) must not wipe an untouched working service,
 		// so services absent from the source are left intact.
-		finalState = workingState
-
 		for _, svc := range []staging.Service{staging.ServiceParam, staging.ServiceSecret} {
 			if !sourceState.ExtractService(svc).IsEmpty() {
-				finalState.RemoveService(svc)
+				workingState.RemoveService(svc)
 			}
 		}
 
-		finalState.Merge(sourceState)
+		workingState.Merge(sourceState)
 	}
 
-	if err := u.Working.WriteState(ctx, "", finalState); err != nil {
-		return nil, &ImportError{Op: ImportOpWrite, Err: err}
-	}
-
-	return &ImportOutput{
-		Merged:     merged,
-		EntryCount: finalState.EntryCount(),
-		TagCount:   finalState.TagCount(),
-	}, nil
+	output.Merged = merged
+	output.EntryCount = workingState.EntryCount()
+	output.TagCount = workingState.TagCount()
 }
 
 // readSource reads the imported state. With a service filter it reads that one


### PR DESCRIPTION
## What

`stage export` and `stage import` did `Drain(keep) → compute → WriteState` across **two separate flock holds**, and `WriteState` blind-overwrites the whole state. A concurrent `StageEntry` from another process (the GUI + CLI on the same scope, or Wails running App methods on their own goroutines) landing between the two holds was silently clobbered by the stale snapshot. Export with the default clear was worst: the concurrent entry ended up in neither the envelope nor the working area.

This closes the window without holding the lock across the slow Argon2id envelope write:

- **export**: clears the working area with per-key `UnstageEntry`/`UnstageTag` of exactly the exported keys instead of rewriting the whole state from the stale snapshot. Each unstage re-reads fresh under its own lock, so a concurrent stage of an *unexported* key survives. `ErrNotStaged` is ignored (the key we meant to clear is already gone).
- **import**: reconciles through a new store-level `Update(fn)` primitive that reads → mutates → writes back under a **single** lock hold, so a concurrent stage is serialized fully before or after the cycle.

New `store.Updater` / `store.WorkingStore` interfaces; `file.Store.Update` built on lock-free `drainLocked`/`writeStateLocked` cores; `MockStore.Update`.

## Why

Defeats exactly the cross-process atomicity the flock comment claims to provide (silent local staged-work loss). Closes #474.

## Tests

- `file.Store.Update` atomicity against a concurrent `StageEntry` (deterministic via a mid-hold test hook; race-clean) — proves nothing is lost.
- Export use-case test: a stage landing during the envelope write is not clobbered by the clear.
- Existing export/import use-case error tests updated for the new per-key clear / atomic reconcile.

## Notes / follow-up

- The narrower **apply** window (a same-key re-stage during the cloud round-trip, then `UnstageEntry` by key) is left as a follow-up (compare-and-delete), to keep this diff focused on the flagship export/import TOCTOU.
- **Rebase risk**: PR #475 also edits `internal/staging/store/file/store.go` (`NewWorkingStore`/keyprovider guard), but a different region from this PR's `Drain`/`WriteState`/`Update` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)