### PR TITLE
feat(cli): accept create/update value via --value-stdin or $EDITOR (#478)

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -402,7 +402,7 @@ suve aws param list --output=json /app/config/
 Create a new parameter.
 
 ```
-suve aws param create [options] <name> <value>
+suve aws param create [options] <name> [<value>]
 ```
 
 **Arguments:**
@@ -410,7 +410,7 @@ suve aws param create [options] <name> <value>
 | Argument | Description |
 |----------|-------------|
 | `name` | Parameter name |
-| `value` | Parameter value |
+| `value` | Parameter value (optional; may instead be read from stdin with `--value-stdin`, or typed into `$EDITOR` when omitted) |
 
 **Options:**
 
@@ -423,6 +423,10 @@ suve aws param create [options] <name> <value>
 | `--data-type` | - | - | Parameter data type (e.g. `text`, `aws:ec2:image`) |
 | `--allowed-pattern` | - | - | Regex the value must match |
 | `--policies` | - | - | Parameter policies as a JSON document |
+| `--value-stdin` | - | `false` | Read the value from stdin instead of the positional argument (keeps it out of argv/ps and shell history) |
+
+> [!NOTE]
+> The value can be provided as a positional argument, piped in with `--value-stdin` (so it never appears in `ps`/argv or shell history), or typed into `$EDITOR` when omitted.
 
 > [!NOTE]
 > `--secure` and `--type` cannot be used together.
@@ -461,7 +465,7 @@ suve aws param create --type StringList /app/config/allowed-hosts "host1,host2,h
 Update an existing parameter's value.
 
 ```
-suve aws param update [options] <name> <value>
+suve aws param update [options] <name> [<value>]
 ```
 
 **Arguments:**
@@ -469,7 +473,7 @@ suve aws param update [options] <name> <value>
 | Argument | Description |
 |----------|-------------|
 | `name` | Parameter name |
-| `value` | New parameter value |
+| `value` | New parameter value (optional; may instead be read from stdin with `--value-stdin`, or typed into `$EDITOR` when omitted) |
 
 **Options:**
 
@@ -483,6 +487,10 @@ suve aws param update [options] <name> <value>
 | `--allowed-pattern` | - | - | Regex the value must match |
 | `--policies` | - | - | Parameter policies as a JSON document |
 | `--yes` | - | `false` | Skip confirmation prompt |
+| `--value-stdin` | - | `false` | Read the value from stdin instead of the positional argument (keeps it out of argv/ps and shell history) |
+
+> [!NOTE]
+> The value can be provided as a positional argument, piped in with `--value-stdin` (so it never appears in `ps`/argv or shell history), or typed into `$EDITOR` when omitted.
 
 > [!NOTE]
 > `--secure` and `--type` cannot be used together.
@@ -1435,7 +1443,7 @@ suve aws secret list --output=json production/
 Create a new secret.
 
 ```
-suve aws secret create [options] <name> <value>
+suve aws secret create [options] <name> [<value>]
 ```
 
 **Arguments:**
@@ -1443,13 +1451,17 @@ suve aws secret create [options] <name> <value>
 | Argument | Description |
 |----------|-------------|
 | `name` | Secret name |
-| `value` | Secret value |
+| `value` | Secret value (optional; may instead be read from stdin with `--value-stdin`, or typed into `$EDITOR` when omitted) |
 
 **Options:**
 
 | Option | Alias | Default | Description |
 |--------|-------|---------|-------------|
 | `--description` | - | - | Description for the secret |
+| `--value-stdin` | - | `false` | Read the value from stdin instead of the positional argument (keeps it out of argv/ps and shell history) |
+
+> [!NOTE]
+> The value can be provided as a positional argument, piped in with `--value-stdin` (so it never appears in `ps`/argv or shell history), or typed into `$EDITOR` when omitted.
 
 **Examples:**
 
@@ -1475,7 +1487,7 @@ Created secret my-database-credentials (version: def67890-1234-1234-1234-1234567
 Update an existing secret's value.
 
 ```
-suve aws secret update [options] <name> <value>
+suve aws secret update [options] <name> [<value>]
 ```
 
 **Arguments:**
@@ -1483,7 +1495,7 @@ suve aws secret update [options] <name> <value>
 | Argument | Description |
 |----------|-------------|
 | `name` | Secret name |
-| `value` | New secret value |
+| `value` | New secret value (optional; may instead be read from stdin with `--value-stdin`, or typed into `$EDITOR` when omitted) |
 
 **Options:**
 
@@ -1491,6 +1503,10 @@ suve aws secret update [options] <name> <value>
 |--------|-------|---------|-------------|
 | `--description` | - | - | Update secret description |
 | `--yes` | - | `false` | Skip confirmation prompt |
+| `--value-stdin` | - | `false` | Read the value from stdin instead of the positional argument (keeps it out of argv/ps and shell history) |
+
+> [!NOTE]
+> The value can be provided as a positional argument, piped in with `--value-stdin` (so it never appears in `ps`/argv or shell history), or typed into `$EDITOR` when omitted.
 
 **Examples:**
 

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -265,7 +265,7 @@ suve azure secret list --output=json prod --vault-name my-vault
 Create a new secret. The given value becomes the secret's first version.
 
 ```
-suve azure secret create [options] <name> <value>
+suve azure secret create [options] <name> [<value>]
 ```
 
 **Arguments:**
@@ -273,7 +273,16 @@ suve azure secret create [options] <name> <value>
 | Argument | Description |
 |----------|-------------|
 | `name` | Secret name |
-| `value` | Secret value |
+| `value` | Secret value (optional; may instead be read from stdin with `--value-stdin`, or typed into `$EDITOR` when omitted) |
+
+**Options:**
+
+| Option | Alias | Default | Description |
+|--------|-------|---------|-------------|
+| `--value-stdin` | - | `false` | Read the value from stdin instead of the positional argument (keeps it out of argv/ps and shell history) |
+
+> [!NOTE]
+> The value can be provided as a positional argument, piped in with `--value-stdin` (so it never appears in `ps`/argv or shell history), or typed into `$EDITOR` when omitted.
 
 **Examples:**
 
@@ -295,7 +304,7 @@ suve azure secret create my-config '{"host":"db"}' --vault-name my-vault
 Update a secret's value by adding a new version. The new version becomes the current one; prior versions remain accessible by id.
 
 ```
-suve azure secret update [options] <name> <value>
+suve azure secret update [options] <name> [<value>]
 ```
 
 **Arguments:**
@@ -303,13 +312,17 @@ suve azure secret update [options] <name> <value>
 | Argument | Description |
 |----------|-------------|
 | `name` | Secret name |
-| `value` | New secret value |
+| `value` | New secret value (optional; may instead be read from stdin with `--value-stdin`, or typed into `$EDITOR` when omitted) |
 
 **Options:**
 
 | Option | Alias | Default | Description |
 |--------|-------|---------|-------------|
 | `--yes` | - | `false` | Skip confirmation prompt |
+| `--value-stdin` | - | `false` | Read the value from stdin instead of the positional argument (keeps it out of argv/ps and shell history) |
+
+> [!NOTE]
+> The value can be provided as a positional argument, piped in with `--value-stdin` (so it never appears in `ps`/argv or shell history), or typed into `$EDITOR` when omitted.
 
 **Examples:**
 
@@ -601,7 +614,7 @@ suve azure param list --output=json app/ --store-name my-store
 Create a new setting (key-value).
 
 ```
-suve azure param create [options] <key> <value>
+suve azure param create [options] <key> [<value>]
 ```
 
 **Arguments:**
@@ -609,7 +622,16 @@ suve azure param create [options] <key> <value>
 | Argument | Description |
 |----------|-------------|
 | `key` | Setting key |
-| `value` | Setting value |
+| `value` | Setting value (optional; may instead be read from stdin with `--value-stdin`, or typed into `$EDITOR` when omitted) |
+
+**Options:**
+
+| Option | Alias | Default | Description |
+|--------|-------|---------|-------------|
+| `--value-stdin` | - | `false` | Read the value from stdin instead of the positional argument (keeps it out of argv/ps and shell history) |
+
+> [!NOTE]
+> The value can be provided as a positional argument, piped in with `--value-stdin` (so it never appears in `ps`/argv or shell history), or typed into `$EDITOR` when omitted.
 
 **Examples:**
 
@@ -631,7 +653,7 @@ suve azure param create app/config '{"host":"db"}' --store-name my-store
 Update a setting's value. App Configuration is unversioned, so the value is replaced in place.
 
 ```
-suve azure param update [options] <key> <value>
+suve azure param update [options] <key> [<value>]
 ```
 
 **Arguments:**
@@ -639,13 +661,17 @@ suve azure param update [options] <key> <value>
 | Argument | Description |
 |----------|-------------|
 | `key` | Setting key |
-| `value` | New value |
+| `value` | New value (optional; may instead be read from stdin with `--value-stdin`, or typed into `$EDITOR` when omitted) |
 
 **Options:**
 
 | Option | Alias | Default | Description |
 |--------|-------|---------|-------------|
 | `--yes` | - | `false` | Skip confirmation prompt |
+| `--value-stdin` | - | `false` | Read the value from stdin instead of the positional argument (keeps it out of argv/ps and shell history) |
+
+> [!NOTE]
+> The value can be provided as a positional argument, piped in with `--value-stdin` (so it never appears in `ps`/argv or shell history), or typed into `$EDITOR` when omitted.
 
 **Examples:**
 

--- a/docs/gcloud.md
+++ b/docs/gcloud.md
@@ -261,7 +261,7 @@ suve gcloud secret list --output=json prod
 Create a new secret. The secret is created with automatic replication, and the given value becomes its first version.
 
 ```
-suve gcloud secret create [options] <name> <value>
+suve gcloud secret create [options] <name> [<value>]
 ```
 
 **Arguments:**
@@ -269,7 +269,16 @@ suve gcloud secret create [options] <name> <value>
 | Argument | Description |
 |----------|-------------|
 | `name` | Secret name |
-| `value` | Secret value |
+| `value` | Secret value (optional; may instead be read from stdin with `--value-stdin`, or typed into `$EDITOR` when omitted) |
+
+**Options:**
+
+| Option | Alias | Default | Description |
+|--------|-------|---------|-------------|
+| `--value-stdin` | - | `false` | Read the value from stdin instead of the positional argument (keeps it out of argv/ps and shell history) |
+
+> [!NOTE]
+> The value can be provided as a positional argument, piped in with `--value-stdin` (so it never appears in `ps`/argv or shell history), or typed into `$EDITOR` when omitted.
 
 **Examples:**
 
@@ -291,7 +300,7 @@ suve gcloud secret create my-config '{"host":"db"}'
 Update a secret's value by adding a new version. The new version becomes the latest; prior versions remain accessible by number.
 
 ```
-suve gcloud secret update [options] <name> <value>
+suve gcloud secret update [options] <name> [<value>]
 ```
 
 **Arguments:**
@@ -299,13 +308,17 @@ suve gcloud secret update [options] <name> <value>
 | Argument | Description |
 |----------|-------------|
 | `name` | Secret name |
-| `value` | New secret value |
+| `value` | New secret value (optional; may instead be read from stdin with `--value-stdin`, or typed into `$EDITOR` when omitted) |
 
 **Options:**
 
 | Option | Alias | Default | Description |
 |--------|-------|---------|-------------|
 | `--yes` | - | `false` | Skip confirmation prompt |
+| `--value-stdin` | - | `false` | Read the value from stdin instead of the positional argument (keeps it out of argv/ps and shell history) |
+
+> [!NOTE]
+> The value can be provided as a positional argument, piped in with `--value-stdin` (so it never appears in `ps`/argv or shell history), or typed into `$EDITOR` when omitted.
 
 **Examples:**
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -132,6 +132,29 @@ func runCommand(t *testing.T, cmd *cli.Command, args ...string) (stdout, stderr 
 	return outBuf.String(), errBuf.String(), err
 }
 
+// runCommandWithStdin executes a CLI command with a custom stdin (e.g. for
+// --value-stdin) and returns stdout, stderr, and error.
+func runCommandWithStdin(
+	t *testing.T, cmd *cli.Command, stdin io.Reader, args ...string,
+) (stdout, stderr string, err error) {
+	t.Helper()
+
+	var outBuf, errBuf bytes.Buffer
+
+	app := &cli.Command{
+		Name:      "suve",
+		Reader:    stdin,
+		Writer:    &outBuf,
+		ErrWriter: &errBuf,
+		Commands:  []*cli.Command{cmd},
+	}
+
+	fullArgs := append([]string{"suve", cmd.Name}, args...)
+	err = app.Run(t.Context(), fullArgs)
+
+	return outBuf.String(), errBuf.String(), err
+}
+
 // runSubCommand executes a subcommand (e.g., "param stage status") and returns stdout, stderr, and error.
 func runSubCommand(t *testing.T, parentCmd *cli.Command, subCmdName string, args ...string) (stdout, stderr string, err error) {
 	t.Helper()

--- a/e2e/param_test.go
+++ b/e2e/param_test.go
@@ -1501,10 +1501,12 @@ func TestParam_UpdateMissingArgs(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	// Only name, no value
+	// Only name, no value: with a non-interactive stdin the editor fallback must
+	// NOT be launched (it would hang); it must fail fast with an actionable error.
 	t.Run("no-value", func(t *testing.T) {
-		_, _, err := runCommand(t, paramupdate.Command(), "/test/param")
-		assert.Error(t, err)
+		_, _, err := runCommandWithStdin(t, paramupdate.Command(), strings.NewReader(""), "/test/param")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "value is required")
 	})
 }
 
@@ -2000,10 +2002,12 @@ func TestParam_CreateMissingArgs(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	// Only name, no value
+	// Only name, no value: with a non-interactive stdin the editor fallback must
+	// NOT be launched (it would hang); it must fail fast with an actionable error.
 	t.Run("no-value", func(t *testing.T) {
-		_, _, err := runCommand(t, paramcreate.Command(), "/test/param")
-		assert.Error(t, err)
+		_, _, err := runCommandWithStdin(t, paramcreate.Command(), strings.NewReader(""), "/test/param")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "value is required")
 	})
 }
 

--- a/e2e/param_test.go
+++ b/e2e/param_test.go
@@ -2283,3 +2283,40 @@ func TestParam_ImportMissingFile(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
+
+// TestParam_ValueStdin proves the direct create/update commands accept the
+// value from stdin (--value-stdin) instead of a positional argument, so the
+// secret never lands in argv/ps or shell history (issue #478). It verifies the
+// value round-trips end to end and that no positional value is required.
+func TestParam_ValueStdin(t *testing.T) {
+	setupEnv(t)
+
+	paramName := "/suve-e2e-test/value-stdin/param"
+
+	_, _, _ = runCommand(t, paramdelete.Command(), "--yes", paramName)
+	t.Cleanup(func() {
+		_, _, _ = runCommand(t, paramdelete.Command(), "--yes", paramName)
+	})
+
+	// Create with the value supplied on stdin (no positional value argument).
+	t.Run("create via --value-stdin", func(t *testing.T) {
+		stdin := strings.NewReader("stdin-created-value\n")
+		stdout, stderr, err := runCommandWithStdin(t, paramcreate.Command(), stdin, "--secure", paramName, "--value-stdin")
+		require.NoError(t, err, "create failed: stdout=%s stderr=%s", stdout, stderr)
+
+		stdout, _, err = runCommand(t, cmdparam.ShowCommand(), "--raw", paramName)
+		require.NoError(t, err)
+		assert.Equal(t, "stdin-created-value", strings.TrimSpace(stdout))
+	})
+
+	// Update with the value supplied on stdin (no positional value argument).
+	t.Run("update via --value-stdin", func(t *testing.T) {
+		stdin := strings.NewReader("stdin-updated-value\n")
+		stdout, stderr, err := runCommandWithStdin(t, paramupdate.Command(), stdin, "--yes", "--secure", paramName, "--value-stdin")
+		require.NoError(t, err, "update failed: stdout=%s stderr=%s", stdout, stderr)
+
+		stdout, _, err = runCommand(t, cmdparam.ShowCommand(), "--raw", paramName)
+		require.NoError(t, err)
+		assert.Equal(t, "stdin-updated-value", strings.TrimSpace(stdout))
+	})
+}

--- a/e2e/secret_test.go
+++ b/e2e/secret_test.go
@@ -598,10 +598,12 @@ func TestSecret_UpdateMissingArgs(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	// Only name, no value
+	// Only name, no value: with a non-interactive stdin the editor fallback must
+	// NOT be launched (it would hang); it must fail fast with an actionable error.
 	t.Run("no-value", func(t *testing.T) {
-		_, _, err := runCommand(t, secretupdate.Command(), "test/secret")
-		assert.Error(t, err)
+		_, _, err := runCommandWithStdin(t, secretupdate.Command(), strings.NewReader(""), "test/secret")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "value is required")
 	})
 }
 
@@ -731,10 +733,12 @@ func TestSecret_CreateMissingArgs(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	// Only name, no value
+	// Only name, no value: with a non-interactive stdin the editor fallback must
+	// NOT be launched (it would hang); it must fail fast with an actionable error.
 	t.Run("no-value", func(t *testing.T) {
-		_, _, err := runCommand(t, secretcreate.Command(), "test/secret")
-		assert.Error(t, err)
+		_, _, err := runCommandWithStdin(t, secretcreate.Command(), strings.NewReader(""), "test/secret")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "value is required")
 	})
 }
 

