### PR TITLE
fix(staging): detect conflicts for staged tag changes (#483)

### DIFF
--- a/e2e/staging_test.go
+++ b/e2e/staging_test.go
@@ -319,6 +319,64 @@ func TestGlobal_StagingWithTags(t *testing.T) {
 	})
 }
 
+// TestGlobal_TagConflictDetection covers #483: a staged tag whose remote was
+// modified after the recorded BaseModifiedAt is rejected as a conflict at apply
+// time, and --ignore-conflicts forces it through. Staging the tag with a
+// BaseModifiedAt in the past simulates the remote being changed out-of-band
+// since the tags were fetched — the real FetchLastModified returns the
+// parameter's actual (newer) modified time.
+func TestGlobal_TagConflictDetection(t *testing.T) {
+	setupEnv(t)
+	setupTempHome(t)
+
+	paramName := "/suve-e2e-global/tag-conflict/param"
+
+	// Cleanup
+	_, _, _ = runCommand(t, paramdelete.Command(), "--yes", paramName)
+	t.Cleanup(func() {
+		_, _, _ = runCommand(t, paramdelete.Command(), "--yes", paramName)
+	})
+
+	// Create a parameter; its LastModified is now.
+	_, _, err := runCommand(t, paramcreate.Command(), paramName, "initial-value")
+	require.NoError(t, err)
+
+	// Stage a tag change whose BaseModifiedAt predates the parameter — as if the
+	// remote had been modified since the tags were fetched.
+	past := time.Now().Add(-24 * time.Hour)
+	store := newStore()
+	err = store.StageTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: paramName}, staging.TagEntry{
+		Add:            map[string]string{"env": "test"},
+		StagedAt:       time.Now(),
+		BaseModifiedAt: &past,
+	})
+	require.NoError(t, err)
+
+	// Apply without --ignore-conflicts: rejected as a conflict; tag stays staged.
+	t.Run("apply-rejected-on-conflict", func(t *testing.T) {
+		_, _, err := runSubCommand(t, paramstage.Command(), "apply", "--yes")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "conflict")
+
+		_, err = store.GetTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: paramName})
+		require.NoError(t, err)
+	})
+
+	// Apply with --ignore-conflicts: forced through and unstaged.
+	t.Run("apply-forced-with-ignore-conflicts", func(t *testing.T) {
+		stdout, _, err := runSubCommand(t, paramstage.Command(), "apply", "--yes", "--ignore-conflicts")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "Tagged")
+
+		_, err = store.GetTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: paramName})
+		require.ErrorIs(t, err, staging.ErrNotStaged)
+
+		stdout, _, err = runCommand(t, cmdparam.ShowCommand(), paramName)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "env: test")
+	})
+}
+
 // TestGlobal_ResetWithTags tests the global reset command with tag entries.
 func TestGlobal_ResetWithTags(t *testing.T) {
 	setupEnv(t)

--- a/internal/staging/conflict.go
+++ b/internal/staging/conflict.go
@@ -102,3 +102,67 @@ func CheckConflicts(ctx context.Context, resolve ApplyStrategyResolver, entries 
 
 	return conflicts
 }
+
+// CheckTagConflicts checks if the remote resource behind each staged tag change
+// was modified after the tags were fetched. Returns the set of EntryKeys that
+// have conflicts.
+//
+// It mirrors the Update/Delete path of CheckConflicts using the tag's own
+// TagEntry.BaseModifiedAt: if the remote's last-modified time is after that base
+// time, someone changed the resource since the tags were staged and the apply is
+// a conflict rather than a silent overwrite. Each tag change is probed through
+// the strategy resolved for its own namespace (App Configuration); other
+// providers resolve the single strategy under the empty namespace.
+//
+// A tag change with no BaseModifiedAt cannot be checked and is never a conflict.
+// A remote that no longer exists (zero time) is skipped too — the tag apply will
+// fail on its own.
+func CheckTagConflicts(ctx context.Context, resolve ApplyStrategyResolver, tags map[EntryKey]TagEntry) map[EntryKey]struct{} {
+	conflicts := make(map[EntryKey]struct{})
+
+	toCheck := make(map[EntryKey]TagEntry)
+
+	for key, tag := range tags {
+		if tag.BaseModifiedAt != nil {
+			toCheck[key] = tag
+		}
+	}
+
+	if len(toCheck) == 0 {
+		return conflicts
+	}
+
+	// Fetch last modified times in parallel, resolving the strategy per entry so
+	// the probe targets the tagged item's own namespace.
+	results := parallel.ExecuteMap(ctx, toCheck, func(ctx context.Context, key EntryKey, _ TagEntry) (time.Time, error) {
+		strategy, err := resolve(key.Namespace)
+		if err != nil {
+			return time.Time{}, err
+		}
+
+		return strategy.FetchLastModified(ctx, key.Name)
+	})
+
+	for key, tag := range toCheck {
+		result := results[key]
+		if result.Err != nil {
+			// If we can't fetch, assume no conflict (will fail on apply anyway)
+			continue
+		}
+
+		awsModified := result.Value
+
+		// Zero time means the resource no longer exists - the tag apply will fail
+		// on its own, so don't report it as a conflict here.
+		if awsModified.IsZero() {
+			continue
+		}
+
+		// If the remote was modified after the tags were fetched, it's a conflict.
+		if awsModified.After(*tag.BaseModifiedAt) {
+			conflicts[key] = struct{}{}
+		}
+	}
+
+	return conflicts
+}

--- a/internal/staging/conflict_test.go
+++ b/internal/staging/conflict_test.go
@@ -255,6 +255,135 @@ func TestCheckConflicts(t *testing.T) {
 	})
 }
 
