### PR TITLE
fix(staging): rename import scope-override flag to --allow-scope-mismatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ This file provides guidance to Claude Code when working with code in this reposi
    - `stage {param,secret} import <file>` - Read a single service from `<file>` (missing file or `service` mismatch = hard error)
    - Each file is a plaintext JSON envelope `{version, provider, scope, service, payload}` whose `payload` is passphrase-encrypted (Argon2id) or plaintext when the passphrase is empty; the full scope is embedded and validated on import
    - `export` flags: `--keep` (retain the working area; default clears it), `--yes`/`--force` (skip overwrite confirmation), `--passphrase-stdin`. NO `--merge`/`--overwrite`
-   - `import` flags: `--merge`/`--overwrite` (mutually exclusive; only used when the working area already has changes), `--yes`, `--passphrase-stdin`, `--force` (override scope mismatch). NO `--keep`
+   - `import` flags: `--merge`/`--overwrite` (mutually exclusive; only used when the working area already has changes), `--yes`, `--passphrase-stdin`, `--allow-scope-mismatch` (override scope mismatch). NO `--keep`
 
 4. **Version Specification**: Git-like revision syntax
    ```

--- a/README.md
+++ b/README.md
@@ -882,11 +882,11 @@ Export writes the working staging area out to portable snapshot files (one per s
 |---------|----------|---------|-------------|
 | `suve stage export` | `<dir>` | `--keep`<br>`--yes` (`--force`)<br>`--passphrase-stdin` | Export every service with staged changes to `<dir>/param.json` + `<dir>/secret.json` |
 | `suve stage {param,secret} export` | `<file>` | `--keep`<br>`--yes` (`--force`)<br>`--passphrase-stdin` | Export a single service to `<file>` |
-| `suve stage import` | `<dir>` | `--merge`<br>`--overwrite`<br>`--yes`<br>`--passphrase-stdin`<br>`--force` | Import `param.json` / `secret.json` from `<dir>` (missing files skipped; nothing imported if both absent) |
-| `suve stage {param,secret} import` | `<file>` | `--merge`<br>`--overwrite`<br>`--yes`<br>`--passphrase-stdin`<br>`--force` | Import a single service from `<file>` (missing file or service mismatch is a hard error) |
+| `suve stage import` | `<dir>` | `--merge`<br>`--overwrite`<br>`--yes`<br>`--passphrase-stdin`<br>`--allow-scope-mismatch` | Import `param.json` / `secret.json` from `<dir>` (missing files skipped; nothing imported if both absent) |
+| `suve stage {param,secret} import` | `<file>` | `--merge`<br>`--overwrite`<br>`--yes`<br>`--passphrase-stdin`<br>`--allow-scope-mismatch` | Import a single service from `<file>` (missing file or service mismatch is a hard error) |
 
 - **`export`** writes the working area out wholesale; there is no `--merge` / `--overwrite`. By default it clears the working staging area; `--keep` retains it. `--yes` / `--force` skip the overwrite confirmation.
-- **`import`** has no `--keep` (it is read-only on the file). `--merge` / `--overwrite` are mutually exclusive and only matter when the working area already holds changes; otherwise the file is applied directly. `--force` imports even when the file's embedded scope differs from the current scope.
+- **`import`** has no `--keep` (it is read-only on the file). `--merge` / `--overwrite` are mutually exclusive and only matter when the working area already holds changes; otherwise the file is applied directly. `--allow-scope-mismatch` imports even when the file's embedded scope differs from the current scope.
 
 ## Environment Variables
 

--- a/e2e/staging_test.go
+++ b/e2e/staging_test.go
@@ -525,9 +525,9 @@ func TestGlobal_ImportScopeMismatch(t *testing.T) {
 		assert.Contains(t, err.Error(), "scope")
 	})
 
-	// --force overrides.
+	// --allow-scope-mismatch overrides.
 	t.Run("forced", func(t *testing.T) {
-		_, _, err := runSubCommand(t, globalstage.Command(), "import", dir, "--force")
+		_, _, err := runSubCommand(t, globalstage.Command(), "import", dir, "--allow-scope-mismatch")
 		require.NoError(t, err)
 
 		stdout, _, err := runCommand(t, globalstatus.Command(awsStageGlobalConfig()))

--- a/internal/staging/cli/command.go
+++ b/internal/staging/cli/command.go
@@ -17,15 +17,16 @@ import (
 // Flag names, flag usages, command names, and arg-usage strings shared across
 // sibling stage command builders.
 const (
-	flagYes              = "yes"
-	usageSkipConfirm     = "Skip confirmation prompt"
-	flagPassphraseStdin  = "passphrase-stdin"
-	usagePassphraseStdin = "Read passphrase from stdin (for scripts/automation)"
-	flagMerge            = "merge"
-	flagOverwrite        = "overwrite"
-	flagForce            = "force"
-	cmdNamePush          = "push"
-	argsUsageName        = "[name]"
+	flagYes                = "yes"
+	usageSkipConfirm       = "Skip confirmation prompt"
+	flagPassphraseStdin    = "passphrase-stdin"
+	usagePassphraseStdin   = "Read passphrase from stdin (for scripts/automation)"
+	flagMerge              = "merge"
+	flagOverwrite          = "overwrite"
+	flagForce              = "force"
+	flagAllowScopeMismatch = "allow-scope-mismatch"
+	cmdNamePush            = "push"
+	argsUsageName          = "[name]"
 )
 
 // CommandConfig holds service-specific configuration for building stage commands.

--- a/internal/staging/cli/import.go
+++ b/internal/staging/cli/import.go
@@ -60,7 +60,7 @@ func importFlags() []cli.Flag {
 			Usage: usagePassphraseStdin,
 		},
 		&cli.BoolFlag{
-			Name:  flagForce,
+			Name:  flagAllowScopeMismatch,
 			Usage: "Import even if the file's scope differs from the current scope",
 		},
 	}
@@ -157,7 +157,7 @@ type presentEnvelope struct {
 // prompted. For a service-specific import the single file must exist and its
 // header service must match. For a global import it reads whichever of
 // param.json / secret.json exist (missing ones are skipped); neither present is
-// an error. Scope mismatches are refused unless --force.
+// an error. Scope mismatches are refused unless --allow-scope-mismatch.
 func collectImportEnvelopes(
 	cmd *cli.Command, service staging.Service, pathFor func(staging.Service) string, wantScope string,
 ) ([]presentEnvelope, error) {
@@ -188,7 +188,7 @@ func collectImportEnvelopes(
 
 		// The file's header service must match what is expected here: the command's
 		// service for a service-specific import, or the per-service filename for a
-		// global import. A mismatch is a hard error (no --force override): importing
+		// global import. A mismatch is a hard error (no override): importing
 		// another service's data under the wrong service would corrupt the working
 		// area, and export always writes matching names/headers.
 		if env.Service != string(svc) {
@@ -198,9 +198,9 @@ func collectImportEnvelopes(
 			)
 		}
 
-		if env.Scope != wantScope && !cmd.Bool(flagForce) {
+		if env.Scope != wantScope && !cmd.Bool(flagAllowScopeMismatch) {
 			return nil, fmt.Errorf(
-				"export file scope %q does not match the current scope %q; re-run with --force to import anyway",
+				"export file scope %q does not match the current scope %q; re-run with --allow-scope-mismatch to import anyway",
 				env.Scope, wantScope,
 			)
 		}
@@ -402,8 +402,9 @@ Reads one file per service:
    <dir>/secret.json   Secrets Manager staged changes
 
 Missing files are skipped; it is an error only when neither exists. Each file's
-scope is validated against the current scope (override with --force). A
-Merge / Overwrite prompt appears only when the working staging area already
+scope is validated against the current scope (override with
+--allow-scope-mismatch). A Merge / Overwrite prompt appears only when the
+working staging area already
 holds changes; use --merge / --overwrite to choose non-interactively.
 
 EXAMPLES:
@@ -431,8 +432,9 @@ func NewImportCommand(cfg CommandConfig) *cli.Command {
 
 The file's service must match (%s); importing another service's file is a hard
 error. The file's scope is validated against the current scope (override with
---force). A Merge / Overwrite prompt appears only when the working staging area
-already holds changes; use --merge / --overwrite to choose non-interactively.
+--allow-scope-mismatch). A Merge / Overwrite prompt appears only when the working
+staging area already holds changes; use --merge / --overwrite to choose
+non-interactively.
 
 EXAMPLES:
    suve stage %s import ./%s.json                     Import staged %s changes

--- a/internal/staging/cli/import_test.go
+++ b/internal/staging/cli/import_test.go
@@ -132,7 +132,7 @@ func TestGlobalImport(t *testing.T) {
 		assert.Contains(t, err.Error(), "usage")
 	})
 
-	t.Run("scope mismatch refused, allowed with --force", func(t *testing.T) {
+	t.Run("scope mismatch refused, allowed with --allow-scope-mismatch", func(t *testing.T) {
 		scopeA := setupExportImportEnv(t)
 		dir := exportDir(t, scopeA, func() {
 			stageEntry(t, scopeA, staging.ServiceParam, "/app/config", "pval")
@@ -145,10 +145,21 @@ func TestGlobalImport(t *testing.T) {
 		assert.Contains(t, err.Error(), scopeA.Key())
 		assert.Contains(t, err.Error(), scopeB.Key())
 
-		// --force overrides.
-		_, _, err = runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scopeB)), nil, dir, "--force")
+		// --allow-scope-mismatch overrides.
+		_, _, err = runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scopeB)), nil, dir, "--allow-scope-mismatch")
 		require.NoError(t, err)
 		assert.False(t, workingState(t, scopeB).ExtractService(staging.ServiceParam).IsEmpty())
+	})
+
+	t.Run("legacy --force is no longer accepted on import", func(t *testing.T) {
+		scope := setupExportImportEnv(t)
+		dir := exportDir(t, scope, func() {
+			stageEntry(t, scope, staging.ServiceParam, "/app/config", "pval")
+		})
+
+		_, _, err := runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scope)), nil, dir, "--force")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "force")
 	})
 
 	t.Run("encrypted import in non-TTY without --passphrase-stdin is refused", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Renames the `stage import` scope-override flag from `--force` to `--allow-scope-mismatch`, per the AGREED approach in #487 (immediate rename, no alias).

The old `stage import --force` overloaded the name `--force`, which on `stage export` is an alias of `--yes` (skip overwrite confirmation) — an entirely different behavior. The import flag now states exactly what it does: allow importing an envelope whose embedded scope differs from the current scope.

- `stage import --force` removed; use `stage import --allow-scope-mismatch`.
- **No** `--force` alias kept on import.
- `stage export`'s `--force` (alias of `--yes`) is untouched.
- `stage secret delete --force` (immediate deletion) is a separate, unrelated flag — untouched.
- Help text, README, CLAUDE.md, and tests (unit + e2e) updated. Added a unit test asserting the legacy `--force` is now rejected on import.

## ⚠️ breaking-change

`stage import --force` → `stage import --allow-scope-mismatch`. Scripts that pass `--force` to `stage import` must update.

## Testing

- `SUVE_STAGING_KEY=... mise test` — pass
- `golangci-lint run ./internal/staging/cli/...` — 0 issues
- `go vet -tags e2e ./e2e/...` — clean

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)