### PR TITLE
fix(list): sort names alphabetically across all providers

### DIFF
--- a/internal/provider/azure/appconfig/appconfig.go
+++ b/internal/provider/azure/appconfig/appconfig.go
@@ -139,9 +139,10 @@ func (s *Store) History(_ context.Context, _ string) ([]domain.Version, error) {
 }
 
 // List returns the distinct key names visible under the selected namespace
-// filter, sorted. The raw --namespace value is forwarded as an App
-// Configuration LabelFilter (empty -> the null-label filter); its `*`/`,`/`\`
-// grammar is honored natively by the service.
+// filter. The raw --namespace value is forwarded as an App Configuration
+// LabelFilter (empty -> the null-label filter); its `*`/`,`/`\` grammar is
+// honored natively by the service. Ordering is left to the caller: the list
+// use case sorts every provider's names uniformly (#480).
 func (s *Store) List(ctx context.Context) ([]string, error) {
 	settings, err := s.client.ListSettings(ctx, aznamespace.Filter(s.namespace))
 	if err != nil {
@@ -162,8 +163,6 @@ func (s *Store) List(ctx context.Context) ([]string, error) {
 
 		names = append(names, name)
 	}
-
-	sort.Strings(names)
 
 	// The totals make a successful-but-empty result (wrong store) visible at a
 	// glance, which a bodyless HTTP log cannot.

--- a/internal/provider/azure/appconfig/appconfig_test.go
+++ b/internal/provider/azure/appconfig/appconfig_test.go
@@ -258,7 +258,10 @@ func TestList(t *testing.T) {
 
 	names, err := store.List(t.Context())
 	require.NoError(t, err)
-	assert.Equal(t, []string{"alpha", "beta"}, names)
+	// List dedups but no longer sorts: ordering is owned by the list use case,
+	// which sorts every provider's names uniformly (#480). Distinct keys are
+	// returned in first-seen order.
+	assert.Equal(t, []string{"beta", "alpha"}, names)
 }
 
 func TestList_ForwardsFilter(t *testing.T) {

--- a/internal/usecase/azure/azure_test.go
+++ b/internal/usecase/azure/azure_test.go
@@ -221,3 +221,27 @@ func TestListNamespacesUseCase(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to list entries")
 	})
 }
+
+// TestListUseCase_SortsNames verifies the list use case emits names in a stable
+// alphabetical order regardless of the provider's native ordering. This covers
+// Key Vault, whose API returns names in an unspecified order (#480).
+func TestListUseCase_SortsNames(t *testing.T) {
+	t.Parallel()
+
+	store := &providermock.Store{
+		ListFunc: func(_ context.Context) ([]string, error) {
+			return []string{"charlie", "alpha", "bravo"}, nil
+		},
+	}
+
+	uc := &azure.ListUseCase{Reader: store}
+	out, err := uc.Execute(t.Context(), azure.ListInput{})
+	require.NoError(t, err)
+
+	names := make([]string, len(out.Entries))
+	for i, e := range out.Entries {
+		names[i] = e.Name
+	}
+
+	assert.Equal(t, []string{"alpha", "bravo", "charlie"}, names)
+}

--- a/internal/usecase/azure/list.go
+++ b/internal/usecase/azure/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/samber/lo"
@@ -72,6 +73,10 @@ func (u *ListUseCase) Execute(ctx context.Context, input ListInput) (*ListOutput
 	// dropped everything" — the two look identical in the final output.
 	debug.From(ctx).Logf("azure list: provider returned %d names, %d after filters (prefix=%q, filter=%q)\n",
 		len(names), len(filtered), input.Prefix, input.Filter)
+
+	// Sort names alphabetically so the listing has a stable, deterministic order
+	// regardless of the provider API's native ordering (#480).
+	slices.Sort(filtered)
 
 	return u.buildOutput(ctx, input.WithValue, filtered), nil
 }

--- a/internal/usecase/gcloud/gcloud_test.go
+++ b/internal/usecase/gcloud/gcloud_test.go
@@ -143,3 +143,26 @@ func TestListUseCase_PrefixFilter(t *testing.T) {
 	assert.Equal(t, "prod-a", out.Entries[0].Name)
 	assert.Equal(t, "prod-b", out.Entries[1].Name)
 }
+
+// TestListUseCase_SortsNames verifies the list use case emits names in a stable
+// alphabetical order regardless of the provider's native ordering (#480).
+func TestListUseCase_SortsNames(t *testing.T) {
+	t.Parallel()
+
+	store := &providermock.Store{
+		ListFunc: func(_ context.Context) ([]string, error) {
+			return []string{"charlie", "alpha", "bravo"}, nil
+		},
+	}
+
+	uc := &gcloud.ListUseCase{Reader: store}
+	out, err := uc.Execute(t.Context(), gcloud.ListInput{})
+	require.NoError(t, err)
+
+	names := make([]string, len(out.Entries))
+	for i, e := range out.Entries {
+		names[i] = e.Name
+	}
+
+	assert.Equal(t, []string{"alpha", "bravo", "charlie"}, names)
+}

--- a/internal/usecase/gcloud/list.go
+++ b/internal/usecase/gcloud/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/samber/lo"
@@ -72,6 +73,10 @@ func (u *ListUseCase) Execute(ctx context.Context, input ListInput) (*ListOutput
 	// dropped everything" — the two look identical in the final output.
 	debug.From(ctx).Logf("gcloud secretmanager list: provider returned %d names, %d after filters (prefix=%q, filter=%q)\n",
 		len(names), len(filtered), input.Prefix, input.Filter)
+
+	// Sort names alphabetically so the listing has a stable, deterministic order
+	// regardless of the provider API's native ordering (#480).
+	slices.Sort(filtered)
 
 	return u.buildOutput(ctx, input.WithValue, filtered), nil
 }

--- a/internal/usecase/param/list.go
+++ b/internal/usecase/param/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/samber/lo"
@@ -74,6 +75,10 @@ func (u *ListUseCase) Execute(ctx context.Context, input ListInput) (*ListOutput
 	// dropped everything" — the two look identical in the final output.
 	debug.From(ctx).Logf("aws ssm list: provider returned %d names, %d after filters (prefix=%q, recursive=%v, filter=%q)\n",
 		len(names), len(filtered), input.Prefix, input.Recursive, input.Filter)
+
+	// Sort names alphabetically so the listing has a stable, deterministic order
+	// regardless of the provider API's native ordering (#480).
+	slices.Sort(filtered)
 
 	return u.buildOutput(ctx, input.WithValue, filtered), nil
 }

--- a/internal/usecase/param/list_test.go
+++ b/internal/usecase/param/list_test.go
@@ -272,3 +272,23 @@ func TestListUseCase_Execute_WithValue_Empty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, output.Entries)
 }