+func TestCheckTagConflicts(t *testing.T) {
+	t.Parallel()
+
+	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	laterTime := time.Date(2024, 1, 1, 13, 0, 0, 0, time.UTC)
+
+	t.Run("empty tags returns empty conflicts", func(t *testing.T) {
+		t.Parallel()
+
+		strategy := &mockApplyStrategy{}
+		conflicts := staging.CheckTagConflicts(t.Context(), resolverFor(strategy), map[staging.EntryKey]staging.TagEntry{})
+		assert.Empty(t, conflicts)
+	})
+
+	t.Run("tag without base time is never a conflict", func(t *testing.T) {
+		t.Parallel()
+
+		strategy := &mockApplyStrategy{
+			fetchLastModifiedFunc: func(_ context.Context, _ string) (time.Time, error) {
+				return laterTime, nil // modified, but no base to compare against
+			},
+		}
+		tags := map[staging.EntryKey]staging.TagEntry{
+			{Name: "item1"}: {Add: map[string]string{"env": "prod"}},
+		}
+		conflicts := staging.CheckTagConflicts(t.Context(), resolverFor(strategy), tags)
+		assert.Empty(t, conflicts)
+	})
+
+	t.Run("conflict - remote modified after base", func(t *testing.T) {
+		t.Parallel()
+
+		strategy := &mockApplyStrategy{
+			fetchLastModifiedFunc: func(_ context.Context, _ string) (time.Time, error) {
+				return laterTime, nil
+			},
+		}
+		tags := map[staging.EntryKey]staging.TagEntry{
+			{Name: "existing-item"}: {
+				Add:            map[string]string{"env": "prod"},
+				BaseModifiedAt: &baseTime,
+			},
+		}
+		conflicts := staging.CheckTagConflicts(t.Context(), resolverFor(strategy), tags)
+		assert.Contains(t, conflicts, staging.EntryKey{Name: "existing-item"})
+	})
+
+	t.Run("no conflict - remote unchanged since base", func(t *testing.T) {
+		t.Parallel()
+
+		strategy := &mockApplyStrategy{
+			fetchLastModifiedFunc: func(_ context.Context, _ string) (time.Time, error) {
+				return baseTime, nil // same time as base
+			},
+		}
+		tags := map[staging.EntryKey]staging.TagEntry{
+			{Name: "existing-item"}: {
+				Add:            map[string]string{"env": "prod"},
+				BaseModifiedAt: &baseTime,
+			},
+		}
+		conflicts := staging.CheckTagConflicts(t.Context(), resolverFor(strategy), tags)
+		assert.Empty(t, conflicts)
+	})
+
+	t.Run("no conflict - remote no longer exists", func(t *testing.T) {
+		t.Parallel()
+
+		strategy := &mockApplyStrategy{
+			fetchLastModifiedFunc: func(_ context.Context, _ string) (time.Time, error) {
+				return time.Time{}, nil // zero time: resource gone
+			},
+		}
+		tags := map[staging.EntryKey]staging.TagEntry{
+			{Name: "existing-item"}: {
+				Add:            map[string]string{"env": "prod"},
+				BaseModifiedAt: &baseTime,
+			},
+		}
+		conflicts := staging.CheckTagConflicts(t.Context(), resolverFor(strategy), tags)
+		assert.Empty(t, conflicts)
+	})
+
+	t.Run("fetch error - no conflict assumed", func(t *testing.T) {
+		t.Parallel()
+
+		strategy := &mockApplyStrategy{
+			fetchLastModifiedFunc: func(_ context.Context, _ string) (time.Time, error) {
+				return time.Time{}, errors.New("access denied")
+			},
+		}
+		tags := map[staging.EntryKey]staging.TagEntry{
+			{Name: "existing-item"}: {
+				Add:            map[string]string{"env": "prod"},
+				BaseModifiedAt: &baseTime,
+			},
+		}
+		conflicts := staging.CheckTagConflicts(t.Context(), resolverFor(strategy), tags)
+		assert.Empty(t, conflicts)
+	})
+
+	t.Run("per-namespace - each probed against its own remote", func(t *testing.T) {
+		t.Parallel()
+
+		remoteByNamespace := map[string]time.Time{
+			"":    baseTime,  // unchanged since base -> no conflict
+			"dev": laterTime, // modified after base -> conflict
+		}
+
+		resolve := func(namespace string) (staging.ApplyStrategy, error) {
+			return &mockApplyStrategy{
+				fetchLastModifiedFunc: func(_ context.Context, _ string) (time.Time, error) {
+					return remoteByNamespace[namespace], nil
+				},
+			}, nil
+		}
+
+		tags := map[staging.EntryKey]staging.TagEntry{
+			{Name: "k", Namespace: ""}:    {Add: map[string]string{"a": "1"}, BaseModifiedAt: &baseTime},
+			{Name: "k", Namespace: "dev"}: {Add: map[string]string{"a": "1"}, BaseModifiedAt: &baseTime},
+		}
+
+		conflicts := staging.CheckTagConflicts(t.Context(), resolve, tags)
+		assert.Len(t, conflicts, 1)
+		assert.Contains(t, conflicts, staging.EntryKey{Name: "k", Namespace: "dev"})
+		assert.NotContains(t, conflicts, staging.EntryKey{Name: "k", Namespace: ""})
+	})
+}
+
 // TestCheckConflicts_ResolverError verifies that a per-namespace resolver which
 // fails to resolve a strategy is treated like a fetch error: the entry is
 // skipped (no conflict) and the failure surfaces later on the apply attempt.