--- a/internal/cli/commands/azure/param/create.go
+++ b/internal/cli/commands/azure/param/create.go
@@ -2,7 +2,7 @@ package param
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 
 	"github.com/urfave/cli/v3"
@@ -31,34 +31,62 @@ func CreateCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "create",
 		Usage:     "Create a new setting",
-		ArgsUsage: "<key> <value>",
+		ArgsUsage: "<key> [<value>]",
 		Description: `Create a new setting (key-value) in Azure App Configuration.
 
 Use this command for new keys only. To change the value of an existing key, use
 'suve azure param update' instead.
 
+The value may be given as a positional argument, read from stdin with
+--value-stdin (so it never appears in argv/ps or shell history), or, when
+omitted, typed into $EDITOR.
+
 EXAMPLES:
    suve azure param create app/timeout "30"                  Create simple setting
-   suve azure param create app/config '{"host":"db"}'        Create JSON setting`,
-		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if cmd.Args().Len() < 2 { //nolint:mnd // minimum required args: key and value
-				return fmt.Errorf("usage: suve azure param create <key> <value>")
-			}
-
-			store, err := cliinternal.AzureAppConfigStore(ctx)
-			if err != nil {
-				return err
-			}
-
-			r := &CreateRunner{
-				UseCase: &azure.CreateUseCase{Writer: store},
-				Stdout:  cmd.Root().Writer,
-				Stderr:  cmd.Root().ErrWriter,
-			}
-
-			return r.Run(ctx, CreateOptions{Name: cmd.Args().Get(0), Value: cmd.Args().Get(1)})
+   suve azure param create app/config '{"host":"db"}'        Create JSON setting
+   printf '%s' "$V" | suve azure param create app/key --value-stdin  Read value from stdin
+   suve azure param create app/key                           Type value into $EDITOR`,
+		Flags: []cli.Flag{
+			cliinternal.ValueStdinFlag(),
 		},
+		Action: createAction,
 	}
+}
+
+func createAction(ctx context.Context, cmd *cli.Command) error {
+	args := cmd.Args()
+	if args.Len() < 1 {
+		return errors.New("usage: suve azure param create <key> [<value>]")
+	}
+
+	value, proceed, err := cliinternal.ResolveValue(ctx, cliinternal.ValueSource{
+		FromStdin: cmd.Bool(cliinternal.FlagValueStdin),
+		HasArg:    args.Len() >= 2, //nolint:mnd // arg 0 is the key, arg 1 is the optional value
+		Arg:       args.Get(1),
+		Stdin:     cliinternal.Stdin(cmd),
+	})
+	if err != nil {
+		return err
+	}
+
+	if !proceed {
+		output.Info(cmd.Root().Writer, "Empty value, nothing to create.")
+
+		return nil
+	}
+
+	store, err := cliinternal.AzureAppConfigStore(ctx)
+	if err != nil {
+		return err
+	}
+
+	r := &CreateRunner{
+		UseCase: &azure.CreateUseCase{Writer: store},
+		Stdout:  cmd.Root().Writer,
+		Stderr:  cmd.Root().ErrWriter,
+	}
+
+	return r.Run(ctx, CreateOptions{Name: args.Get(0), Value: value})
 }
 
 // Run executes the create command.

--- a/internal/cli/commands/azure/param/update.go
+++ b/internal/cli/commands/azure/param/update.go
@@ -2,9 +2,8 @@ package param
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
-	"os"
 
 	"github.com/urfave/cli/v3"
 
@@ -33,33 +32,56 @@ func UpdateCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "update",
 		Usage:     "Update a setting value",
-		ArgsUsage: "<key> <value>",
+		ArgsUsage: "<key> [<value>]",
 		Description: `Update the value of an existing setting.
 
 App Configuration is unversioned: the value is replaced in place.
 Use 'suve azure param create' to create a new setting.
 
