### PR TITLE
docs: document same-second conflict-detection limitation on coarse-timestamp providers

### DIFF
--- a/docs/azure.md
+++ b/docs/azure.md
@@ -14,7 +14,7 @@ Azure splits into two services under `suve azure`:
 
 Azure also supports the local **staging workflow** via `suve azure stage` (or the bare `suve stage` alias when Azure is the only active staging backend). It is **per-service**, because Key Vault and App Configuration keep separate staging state:
 
-- `suve azure stage secret` — Key Vault secrets. Full workflow (`add`/`edit`/`delete`/`status`/`diff`/`apply`/`reset`/`tag`/`untag`/`export`/`import`). Versions are immutable, so a staged `edit` applies as a new version.
+- `suve azure stage secret` — Key Vault secrets. Full workflow (`add`/`edit`/`delete`/`status`/`diff`/`apply`/`reset`/`tag`/`untag`/`export`/`import`). Versions are immutable, so a staged `edit` applies as a new version. Key Vault's modified time is **second-granular**, so conflict detection cannot see an out-of-band write that lands in the same wall-clock second as the recorded base — such a write is not flagged and can be overwritten on apply (see [Conflict Detection](./staging-state-transitions.md#conflict-detection)).
 - `suve azure stage param` — App Configuration settings. Because App Configuration is **unversioned**, staging uses **last-write-wins** (no modified-after conflict check). Tags are writable via a GET-merge-PUT, so `tag`/`untag` are available. Workflow: `add`/`edit`/`delete`/`status`/`diff`/`apply`/`reset`/`tag`/`untag`/`export`/`import`.
 
 The two services keep distinct staging scopes, but provider-wide `azure stage status`/`diff`/`apply`/`reset` span both — each resolves its own scope and any service that is not configured (no `--store-name`/`--vault-name`) is skipped. See the [staging workflow](../README.md#staging-workflow) overview for the general flow.

--- a/docs/staging-state-transitions.md
+++ b/docs/staging-state-transitions.md
@@ -202,6 +202,8 @@ When applying changes, suve checks for conflicts by comparing the `BaseModifiedA
 
 Use `--ignore-conflicts` to force apply despite conflicts.
 
+> **Timestamp precision.** Update/Delete conflicts are detected only when the remote `LastModified` is *strictly after* the recorded `BaseModifiedAt`. On providers whose modified time is second-granular (notably Azure Key Vault), an out-of-band write that lands in the same wall-clock second as the recorded base compares as equal, so it is not flagged as a conflict and can be overwritten on apply. The window is narrow and inherent to the provider's timestamp precision.
+
 ## Implementation
 
 The state machine is implemented in `internal/staging/transition/`:

--- a/internal/staging/conflict.go
+++ b/internal/staging/conflict.go
@@ -94,7 +94,10 @@ func CheckConflicts(ctx context.Context, resolve ApplyStrategyResolver, entries 
 			continue
 		}
 
-		// If AWS was modified after the base value was fetched, it's a conflict
+		// If AWS was modified after the base value was fetched, it's a conflict.
+		// Strict After: on second-granular providers (e.g. Azure Key Vault) an
+		// out-of-band write in the same wall-clock second compares as equal and
+		// escapes detection. See docs/staging-state-transitions.md.
 		if awsModified.After(*entry.BaseModifiedAt) {
 			conflicts[key] = struct{}{}
 		}


### PR DESCRIPTION
## What

Documents a conflict-detection limitation. No logic changes.

- `docs/staging-state-transitions.md` — note in the Conflict Detection section explaining the strict `After` comparison and the same-second gap.
- `docs/azure.md` — Key Vault staging entry now calls out its second-granular modified time and links to the note.
- `internal/staging/conflict.go` — minimal comment near the `After()` comparison.

## Why

Update/Delete conflicts use a strict `awsModified.After(BaseModifiedAt)` comparison. On providers whose modified time is second-granular (notably Azure Key Vault), an out-of-band write that lands in the same wall-clock second as the recorded base compares as equal, so it is not flagged as a conflict and can be overwritten on apply. The window is narrow and inherent to the provider's timestamp precision, so per the agreed approach this is documented rather than changing the conflict logic. Equal-time == no-conflict remains correct semantics otherwise.

Closes #484

🤖 Generated with [Claude Code](https://claude.com/claude-code)