--- a/internal/usecase/staging/apply.go
+++ b/internal/usecase/staging/apply.go
@@ -151,9 +151,16 @@ func (u *ApplyUseCase) Execute(ctx context.Context, input ApplyInput) (*ApplyOut
 		return output, nil
 	}
 
-	// Check for conflicts (only for entries, as tags don't have value conflicts)
-	if !input.IgnoreConflicts && len(entries) > 0 {
+	// Check for conflicts. Both value entries and tag changes carry a
+	// BaseModifiedAt; a remote modified after that base time is a conflict for
+	// either kind. Merge both sets so a resource staged with both a value change
+	// and a tag change is reported once.
+	if !input.IgnoreConflicts {
 		conflicts := staging.CheckConflicts(ctx, u.strategyForNamespace, entries)
+		for key := range staging.CheckTagConflicts(ctx, u.strategyForNamespace, tags) {
+			conflicts[key] = struct{}{}
+		}
+
 		if len(conflicts) > 0 {
 			// Report the full EntryKey (sorted for determinism) so callers can
 			// render the namespace badge.

--- a/internal/usecase/staging/apply_test.go
+++ b/internal/usecase/staging/apply_test.go
@@ -513,6 +513,113 @@ func TestApplyUseCase_Execute_ListTagsError(t *testing.T) {
 	assert.Contains(t, err.Error(), "list tags error")
 }
 
+// TestApplyUseCase_Execute_TagConflictDetection verifies that a staged tag whose
+// remote was modified after its BaseModifiedAt is reported as a conflict and the
+// apply is rejected (#483).
+func TestApplyUseCase_Execute_TagConflictDetection(t *testing.T) {
+	t.Parallel()
+
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	awsTime := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC) // modified after staging
+
+	store := testutil.NewMockStore()
+	require.NoError(t, store.StageTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"}, staging.TagEntry{
+		Add:            map[string]string{"env": "prod"},
+		StagedAt:       time.Now(),
+		BaseModifiedAt: &baseTime,
+	}))
+
+	strategy := newMockApplyTagStrategy()
+	strategy.lastModified["/app/config"] = awsTime
+
+	uc := &usecasestaging.ApplyUseCase{
+		Strategy: strategy,
+		Store:    store,
+	}
+
+	output, err := uc.Execute(t.Context(), usecasestaging.ApplyInput{
+		IgnoreConflicts: false,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflict")
+	assert.Len(t, output.Conflicts, 1)
+	assert.Equal(t, staging.EntryKey{Name: "/app/config"}, output.Conflicts[0])
+
+	// The tag must NOT be applied or unstaged when a conflict is detected.
+	assert.Equal(t, 0, output.TagSucceeded)
+
+	_, err = store.GetTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
+	require.NoError(t, err)
+}
+
+// TestApplyUseCase_Execute_TagConflictIgnored verifies that --ignore-conflicts
+// bypasses tag conflict detection and applies the staged tag regardless (#483).
+func TestApplyUseCase_Execute_TagConflictIgnored(t *testing.T) {
+	t.Parallel()
+
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	awsTime := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC) // modified after staging
+
+	store := testutil.NewMockStore()
+	require.NoError(t, store.StageTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"}, staging.TagEntry{
+		Add:            map[string]string{"env": "prod"},
+		StagedAt:       time.Now(),
+		BaseModifiedAt: &baseTime,
+	}))
+
+	strategy := newMockApplyTagStrategy()
+	strategy.lastModified["/app/config"] = awsTime
+
+	uc := &usecasestaging.ApplyUseCase{
+		Strategy: strategy,
+		Store:    store,
+	}
+
+	output, err := uc.Execute(t.Context(), usecasestaging.ApplyInput{
+		IgnoreConflicts: true,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, output.Conflicts)
+	assert.Equal(t, 1, output.TagSucceeded)
+
+	// Applied cleanly, so the tag is unstaged.
+	_, err = store.GetTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
+	require.ErrorIs(t, err, staging.ErrNotStaged)
+}
+
+// TestApplyUseCase_Execute_TagNoConflict verifies that a staged tag whose remote
+// is unchanged since its BaseModifiedAt applies cleanly without --ignore-conflicts.
+func TestApplyUseCase_Execute_TagNoConflict(t *testing.T) {
+	t.Parallel()
+
+	baseTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	store := testutil.NewMockStore()
+	require.NoError(t, store.StageTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"}, staging.TagEntry{
+		Add:            map[string]string{"env": "prod"},
+		StagedAt:       time.Now(),
+		BaseModifiedAt: &baseTime,
+	}))
+
+	strategy := newMockApplyTagStrategy()
+	strategy.lastModified["/app/config"] = baseTime // unchanged since base
+
+	uc := &usecasestaging.ApplyUseCase{
+		Strategy: strategy,
+		Store:    store,
+	}
+
+	output, err := uc.Execute(t.Context(), usecasestaging.ApplyInput{
+		IgnoreConflicts: false,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, output.Conflicts)
+	assert.Equal(t, 1, output.TagSucceeded)
+
+	_, err = store.GetTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
+	require.ErrorIs(t, err, staging.ErrNotStaged)
+}
+
 // TestApplyUseCase_Execute_PerNamespaceResolver covers the App Configuration
 // path (#431): the same key staged under two namespaces lives in one store as
 // two entries, each applied through the strategy resolved for its own namespace,


