### PR TITLE
fix(diff): require a specifier prefix on 3-arg version tokens (#482)

### DIFF
--- a/internal/cli/commands/azure/secret/diff.go
+++ b/internal/cli/commands/azure/secret/diff.go
@@ -87,7 +87,7 @@ func (p *diffPresenter) Hints(stderr io.Writer) {
 func DiffCommand() *cli.Command {
 	return genericdiff.Command(genericdiff.Config[*azurekvversion.Spec]{
 		Usage:     "Show diff between two versions",
-		ArgsUsage: "<spec1> [spec2] | <name> <version1> [version2]",
+		ArgsUsage: "<spec1> [spec2] | <name> #<version1> [#<version2>]",
 		Description: `Compare two versions of a secret in unified diff format.
 If only one version/spec is specified, compares against the current version.
 

--- a/internal/cli/commands/gcloud/diff.go
+++ b/internal/cli/commands/gcloud/diff.go
@@ -82,7 +82,7 @@ func (p *diffPresenter) Hints(stderr io.Writer) {
 func DiffCommand() *cli.Command {
 	return genericdiff.Command(genericdiff.Config[*gcloudversion.Spec]{
 		Usage:     "Show diff between two versions",
-		ArgsUsage: "<spec1> [spec2] | <name> <version1> [version2]",
+		ArgsUsage: "<spec1> [spec2] | <name> #<version1> [#<version2>]",
 		Description: `Compare two versions of a secret in unified diff format.
 If only one version/spec is specified, compares against the latest version.
 

--- a/internal/cli/commands/param/diff.go
+++ b/internal/cli/commands/param/diff.go
@@ -83,7 +83,7 @@ func (p *diffPresenter) Hints(stderr io.Writer) {
 func DiffCommand() *cli.Command {
 	return genericdiff.Command(genericdiff.Config[*paramversion.Spec]{
 		Usage:     "Show diff between two versions",
-		ArgsUsage: "<spec1> [spec2] | <name> <version1> [version2]",
+		ArgsUsage: "<spec1> [spec2] | <name> #<version1> [#<version2>]",
 		Description: `Compare two versions of a parameter in unified diff format.
 If only one version/spec is specified, compares against latest.
 

--- a/internal/cli/commands/secret/diff.go
+++ b/internal/cli/commands/secret/diff.go
@@ -84,7 +84,7 @@ func (p *diffPresenter) Hints(stderr io.Writer) {
 func DiffCommand() *cli.Command {
 	return genericdiff.Command(genericdiff.Config[*secretversion.Spec]{
 		Usage:     "Show diff between two versions",
-		ArgsUsage: "<spec1> [spec2] | <name> <version1> [version2]",
+		ArgsUsage: "<spec1> [spec2] | <name> #<version1> [#<version2>]",
 		Description: `Compare two versions of a secret in unified diff format.
 If only one version/spec is specified, compares against AWSCURRENT.
 

--- a/internal/cli/diffargs/args.go
+++ b/internal/cli/diffargs/args.go
@@ -95,7 +95,7 @@ import (
 //	    paramversion.Parse,
 //	    func(abs paramversion.AbsoluteSpec) bool { return abs.Version != nil },
 //	    "#~",
-//	    "usage: suve param diff <spec1> [spec2] | <name> <version1> [version2]",
+//	    "usage: suve param diff <spec1> [spec2] | <name> #<version1> [#<version2>]",
 //	)
 //
 // Secrets Manager usage:
@@ -105,7 +105,7 @@ import (
 //	    secretversion.Parse,
 //	    func(abs secretversion.AbsoluteSpec) bool { return abs.ID != nil || abs.Label != nil },
 //	    "#:~",
-//	    "usage: suve secret diff <spec1> [spec2] | <name> <version1> [version2]",
+//	    "usage: suve secret diff <spec1> [spec2] | <name> #<version1> [#<version2>]",
 //	)
 func ParseArgs[A any](
 	args []string,
@@ -124,7 +124,7 @@ func ParseArgs[A any](
 	case 2: //nolint:mnd // two-arg case for version comparison
 		return parseTwoArgs(args[0], args[1], parse, hasAbsolute, prefixes)
 	default: // case 3
-		return parseThreeArgs(args[0], args[1], args[2], parse)
+		return parseThreeArgs(args[0], args[1], args[2], parse, prefixes)
 	}
 }
 
@@ -254,13 +254,28 @@ func parseTwoArgs[A any](
 //	"my-secret" ":AWSPREVIOUS" ":AWSCURRENT"     → compare AWSPREVIOUS with AWSCURRENT
 //	"/app/config" "~2" "~1"                      → compare 2-versions-ago with 1-version-ago
 //
-// Note: The specifiers don't need to start with a prefix character in this format,
-// because we always concatenate name + specifier. However, in practice they usually
-// do start with #, :, or ~ to avoid ambiguity.
+// Each version argument MUST start with a specifier prefix (#, :, or ~ depending
+// on the service). A bare token such as "3" is rejected with a hard error rather
+// than silently concatenated onto the name: allowing it would turn
+// `diff /app/config 3 1` into a comparison of parameters *named* "/app/config3"
+// and "/app/config1", targeting the wrong resources. Requiring the prefix keeps
+// this format aligned with the usage text.
 func parseThreeArgs[A any](
 	name, version1, version2 string,
 	parse func(string) (*version.Spec[A], error),
+	prefixes string,
 ) (*version.Spec[A], *version.Spec[A], error) {
+	// Both version arguments must be specifier-only (start with #, :, or ~).
+	// Otherwise "name" + "3" would build the resource name "name3" instead of
+	// selecting version 3 of "name".
+	if err := requireSpecifier("version1", version1, prefixes); err != nil {
+		return nil, nil, err
+	}
+
+	if err := requireSpecifier("version2", version2, prefixes); err != nil {
+		return nil, nil, err
+	}
+
 	// Parse name + first specifier
 	spec1, err := parse(name + version1)
 	if err != nil {
@@ -274,4 +289,30 @@ func parseThreeArgs[A any](
 	}
 
 	return spec1, spec2, nil
+}
+
+// requireSpecifier verifies that a version argument in the 3-arg form starts
+// with one of the service's specifier prefix characters. A bare token (e.g.
+// "3") is rejected with a message that names the valid prefixes and suggests
+// the prefixed form.
+func requireSpecifier(label, arg, prefixes string) error {
+	if len(arg) > 0 && strings.ContainsRune(prefixes, rune(arg[0])) {
+		return nil
+	}
+
+	return fmt.Errorf(
+		"%s %q must start with a version specifier (%s); did you mean %q?",
+		label, arg, formatPrefixes(prefixes), string(prefixes[0])+arg,
+	)
+}
+
+// formatPrefixes renders the specifier prefix characters as a human-readable
+// comma-separated list, e.g. "#~" → "#, ~".
+func formatPrefixes(prefixes string) string {
+	parts := make([]string, 0, len(prefixes))
+	for _, r := range prefixes {
+		parts = append(parts, string(r))
+	}
+
+	return strings.Join(parts, ", ")
 }

--- a/internal/cli/diffargs/args_test.go
+++ b/internal/cli/diffargs/args_test.go
@@ -216,6 +216,68 @@ func TestParseArgs_Param(t *testing.T) {
 	}
 }
 
+// TestParseArgs_ThreeArgRequiresSpecifier covers the fix for #482: in the 3-arg
+// form each version argument must start with a specifier prefix so that a bare
+// token (e.g. "3") is rejected instead of being concatenated onto the name.
+func TestParseArgs_ThreeArgRequiresSpecifier(t *testing.T) {
+	t.Parallel()
+
+	parse := paramversion.Parse
+	hasAbsolute := func(abs paramversion.AbsoluteSpec) bool { return abs.Version != nil }
+	prefixes := "#~"
+	usage := "usage: suve param diff"
+
+	tests := []struct {
+		name       string
+		args       []string
+		wantSpec1  *paramversion.Spec
+		wantSpec2  *paramversion.Spec
+		wantErrMsg string
+	}{
+		{
+			name:       "bare version1 rejected",
+			args:       []string{"/p", "3", "1"},
+			wantErrMsg: "must start with a version specifier",
+		},
+		{
+			name:       "bare version2 rejected",
+			args:       []string{"/p", "#3", "1"},
+			wantErrMsg: "must start with a version specifier",
+		},
+		{
+			name: "hash specifiers keep name",
+			args: []string{"/p", "#3", "#1"},
+			wantSpec1: &paramversion.Spec{
+				Name:     "/p",
+				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))},
+			},
+			wantSpec2: &paramversion.Spec{
+				Name:     "/p",
+				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			spec1, spec2, err := diffargs.ParseArgs(tt.args, parse, hasAbsolute, prefixes, usage)
+
+			if tt.wantErrMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantSpec1, spec1)
+			assert.Equal(t, tt.wantSpec2, spec2)
+		})
+	}
+}
+
 func TestParseArgs_Secret(t *testing.T) {
 	t.Parallel()
 

--- a/internal/version/azurekvversion/spec.go
+++ b/internal/version/azurekvversion/spec.go
@@ -110,7 +110,7 @@ func ParseDiffArgs(args []string) (*Spec, *Spec, error) {
 		Parse,
 		hasAbsoluteSpec,
 		"#~",
-		"usage: suve azure secret diff <spec1> [spec2] | <name> <version1> [version2]",
+		"usage: suve azure secret diff <spec1> [spec2] | <name> #<version1> [#<version2>]",
 	)
 }
 

--- a/internal/version/gcloudversion/spec.go
+++ b/internal/version/gcloudversion/spec.go
@@ -114,6 +114,6 @@ func ParseDiffArgs(args []string) (*Spec, *Spec, error) {
 		Parse,
 		func(abs AbsoluteSpec) bool { return abs.Version != nil },
 		"#~",
-		"usage: suve gcloud secret diff <spec1> [spec2] | <name> <version1> [version2]",
+		"usage: suve gcloud secret diff <spec1> [spec2] | <name> #<version1> [#<version2>]",
 	)
 }

--- a/internal/version/paramversion/spec.go
+++ b/internal/version/paramversion/spec.go
@@ -80,6 +80,6 @@ func ParseDiffArgs(args []string) (*Spec, *Spec, error) {
 		Parse,
 		func(abs AbsoluteSpec) bool { return abs.Version != nil },
 		"#~",
-		"usage: suve param diff <spec1> [spec2] | <name> <version1> [version2]",
+		"usage: suve param diff <spec1> [spec2] | <name> #<version1> [#<version2>]",
 	)
 }

--- a/internal/version/secretversion/spec.go
+++ b/internal/version/secretversion/spec.go
@@ -91,7 +91,7 @@ func ParseDiffArgs(args []string) (*Spec, *Spec, error) {
 		Parse,
 		hasAbsoluteSpec,
 		"#:~",
-		"usage: suve secret diff <spec1> [spec2] | <name> <version1> [version2]",
+		"usage: suve secret diff <spec1> [spec2] | <name> #<version1> [#<version2>]",
 	)
 }
 


### PR DESCRIPTION
## What

In the 3-arg diff form `<name> <version1> [version2]`, `diffargs.parseThreeArgs` now requires each version argument to begin with a specifier prefix (`#`, `:`, or `~`, depending on the service). A bare token such as `3` is rejected with a clear error that names the valid prefixes and suggests the prefixed form (e.g. `#3`).

Usage/help text for every `diff` command (param, secret, gcloud, azure) is updated from `<name> <version1> [version2]` to `<name> #<version1> [#<version2>]` to make the required prefix explicit.

## Why

`parseThreeArgs` previously concatenated `name + token` unconditionally, so `suve param diff /app/config 3 1` compared parameters **named** `/app/config3` and `/app/config1` instead of versions 3 and 1 of `/app/config`. Usually this surfaces as a loud not-found, but it silently diffs the wrong resources when an unluckily-named sibling exists.

## Approach

Recommended default: a **hard error** on a missing prefix rather than auto-prepending `#`. This is safer (no silent guessing) and matches the usage text. `#`/`:`/`~` prefixes are still accepted as before.

## Tests

Added a dedicated `TestParseArgs_ThreeArgRequiresSpecifier`: `ParseArgs(["/p","3","1"])` and `["/p","#3","1"]` now error with "must start with a version specifier"; `["/p","#3","#1"]` yields `Name=="/p"` with versions 3/1. `mise test` passes; `golangci-lint run ./internal/cli/diffargs/...` reports 0 issues.

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)