+The value may be given as a positional argument, read from stdin with
+--value-stdin (so it never appears in argv/ps or shell history), or, when
+omitted, typed into $EDITOR.
+
 EXAMPLES:
   suve azure param update app/timeout "60"        Replace the value
-  suve azure param update --yes app/timeout "60"  Update without confirmation`,
+  suve azure param update --yes app/timeout "60"  Update without confirmation
+  printf '%s' "$V" | suve azure param update --yes app/key --value-stdin  Read value from stdin
+  suve azure param update app/key                 Type value into $EDITOR`,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "yes",
 				Usage: "Skip confirmation prompt",
 			},
+			cliinternal.ValueStdinFlag(),
 		},
 		Action: updateAction,
 	}
 }
 
 func updateAction(ctx context.Context, cmd *cli.Command) error {
-	if cmd.Args().Len() < 2 { //nolint:mnd // minimum required args: key and value
-		return fmt.Errorf("usage: suve azure param update <key> <value>")
+	args := cmd.Args()
+	if args.Len() < 1 {
+		return errors.New("usage: suve azure param update <key> [<value>]")
 	}
 
-	name := cmd.Args().Get(0)
-	newValue := cmd.Args().Get(1)
+	name := args.Get(0)
 	skipConfirm := cmd.Bool("yes")
+
+	newValue, proceed, err := cliinternal.ResolveValue(ctx, cliinternal.ValueSource{
+		FromStdin: cmd.Bool(cliinternal.FlagValueStdin),
+		HasArg:    args.Len() >= 2, //nolint:mnd // arg 0 is the key, arg 1 is the optional value
+		Arg:       args.Get(1),
+		Stdin:     cliinternal.Stdin(cmd),
+	})
+	if err != nil {
+		return err
+	}
+
+	if !proceed {
+		output.Info(cmd.Root().Writer, "Empty value, nothing to update.")
+
+		return nil
+	}
 
 	store, err := cliinternal.AzureAppConfigStore(ctx)
 	if err != nil {
@@ -78,7 +100,7 @@ func updateAction(ctx context.Context, cmd *cli.Command) error {
 		}
 
 		prompter := &confirm.Prompter{
-			Stdin:  os.Stdin,
+			Stdin:  cliinternal.Stdin(cmd),
 			Stdout: cmd.Root().Writer,
 			Stderr: cmd.Root().ErrWriter,
 		}

--- a/internal/cli/commands/azure/secret/create.go
+++ b/internal/cli/commands/azure/secret/create.go
@@ -2,7 +2,7 @@ package secret
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 
 	"github.com/urfave/cli/v3"
@@ -31,7 +31,7 @@ func CreateCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "create",
 		Usage:     "Create a new secret",
-		ArgsUsage: "<name> <value>",
+		ArgsUsage: "<name> [<value>]",
 		Description: `Create a new secret in Azure Key Vault.
 
 Use this command for new secrets only. To add a new version to an existing
@@ -40,28 +40,56 @@ secret, use 'suve azure secret update' instead.
 The given value becomes the secret's first version. To add tags after creation,
 use 'suve azure secret tag'.
 
+The value may be given as a positional argument, read from stdin with
+--value-stdin (so it never appears in argv/ps or shell history), or, when
+omitted, typed into $EDITOR.
+
 EXAMPLES:
    suve azure secret create my-api-key "sk-12345"             Create simple secret
-   suve azure secret create my-config '{"host":"db"}'         Create JSON secret`,
-		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if cmd.Args().Len() < 2 { //nolint:mnd // minimum required args: name and value
-				return fmt.Errorf("usage: suve azure secret create <name> <value>")
-			}
-
-			store, err := cliinternal.AzureKeyVaultStore(ctx)
-			if err != nil {
-				return err
-			}
-
-			r := &CreateRunner{
-				UseCase: &azure.CreateUseCase{Writer: store},
-				Stdout:  cmd.Root().Writer,
-				Stderr:  cmd.Root().ErrWriter,
-			}
-
-			return r.Run(ctx, CreateOptions{Name: cmd.Args().Get(0), Value: cmd.Args().Get(1)})
+   suve azure secret create my-config '{"host":"db"}'         Create JSON secret
+   printf '%s' "$V" | suve azure secret create my-key --value-stdin  Read value from stdin
+   suve azure secret create my-key                            Type value into $EDITOR`,
+		Flags: []cli.Flag{
+			cliinternal.ValueStdinFlag(),
 		},
+		Action: createAction,
 	}
+}
+
+func createAction(ctx context.Context, cmd *cli.Command) error {
+	args := cmd.Args()
+	if args.Len() < 1 {
+		return errors.New("usage: suve azure secret create <name> [<value>]")
+	}
+
+	value, proceed, err := cliinternal.ResolveValue(ctx, cliinternal.ValueSource{
+		FromStdin: cmd.Bool(cliinternal.FlagValueStdin),
+		HasArg:    args.Len() >= 2, //nolint:mnd // arg 0 is the name, arg 1 is the optional value
+		Arg:       args.Get(1),
+		Stdin:     cliinternal.Stdin(cmd),
+	})
+	if err != nil {
+		return err
+	}
+
+	if !proceed {
+		output.Info(cmd.Root().Writer, "Empty value, nothing to create.")
+
+		return nil
+	}
+
+	store, err := cliinternal.AzureKeyVaultStore(ctx)
+	if err != nil {
+		return err
+	}
+
+	r := &CreateRunner{
+		UseCase: &azure.CreateUseCase{Writer: store},
+		Stdout:  cmd.Root().Writer,
+		Stderr:  cmd.Root().ErrWriter,
+	}
+
+	return r.Run(ctx, CreateOptions{Name: args.Get(0), Value: value})
 }
 
 // Run executes the create command.

--- a/internal/cli/commands/azure/secret/secret_test.go
+++ b/internal/cli/commands/azure/secret/secret_test.go
@@ -36,9 +36,16 @@ func TestCommandValidation(t *testing.T) {
 			wantErr: "usage:",
 		},
 		{
-			name:    "update missing value",
-			args:    []string{"suve", "azure", "secret", "update", "my-secret"},
+			name:    "update missing name",
+			args:    []string{"suve", "azure", "secret", "update"},
 			wantErr: "usage:",
+		},
+		{
+			// The value is now optional (stdin/editor fallback), but a positional
+			// value cannot be combined with --value-stdin.
+			name:    "create value with --value-stdin conflicts",
+			args:    []string{"suve", "azure", "secret", "create", "my-secret", "value", "--value-stdin"},
+			wantErr: "cannot combine a positional value with --value-stdin",
 		},
 		{
 			name:    "delete missing name",

--- a/internal/cli/commands/azure/secret/update.go
+++ b/internal/cli/commands/azure/secret/update.go
@@ -2,9 +2,8 @@ package secret
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
-	"os"
 
 	"github.com/urfave/cli/v3"
 
@@ -33,33 +32,56 @@ func UpdateCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "update",
 		Usage:     "Update a secret value",
-		ArgsUsage: "<name> <value>",
+		ArgsUsage: "<name> [<value>]",
 		Description: `Update the value of an existing secret by adding a new version.
 
 The new version becomes the current one; prior versions remain accessible by id.
 Use 'suve azure secret create' to create a new secret.
 
+The value may be given as a positional argument, read from stdin with
+--value-stdin (so it never appears in argv/ps or shell history), or, when
+omitted, typed into $EDITOR.
+
 EXAMPLES:
   suve azure secret update my-api-key "new-value"       Add a new version
-  suve azure secret update --yes my-api-key "new-value" Update without confirmation`,
+  suve azure secret update --yes my-api-key "new-value" Update without confirmation
+  printf '%s' "$V" | suve azure secret update --yes my-key --value-stdin  Read value from stdin
+  suve azure secret update my-key                       Type value into $EDITOR`,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "yes",
 				Usage: "Skip confirmation prompt",
 			},
+			cliinternal.ValueStdinFlag(),
 		},
 		Action: updateAction,
 	}
 }
 
 func updateAction(ctx context.Context, cmd *cli.Command) error {
-	if cmd.Args().Len() < 2 { //nolint:mnd // minimum required args: name and value
-		return fmt.Errorf("usage: suve azure secret update <name> <value>")
+	args := cmd.Args()
+	if args.Len() < 1 {
+		return errors.New("usage: suve azure secret update <name> [<value>]")
 	}
 
-	name := cmd.Args().Get(0)
-	newValue := cmd.Args().Get(1)
+	name := args.Get(0)
 	skipConfirm := cmd.Bool("yes")
+
+	newValue, proceed, err := cliinternal.ResolveValue(ctx, cliinternal.ValueSource{
+		FromStdin: cmd.Bool(cliinternal.FlagValueStdin),
+		HasArg:    args.Len() >= 2, //nolint:mnd // arg 0 is the name, arg 1 is the optional value
+		Arg:       args.Get(1),
+		Stdin:     cliinternal.Stdin(cmd),
+	})
+	if err != nil {
+		return err
+	}
+
+	if !proceed {
+		output.Info(cmd.Root().Writer, "Empty value, nothing to update.")
+
+		return nil
+	}
 
 	store, err := cliinternal.AzureKeyVaultStore(ctx)
 	if err != nil {
@@ -78,7 +100,7 @@ func updateAction(ctx context.Context, cmd *cli.Command) error {
 		}
 
 		prompter := &confirm.Prompter{
-			Stdin:  os.Stdin,
+			Stdin:  cliinternal.Stdin(cmd),
 			Stdout: cmd.Root().Writer,
 			Stderr: cmd.Root().ErrWriter,
 		}

--- a/internal/cli/commands/gcloud/create.go
+++ b/internal/cli/commands/gcloud/create.go
@@ -2,7 +2,7 @@ package gcloud
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 
 	"github.com/urfave/cli/v3"
@@ -30,7 +30,7 @@ func CreateCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "create",
 		Usage:     "Create a new secret",
-		ArgsUsage: "<name> <value>",
+		ArgsUsage: "<name> [<value>]",
 		Description: `Create a new secret in Google Cloud Secret Manager.
 
 Use this command for new secrets only. To add a new version to an existing
@@ -39,28 +39,56 @@ secret, use 'suve gcloud secret update' instead.
 The secret is created with automatic replication, and the given value becomes
 its first version. To add labels after creation, use 'suve gcloud secret tag'.
 
+The value may be given as a positional argument, read from stdin with
+--value-stdin (so it never appears in argv/ps or shell history), or, when
+omitted, typed into $EDITOR.
+
 EXAMPLES:
    suve gcloud secret create my-api-key "sk-12345"             Create simple secret
-   suve gcloud secret create my-config '{"host":"db"}'         Create JSON secret`,
-		Action: func(ctx context.Context, cmd *cli.Command) error {
-			if cmd.Args().Len() < 2 { //nolint:mnd // minimum required args: name and value
-				return fmt.Errorf("usage: suve gcloud secret create <name> <value>")
-			}
-
-			store, err := cliinternal.GoogleCloudSecretStore(ctx)
-			if err != nil {
-				return err
-			}
-
-			r := &CreateRunner{
-				UseCase: &gcloud.CreateUseCase{Writer: store},
-				Stdout:  cmd.Root().Writer,
-				Stderr:  cmd.Root().ErrWriter,
-			}
-
-			return r.Run(ctx, CreateOptions{Name: cmd.Args().Get(0), Value: cmd.Args().Get(1)})
+   suve gcloud secret create my-config '{"host":"db"}'         Create JSON secret
+   printf '%s' "$V" | suve gcloud secret create my-key --value-stdin  Read value from stdin
+   suve gcloud secret create my-key                            Type value into $EDITOR`,
+		Flags: []cli.Flag{
+			cliinternal.ValueStdinFlag(),
 		},
+		Action: createAction,
 	}
+}
+
+func createAction(ctx context.Context, cmd *cli.Command) error {
+	args := cmd.Args()
+	if args.Len() < 1 {
+		return errors.New("usage: suve gcloud secret create <name> [<value>]")
+	}
+
+	value, proceed, err := cliinternal.ResolveValue(ctx, cliinternal.ValueSource{
+		FromStdin: cmd.Bool(cliinternal.FlagValueStdin),
+		HasArg:    args.Len() >= 2, //nolint:mnd // arg 0 is the name, arg 1 is the optional value
+		Arg:       args.Get(1),
+		Stdin:     cliinternal.Stdin(cmd),
+	})
+	if err != nil {
+		return err
+	}
+
+	if !proceed {
+		output.Info(cmd.Root().Writer, "Empty value, nothing to create.")
+
+		return nil
+	}
+
+	store, err := cliinternal.GoogleCloudSecretStore(ctx)
+	if err != nil {
+		return err
+	}
+
+	r := &CreateRunner{
+		UseCase: &gcloud.CreateUseCase{Writer: store},
+		Stdout:  cmd.Root().Writer,
+		Stderr:  cmd.Root().ErrWriter,
+	}
+
+	return r.Run(ctx, CreateOptions{Name: args.Get(0), Value: value})
 }
 
 // Run executes the create command.

--- a/internal/cli/commands/gcloud/gcloud_test.go
+++ b/internal/cli/commands/gcloud/gcloud_test.go
@@ -36,9 +36,16 @@ func TestCommandValidation(t *testing.T) {
 			wantErr: "usage:",
 		},
 		{
-			name:    "update missing value",
-			args:    []string{"suve", "gcloud", "secret", "update", "my-secret"},
+			name:    "update missing name",
+			args:    []string{"suve", "gcloud", "secret", "update"},
 			wantErr: "usage:",
+		},
+		{
+			// The value is now optional (stdin/editor fallback), but a positional
+			// value cannot be combined with --value-stdin.
+			name:    "create value with --value-stdin conflicts",
+			args:    []string{"suve", "gcloud", "secret", "create", "my-secret", "value", "--value-stdin"},
+			wantErr: "cannot combine a positional value with --value-stdin",
 		},
 		{
 			name:    "delete missing name",

--- a/internal/cli/commands/gcloud/update.go
+++ b/internal/cli/commands/gcloud/update.go
@@ -2,9 +2,8 @@ package gcloud
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
-	"os"
 
 	"github.com/urfave/cli/v3"
 
@@ -32,33 +31,56 @@ func UpdateCommand() *cli.Command {
 	return &cli.Command{
 		Name:      "update",
 		Usage:     "Update a secret value",
-		ArgsUsage: "<name> <value>",
+		ArgsUsage: "<name> [<value>]",
 		Description: `Update the value of an existing secret by adding a new version.
 
 The new version becomes the latest; prior versions remain accessible by number.
 Use 'suve gcloud secret create' to create a new secret.
 
+The value may be given as a positional argument, read from stdin with
+--value-stdin (so it never appears in argv/ps or shell history), or, when
+omitted, typed into $EDITOR.
+
 EXAMPLES:
   suve gcloud secret update my-api-key "new-value"       Add a new version
-  suve gcloud secret update --yes my-api-key "new-value" Update without confirmation`,
+  suve gcloud secret update --yes my-api-key "new-value" Update without confirmation
+  printf '%s' "$V" | suve gcloud secret update --yes my-key --value-stdin  Read value from stdin
+  suve gcloud secret update my-key                       Type value into $EDITOR`,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "yes",
 				Usage: "Skip confirmation prompt",
 			},
+			cliinternal.ValueStdinFlag(),
 		},
 		Action: updateAction,
 	}
 }
 
 func updateAction(ctx context.Context, cmd *cli.Command) error {
-	if cmd.Args().Len() < 2 { //nolint:mnd // minimum required args: name and value
-		return fmt.Errorf("usage: suve gcloud secret update <name> <value>")
+	args := cmd.Args()
+	if args.Len() < 1 {
+		return errors.New("usage: suve gcloud secret update <name> [<value>]")
 	}
 
-	name := cmd.Args().Get(0)
-	newValue := cmd.Args().Get(1)
+	name := args.Get(0)
 	skipConfirm := cmd.Bool("yes")
+
+	newValue, proceed, err := cliinternal.ResolveValue(ctx, cliinternal.ValueSource{
+		FromStdin: cmd.Bool(cliinternal.FlagValueStdin),
+		HasArg:    args.Len() >= 2, //nolint:mnd // arg 0 is the name, arg 1 is the optional value
+		Arg:       args.Get(1),
+		Stdin:     cliinternal.Stdin(cmd),
+	})
+	if err != nil {
+		return err
+	}
+
+	if !proceed {
+		output.Info(cmd.Root().Writer, "Empty value, nothing to update.")
+
+		return nil
+	}
 
 	store, err := cliinternal.GoogleCloudSecretStore(ctx)
 	if err != nil {
@@ -77,7 +99,7 @@ func updateAction(ctx context.Context, cmd *cli.Command) error {
 		}
 
 		prompter := &confirm.Prompter{
-			Stdin:  os.Stdin,
+			Stdin:  cliinternal.Stdin(cmd),
 			Stdout: cmd.Root().Writer,
 			Stderr: cmd.Root().ErrWriter,
 		}

--- a/internal/cli/commands/internal/valueinput.go
+++ b/internal/cli/commands/internal/valueinput.go
@@ -11,6 +11,15 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/cli/editor"
+	"github.com/mpyw/suve/internal/cli/terminal"
+)
+
+// ErrValueRequired is returned when no value was provided and the editor
+// fallback is unavailable because the session is non-interactive (a pipe, CI,
+// or any non-TTY stdin). It never hangs waiting on an editor.
+var ErrValueRequired = errors.New(
+	"value is required: pass it as an argument, pipe it in with --" + FlagValueStdin +
+		", or run interactively to edit it in $EDITOR",
 )
 
 // FlagValueStdin is the name of the flag that reads a create/update value from
@@ -36,6 +45,16 @@ func Stdin(cmd *cli.Command) io.Reader {
 	}
 
 	return os.Stdin
+}
+
+// interactiveReader reports whether r is a terminal, i.e. whether it is safe to
+// fall back to $EDITOR. os.Stdin is a terminal in an interactive shell but not
+// under a pipe or CI, so this prevents the editor fallback from hanging in a
+// non-interactive session. A nil reader (unset) is treated as non-interactive.
+func interactiveReader(r io.Reader) bool {
+	f, ok := r.(terminal.Fder)
+
+	return ok && terminal.IsTTY(f.Fd())
 }
 
 // ValueSource describes where a create/update value may come from. Exactly one
@@ -89,6 +108,14 @@ func ResolveValue(ctx context.Context, src ValueSource) (value string, proceed b
 	default:
 		openEditor := src.OpenEditor
 		if openEditor == nil {
+			// The real $EDITOR is a blocking, interactive program: launching it
+			// under a pipe or in CI would hang forever. Only fall back to it when
+			// stdin is a TTY; otherwise fail with an actionable error. Tests inject
+			// a non-blocking OpenEditor and are therefore exempt from this guard.
+			if !interactiveReader(src.Stdin) {
+				return "", false, ErrValueRequired
+			}
+
 			openEditor = editor.Open
 		}
 

--- a/internal/cli/commands/internal/valueinput.go
+++ b/internal/cli/commands/internal/valueinput.go
@@ -1,0 +1,112 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/urfave/cli/v3"
+
+	"github.com/mpyw/suve/internal/cli/editor"
+)
+
+// FlagValueStdin is the name of the flag that reads a create/update value from
+// stdin instead of a positional argument, keeping the secret out of argv (and
+// therefore out of ps/proc/cmdline and shell history).
+const FlagValueStdin = "value-stdin"
+
+// ValueStdinFlag returns the shared --value-stdin flag used by the direct
+// create/update commands across every provider.
+func ValueStdinFlag() cli.Flag {
+	return &cli.BoolFlag{
+		Name:  FlagValueStdin,
+		Usage: "Read the value from stdin instead of a positional argument (keeps it out of argv/ps and shell history)",
+	}
+}
+
+// Stdin returns the command's configured reader, falling back to os.Stdin when
+// none is set. The production app leaves Reader unset, so this preserves the
+// real stdin there while letting tests inject a reader through cmd.Root().Reader.
+func Stdin(cmd *cli.Command) io.Reader {
+	if r := cmd.Root().Reader; r != nil {
+		return r
+	}
+
+	return os.Stdin
+}
+
+// ValueSource describes where a create/update value may come from. Exactly one
+// of the non-editor sources is selected by ResolveValue's precedence rules.
+type ValueSource struct {
+	// FromStdin is true when --value-stdin was given.
+	FromStdin bool
+	// HasArg is true when a positional value argument was supplied.
+	HasArg bool
+	// Arg is the positional value argument (only meaningful when HasArg).
+	Arg string
+	// Stdin is the reader used when FromStdin is true (nil -> os.Stdin).
+	Stdin io.Reader
+	// OpenEditor is the editor seam used for the fallback path (nil -> editor.Open).
+	OpenEditor editor.OpenFunc
+}
+
+// ResolveValue determines the value for a create/update command. Precedence:
+//
+//  1. --value-stdin: read the whole of stdin (one trailing newline trimmed).
+//  2. the positional value argument, when supplied.
+//  3. $EDITOR fallback: open an empty buffer and use whatever is saved.
+//
+// proceed reports whether the command should continue. It is false only when
+// the editor fallback returns an empty value, which is treated as a
+// cancellation (matching the staging add/edit UX). --value-stdin and the
+// positional argument always proceed, even with an empty value, because those
+// are explicit.
+func ResolveValue(ctx context.Context, src ValueSource) (value string, proceed bool, err error) {
+	switch {
+	case src.FromStdin:
+		if src.HasArg {
+			return "", false, errors.New("cannot combine a positional value with --" + FlagValueStdin)
+		}
+
+		reader := src.Stdin
+		if reader == nil {
+			reader = os.Stdin
+		}
+
+		data, rerr := io.ReadAll(reader)
+		if rerr != nil {
+			return "", false, fmt.Errorf("failed to read value from stdin: %w", rerr)
+		}
+
+		return trimTrailingNewline(string(data)), true, nil
+
+	case src.HasArg:
+		return src.Arg, true, nil
+
+	default:
+		openEditor := src.OpenEditor
+		if openEditor == nil {
+			openEditor = editor.Open
+		}
+
+		edited, eerr := openEditor(ctx, "")
+		if eerr != nil {
+			return "", false, fmt.Errorf("failed to edit value: %w", eerr)
+		}
+
+		return edited, edited != "", nil
+	}
+}
+
+// trimTrailingNewline removes a single trailing newline (CRLF or LF), matching
+// the trailing-newline handling of the external editor so that
+// `printf '%s\n' secret | ... --value-stdin` and an editor session behave alike.
+func trimTrailingNewline(s string) string {
+	s = strings.TrimSuffix(s, "\r\n")
+	s = strings.TrimSuffix(s, "\n")
+
+	return s
+}

--- a/internal/cli/commands/internal/valueinput_test.go
+++ b/internal/cli/commands/internal/valueinput_test.go
@@ -1,0 +1,127 @@
+package internal_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cliinternal "github.com/mpyw/suve/internal/cli/commands/internal"
+)
+
+func TestResolveValue_FromStdin(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reads stdin and trims a single trailing newline", func(t *testing.T) {
+		t.Parallel()
+
+		value, proceed, err := cliinternal.ResolveValue(t.Context(), cliinternal.ValueSource{
+			FromStdin: true,
+			Stdin:     strings.NewReader("sk-12345\n"),
+		})
+		require.NoError(t, err)
+		assert.True(t, proceed)
+		assert.Equal(t, "sk-12345", value)
+	})
+
+	t.Run("preserves interior newlines and CRLF trailing", func(t *testing.T) {
+		t.Parallel()
+
+		value, proceed, err := cliinternal.ResolveValue(t.Context(), cliinternal.ValueSource{
+			FromStdin: true,
+			Stdin:     strings.NewReader("{\n  \"a\": 1\n}\r\n"),
+		})
+		require.NoError(t, err)
+		assert.True(t, proceed)
+		assert.Equal(t, "{\n  \"a\": 1\n}", value)
+	})
+
+	t.Run("empty stdin still proceeds with an empty value", func(t *testing.T) {
+		t.Parallel()
+
+		value, proceed, err := cliinternal.ResolveValue(t.Context(), cliinternal.ValueSource{
+			FromStdin: true,
+			Stdin:     strings.NewReader(""),
+		})
+		require.NoError(t, err)
+		assert.True(t, proceed)
+		assert.Empty(t, value)
+	})
+
+	t.Run("combining a positional value with --value-stdin is an error", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, err := cliinternal.ResolveValue(t.Context(), cliinternal.ValueSource{
+			FromStdin: true,
+			HasArg:    true,
+			Arg:       "positional",
+			Stdin:     strings.NewReader("from-stdin"),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot combine a positional value with --value-stdin")
+	})
+}
+
+func TestResolveValue_FromArg(t *testing.T) {
+	t.Parallel()
+
+	value, proceed, err := cliinternal.ResolveValue(t.Context(), cliinternal.ValueSource{
+		HasArg: true,
+		Arg:    "hunter2",
+	})
+	require.NoError(t, err)
+	assert.True(t, proceed)
+	assert.Equal(t, "hunter2", value)
+}
+
+func TestResolveValue_EditorFallback(t *testing.T) {
+	t.Parallel()
+
+	t.Run("opens the editor with an empty buffer and uses the result", func(t *testing.T) {
+		t.Parallel()
+
+		var gotInitial string
+
+		value, proceed, err := cliinternal.ResolveValue(t.Context(), cliinternal.ValueSource{
+			OpenEditor: func(_ context.Context, content string) (string, error) {
+				gotInitial = content
+
+				return "edited-secret", nil
+			},
+		})
+		require.NoError(t, err)
+		assert.True(t, proceed)
+		assert.Equal(t, "edited-secret", value)
+		assert.Empty(t, gotInitial, "the editor should open on an empty buffer")
+	})
+
+	t.Run("an empty editor result cancels (proceed=false)", func(t *testing.T) {
+		t.Parallel()
+
+		value, proceed, err := cliinternal.ResolveValue(t.Context(), cliinternal.ValueSource{
+			OpenEditor: func(_ context.Context, _ string) (string, error) {
+				return "", nil
+			},
+		})
+		require.NoError(t, err)
+		assert.False(t, proceed)
+		assert.Empty(t, value)
+	})
+
+	t.Run("editor errors are surfaced", func(t *testing.T) {
+		t.Parallel()
+
+		sentinel := errors.New("editor exploded")
+
+		_, _, err := cliinternal.ResolveValue(t.Context(), cliinternal.ValueSource{
+			OpenEditor: func(_ context.Context, _ string) (string, error) {
+				return "", sentinel
+			},
+		})
+		require.Error(t, err)
+		assert.ErrorIs(t, err, sentinel)
+	})
+}

