### PR TITLE
fix(staging): bind export envelope header to ciphertext via AEAD AAD (#476)

### DIFF
--- a/internal/staging/store/file/envelope.go
+++ b/internal/staging/store/file/envelope.go
@@ -1,7 +1,9 @@
 package file
 
 import (
+	"bytes"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -14,7 +16,12 @@ import (
 )
 
 // EnvelopeVersion is the current export/import envelope schema version.
-const EnvelopeVersion = 1
+//
+// v2 binds the plaintext header (version/provider/scope/service) to the
+// encrypted payload as AES-GCM associated data (AAD). This is a breaking
+// change: v1 files (no AAD binding) are rejected on import and must be
+// re-created with `stage export`.
+const EnvelopeVersion = 2
 
 // Envelope is the on-disk format for `stage export` / `stage import` files.
 //
@@ -51,10 +58,44 @@ var (
 	ErrUnsupportedEnvelopeVersion = errors.New("unsupported export file version")
 )
 
+// aadDomain is a domain-separation prefix for the envelope AAD, so the bound
+// bytes can never be confused with any other AES-GCM associated data.
+const aadDomain = "suve/staging/export-envelope\x00"
+
+// associatedData returns the canonical AES-GCM associated data that binds the
+// envelope header (version/provider/scope/service) to the encrypted payload.
+//
+// The encoding is a fixed-order, length-prefixed concatenation so that no field
+// boundary is ambiguous: tampering with any single header field yields
+// different AAD, which makes DecryptWithAAD fail with crypt.ErrDecryptionFailed.
+func (e *Envelope) associatedData() []byte {
+	var buf bytes.Buffer
+
+	buf.WriteString(aadDomain)
+
+	var num [8]byte
+
+	binary.BigEndian.PutUint64(num[:], uint64(e.Version)) //nolint:gosec // version is a small non-negative schema constant
+	buf.Write(num[:])
+
+	writeField := func(s string) {
+		binary.BigEndian.PutUint64(num[:], uint64(len(s)))
+		buf.Write(num[:])
+		buf.WriteString(s)
+	}
+
+	writeField(e.Provider)
+	writeField(e.Scope)
+	writeField(e.Service)
+
+	return buf.Bytes()
+}
+
 // encodePayload marshals a single-service state into the base64 payload. With an
 // empty passphrase the state JSON is stored as plaintext (base64 only, no
-// encryption); otherwise it is encrypted with the passphrase-based (v1) format.
-func encodePayload(state *staging.State, passphrase string) (string, error) {
+// encryption); otherwise it is encrypted with the passphrase-based (v1) format,
+// binding aad (the canonical envelope header) to the ciphertext.
+func encodePayload(state *staging.State, passphrase string, aad []byte) (string, error) {
 	// staging.State implements json.Marshaler (MarshalJSON), emitting its
 	// EntryKey-keyed maps as arrays of (name, namespace) records, so the static
 	// errchkjson "unsupported map key" warning is a false positive here.
@@ -64,7 +105,7 @@ func encodePayload(state *staging.State, passphrase string) (string, error) {
 	}
 
 	if passphrase != "" {
-		data, err = crypt.Encrypt(data, passphrase)
+		data, err = crypt.EncryptWithAAD(data, passphrase, aad)
 		if err != nil {
 			return "", fmt.Errorf("failed to encrypt payload: %w", err)
 		}
@@ -82,18 +123,21 @@ func encodePayload(state *staging.State, passphrase string) (string, error) {
 // WARNING: an empty passphrase writes the secret values UNENCRYPTED (base64
 // only); callers must warn the user first.
 func WriteEnvelopeFile(path string, scope provider.Scope, svc staging.Service, state *staging.State, passphrase string) error {
-	payload, err := encodePayload(state.ExtractService(svc), passphrase)
-	if err != nil {
-		return err
-	}
-
 	env := Envelope{
 		Version:  EnvelopeVersion,
 		Provider: string(scope.Provider),
 		Scope:    scope.Key(),
 		Service:  string(svc),
-		Payload:  payload,
 	}
+
+	// The header is bound to the ciphertext as AAD, so it must be filled in
+	// before the payload is encoded.
+	payload, err := encodePayload(state.ExtractService(svc), passphrase, env.associatedData())
+	if err != nil {
+		return err
+	}
+
+	env.Payload = payload
 
 	data, err := json.MarshalIndent(env, "", "  ")
 	if err != nil {
@@ -126,7 +170,10 @@ func ReadEnvelopeFile(path string) (*Envelope, error) {
 	}
 
 	if env.Version != EnvelopeVersion {
-		return nil, fmt.Errorf("%w: %d", ErrUnsupportedEnvelopeVersion, env.Version)
+		return nil, fmt.Errorf(
+			"%w: file is version %d, but this build only reads version %d; re-create it with `stage export`",
+			ErrUnsupportedEnvelopeVersion, env.Version, EnvelopeVersion,
+		)
 	}
 
 	if env.Provider == "" || env.Scope == "" || env.Service == "" || env.Payload == "" {
@@ -171,7 +218,9 @@ func (e *Envelope) DecodeState(passphrase string) (*staging.State, error) {
 			return nil, crypt.ErrDecryptionFailed
 		}
 
-		raw, err = crypt.Decrypt(raw, passphrase)
+		// The header is bound to the ciphertext as AAD: any tampering with
+		// version/provider/scope/service makes GCM authentication fail here.
+		raw, err = crypt.DecryptWithAAD(raw, passphrase, e.associatedData())
 		if err != nil {
 			return nil, err
 		}

--- a/internal/staging/store/file/envelope_internal_test.go
+++ b/internal/staging/store/file/envelope_internal_test.go
@@ -1,0 +1,100 @@
+package file
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/staging"
+	"github.com/mpyw/suve/internal/staging/store/file/internal/crypt"
+)
+
+// singleParamState builds a single-service (param) state with one create entry.
+func singleParamState(name, value string) *staging.State {
+	state := staging.NewEmptyState()
+	state.Entries[staging.ServiceParam][staging.EntryKey{Name: name}] = staging.Entry{
+		Operation: staging.OperationCreate,
+		Value:     lo.ToPtr(value),
+	}
+
+	return state
+}
+
+// encryptedEnvelope builds a v2 envelope whose encrypted payload is bound to its
+// own header via AAD, mirroring what WriteEnvelopeFile produces.
+func encryptedEnvelope(t *testing.T, passphrase string) Envelope {
+	t.Helper()
+
+	env := Envelope{
+		Version:  EnvelopeVersion,
+		Provider: "aws",
+		Scope:    "aws/123456789012/ap-northeast-1",
+		Service:  "param",
+	}
+
+	payload, err := encodePayload(singleParamState("/app/config", "secret-value"), passphrase, env.associatedData())
+	require.NoError(t, err)
+
+	env.Payload = payload
+
+	return env
+}
+
+// TestDecodeState_AADBindsHeaderFields verifies the header (version/provider/
+// scope/service) is authenticated with the ciphertext: the untouched envelope
+// round-trips, but tampering with any single header field makes decryption fail
+// with crypt.ErrDecryptionFailed.
+func TestDecodeState_AADBindsHeaderFields(t *testing.T) {
+	t.Parallel()
+
+	base := encryptedEnvelope(t, "correct horse")
+
+	// Baseline: an untampered round-trip still works.
+	got, err := base.DecodeState("correct horse")
+	require.NoError(t, err)
+	assert.Equal(t, "secret-value",
+		lo.FromPtr(got.Entries[staging.ServiceParam][staging.EntryKey{Name: "/app/config"}].Value))
+
+	tampers := map[string]func(e *Envelope){
+		"version":  func(e *Envelope) { e.Version = EnvelopeVersion + 1 },
+		"provider": func(e *Envelope) { e.Provider = "googlecloud" },
+		"scope":    func(e *Envelope) { e.Scope = "aws/999999999999/us-east-1" },
+		"service":  func(e *Envelope) { e.Service = "secret" },
+	}
+
+	for name, tamper := range tampers {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			env := base
+			tamper(&env)
+
+			_, err := env.DecodeState("correct horse")
+			require.ErrorIs(t, err, crypt.ErrDecryptionFailed)
+		})
+	}
+}
+
+// TestDecodeState_EncryptedDecryptsToInvalidJSON covers the path where the AAD
+// matches and decryption succeeds, but the plaintext is not valid state JSON.
+func TestDecodeState_EncryptedDecryptsToInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	env := Envelope{
+		Version:  EnvelopeVersion,
+		Provider: "aws",
+		Scope:    "aws/1/r",
+		Service:  "param",
+	}
+
+	blob, err := crypt.EncryptWithAAD([]byte("not json"), "pw", env.associatedData())
+	require.NoError(t, err)
+
+	env.Payload = base64.StdEncoding.EncodeToString(blob)
+
+	_, err = env.DecodeState("pw")
+	require.ErrorIs(t, err, ErrInvalidEnvelope)
+}

--- a/internal/staging/store/file/envelope_test.go
+++ b/internal/staging/store/file/envelope_test.go
@@ -300,19 +300,24 @@ func TestReadEnvelopeFile_Errors(t *testing.T) {
 	t.Run("unsupported version", func(t *testing.T) {
 		t.Parallel()
 
-		path := filepath.Join(t.TempDir(), "v99.json")
-		data, err := json.Marshal(file.Envelope{
-			Version:  99,
-			Provider: "aws",
-			Scope:    "aws/1/r",
-			Service:  "param",
-			Payload:  base64.StdEncoding.EncodeToString([]byte("{}")),
-		})
-		require.NoError(t, err)
-		require.NoError(t, os.WriteFile(path, data, 0o600))
+		// version 1 is the pre-AAD format that is deliberately no longer readable.
+		for _, ver := range []int{1, 99} {
+			path := filepath.Join(t.TempDir(), "old.json")
+			data, err := json.Marshal(file.Envelope{
+				Version:  ver,
+				Provider: "aws",
+				Scope:    "aws/1/r",
+				Service:  "param",
+				Payload:  base64.StdEncoding.EncodeToString([]byte("{}")),
+			})
+			require.NoError(t, err)
+			require.NoError(t, os.WriteFile(path, data, 0o600))
 
-		_, err = file.ReadEnvelopeFile(path)
-		require.ErrorIs(t, err, file.ErrUnsupportedEnvelopeVersion)
+			_, err = file.ReadEnvelopeFile(path)
+			require.ErrorIs(t, err, file.ErrUnsupportedEnvelopeVersion)
+			// The error must guide the user to re-create the file.
+			assert.Contains(t, err.Error(), "stage export")
+		}
 	})
 
 	t.Run("missing required fields", func(t *testing.T) {
@@ -370,18 +375,8 @@ func TestDecodeState_CorruptedPayload(t *testing.T) {
 		require.ErrorIs(t, err, file.ErrInvalidEnvelope)
 	})
 
-	t.Run("encrypted payload decrypts to invalid json", func(t *testing.T) {
-		t.Parallel()
-
-		blob, err := crypt.Encrypt([]byte("not json"), "pw")
-		require.NoError(t, err)
-
-		env := base
-		env.Payload = base64.StdEncoding.EncodeToString(blob)
-
-		_, err = env.DecodeState("pw")
-		require.ErrorIs(t, err, file.ErrInvalidEnvelope)
-	})
+	// The "encrypted payload decrypts to invalid json" case needs the exact AAD
+	// the header binds, so it lives in envelope_internal_test.go.
 }
 
 func TestIsEncryptedPayload_BadBase64(t *testing.T) {

--- a/internal/staging/store/file/internal/crypt/crypt.go
+++ b/internal/staging/store/file/internal/crypt/crypt.go
@@ -123,7 +123,17 @@ func newGCM(key []byte) (cipher.AEAD, error) {
 
 // Encrypt encrypts data with the given passphrase using AES-256-GCM with Argon2id key derivation.
 // Returns encrypted data in format: magic header + version(1) + salt + nonce + ciphertext.
+//
+// It is a convenience wrapper around EncryptWithAAD with no associated data.
 func Encrypt(data []byte, passphrase string) ([]byte, error) {
+	return EncryptWithAAD(data, passphrase, nil)
+}
+
+// EncryptWithAAD is Encrypt with additional authenticated data (AAD) bound to
+// the ciphertext via AES-GCM. The AAD is authenticated but not encrypted; the
+// exact same aad must be supplied to DecryptWithAAD or authentication fails
+// with ErrDecryptionFailed. A nil aad is equivalent to Encrypt.
+func EncryptWithAAD(data []byte, passphrase string, aad []byte) ([]byte, error) {
 	params := kdfParamsByVersion[Version]
 
 	// Generate random salt
@@ -146,8 +156,8 @@ func Encrypt(data []byte, passphrase string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to generate nonce: %w", err)
 	}
 
-	// Encrypt data
-	ciphertext := gcm.Seal(nil, nonce, data, nil)
+	// Encrypt data, binding the AAD (if any) to the ciphertext.
+	ciphertext := gcm.Seal(nil, nonce, data, aad)
 
 	// Build output: header + salt + nonce + ciphertext
 	result := make([]byte, 0, headerLen+saltLen+nonceLen+len(ciphertext))
@@ -164,7 +174,17 @@ func Encrypt(data []byte, passphrase string) ([]byte, error) {
 // Returns ErrNotEncrypted if data doesn't have the encryption header.
 // Returns ErrInvalidFormat for raw-key (v2) or unknown-version data.
 // Returns ErrDecryptionFailed if the passphrase is wrong or data is corrupted.
+//
+// It is a convenience wrapper around DecryptWithAAD with no associated data.
 func Decrypt(data []byte, passphrase string) ([]byte, error) {
+	return DecryptWithAAD(data, passphrase, nil)
+}
+
+// DecryptWithAAD is Decrypt with additional authenticated data (AAD). The aad
+// must be byte-identical to the aad passed to EncryptWithAAD; otherwise GCM
+// authentication fails and ErrDecryptionFailed is returned. A nil aad is
+// equivalent to Decrypt.
+func DecryptWithAAD(data []byte, passphrase string, aad []byte) ([]byte, error) {
 	if !IsEncrypted(data) {
 		return nil, ErrNotEncrypted
 	}
@@ -205,7 +225,7 @@ func Decrypt(data []byte, passphrase string) ([]byte, error) {
 		return nil, err
 	}
 
-	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, aad)
 	if err != nil {
 		return nil, ErrDecryptionFailed
 	}

--- a/internal/staging/store/file/internal/crypt/crypt_test.go
+++ b/internal/staging/store/file/internal/crypt/crypt_test.go
@@ -93,6 +93,30 @@ func TestDecrypt_WrongPassphrase(t *testing.T) {
 	assert.ErrorIs(t, err, crypt.ErrDecryptionFailed)
 }
 
+func TestEncryptDecryptWithAAD(t *testing.T) {
+	t.Parallel()
+
+	data := []byte("secret data")
+	passphrase := "correct horse"
+	aad := []byte("bound-header")
+
+	encrypted, err := crypt.EncryptWithAAD(data, passphrase, aad)
+	require.NoError(t, err)
+
+	// Matching AAD round-trips.
+	decrypted, err := crypt.DecryptWithAAD(encrypted, passphrase, aad)
+	require.NoError(t, err)
+	assert.Equal(t, data, decrypted)
+
+	// A different AAD fails authentication.
+	_, err = crypt.DecryptWithAAD(encrypted, passphrase, []byte("other-header"))
+	require.ErrorIs(t, err, crypt.ErrDecryptionFailed)
+
+	// The no-AAD wrappers cannot decrypt an AAD-bound ciphertext.
+	_, err = crypt.Decrypt(encrypted, passphrase)
+	require.ErrorIs(t, err, crypt.ErrDecryptionFailed)
+}
+
 func TestDecrypt_NotEncrypted(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Binds the export/import envelope's plaintext header (`version`/`provider`/`scope`/`service`) to its encrypted payload by passing a canonical, length-prefixed serialization of the header as the AES-GCM **associated data (AAD)** to `Seal`/`Open`. The header is thereby authenticated together with the ciphertext: tampering with any single header field now makes decryption fail with `ErrDecryptionFailed` instead of silently decrypting under a mismatched identity.

Implementation:
- `crypt`: added `EncryptWithAAD` / `DecryptWithAAD`; `Encrypt` / `Decrypt` are now thin no-AAD wrappers (working-store call sites unchanged).
- `envelope.go`: new `associatedData()` (domain-separated, length-prefixed, fixed field order) threaded through `encodePayload` and `DecodeState`.

## ⚠️ Breaking change

The envelope schema `version` is bumped **1 → 2**. This intentionally drops backward compatibility: **old (v1) export files can no longer be imported and must be re-created** with `stage export`. Importing a v1 (or any non-current) file returns a clear, hard error pointing the user at `stage export`. No old-format (no-AAD) decrypt path is kept, per the agreed approach on the issue.

## Tests

- Tampering with any header field (`version`/`provider`/`scope`/`service`) fails with `ErrDecryptionFailed`.
- Round-trip export → import still works.
- An old-version (v1) envelope yields the explanatory re-export error.
- `crypt`-level AAD round-trip / mismatch coverage.

`mise test` passes (`SUVE_STAGING_KEY` set). Self-lint of the touched packages is clean.

## Note

PRs for #471/#472 (stdin) also touch `internal/staging/cli/export.go` & `import.go`. This PR does **not** modify those files, but reviewers should be aware of possible rebase interplay in that area.

Closes #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)