+
+// TestListUseCase_Execute_SortsNames verifies the list use case emits names in a
+// stable alphabetical order regardless of the provider's native ordering (#480).
+func TestListUseCase_Execute_SortsNames(t *testing.T) {
+	t.Parallel()
+
+	store := &providermock.Store{ListFunc: listNames("/app/charlie", "/app/alpha", "/app/bravo")}
+
+	uc := &param.ListUseCase{Reader: store}
+
+	output, err := uc.Execute(t.Context(), param.ListInput{})
+	require.NoError(t, err)
+
+	names := make([]string, len(output.Entries))
+	for i, e := range output.Entries {
+		names[i] = e.Name
+	}
+
+	assert.Equal(t, []string{"/app/alpha", "/app/bravo", "/app/charlie"}, names)
+}

--- a/internal/usecase/secret/list.go
+++ b/internal/usecase/secret/list.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/samber/lo"
@@ -77,6 +78,10 @@ func (u *ListUseCase) Execute(ctx context.Context, input ListInput) (*ListOutput
 	// dropped everything" — the two look identical in the final output.
 	debug.From(ctx).Logf("aws secretsmanager list: provider returned %d names, %d after filters (prefix=%q, filter=%q)\n",
 		len(names), len(filtered), input.Prefix, input.Filter)
+
+	// Sort names alphabetically so the listing has a stable, deterministic order
+	// regardless of the provider API's native ordering (#480).
+	slices.Sort(filtered)
 
 	return u.buildOutput(ctx, input.WithValue, filtered), nil
 }

--- a/internal/usecase/secret/list_test.go
+++ b/internal/usecase/secret/list_test.go
@@ -161,3 +161,21 @@ func TestListUseCase_Execute_WithValue_PartialError(t *testing.T) {
 	assert.True(t, hasValue)
 	assert.True(t, hasError)
 }
+
+// TestListUseCase_Execute_SortsNames verifies the list use case emits names in a
+// stable alphabetical order regardless of the provider's native ordering (#480).
+func TestListUseCase_Execute_SortsNames(t *testing.T) {
+	t.Parallel()
+
+	uc := &secret.ListUseCase{Reader: listStore([]string{"charlie", "alpha", "bravo"}, nil, nil)}
+
+	output, err := uc.Execute(t.Context(), secret.ListInput{})
+	require.NoError(t, err)
+
+	names := make([]string, len(output.Entries))
+	for i, e := range output.Entries {
+		names[i] = e.Name
+	}
+
+	assert.Equal(t, []string{"alpha", "bravo", "charlie"}, names)
+}


### PR DESCRIPTION
## Summary

Fixes #480: `list` output previously reflected each cloud API's native ordering, which differed per provider and was unstable across calls. This sorts the filtered names in a single shared place — each list use case (`param`, `secret`, `gcloud`, `azure`) after `Reader.List` — so AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration all yield a stable, deterministic alphabetical order.

The Azure App Configuration provider-level `Store.List` sort is now redundant and removed; ordering is owned uniformly by the use case (the App-Config-specific `ListWithNamespaces` used by the GUI keeps its own (key, namespace) sort).

## Safety

The list path fully drains pagination and materializes all results before printing — there is no `--limit`, count cap, or server-side truncation on `list` (those are `log`-only), and `--show` only does N+1 value fetches without truncating the listing. So sorting the fully-gathered set is safe and complete.

## Breaking change

<!-- breaking-change / release-note -->
This changes the existing `list` output order for AWS param/secret, Google Cloud, and Azure Key Vault. Any scripts that depend on the previous (native API) ordering are affected. **breaking-change** — call out in the release notes.

## Tests

Added use-case unit tests that feed the mock `Reader.List` an out-of-order slice and assert sorted output for param, secret, gcloud, and Key Vault (azure). Updated the App Config provider `TestList` to reflect that `Store.List` now dedups in first-seen order without sorting. `mise test` passes.

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)