--- a/internal/cli/commands/internal/valueinput_test.go
+++ b/internal/cli/commands/internal/valueinput_test.go
@@ -111,6 +111,20 @@ func TestResolveValue_EditorFallback(t *testing.T) {
 		assert.Empty(t, value)
 	})
 
+	t.Run("non-interactive stdin without a value fails instead of hanging on the editor", func(t *testing.T) {
+		t.Parallel()
+
+		// No OpenEditor override: the real editor.Open would be selected, but a
+		// non-TTY stdin (here strings.Reader) must short-circuit to an error
+		// rather than block waiting on an interactive editor.
+		_, proceed, err := cliinternal.ResolveValue(t.Context(), cliinternal.ValueSource{
+			Stdin: strings.NewReader(""),
+		})
+		require.Error(t, err)
+		assert.False(t, proceed)
+		assert.ErrorIs(t, err, cliinternal.ErrValueRequired)
+	})
+
 	t.Run("editor errors are surfaced", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/cli/commands/param/create/create.go
+++ b/internal/cli/commands/param/create/create.go
@@ -38,7 +38,7 @@ func Command() *cli.Command {
 	return &cli.Command{
 		Name:      "create",
 		Usage:     "Create a new parameter",
-		ArgsUsage: "<name> <value>",
+		ArgsUsage: "<name> [<value>]",
 		Description: `Create a new parameter in AWS Systems Manager Parameter Store.
 
 Use this command for new parameters only. To update an existing parameter,
@@ -52,13 +52,19 @@ PARAMETER TYPES:
 The --secure flag is a shorthand for --type SecureString.
 You cannot use both --secure and --type together.
 
+The value may be given as a positional argument, read from stdin with
+--value-stdin (so it never appears in argv/ps or shell history), or, when
+omitted, typed into $EDITOR.
+
 To add tags after creation, use 'suve param tag' command.
 
 EXAMPLES:
    suve param create /app/config/db-url "postgres://..."       Create String parameter
    suve param create --secure /app/config/api-key "secret123"  Create SecureString
    suve param create --type StringList /app/hosts "a.com,b.com" Create StringList
-   suve param create --description "DB URL" /app/db-url "..."  With description`,
+   suve param create --description "DB URL" /app/db-url "..."  With description
+   printf '%s' "$V" | suve param create --secure /app/key --value-stdin  Read value from stdin
+   suve param create --secure /app/key                         Type value into $EDITOR`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "type",
@@ -89,14 +95,16 @@ EXAMPLES:
 				Name:  "policies",
 				Usage: "Parameter policies as a JSON document",
 			},
+			internal.ValueStdinFlag(),
 		},
 		Action: action,
 	}
 }
 
 func action(ctx context.Context, cmd *cli.Command) error {
-	if cmd.Args().Len() < 2 { //nolint:mnd // minimum required args: name and value
-		return errors.New("usage: suve param create <name> <value>")
+	args := cmd.Args()
+	if args.Len() < 1 {
+		return errors.New("usage: suve param create <name> [<value>]")
 	}
 
 	secure := cmd.Bool("secure")
@@ -119,6 +127,22 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
+	value, proceed, err := internal.ResolveValue(ctx, internal.ValueSource{
+		FromStdin: cmd.Bool(internal.FlagValueStdin),
+		HasArg:    args.Len() >= 2, //nolint:mnd // arg 0 is the name, arg 1 is the optional value
+		Arg:       args.Get(1),
+		Stdin:     internal.Stdin(cmd),
+	})
+	if err != nil {
+		return err
+	}
+
+	if !proceed {
+		output.Info(cmd.Root().Writer, "Empty value, nothing to create.")
+
+		return nil
+	}
+
 	store, err := internal.ParamStore(ctx)
 	if err != nil {
 		return err
@@ -131,8 +155,8 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	return r.Run(ctx, Options{
-		Name:        cmd.Args().Get(0),
-		Value:       cmd.Args().Get(1),
+		Name:        args.Get(0),
+		Value:       value,
 		Type:        paramType,
 		Description: cmd.String("description"),
 		ParamOpts: paramopts.Values{

--- a/internal/cli/commands/param/create/create_test.go
+++ b/internal/cli/commands/param/create/create_test.go
@@ -30,13 +30,15 @@ func TestCommand_Validation(t *testing.T) {
 		assert.Contains(t, err.Error(), "usage:")
 	})
 
-	t.Run("missing value argument", func(t *testing.T) {
+	// The value is now optional (--value-stdin / editor fallback), but a
+	// positional value cannot be combined with --value-stdin.
+	t.Run("positional value with --value-stdin conflicts", func(t *testing.T) {
 		t.Parallel()
 
 		app := apptest.AWSApp()
-		err := app.Run(t.Context(), []string{"suve", "param", "create", "/app/param"})
+		err := app.Run(t.Context(), []string{"suve", "param", "create", "/app/param", "value", "--value-stdin"})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "usage:")
+		assert.Contains(t, err.Error(), "cannot combine a positional value with --value-stdin")
 	})
 
 	t.Run("conflicting secure and type flags", func(t *testing.T) {

--- a/internal/cli/commands/param/update/update.go
+++ b/internal/cli/commands/param/update/update.go
@@ -3,9 +3,8 @@ package update
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
-	"os"
 
 	"github.com/urfave/cli/v3"
 
@@ -41,7 +40,7 @@ func Command() *cli.Command {
 	return &cli.Command{
 		Name:      "update",
 		Usage:     "Update a parameter value",
-		ArgsUsage: "<name> <value>",
+		ArgsUsage: "<name> [<value>]",
 		Description: `Update the value of an existing parameter.
 
 This creates a new version of the parameter in AWS Systems Manager Parameter Store.
@@ -57,10 +56,16 @@ PARAMETER TYPES:
 The --secure flag is a shorthand for --type SecureString.
 You cannot use both --secure and --type together.
 
+The value may be given as a positional argument, read from stdin with
+--value-stdin (so it never appears in argv/ps or shell history), or, when
+omitted, typed into $EDITOR.
+
 EXAMPLES:
    suve param update /app/config/db-url "postgres://..."       Update parameter
    suve param update --secure /app/config/api-key "secret123"  Update as SecureString
-   suve param update --yes /app/config/db-url "postgres://..." Update without confirmation`,
+   suve param update --yes /app/config/db-url "postgres://..." Update without confirmation
+   printf '%s' "$V" | suve param update --yes --secure /app/key --value-stdin  Read value from stdin
+   suve param update --secure /app/key                         Type value into $EDITOR`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "type",
@@ -95,14 +100,16 @@ EXAMPLES:
 				Name:  "yes",
 				Usage: "Skip confirmation prompt",
 			},
+			internal.ValueStdinFlag(),
 		},
 		Action: action,
 	}
 }
 
 func action(ctx context.Context, cmd *cli.Command) error {
-	if cmd.Args().Len() < 2 { //nolint:mnd // minimum required args: name and value
-		return fmt.Errorf("usage: suve param update <name> <value>")
+	args := cmd.Args()
+	if args.Len() < 1 {
+		return errors.New("usage: suve param update <name> [<value>]")
 	}
 
 	secure := cmd.Bool("secure")
@@ -110,7 +117,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 
 	// Check for conflicting flags
 	if secure && cmd.IsSet("type") {
-		return fmt.Errorf("cannot use --secure with --type; use one or the other")
+		return errors.New("cannot use --secure with --type; use one or the other")
 	}
 
 	if secure {
@@ -125,8 +132,24 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		return err
 	}
 
-	name := cmd.Args().Get(0)
+	name := args.Get(0)
 	skipConfirm := cmd.Bool("yes")
+
+	newValue, proceed, err := internal.ResolveValue(ctx, internal.ValueSource{
+		FromStdin: cmd.Bool(internal.FlagValueStdin),
+		HasArg:    args.Len() >= 2, //nolint:mnd // arg 0 is the name, arg 1 is the optional value
+		Arg:       args.Get(1),
+		Stdin:     internal.Stdin(cmd),
+	})
+	if err != nil {
+		return err
+	}
+
+	if !proceed {
+		output.Info(cmd.Root().Writer, "Empty value, nothing to update.")
+
+		return nil
+	}
 
 	store, err := internal.ParamStore(ctx)
 	if err != nil {
@@ -134,7 +157,6 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	uc := &param.UpdateUseCase{Store: store}
-	newValue := cmd.Args().Get(1)
 
 	// Fetch current value and show diff before confirming
 	if !skipConfirm {
@@ -148,7 +170,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 
 		// Confirm operation
 		prompter := &confirm.Prompter{
-			Stdin:  os.Stdin,
+			Stdin:  internal.Stdin(cmd),
 			Stdout: cmd.Root().Writer,
 			Stderr: cmd.Root().ErrWriter,
 		}

--- a/internal/cli/commands/param/update/update_test.go
+++ b/internal/cli/commands/param/update/update_test.go
@@ -30,13 +30,15 @@ func TestCommand_Validation(t *testing.T) {
 		assert.Contains(t, err.Error(), "usage:")
 	})
 
-	t.Run("missing value argument", func(t *testing.T) {
+	// The value is now optional (--value-stdin / editor fallback), but a
+	// positional value cannot be combined with --value-stdin.
+	t.Run("positional value with --value-stdin conflicts", func(t *testing.T) {
 		t.Parallel()
 
 		app := apptest.AWSApp()
-		err := app.Run(t.Context(), []string{"suve", "param", "update", "/app/param"})
+		err := app.Run(t.Context(), []string{"suve", "param", "update", "/app/param", "value", "--value-stdin"})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "usage:")
+		assert.Contains(t, err.Error(), "cannot combine a positional value with --value-stdin")
 	})
 
 	t.Run("conflicting secure and type flags", func(t *testing.T) {

--- a/internal/cli/commands/secret/create/create.go
+++ b/internal/cli/commands/secret/create/create.go
@@ -3,7 +3,7 @@ package create
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
 
 	"github.com/urfave/cli/v3"
@@ -32,7 +32,7 @@ func Command() *cli.Command {
 	return &cli.Command{
 		Name:      "create",
 		Usage:     "Create a new secret",
-		ArgsUsage: "<name> <value>",
+		ArgsUsage: "<name> [<value>]",
 		Description: `Create a new secret in AWS Secrets Manager.
 
 Use this command for new secrets only. To update an existing secret,
@@ -41,25 +41,49 @@ use 'suve secret update' instead.
 Secret values are automatically encrypted by Secrets Manager using
 the default KMS key or a custom KMS key configured in the account.
 
+The value may be given as a positional argument, read from stdin with
+--value-stdin (so it never appears in argv/ps or shell history), or, when
+omitted, typed into $EDITOR.
+
 To add tags after creation, use 'suve secret tag' command.
 
 EXAMPLES:
    suve secret create my-api-key "sk-12345"                    Create simple secret
    suve secret create --description "API Key for X" my-key "..." With description
-   suve secret create my-config '{"host":"db.example.com"}'    Create JSON secret`,
+   suve secret create my-config '{"host":"db.example.com"}'    Create JSON secret
+   printf '%s' "$VALUE" | suve secret create my-key --value-stdin  Read value from stdin
+   suve secret create my-key                                   Type value into $EDITOR`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "description",
 				Usage: "Description for the secret",
 			},
+			internal.ValueStdinFlag(),
 		},
 		Action: action,
 	}
 }
 
 func action(ctx context.Context, cmd *cli.Command) error {
-	if cmd.Args().Len() < 2 { //nolint:mnd // minimum required args: name and value
-		return fmt.Errorf("usage: suve secret create <name> <value>")
+	args := cmd.Args()
+	if args.Len() < 1 {
+		return errors.New("usage: suve secret create <name> [<value>]")
+	}
+
+	value, proceed, err := internal.ResolveValue(ctx, internal.ValueSource{
+		FromStdin: cmd.Bool(internal.FlagValueStdin),
+		HasArg:    args.Len() >= 2, //nolint:mnd // arg 0 is the name, arg 1 is the optional value
+		Arg:       args.Get(1),
+		Stdin:     internal.Stdin(cmd),
+	})
+	if err != nil {
+		return err
+	}
+
+	if !proceed {
+		output.Info(cmd.Root().Writer, "Empty value, nothing to create.")
+
+		return nil
 	}
 
 	store, err := internal.SecretStore(ctx)
@@ -74,8 +98,8 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	return r.Run(ctx, Options{
-		Name:        cmd.Args().Get(0),
-		Value:       cmd.Args().Get(1),
+		Name:        args.Get(0),
+		Value:       value,
 		Description: cmd.String("description"),
 	})
 }

--- a/internal/cli/commands/secret/create/create_test.go
+++ b/internal/cli/commands/secret/create/create_test.go
@@ -29,13 +29,15 @@ func TestCommand_Validation(t *testing.T) {
 		assert.Contains(t, err.Error(), "usage:")
 	})
 
-	t.Run("missing value argument", func(t *testing.T) {
+	// The value is now optional (--value-stdin / editor fallback), but a
+	// positional value cannot be combined with --value-stdin.
+	t.Run("positional value with --value-stdin conflicts", func(t *testing.T) {
 		t.Parallel()
 
 		app := apptest.AWSApp()
-		err := app.Run(t.Context(), []string{"suve", "secret", "create", "my-secret"})
+		err := app.Run(t.Context(), []string{"suve", "secret", "create", "my-secret", "value", "--value-stdin"})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "usage:")
+		assert.Contains(t, err.Error(), "cannot combine a positional value with --value-stdin")
 	})
 }
 

--- a/internal/cli/commands/secret/update/update.go
+++ b/internal/cli/commands/secret/update/update.go
@@ -3,9 +3,8 @@ package update
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"io"
-	"os"
 
 	"github.com/urfave/cli/v3"
 
@@ -35,7 +34,7 @@ func Command() *cli.Command {
 	return &cli.Command{
 		Name:      "update",
 		Usage:     "Update a secret value",
-		ArgsUsage: "<name> <value>",
+		ArgsUsage: "<name> [<value>]",
 		Description: `Update the value of an existing secret.
 
 This creates a new version of the secret. The previous version will
@@ -44,10 +43,16 @@ have its AWSCURRENT label moved to AWSPREVIOUS.
 Use 'suve secret create' to create a new secret.
 To manage tags, use 'suve secret tag' and 'suve secret untag' commands.
 
+The value may be given as a positional argument, read from stdin with
+--value-stdin (so it never appears in argv/ps or shell history), or, when
+omitted, typed into $EDITOR.
+
 EXAMPLES:
   suve secret update my-api-key "new-key-value"         Update with new value
   suve secret update my-config '{"host":"new-db.com"}'  Update JSON secret
-  suve secret update --yes my-api-key "new-key-value"   Update without confirmation`,
+  suve secret update --yes my-api-key "new-key-value"   Update without confirmation
+  printf '%s' "$VALUE" | suve secret update --yes my-key --value-stdin  Read value from stdin
+  suve secret update my-key                             Type value into $EDITOR`,
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "description",
@@ -57,18 +62,36 @@ EXAMPLES:
 				Name:  "yes",
 				Usage: "Skip confirmation prompt",
 			},
+			internal.ValueStdinFlag(),
 		},
 		Action: action,
 	}
 }
 
 func action(ctx context.Context, cmd *cli.Command) error {
-	if cmd.Args().Len() < 2 { //nolint:mnd // minimum required args: name and value
-		return fmt.Errorf("usage: suve secret update <name> <value>")
+	args := cmd.Args()
+	if args.Len() < 1 {
+		return errors.New("usage: suve secret update <name> [<value>]")
 	}
 
-	name := cmd.Args().Get(0)
+	name := args.Get(0)
 	skipConfirm := cmd.Bool("yes")
+
+	newValue, proceed, err := internal.ResolveValue(ctx, internal.ValueSource{
+		FromStdin: cmd.Bool(internal.FlagValueStdin),
+		HasArg:    args.Len() >= 2, //nolint:mnd // arg 0 is the name, arg 1 is the optional value
+		Arg:       args.Get(1),
+		Stdin:     internal.Stdin(cmd),
+	})
+	if err != nil {
+		return err
+	}
+
+	if !proceed {
+		output.Info(cmd.Root().Writer, "Empty value, nothing to update.")
+
+		return nil
+	}
 
 	store, err := internal.SecretStore(ctx)
 	if err != nil {
@@ -76,7 +99,6 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	uc := &secret.UpdateUseCase{Store: store}
-	newValue := cmd.Args().Get(1)
 
 	// Fetch current value and show diff before confirming
 	if !skipConfirm {
@@ -90,7 +112,7 @@ func action(ctx context.Context, cmd *cli.Command) error {
 
 		// Confirm operation
 		prompter := &confirm.Prompter{
-			Stdin:  os.Stdin,
+			Stdin:  internal.Stdin(cmd),
 			Stdout: cmd.Root().Writer,
 			Stderr: cmd.Root().ErrWriter,
 		}

--- a/internal/cli/commands/secret/update/update_test.go
+++ b/internal/cli/commands/secret/update/update_test.go
@@ -29,13 +29,15 @@ func TestCommand_Validation(t *testing.T) {
 		assert.Contains(t, err.Error(), "usage:")
 	})
 
-	t.Run("missing value argument", func(t *testing.T) {
+	// The value is now optional (--value-stdin / editor fallback), but a
+	// positional value cannot be combined with --value-stdin.
+	t.Run("positional value with --value-stdin conflicts", func(t *testing.T) {
 		t.Parallel()
 
 		app := apptest.AWSApp()
-		err := app.Run(t.Context(), []string{"suve", "secret", "update", "my-secret"})
+		err := app.Run(t.Context(), []string{"suve", "secret", "update", "my-secret", "value", "--value-stdin"})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "usage:")
+		assert.Contains(t, err.Error(), "cannot combine a positional value with --value-stdin")
 	})
 }
 


### PR DESCRIPTION
## What

Adds a non-argv value input path to the direct (non-staging) create/update commands across every provider — AWS `param` + `secret`, Google Cloud `secret`, and Azure Key Vault `secret` + App Configuration `param`:

- **`--value-stdin`** (mirroring `--passphrase-stdin`): reads the value from stdin (one trailing newline trimmed) instead of argv.
- **`$EDITOR` fallback**: when the positional value is omitted and `--value-stdin` is not set, the value is typed into `$EDITOR`, matching the `stage add`/`stage edit` UX. An empty editor result cancels.
- The **positional value keeps working unchanged** (additive / backward compatible). Combining a positional value with `--value-stdin` is rejected.

A shared helper `internal.ResolveValue` / `internal.ValueStdinFlag` centralizes the logic. Value resolution now runs before store resolution so argument validation is uniform across providers, and confirmation prompts read from the command reader (falling back to `os.Stdin`) so they stay testable.

Docs (`docs/aws.md`, `docs/gcloud.md`, `docs/azure.md`) and command help now document the exposure and the new input paths.

## Why

Previously the value was only a positional argument — `suve secret create /prod/db-pw hunter2` — so the plaintext secret was visible in `ps` / `/proc/<pid>/cmdline` and retained in shell history. This is the recommended default fix: a safe in-tool input path, consistent across providers, with the positional argument still available for backward compatibility.

## Tests

- Unit tests for `ResolveValue`: stdin read + trailing-newline trim, positional, editor fallback (mocked editor), empty-editor cancel, and the positional+`--value-stdin` conflict.
- Command-level validation tests for the conflict across providers.
- E2E (`e2e/param_test.go`): `param create` / `update` via `--value-stdin` against localstack, asserting the value round-trips and no positional value is required.

`mise test` passes (`SUVE_STAGING_KEY` set); `golangci-lint run ./internal/cli/commands/...` reports 0 issues.

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)