### PR DESCRIPTION
## Summary

Staged tag changes previously applied unconditionally: the persisted `TagEntry.BaseModifiedAt` was stored but never consulted, so `stage apply` overwrote remote tags even when the resource had been modified since the tags were staged.

This wires tags into conflict detection the same way value entries already are:

- New `staging.CheckTagConflicts` probes each staged tag (keyed by `EntryKey`) through the per-namespace `ApplyStrategyResolver`, comparing the tag's `BaseModifiedAt` against `FetchLastModified`. A remote modified after the base time is a conflict.
- `ApplyUseCase.Execute` now merges tag conflicts with entry conflicts before applying, so a resource staged with both a value change and a tag change is reported once.
- `--ignore-conflicts` continues to force the apply through, unchanged.

## Behavior change

⚠️ Previously-passing tag applies may now be **rejected as conflicts** when the remote was modified after the tags were staged. Use `--ignore-conflicts` to force the apply through (same escape hatch as value entries). Worth a release-note callout.

## Tests

- `internal/staging/conflict_test.go`: `CheckTagConflicts` — conflict when remote modified after base, no conflict when unchanged, nil base / zero remote / fetch error skipped, per-namespace probing.
- `internal/usecase/staging/apply_test.go`: staged tag conflict rejects the apply (tag stays staged); `--ignore-conflicts` bypasses and unstages; unchanged remote applies cleanly.
- `e2e/staging_test.go`: `TestGlobal_TagConflictDetection` — create param, stage tag with an out-of-date base, apply rejected as conflict, then `--ignore-conflicts` forces it through.

`mise test` passes; scoped `golangci-lint` (staging + usecase/staging + stage commands, plus the e2e file) reports 0 issues.

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)