### PR TITLE
fix(staging): guard import provenance — refuse cross-provider imports (CLI) + backend scope check (GUI)

### DIFF
--- a/internal/gui/frontend/src/lib/StagingView.svelte
+++ b/internal/gui/frontend/src/lib/StagingView.svelte
@@ -444,7 +444,11 @@
     importLoading = true;
     importError = '';
     try {
-      const result = await StagingImport(importPath, importService, passphrase, importMode);
+      // Pass force=true only for a confirmed scope mismatch: reaching runImport
+      // with importInfo.scopeMatches === false means the user clicked through the
+      // Scope Mismatch modal, so the backend scope guard should be overridden.
+      const force = importInfo ? !importInfo.scopeMatches : false;
+      const result = await StagingImport(importPath, importService, passphrase, importMode, force);
       importResult = result;
       showImportModeModal = false;
       showImportPassphrase = false;

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -1382,7 +1382,7 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
       // Import ONE concrete service from a per-service envelope into the working
       // area. A service mismatch is a hard error; an encrypted payload needs a
       // passphrase. The working store is resolved per service (#445).
-      StagingImport: async (path: string, service: Service, passphrase: string, mode: string) => {
+      StagingImport: async (path: string, service: Service, passphrase: string, mode: string, force: boolean) => {
         if (state.simulateError?.operation === 'StagingImport') {
           throw new Error(state.simulateError.message);
         }
@@ -1392,6 +1392,17 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
         }
         if (file.service !== service) {
           throw new Error(`import file holds "${file.service}" data but "${service}" was selected`);
+        }
+        // Mirror the backend provenance guards (#486): a provider mismatch is a
+        // hard error (never overridable); a scope mismatch is refused unless force.
+        const wantProvider = (state.currentScope || {}).provider || 'aws';
+        if (file.provider !== wantProvider) {
+          throw new Error(
+            `import file provider "${file.provider}" does not match the current provider "${wantProvider}"`);
+        }
+        if (file.scope !== expectedScopeKey(service) && !force) {
+          throw new Error(
+            `import file scope "${file.scope}" does not match the current scope "${expectedScopeKey(service)}"`);
         }
         if (file.encrypted && !passphrase) {
           throw new Error('passphrase required for encrypted file');

--- a/internal/gui/frontend/tests/staging-export-import.spec.ts
+++ b/internal/gui/frontend/tests/staging-export-import.spec.ts
@@ -225,6 +225,35 @@ test.describe('Import', () => {
     await expect(page.locator('.entry-name').filter({ hasText: '/foreign/param' })).toBeVisible();
   });
 
+  test('refuses a provider mismatch even after confirming the warning (#486)', async ({ page }) => {
+    // An Azure App Config param file imported into the default AWS scope. The
+    // frontend surfaces the scope warning; confirming it passes force=true, but
+    // the backend still refuses a provider change (defense-in-depth parity).
+    await setupWailsMocks(page, createImportFileState('/mock/azure.json', {
+      service: 'param',
+      entries: [createStagedValue('/foreign/param', 'create', 'v')],
+      provider: 'azure',
+      scope: 'azure/appconfig/mystore',
+    }));
+    await page.goto('/');
+    await navigateTo(page, 'Staging');
+    await page.getByTestId('transfer-menu').waitFor();
+
+    await openTransferMenu(page);
+    await page.getByTestId('import-param').click();
+
+    await expect(page.locator('.modal-title')).toHaveText(/Scope Mismatch/);
+    await page.getByTestId('import-warn-continue').click();
+
+    // The backend refuses the provider change; an error modal appears.
+    await expect(page.locator('.modal-title')).toHaveText(/Import Failed/);
+    await expect(page.getByTestId('import-error')).toContainText('provider');
+
+    // Nothing was imported.
+    await page.getByRole('button', { name: 'Close' }).click();
+    await expect(page.locator('.entry-item')).toHaveCount(0);
+  });
+
   test('refuses a service mismatch (file holds another service)', async ({ page }) => {
     // A secret file, but the user picked "Import Param".
     await setupWailsMocks(page, createImportFileState('/mock/secret.json', {

--- a/internal/gui/frontend/wailsjs/go/gui/App.d.ts
+++ b/internal/gui/frontend/wailsjs/go/gui/App.d.ts
@@ -80,7 +80,7 @@ export function StagingEdit(arg1:string,arg2:string,arg3:string,arg4:string):Pro
 
 export function StagingExport(arg1:string,arg2:string,arg3:string,arg4:boolean):Promise<gui.StagingExportResult>;
 
-export function StagingImport(arg1:string,arg2:string,arg3:string,arg4:string):Promise<gui.StagingImportResult>;
+export function StagingImport(arg1:string,arg2:string,arg3:string,arg4:string,arg5:boolean):Promise<gui.StagingImportResult>;
 
 export function StagingRemoveTag(arg1:string,arg2:string,arg3:string,arg4:string):Promise<gui.StagingRemoveTagResult>;
 

--- a/internal/gui/frontend/wailsjs/go/gui/App.js
+++ b/internal/gui/frontend/wailsjs/go/gui/App.js
@@ -158,8 +158,8 @@ export function StagingExport(arg1, arg2, arg3, arg4) {
   return window['go']['gui']['App']['StagingExport'](arg1, arg2, arg3, arg4);
 }
 
-export function StagingImport(arg1, arg2, arg3, arg4) {
-  return window['go']['gui']['App']['StagingImport'](arg1, arg2, arg3, arg4);
+export function StagingImport(arg1, arg2, arg3, arg4, arg5) {
+  return window['go']['gui']['App']['StagingImport'](arg1, arg2, arg3, arg4, arg5);
 }
 
 export function StagingRemoveTag(arg1, arg2, arg3, arg4) {

--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -1009,15 +1009,18 @@ func (a *App) InspectImportFile(path string) (*EnvelopeInfoResult, error) {
 
 // StagingImport reads a per-service envelope file into the working staging area
 // for the selected service, mirroring `stage <svc> import`. A service mismatch
-// (the file holds another service's data) is a hard error. Scope validation is
-// surfaced to the frontend via InspectImportFile: the GUI warns and lets the
-// user confirm before calling this (the equivalent of the CLI's --force), so
-// StagingImport does not re-refuse a scope mismatch here.
+// (the file holds another service's data) is a hard error, as is a provider
+// mismatch (never overridable — a provider change is qualitatively different
+// from an account/region/vault change). A scope mismatch is refused unless force
+// is true; the frontend passes force after the user confirms the InspectImportFile
+// scope warning (the equivalent of the CLI's --force). This backend guard restores
+// defense-in-depth parity with the CLI so a frontend regression cannot import
+// cross-scope changes unchecked.
 //
 // mode is "merge" (default) or "overwrite"; it only matters when the working
 // area already holds changes for the service. The working store is resolved per
 // service via stagingScopeForKind (#445).
-func (a *App) StagingImport(path, service, passphrase, mode string) (*StagingImportResult, error) {
+func (a *App) StagingImport(path, service, passphrase, mode string, force bool) (*StagingImportResult, error) {
 	svc, err := a.getService(service)
 	if err != nil {
 		return nil, err
@@ -1031,6 +1034,23 @@ func (a *App) StagingImport(path, service, passphrase, mode string) (*StagingImp
 	if env.Service != service {
 		return nil, fmt.Errorf(
 			"import file holds %q data but %q was selected; choose the matching service", env.Service, service)
+	}
+
+	scope, err := a.stagingScopeForKind(kindForService(service))
+	if err != nil {
+		return nil, err
+	}
+
+	if env.Provider != string(scope.Provider) {
+		return nil, fmt.Errorf(
+			"import file provider %q does not match the current provider %q; a provider change cannot be imported",
+			env.Provider, scope.Provider)
+	}
+
+	if env.Scope != scope.Key() && !force {
+		return nil, fmt.Errorf(
+			"import file scope %q does not match the current scope %q; confirm the scope mismatch to import anyway",
+			env.Scope, scope.Key())
 	}
 
 	working, err := a.getWorkingFileStore(kindForService(service))

--- a/internal/gui/staging_integration_internal_test.go
+++ b/internal/gui/staging_integration_internal_test.go
@@ -569,7 +569,7 @@ func TestApp_ExportImport(t *testing.T) {
 		assert.Equal(t, "param", info.Service)
 
 		// Import restores it.
-		imp, err := app.StagingImport(path, "param", "", "merge")
+		imp, err := app.StagingImport(path, "param", "", "merge", false)
 		require.NoError(t, err)
 		assert.Equal(t, 1, imp.EntryCount)
 
@@ -620,7 +620,7 @@ func TestApp_ExportImport(t *testing.T) {
 		_, err := app.StagingExport(path, "secret", "", false)
 		require.NoError(t, err)
 
-		_, err = app.StagingImport(path, "param", "", "merge")
+		_, err = app.StagingImport(path, "param", "", "merge", false)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "secret")
 		assert.Contains(t, err.Error(), "param")
@@ -633,8 +633,59 @@ func TestApp_ExportImport(t *testing.T) {
 		_, err := app.StagingExport(filepath.Join(t.TempDir(), "x.json"), "bogus", "", false)
 		require.ErrorIs(t, err, errInvalidService)
 
-		_, err = app.StagingImport(filepath.Join(t.TempDir(), "x.json"), "bogus", "", "merge")
+		_, err = app.StagingImport(filepath.Join(t.TempDir(), "x.json"), "bogus", "", "merge", false)
 		require.ErrorIs(t, err, errInvalidService)
+	})
+
+	// #486: the backend must refuse a scope mismatch when force is false, restoring
+	// defense-in-depth parity with the CLI (a frontend regression can no longer
+	// import cross-scope changes unchecked). force=true (the confirmed-warning path)
+	// still lets a same-provider scope change through.
+	t.Run("import refuses a scope mismatch unless force is passed", func(t *testing.T) {
+		t.Parallel()
+
+		// Craft a param envelope headed for a DIFFERENT AWS scope (same provider).
+		otherScope := provider.AWSScope("999999999999", "eu-west-1")
+		state := staging.NewEmptyState()
+		state.Entries[staging.ServiceParam][staging.EntryKey{Name: "/app/config"}] =
+			staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr("v")}
+
+		path := filepath.Join(t.TempDir(), "param.json")
+		require.NoError(t, file.WriteEnvelopeFile(path, otherScope, staging.ServiceParam, state, ""))
+
+		app := newTransferTestApp(t, awsScope)
+
+		// force=false: refused.
+		_, err := app.StagingImport(path, "param", "", "merge", false)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "scope")
+
+		// force=true: same-provider scope change is allowed.
+		imp, err := app.StagingImport(path, "param", "", "merge", true)
+		require.NoError(t, err)
+		assert.Equal(t, 1, imp.EntryCount)
+	})
+
+	// #486: a provider mismatch is qualitatively different from an account/region
+	// change and must be refused even when force is true.
+	t.Run("import refuses a provider mismatch even with force", func(t *testing.T) {
+		t.Parallel()
+
+		// Craft an Azure App Config param envelope, then import into an AWS scope.
+		azureScope := provider.AzureAppConfigScope("mystore")
+		state := staging.NewEmptyState()
+		state.Entries[staging.ServiceParam][staging.EntryKey{Name: "app/flag"}] =
+			staging.Entry{Operation: staging.OperationCreate, Value: lo.ToPtr("on")}
+
+		path := filepath.Join(t.TempDir(), "param.json")
+		require.NoError(t, file.WriteEnvelopeFile(path, azureScope, staging.ServiceParam, state, ""))
+
+		app := newTransferTestApp(t, awsScope)
+
+		_, err := app.StagingImport(path, "param", "", "merge", true)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "provider")
+		assert.Contains(t, err.Error(), string(provider.ProviderAzure))
 	})
 
 	// #445: an Azure App Configuration param must export under the App

--- a/internal/staging/cli/import.go
+++ b/internal/staging/cli/import.go
@@ -163,9 +163,10 @@ type presentEnvelope struct {
 // prompted. For a service-specific import the single file must exist and its
 // header service must match. For a global import it reads whichever of
 // param.json / secret.json exist (missing ones are skipped); neither present is
-// an error. Scope mismatches are refused unless --allow-scope-mismatch.
+// an error. Provider mismatches are ALWAYS refused (not overridable); scope
+// mismatches are refused unless --allow-scope-mismatch.
 func collectImportEnvelopes(
-	cmd *cli.Command, service staging.Service, pathFor func(staging.Service) string, wantScope string,
+	cmd *cli.Command, service staging.Service, pathFor func(staging.Service) string, wantProvider, wantScope string,
 ) ([]presentEnvelope, error) {
 	var services []staging.Service
 	if service != "" {
@@ -201,6 +202,17 @@ func collectImportEnvelopes(
 			return nil, fmt.Errorf(
 				"export file %s holds %q data but %q was expected; use the matching command/file",
 				path, env.Service, svc,
+			)
+		}
+
+		// A provider change is qualitatively different from an account/region/vault
+		// change: e.g. an Azure App Config envelope carries namespace-bearing entries
+		// that an AWS SSM working area would silently push to a provider that ignores
+		// namespaces. Refuse it outright, even under --allow-scope-mismatch.
+		if env.Provider != wantProvider {
+			return nil, fmt.Errorf(
+				"export file provider %q does not match the current provider %q; a provider change cannot be imported (not even with --allow-scope-mismatch)",
+				env.Provider, wantProvider,
 			)
 		}
 
@@ -299,7 +311,7 @@ func importAction(service staging.Service, resolver staging.ScopeResolver) func(
 
 		// Validate scope/service on the plaintext headers before prompting for a
 		// passphrase.
-		present, err := collectImportEnvelopes(cmd, service, pathFor, scope.Key())
+		present, err := collectImportEnvelopes(cmd, service, pathFor, string(scope.Provider), scope.Key())
 		if err != nil {
 			if errors.Is(err, usestaging.ErrNothingToImport) {
 				output.Info(cmd.Root().Writer, "No staged changes to import.")

--- a/internal/staging/cli/import_test.go
+++ b/internal/staging/cli/import_test.go
@@ -228,6 +228,36 @@ func TestGlobalImport(t *testing.T) {
 	})
 }
 
+// TestGlobalImport_ProviderMismatch covers the #486 guard: a provider change is
+// qualitatively different from an account/region change, so it must be refused
+// even under the --allow-scope-mismatch scope override. Kept as its own function
+// so TestGlobalImport stays under the funlen limit.
+//
+//nolint:paralleltest // uses t.Setenv (HOME/SUVE_STAGING_KEY); cannot run in parallel
+func TestGlobalImport_ProviderMismatch(t *testing.T) {
+	// Mirrors the failure scenario: an Azure App Config param envelope
+	// {Provider: azure} imported into an AWS SSM param working area.
+	setupExportImportEnv(t)
+
+	azureScope := provider.AzureAppConfigScope("mystore")
+	dir := exportDir(t, azureScope, func() {
+		stageEntry(t, azureScope, staging.ServiceParam, "/app/config", "pval")
+	})
+
+	awsScope := provider.AWSScope("123456789012", "us-east-1")
+
+	// --allow-scope-mismatch bypasses the scope check but the provider guard
+	// still refuses.
+	_, _, err := runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(awsScope)), nil, dir, "--allow-scope-mismatch")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "provider")
+	assert.Contains(t, err.Error(), string(provider.ProviderAzure))
+	assert.Contains(t, err.Error(), string(provider.ProviderAWS))
+
+	// Nothing leaked into the AWS working area.
+	assert.True(t, workingState(t, awsScope).IsEmpty())
+}
+
 //nolint:paralleltest // uses t.Setenv (HOME/SUVE_STAGING_KEY); cannot run in parallel
 func TestServiceImport(t *testing.T) {
 	t.Run("service mismatch is a hard error", func(t *testing.T) {


### PR DESCRIPTION
## What

Closes #486 — closes two import-provenance validation gaps.

**CLI (`internal/staging/cli/import.go`)**: `collectImportEnvelopes` validated `Service` (hard) and `Scope` (soft, `--allow-scope-mismatch`-overridable) but never compared the envelope's `Provider`. It now checks the provider **independently and refuses a mismatch outright — even under `--allow-scope-mismatch`**. Scope validation stays soft as before.

**GUI (`internal/gui/staging.go`)**: `StagingImport` checked service but deliberately not scope, relying entirely on the Svelte frontend gate. It now mirrors the CLI — provider mismatch is a hard error, scope mismatch is refused unless an explicit `force` boolean is passed from the frontend (set only after the user confirms the Scope Mismatch warning). This restores defense-in-depth parity so a frontend regression can no longer import cross-scope changes unchecked.

## Why

Scope keys embed a provider prefix, so a scope match implies a provider match — but under the scope-override flag there was no independent provider guard. A cross-provider envelope (e.g. an Azure App Config `param`) could import into an AWS SSM working area and later push namespace-bearing entries into a provider that ignores namespaces. A **provider change is qualitatively different** from an account/region/vault change (the agreed recommended-default approach), so it is never overridable.

## Approach (agreed)

1. CLI: validate `env.Provider` against the current scope's provider even under `--allow-scope-mismatch`; refuse on mismatch.
2. GUI: add a backend provider (hard) + scope (soft) check to `StagingImport`, gated by a `force` boolean threaded from the frontend.

## Tests

- CLI: an envelope with a mismatched `Provider` is refused even with `--allow-scope-mismatch`.
- Go: `App.StagingImport` with a mismatched scope + no force returns an error; a mismatched provider + force also returns an error.
- Playwright: a provider-mismatched file, after the user confirms the warning, now surfaces a backend "Import Failed" error (new user-visible behavior).
- `mise test` passes; GUI production-tagged Go tests and the full `staging-export-import` Playwright suite pass; self-lint clean.

## Notes

- Rebased onto latest `main`: the scope-override flag rename from #506 (`--force` → `--allow-scope-mismatch`) and #514's stdin/mode handling in `import.go` are integrated. The provider guard is flag-independent (always enforced), so it slots in cleanly ahead of the soft scope check.
- The Wails binding arity for `StagingImport` changed (regenerated `wailsjs` bindings; updated the test mock + frontend call site). Bindings verified to match the current Go signatures (fresh regeneration produced no diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)