### PR TITLE
fix(staging): stop --passphrase-stdin from consuming interactive prompts (#471, #472)

### DIFF
--- a/internal/cli/confirm/confirm.go
+++ b/internal/cli/confirm/confirm.go
@@ -17,6 +17,13 @@ type Prompter struct {
 	Stdout io.Writer
 	Stderr io.Writer
 
+	// BufReader, when set, is a shared buffered stdin reader used instead of
+	// allocating a per-call one. Sharing one reader across prompters (e.g. a
+	// passphrase prompt then a confirm prompt) prevents double-buffering: a
+	// fresh bufio.Reader over piped stdin would find the bytes already
+	// read-ahead into the first reader's buffer and hit EOF.
+	BufReader *bufio.Reader
+
 	// Target is a provider-neutral, human-readable description of where the
 	// operation applies (e.g. "my-profile (123456789012 / us-east-1)" for AWS or
 	// "project my-gcloud-project" for Google Cloud). When set, it is shown before
@@ -49,11 +56,19 @@ func (p *Prompter) printTargetInfo() {
 	}
 }
 
+// reader returns the shared buffered reader when one was injected, otherwise a
+// per-call reader over Stdin.
+func (p *Prompter) reader() *bufio.Reader {
+	if p.BufReader != nil {
+		return p.BufReader
+	}
+
+	return bufio.NewReader(p.Stdin)
+}
+
 // readYesNo reads a yes/no response from stdin.
 func (p *Prompter) readYesNo() (bool, error) {
-	reader := bufio.NewReader(p.Stdin)
-
-	response, err := reader.ReadString('\n')
+	response, err := p.reader().ReadString('\n')
 	if err != nil {
 		return false, fmt.Errorf("failed to read response: %w", err)
 	}
@@ -127,9 +142,7 @@ func (p *Prompter) ConfirmChoice(message string, choices []Choice) (ChoiceResult
 
 	output.Printf(p.Stderr, "Enter choice [1]: ")
 
-	reader := bufio.NewReader(p.Stdin)
-
-	response, err := reader.ReadString('\n')
+	response, err := p.reader().ReadString('\n')
 	if err != nil {
 		return ChoiceCancelled, fmt.Errorf("failed to read response: %w", err)
 	}

--- a/internal/cli/passphrase/passphrase.go
+++ b/internal/cli/passphrase/passphrase.go
@@ -31,6 +31,15 @@ type Prompter struct {
 	bufReader *bufio.Reader
 }
 
+// UseBufReader shares an externally-owned buffered stdin reader with this
+// Prompter. Reading a single piped stdin across more than one Prompter (e.g. a
+// passphrase prompt followed by a confirmation prompt) requires them to share
+// one buffered reader; otherwise a second bufio.Reader over the same fd finds
+// the bytes already read-ahead into the first buffer and hits EOF.
+func (p *Prompter) UseBufReader(r *bufio.Reader) {
+	p.bufReader = r
+}
+
 // PromptForEncrypt prompts for passphrase with confirmation for encryption.
 // Returns empty string if user chooses to continue without encryption after warning.
 // Returns ErrCancelled if user declines to continue without encryption.

--- a/internal/cli/passphrase/shared_reader_test.go
+++ b/internal/cli/passphrase/shared_reader_test.go
@@ -1,0 +1,72 @@
+package passphrase_test
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/cli/confirm"
+	"github.com/mpyw/suve/internal/cli/passphrase"
+)
+
+// TestSharedBufReader is the shared-reader regression for #471/#472: a
+// confirmation prompt followed by a passphrase read over ONE piped stdin must
+// read both lines correctly. A per-prompter bufio.Reader read-ahead buffers the
+// whole pipe on the first read, stranding the second line and leaving the second
+// reader at EOF.
+func TestSharedBufReader(t *testing.T) {
+	t.Parallel()
+
+	t.Run("one shared reader reads confirm then passphrase", func(t *testing.T) {
+		t.Parallel()
+
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+
+		_, err = w.WriteString("y\nmypass\n")
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+
+		shared := bufio.NewReader(r)
+
+		cp := &confirm.Prompter{Stdin: r, Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}, BufReader: shared}
+		ok, err := cp.Confirm("Continue?", false)
+		require.NoError(t, err)
+		assert.True(t, ok)
+
+		pp := &passphrase.Prompter{Stdin: r, Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+		pp.UseBufReader(shared)
+
+		pass, err := pp.ReadFromStdin()
+		require.NoError(t, err)
+		assert.Equal(t, "mypass", pass)
+	})
+
+	// Control: two independent readers over the same fd drop the second line,
+	// which is precisely the double-buffering bug the shared reader fixes.
+	t.Run("independent readers drop the second line", func(t *testing.T) {
+		t.Parallel()
+
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+
+		_, err = w.WriteString("y\nmypass\n")
+		require.NoError(t, err)
+		require.NoError(t, w.Close())
+
+		cp := &confirm.Prompter{Stdin: r, Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+		ok, err := cp.Confirm("Continue?", false)
+		require.NoError(t, err)
+		assert.True(t, ok)
+
+		pp := &passphrase.Prompter{Stdin: r, Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+
+		pass, err := pp.ReadFromStdin()
+		require.NoError(t, err)
+		assert.Empty(t, pass)
+	})
+}

--- a/internal/staging/cli/export.go
+++ b/internal/staging/cli/export.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -62,12 +63,13 @@ func exportFlags() []cli.Flag {
 // It returns the passphrase (empty means plaintext), whether the user cancelled,
 // and any error. --passphrase-stdin reads from stdin; otherwise a TTY is prompted
 // interactively and a non-TTY falls back to plaintext with a warning.
-func exportPassphrase(cmd *cli.Command) (pass string, cancelled bool, err error) {
+func exportPassphrase(cmd *cli.Command, stdin *bufio.Reader) (pass string, cancelled bool, err error) {
 	prompter := &passphrase.Prompter{
 		Stdin:  cmd.Root().Reader,
 		Stdout: cmd.Root().Writer,
 		Stderr: cmd.Root().ErrWriter,
 	}
+	prompter.UseBufReader(stdin)
 
 	switch {
 	case cmd.Bool(flagPassphraseStdin):
@@ -118,7 +120,7 @@ func exportServices(service staging.Service, state *staging.State) []staging.Ser
 // confirmExportOverwrite prompts (or refuses) before overwriting existing export
 // files. It is a plain overwrite confirmation, NOT a merge: export always writes
 // wholesale. --yes / --force skip it; a non-TTY without --yes is refused.
-func confirmExportOverwrite(cmd *cli.Command, paths []string) (proceed bool, err error) {
+func confirmExportOverwrite(cmd *cli.Command, paths []string, stdin *bufio.Reader) (proceed bool, err error) {
 	if cmd.Bool(flagYes) {
 		return true, nil
 	}
@@ -135,7 +137,11 @@ func confirmExportOverwrite(cmd *cli.Command, paths []string) (proceed bool, err
 		return true, nil
 	}
 
-	if !terminal.IsTerminalWriter(cmd.Root().ErrWriter) {
+	// With --passphrase-stdin, stdin carries the passphrase, not an interactive
+	// answer: prompting here would consume the passphrase line as the y/N reply
+	// and silently cancel (#471). Require --yes explicitly, mirroring the non-TTY
+	// branch, so a scripted overwrite fails loudly instead of no-op'ing at exit 0.
+	if cmd.Bool(flagPassphraseStdin) || !terminal.IsTerminalWriter(cmd.Root().ErrWriter) {
 		return false, fmt.Errorf(
 			"export file(s) already exist: %v; re-run with --yes to overwrite",
 			existing,
@@ -143,9 +149,10 @@ func confirmExportOverwrite(cmd *cli.Command, paths []string) (proceed bool, err
 	}
 
 	prompter := &confirm.Prompter{
-		Stdin:  cmd.Root().Reader,
-		Stdout: cmd.Root().Writer,
-		Stderr: cmd.Root().ErrWriter,
+		Stdin:     cmd.Root().Reader,
+		Stdout:    cmd.Root().Writer,
+		Stderr:    cmd.Root().ErrWriter,
+		BufReader: stdin,
 	}
 
 	output.Warning(cmd.Root().ErrWriter, "Export file(s) already exist and will be overwritten: %v", existing)
@@ -208,7 +215,12 @@ func exportAction(service staging.Service, resolver staging.ScopeResolver) func(
 			targetPaths = append(targetPaths, pathFor(svc))
 		}
 
-		proceed, err := confirmExportOverwrite(cmd, targetPaths)
+		// Share one buffered stdin reader across the overwrite confirmation and the
+		// passphrase prompt so consecutive reads over piped stdin don't
+		// double-buffer and drop bytes.
+		stdin := bufio.NewReader(cmd.Root().Reader)
+
+		proceed, err := confirmExportOverwrite(cmd, targetPaths, stdin)
 		if err != nil {
 			return err
 		}
@@ -219,7 +231,7 @@ func exportAction(service staging.Service, resolver staging.ScopeResolver) func(
 			return nil
 		}
 
-		pass, cancelled, err := exportPassphrase(cmd)
+		pass, cancelled, err := exportPassphrase(cmd, stdin)
 		if err != nil {
 			return err
 		}

--- a/internal/staging/cli/export_test.go
+++ b/internal/staging/cli/export_test.go
@@ -235,6 +235,48 @@ func TestGlobalExport(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "param", env.Service)
 	})
+
+	// Regression for #471: with --passphrase-stdin against a pre-existing target,
+	// the overwrite confirmation must NOT read the passphrase line as a y/N answer
+	// and silently cancel at exit 0. Without --yes it errors clearly; the passphrase
+	// line is never consumed as a confirmation.
+	t.Run("--passphrase-stdin against existing target errors instead of silently cancelling", func(t *testing.T) {
+		scope := setupExportImportEnv(t)
+		stageEntry(t, scope, staging.ServiceParam, "/app/config", "pval")
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "param.json"), []byte("{}"), 0o600))
+
+		stdin := bytes.NewBufferString("pw123\n")
+		stdout, _, err := runLeafCmd(t, stgcli.NewGlobalExportCommand(fixedResolver(scope)), stdin, dir, "--passphrase-stdin")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exist")
+		assert.Contains(t, err.Error(), "--yes")
+		// It must NOT report a successful/cancelled no-op on stdout.
+		assert.NotContains(t, stdout, "Operation cancelled.")
+	})
+
+	// With --passphrase-stdin AND --yes, the overwrite is allowed and the passphrase
+	// line is consumed by the passphrase reader (not the confirmation), producing an
+	// encrypted envelope.
+	t.Run("--passphrase-stdin with --yes overwrites and encrypts using the stdin passphrase", func(t *testing.T) {
+		scope := setupExportImportEnv(t)
+		stageEntry(t, scope, staging.ServiceParam, "/app/config", "pval")
+
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "param.json"), []byte("{}"), 0o600))
+
+		stdin := bytes.NewBufferString("pw123\n")
+		stdout, _, err := runLeafCmd(t, stgcli.NewGlobalExportCommand(fixedResolver(scope)), stdin, dir, "--passphrase-stdin", "--yes")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "encrypted")
+
+		env, err := file.ReadEnvelopeFile(filepath.Join(dir, "param.json"))
+		require.NoError(t, err)
+		enc, err := env.IsEncryptedPayload()
+		require.NoError(t, err)
+		assert.True(t, enc)
+	})
 }
 
 //nolint:paralleltest // uses t.Setenv (HOME/SUVE_STAGING_KEY); cannot run in parallel

--- a/internal/staging/cli/import.go
+++ b/internal/staging/cli/import.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -90,9 +91,14 @@ type ImportModeInput struct {
 	// SkipPrompt (--yes) accepts the default (Merge) without the interactive
 	// Merge/Overwrite/Cancel prompt, for scripts/automation.
 	SkipPrompt bool
-	HasChanges bool
-	ItemCount  int
-	IsTTY      bool
+	// PassphraseStdin (--passphrase-stdin) means stdin carries the passphrase, not
+	// an interactive answer. Prompting would double-buffer/EOF against the
+	// passphrase read (#472), so the mode is resolved from flags only (default
+	// Merge) without prompting.
+	PassphraseStdin bool
+	HasChanges      bool
+	ItemCount       int
+	IsTTY           bool
 }
 
 // ImportModeResult holds the outcome of import-mode selection.
@@ -121,7 +127,7 @@ func (c *ImportModeChooser) ChooseMode(input ImportModeInput) (ImportModeResult,
 		return ImportModeResult{Mode: usestaging.ImportModeMerge}, nil
 	}
 
-	if input.HasChanges && input.IsTTY && !input.SkipPrompt {
+	if input.HasChanges && input.IsTTY && !input.SkipPrompt && !input.PassphraseStdin {
 		output.Warning(c.Stderr, "Working staging area already has %d staged change(s).", input.ItemCount)
 
 		choice, err := c.Prompter.ConfirmChoice("How do you want to proceed?", []confirm.Choice{
@@ -233,12 +239,13 @@ func anyEncrypted(present []presentEnvelope) (bool, error) {
 
 // importPassphrase prompts for the decryption passphrase once. It is only called
 // when at least one present envelope is encrypted.
-func importPassphrase(cmd *cli.Command) (string, error) {
+func importPassphrase(cmd *cli.Command, stdin *bufio.Reader) (string, error) {
 	prompter := &passphrase.Prompter{
 		Stdin:  cmd.Root().Reader,
 		Stdout: cmd.Root().Writer,
 		Stderr: cmd.Root().ErrWriter,
 	}
+	prompter.UseBufReader(stdin)
 
 	switch {
 	case cmd.Bool(flagPassphraseStdin):
@@ -308,10 +315,15 @@ func importAction(service staging.Service, resolver staging.ScopeResolver) func(
 			return err
 		}
 
+		// Share one buffered stdin reader across the passphrase prompt and the
+		// merge/overwrite confirmation so consecutive reads over piped stdin don't
+		// double-buffer and drop bytes (#472).
+		stdin := bufio.NewReader(cmd.Root().Reader)
+
 		var pass string
 
 		if encrypted {
-			pass, err = importPassphrase(cmd)
+			pass, err = importPassphrase(cmd, stdin)
 			if err != nil {
 				return err
 			}
@@ -330,22 +342,24 @@ func importAction(service staging.Service, resolver staging.ScopeResolver) func(
 
 		chooser := &ImportModeChooser{
 			Prompter: &confirm.Prompter{
-				Stdin:  cmd.Root().Reader,
-				Stdout: cmd.Root().Writer,
-				Stderr: cmd.Root().ErrWriter,
-				Target: resolved.Target,
+				Stdin:     cmd.Root().Reader,
+				Stdout:    cmd.Root().Writer,
+				Stderr:    cmd.Root().ErrWriter,
+				Target:    resolved.Target,
+				BufReader: stdin,
 			},
 			Stderr: cmd.Root().ErrWriter,
 			Stdout: cmd.Root().Writer,
 		}
 
 		mode, err := chooser.ChooseMode(ImportModeInput{
-			MergeFlag:     cmd.Bool(flagMerge),
-			OverwriteFlag: cmd.Bool(flagOverwrite),
-			SkipPrompt:    cmd.Bool(flagYes),
-			HasChanges:    !existing.IsEmpty(),
-			ItemCount:     existing.TotalCount(),
-			IsTTY:         terminal.IsTerminalWriter(cmd.Root().ErrWriter),
+			MergeFlag:       cmd.Bool(flagMerge),
+			OverwriteFlag:   cmd.Bool(flagOverwrite),
+			SkipPrompt:      cmd.Bool(flagYes),
+			PassphraseStdin: cmd.Bool(flagPassphraseStdin),
+			HasChanges:      !existing.IsEmpty(),
+			ItemCount:       existing.TotalCount(),
+			IsTTY:           terminal.IsTerminalWriter(cmd.Root().ErrWriter),
 		})
 		if err != nil {
 			return err

--- a/internal/staging/cli/import_test.go
+++ b/internal/staging/cli/import_test.go
@@ -177,6 +177,31 @@ func TestGlobalImport(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	// Regression for #472: an encrypted import via --passphrase-stdin with a dirty
+	// working area must merge (the default) without an EOF failure. The passphrase
+	// read and the mode resolution must not double-buffer the single stdin stream.
+	t.Run("encrypted --passphrase-stdin with dirty working area merges without EOF", func(t *testing.T) {
+		scope := setupExportImportEnv(t)
+		stageEntry(t, scope, staging.ServiceParam, "/app/param1", "v1")
+
+		dir := filepath.Join(t.TempDir(), "backup")
+		_, _, err := runLeafCmd(t, stgcli.NewGlobalExportCommand(fixedResolver(scope)), bytes.NewBufferString("pw123\n"), dir, "--passphrase-stdin")
+		require.NoError(t, err)
+		require.True(t, workingState(t, scope).IsEmpty())
+
+		// Dirty the working area so the reconcile path is exercised.
+		stageEntry(t, scope, staging.ServiceParam, "/app/param2", "v2")
+
+		// Only the passphrase is on stdin (no merge/overwrite answer line).
+		stdout, _, err := runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scope)), bytes.NewBufferString("pw123\n"), dir, "--passphrase-stdin")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "merged")
+
+		entries := workingState(t, scope).Entries[staging.ServiceParam]
+		assert.Contains(t, entries, staging.EntryKey{Name: "/app/param1"})
+		assert.Contains(t, entries, staging.EntryKey{Name: "/app/param2"})
+	})
+
 	t.Run("encrypted round-trip via --passphrase-stdin", func(t *testing.T) {
 		scope := setupExportImportEnv(t)
 		stageEntry(t, scope, staging.ServiceParam, "/app/config", "pval")
@@ -287,6 +312,27 @@ func TestImportModeChooser_ChooseMode(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, result.Cancelled)
 		assert.Equal(t, usestaging.ImportModeMerge, result.Mode)
+	})
+
+	// Regression for #472: with --passphrase-stdin, stdin carries the passphrase,
+	// not an interactive answer. The mode must resolve to the default (Merge)
+	// without prompting, so the passphrase read and a would-be confirmation prompt
+	// never contend over the same stdin.
+	t.Run("--passphrase-stdin skips the prompt and defaults to merge", func(t *testing.T) {
+		t.Parallel()
+
+		stderr := &bytes.Buffer{}
+		// A Prompter whose stdin would error if read, proving no prompt occurs.
+		chooser := &stgcli.ImportModeChooser{
+			Prompter: &confirm.Prompter{Stdin: bytes.NewBufferString(""), Stdout: &bytes.Buffer{}, Stderr: stderr},
+			Stderr:   stderr,
+			Stdout:   &bytes.Buffer{},
+		}
+		result, err := chooser.ChooseMode(stgcli.ImportModeInput{PassphraseStdin: true, HasChanges: true, ItemCount: 2, IsTTY: true})
+		require.NoError(t, err)
+		assert.False(t, result.Cancelled)
+		assert.Equal(t, usestaging.ImportModeMerge, result.Mode)
+		assert.NotContains(t, stderr.String(), "How do you want to proceed?")
 	})
 
 	t.Run("prompt selects merge", func(t *testing.T) {


### PR DESCRIPTION
## What

When `--passphrase-stdin` is set, stdin carries the passphrase — not an interactive answer. Two staging prompts wrongly read from that stream. This fixes both, plus the shared root cause.

### #471 — `stage export` silently cancels at exit 0
`exportAction` ran the overwrite confirmation **before** the passphrase read, gated on **stderr** being a TTY. With a piped stdin (`printf 'pass\n' | suve stage export ./backup --passphrase-stdin` against an existing dir), the confirm consumed the passphrase line as the y/N answer, printed `Operation cancelled.` and returned `nil` → **exit 0, nothing written**. A scripted backup refresh silently no-ops while reporting success.

### #472 — `stage import` fails with EOF on the merge/overwrite choice
`importAction` read the passphrase through its own `bufio.Reader`, then `ChooseMode`'s `ConfirmChoice` built a **separate** `bufio.Reader` over the same fd. The first reader's read-ahead buffered the whole pipe, so the second hit EOF → `failed to get confirmation` → **exit 1** for the documented `echo secret | suve stage import ./backup --passphrase-stdin` with a dirty working area.

## Why / approach

Recommended default (agreed): **when `--passphrase-stdin` is set, do not read interactive answers from stdin.**

- **export**: never prompt for overwrite under `--passphrase-stdin`; require `--yes` for pre-existing files and otherwise refuse with a clear error (mirrors the existing non-TTY branch). No silent exit-0 cancel.
- **import**: resolve the merge/overwrite mode from flags only (default **Merge**) instead of prompting.
- **shared root cause**: thread **one** buffered stdin reader through both the confirm and passphrase Prompters (`confirm.Prompter.BufReader` + `passphrase.Prompter.UseBufReader`) so two consecutive reads over piped stdin don't double-buffer and drop bytes.

## Tests

- export `--passphrase-stdin` against an existing target errors clearly (no silent exit-0 cancel); with `--yes` it overwrites and encrypts using the stdin passphrase.
- import `--passphrase-stdin` with a dirty working area merges without an EOF failure; `ImportModeChooser` unit test for the `PassphraseStdin` path (no prompt, default Merge).
- shared-reader test: confirm-then-passphrase over one piped `os.Pipe` reads both lines correctly, with a control showing independent readers drop the second line.

`mise test` passes; `golangci-lint run` on the touched packages reports 0 issues.

## Note on overlap / rebase risk

`internal/staging/cli/import.go` and `export.go` are also edited by PRs #476, #487, #486 — expect rebase conflicts depending on merge order.

Closes #471
Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)