### PR TITLE
fix(editor): make editor save round-trip lossless

### DIFF
--- a/internal/cli/editor/editor.go
+++ b/internal/cli/editor/editor.go
@@ -58,11 +58,31 @@ func Open(ctx context.Context, content string) (string, error) {
 		return "", err
 	}
 
-	// Trim trailing newline that editors often add
-	// Handle both Unix (\n) and Windows (\r\n) line endings
-	result := string(data)
-	result = strings.TrimSuffix(result, "\r\n")
-	result = strings.TrimSuffix(result, "\n")
+	return normalize(content, string(data)), nil
+}
 
-	return result, nil
+// normalize applies the round-trip-lossless rule to the editor's read-back
+// (result) given the exact content that was written into the tmpfile.
+//
+// Editors typically auto-append a single trailing newline to a buffer that did
+// not already end with one. We reverse ONLY that editor-added newline: if the
+// original content did not end with a newline, a single trailing newline (Unix
+// "\n" or Windows "\r\n") is stripped from the read-back. A trailing newline the
+// value carried in (PEM keys, JSON, ...) is preserved, so opening a value and
+// saving it untouched is byte-identical — which the callers then detect and
+// report as a no-op change.
+func normalize(content, result string) string {
+	// The value already carried a trailing newline: the editor did not add one,
+	// so keep the read-back verbatim to stay lossless.
+	if strings.HasSuffix(content, "\n") {
+		return result
+	}
+
+	// Strip the single line ending the editor auto-appended, handling both Unix
+	// (\n) and Windows (\r\n) endings.
+	if trimmed, ok := strings.CutSuffix(result, "\r\n"); ok {
+		return trimmed
+	}
+
+	return strings.TrimSuffix(result, "\n")
 }

--- a/internal/cli/editor/editor_test.go
+++ b/internal/cli/editor/editor_test.go
@@ -102,6 +102,51 @@ echo "with-newline" > "$1"
 	assert.Equal(t, "with-newline", result)
 }
 
+func TestOpen_PreservesTrailingNewlineWhenUntouched(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("Skipping on Windows - requires Unix shell")
+	}
+
+	// Use 'true' as editor (no-op command): the file is saved untouched.
+	t.Setenv("EDITOR", "true")
+	t.Setenv("VISUAL", "")
+
+	// A value that already ends in a newline (e.g. a PEM key or JSON document)
+	// must round-trip byte-identically: the trailing newline is the value's own,
+	// not one the editor auto-appended, so it must be preserved.
+	const content = "-----BEGIN KEY-----\nabc\n-----END KEY-----\n"
+
+	result, err := editor.Open(t.Context(), content)
+	require.NoError(t, err)
+	assert.Equal(t, content, result, "trailing newline the value already had must be preserved")
+}
+
+func TestOpen_TrimsEditorAppendedNewlineOnNonNewlineValue(t *testing.T) {
+	if runtime.GOOS == goosWindows {
+		t.Skip("Skipping on Windows - requires Unix shell")
+	}
+
+	// A script that mimics an editor auto-appending a single trailing newline to
+	// a value that did not already end with one.
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "test-editor.sh")
+	script := `#!/bin/sh
+content=$(cat "$1")
+printf '%s\n' "$content" > "$1"
+`
+	//nolint:gosec // G306: executable permission required for test shell script
+	require.NoError(t, os.WriteFile(scriptPath, []byte(script), 0o755))
+
+	t.Setenv("EDITOR", scriptPath)
+	t.Setenv("VISUAL", "")
+
+	// The input has no trailing newline; the editor-appended newline must be
+	// trimmed so the stored value matches the original bytes.
+	result, err := editor.Open(t.Context(), "no-trailing-newline")
+	require.NoError(t, err)
+	assert.Equal(t, "no-trailing-newline", result)
+}
+
 func TestOpen_TrimsCRLF(t *testing.T) {
 	if runtime.GOOS == goosWindows {
 		t.Skip("Skipping on Windows - requires Unix shell")

--- a/internal/staging/cli/cli_test.go
+++ b/internal/staging/cli/cli_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"runtime"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/mpyw/suve/internal/cli/confirm"
+	"github.com/mpyw/suve/internal/cli/editor"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/cli"
@@ -707,6 +709,41 @@ func TestDiffRunner_Run(t *testing.T) {
 // =============================================================================
 // EditRunner Tests
 // =============================================================================
+
+// TestEditRunner_RoundTripLossless exercises the real editor.Open (not a mock)
+// so the round-trip-lossless normalization is covered end to end: a baseline
+// value that already ends in a newline, opened and saved untouched, must be
+// reported as "No changes made." and leave nothing staged.
+func TestEditRunner_RoundTripLossless(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows - requires Unix shell")
+	}
+
+	// 'true' is a no-op editor: it saves the tmpfile untouched.
+	t.Setenv("EDITOR", "true")
+	t.Setenv("VISUAL", "")
+
+	store := testutil.NewMockStore()
+
+	var stdout, stderr bytes.Buffer
+
+	r := &cli.EditRunner{
+		UseCase: &stagingusecase.EditUseCase{
+			Strategy: &fullMockStrategy{service: staging.ServiceParam, fetchCurrentVal: "line1\nline2\n"},
+			Store:    store,
+		},
+		Stdout:     &stdout,
+		Stderr:     &stderr,
+		OpenEditor: editor.Open,
+	}
+
+	err := r.Run(t.Context(), cli.EditOptions{Name: "/app/config"})
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "No changes made")
+
+	_, err = store.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config", Namespace: ""})
+	require.ErrorIs(t, err, staging.ErrNotStaged, "a lossless no-op edit must not stage anything")
+}
 
 func TestEditRunner_Run(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Fixes the editor path stripping a trailing newline that the value legitimately owned. Opening a value that already ends in a newline (PEM keys, JSON documents, ...) and saving it untouched previously dropped that newline and was reported as a spurious change.

Per the agreed **round-trip lossless** approach on the issue:

- The editor's read-back is normalized against the exact bytes written into the tmpfile.
- Only the single trailing newline the editor auto-appends to a value that did **not** already end with one is stripped (Unix `\n` or Windows `\r\n`).
- A trailing newline the value carried in is **preserved**, so open + save untouched is byte-identical.
- The add/edit runners then detect that byte-identical read-back as "No changes made." and stage nothing.
- This aligns the normalization concept across the editor path, the `--value` path, and the GUI — the latter two already store the value verbatim, so no route now silently strips a newline the value legitimately had.

## Tests

- `internal/cli/editor`: a value ending in `\n` opened + saved untouched stays byte-identical; an editor-appended newline on a non-newline value is still trimmed; existing CRLF / modify / no-op cases still pass.
- `internal/staging/cli`: end-to-end runner test wiring the real `editor.Open` (no-op `EDITOR`) against a baseline ending in `\n` — reported as "No changes made." with nothing staged.

`mise test` passes. `golangci-lint` clean on the changed packages.

Closes #473

🤖 Generated with [Claude Code](https://claude.com/claude-code)