### PR TITLE
fix(secret): reject binary secrets on read and guard staged overwrites

### DIFF
--- a/internal/provider/aws/secret/secret.go
+++ b/internal/provider/aws/secret/secret.go
@@ -254,6 +254,14 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 		return nil, fmt.Errorf("failed to get secret value: %w", err)
 	}
 
+	// A secret stored via SecretBinary (SecretString nil) has no text form. Mapping
+	// it through aws.ToString would silently yield an empty value with no error,
+	// which misrepresents a non-empty secret and lets a staged string edit clobber
+	// it on apply. Reject it explicitly instead (#469).
+	if out.SecretString == nil && len(out.SecretBinary) > 0 {
+		return nil, fmt.Errorf("%w: %s", provider.ErrBinaryValue, name)
+	}
+
 	entry := &domain.Entry{
 		Name:  aws.ToString(out.Name),
 		Value: aws.ToString(out.SecretString),

--- a/internal/provider/aws/secret/secret_test.go
+++ b/internal/provider/aws/secret/secret_test.go
@@ -730,6 +730,30 @@ func TestGet_NotFoundMapsSentinel(t *testing.T) {
 	assert.ErrorIs(t, err, provider.ErrNotFound)
 }
 
+// TestGet_BinarySecretRejected guards #469: a secret stored via SecretBinary
+// (SecretString nil) must NOT be mapped to an empty value with a nil error, as
+// that misrepresents a non-empty secret and lets a staged string edit clobber it
+// on apply. Get must fail with provider.ErrBinaryValue instead.
+func TestGet_BinarySecretRejected(t *testing.T) {
+	t.Parallel()
+
+	store := secret.New(&mockClient{
+		getValue: func(*secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+			return &secretsmanager.GetSecretValueOutput{
+				Name:         aws.String("my-secret"),
+				SecretBinary: []byte{0x00, 0x01},
+				SecretString: nil,
+				VersionId:    aws.String("id-1"),
+			}, nil
+		},
+	})
+
+	entry, err := store.Get(t.Context(), "my-secret", provider.VersionRef{})
+	require.Error(t, err)
+	require.ErrorIs(t, err, provider.ErrBinaryValue)
+	assert.Nil(t, entry)
+}
+
 func TestDescribe_NotFoundMapsSentinel(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provider/errors.go
+++ b/internal/provider/errors.go
@@ -11,4 +11,8 @@ var (
 	// ErrAlreadyExists indicates a create was attempted on an entry that
 	// already exists.
 	ErrAlreadyExists = errors.New("provider: entry already exists")
+	// ErrBinaryValue indicates the entry holds a binary value that suve cannot
+	// represent as text (e.g. an AWS Secrets Manager SecretBinary secret).
+	// Callers must not treat such an entry as an empty-string value.
+	ErrBinaryValue = errors.New("binary value is not supported")
 )

--- a/internal/staging/secret.go
+++ b/internal/staging/secret.go
@@ -76,6 +76,15 @@ func (s *SecretStrategy) applyUpdate(ctx context.Context, name string, entry Ent
 		return nil
 	}
 
+	// Overwrite guard: applying a staged string edit issues UpdateSecret with
+	// SecretString, which silently drops a current SecretBinary value. Probe the
+	// current value and refuse when it is binary (#469). Any other probe failure
+	// is left for Put to surface, so the guard never turns a transient read error
+	// into a spurious apply failure.
+	if _, err := s.store.Get(ctx, name, provider.VersionRef{}); errors.Is(err, provider.ErrBinaryValue) {
+		return fmt.Errorf("refusing to overwrite binary secret %q with a string value: %w", name, err)
+	}
+
 	// Put overwrites the existing secret with a new version and, when provided,
 	// updates the description in the same operation.
 	if _, err := s.store.Put(ctx, name, *entry.Value, domain.ValueTypeSecret, lo.FromPtr(entry.Description)); err != nil {

--- a/internal/staging/secret_test.go
+++ b/internal/staging/secret_test.go
@@ -232,6 +232,41 @@ func TestSecretStrategy_Apply(t *testing.T) {
 	})
 }
 
+// TestSecretStrategy_Apply_RefusesBinaryOverwrite guards #469: applying a staged
+// string edit onto a secret whose current version is binary would issue
+// UpdateSecret with SecretString and silently drop the binary value. The update
+// path must probe the current value and refuse when it is binary, without ever
+// calling Put.
+func TestSecretStrategy_Apply_RefusesBinaryOverwrite(t *testing.T) {
+	t.Parallel()
+
+	putCalled := false
+	mock := &providermock.Store{
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			assert.Equal(t, "my-secret", name)
+
+			return nil, fmt.Errorf("%w: %s", provider.ErrBinaryValue, name)
+		},
+		PutFunc: func(
+			_ context.Context, _, _ string, _ domain.ValueType, _ string, _ ...provider.WriteOption,
+		) (domain.Version, error) {
+			putCalled = true
+
+			return domain.Version{}, nil
+		},
+	}
+
+	s := staging.NewSecretStrategy(mock)
+	err := s.Apply(t.Context(), "my-secret", staging.Entry{
+		Operation: staging.OperationUpdate,
+		Value:     lo.ToPtr("string-value"),
+	})
+	require.Error(t, err)
+	require.ErrorIs(t, err, provider.ErrBinaryValue)
+	assert.Contains(t, err.Error(), "refusing to overwrite binary secret")
+	assert.False(t, putCalled, "Put must not be called when the current secret is binary")
+}
+
 func TestSecretStrategy_FetchCurrent(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

- **Read rejection**: `provider.Store.Get` for AWS Secrets Manager now returns the new sentinel `provider.ErrBinaryValue` when a secret is stored via `SecretBinary` (i.e. `SecretString` is nil and `SecretBinary` is set), instead of mapping it through `aws.ToString` to an empty string. This also covers `stage edit` / `stage diff`, which read the current value through `Get`.
- **Overwrite guard**: staging `applyUpdate` probes the current value and refuses to overwrite a binary secret with a string value (which would otherwise issue `UpdateSecret` with `SecretString` and silently drop the binary version). Any other probe failure is left for `Put` to surface, so a transient read error never turns into a spurious apply failure.

## Why

Secrets stored with `SecretBinary` (common for keystores/certs) were presented as an **empty value with no error**: `suve secret show` printed empty for a non-empty secret, and a staged edit + apply silently converted the current version from binary to string — a data-integrity hazard.

Per the agreed approach recorded on the issue (**reject + overwrite-guard**), full binary support (base64 display or a domain `ValueType` extension) is intentionally out of scope and can be filed as a separate feature if needed.

## Tests

- `TestGet_BinarySecretRejected` (provider/aws/secret): asserts `Get` returns `ErrBinaryValue` (not an empty value with nil error) for a `SecretBinary`-only secret.
- `TestSecretStrategy_Apply_RefusesBinaryOverwrite` (staging, providermock): asserts a staged string update against a binary secret is refused and `Put` is never called.

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)