### PR TITLE
fix: surface swallowed unstage errors and harden ExecuteMapWithLimit

### DIFF
--- a/internal/gui/frontend/src/lib/StagingView.svelte
+++ b/internal/gui/frontend/src/lib/StagingView.svelte
@@ -672,6 +672,11 @@
                   {#if result.error}
                     <span class="result-error">{result.error}</span>
                   {/if}
+                  {#if result.unstageError}
+                    <span class="result-warning" data-testid="unstage-warning">
+                      Applied, but still staged (failed to clear): {result.unstageError}
+                    </span>
+                  {/if}
                 </li>
               {/each}
             </ul>
@@ -687,6 +692,11 @@
                   <span class="result-status status-updated">tags</span>
                   {#if result.error}
                     <span class="result-error">{result.error}</span>
+                  {/if}
+                  {#if result.unstageError}
+                    <span class="result-warning" data-testid="unstage-warning">
+                      Applied, but still staged (failed to clear): {result.unstageError}
+                    </span>
                   {/if}
                 </li>
               {/each}
@@ -1347,6 +1357,13 @@
   .result-error {
     font-size: 12px;
     color: #f44336;
+    width: 100%;
+    margin-top: 4px;
+  }
+
+  .result-warning {
+    font-size: 12px;
+    color: #ff9800;
     width: 100%;
     margin-top: 4px;
   }

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -188,6 +188,12 @@ export interface MockState {
   // turning any Execute error (conflict / per-entry failure) into a rejected
   // Wails promise, so "Apply All" can succeed for one service and fail another.
   stagingApplyFailService?: Service;
+  // Per-service post-apply unstage failure: when set, StagingApply for this
+  // service reports each entry/tag as successfully applied but carries an
+  // unstageError (the cloud write landed but the staged entry could not be
+  // cleared). The bucket is NOT emptied, so the entries remain staged — exactly
+  // the drift the GUI must now surface as a warning (#447).
+  stagingApplyUnstageErrorService?: Service;
 }
 
 // ============================================================================
@@ -1199,6 +1205,20 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
         const tagStaged = service === 'param' ? currentBucket().paramTags : currentBucket().secretTags;
         const entryCount = staged.length;
         const tagCount = tagStaged.length;
+        // The cloud write landed but clearing the staged entries failed: report
+        // each result with an unstageError and leave the bucket populated (#447).
+        if (state.stagingApplyUnstageErrorService === service) {
+          return {
+            serviceName: service,
+            entryResults: entryCount > 0 ? staged.map((s: any) => ({ name: s.name, status: s.operation === 'delete' ? 'deleted' : 'updated', unstageError: 'keychain locked' })) : null,
+            tagResults: tagCount > 0 ? tagStaged.map((t: any) => ({ name: t.name, status: 'updated', unstageError: 'keychain locked' })) : null,
+            conflicts: null,
+            entrySucceeded: entryCount,
+            entryFailed: 0,
+            tagSucceeded: tagCount,
+            tagFailed: 0,
+          };
+        }
         if (service === 'param') {
           currentBucket().param = [];
           currentBucket().paramTags = [];

--- a/internal/gui/frontend/tests/staging-apply-unstage-warning.spec.ts
+++ b/internal/gui/frontend/tests/staging-apply-unstage-warning.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupWailsMocks,
+  createStagedValue,
+  navigateTo,
+} from './fixtures/wails-mock';
+
+// Regression (#447): when the cloud write succeeds but clearing the staged
+// entry afterwards fails, the apply result carries an unstageError. The GUI used
+// to drop it (the DTO had no field and the mapping ignored it), so the entry
+// silently survived while the UI reported success. The apply-result view must
+// now surface it as a warning row.
+
+test.describe('Staging apply surfaces a post-apply unstage failure (#447)', () => {
+  test('an applied-but-still-staged entry shows a warning', async ({ page }) => {
+    await setupWailsMocks(page, {
+      stagedParam: [createStagedValue('/app/param-a', 'create', 'pv')],
+      stagingApplyUnstageErrorService: 'param',
+    });
+    await page.goto('/');
+    await navigateTo(page, 'Staging');
+
+    await expect(page.locator('.entry-item').filter({ hasText: '/app/param-a' })).toBeVisible();
+
+    // Open the param apply flow and confirm.
+    await page.getByRole('button', { name: /Apply/i }).first().click();
+    await expect(page.locator('.modal-backdrop')).toBeVisible();
+    await page.locator('.form-actions').getByRole('button', { name: /Apply|Confirm/i }).first().click();
+
+    // The result view renders and the entry reports its applied status plus the
+    // unstage warning (before the fix, no warning appeared at all).
+    await expect(page.getByRole('button', { name: 'Close' })).toBeVisible({ timeout: 10000 });
+
+    const warning = page.getByTestId('unstage-warning');
+    await expect(warning).toBeVisible();
+    await expect(warning).toContainText('keychain locked');
+  });
+});

--- a/internal/gui/frontend/wailsjs/go/models.ts
+++ b/internal/gui/frontend/wailsjs/go/models.ts
@@ -651,6 +651,7 @@ export namespace gui {
 	    name: string;
 	    status: string;
 	    error?: string;
+	    unstageError?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new StagingApplyEntryResult(source);
@@ -661,6 +662,7 @@ export namespace gui {
 	        this.name = source["name"];
 	        this.status = source["status"];
 	        this.error = source["error"];
+	        this.unstageError = source["unstageError"];
 	    }
 	}
 	export class StagingApplyTagResult {
@@ -668,6 +670,7 @@ export namespace gui {
 	    addTags?: Record<string, string>;
 	    removeTags?: string[];
 	    error?: string;
+	    unstageError?: string;
 	
 	    static createFrom(source: any = {}) {
 	        return new StagingApplyTagResult(source);
@@ -679,6 +682,7 @@ export namespace gui {
 	        this.addTags = source["addTags"];
 	        this.removeTags = source["removeTags"];
 	        this.error = source["error"];
+	        this.unstageError = source["unstageError"];
 	    }
 	}
 	export class StagingApplyResult {

--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -59,6 +59,10 @@ type StagingApplyEntryResult struct {
 	Name   string `json:"name"`
 	Status string `json:"status"`
 	Error  string `json:"error,omitempty"`
+	// UnstageError is set when the cloud apply succeeded but clearing the entry
+	// from the staging store afterwards failed. The entry is still staged, so a
+	// later apply would re-run it; the frontend surfaces this as a warning row.
+	UnstageError string `json:"unstageError,omitempty"`
 }
 
 // StagingApplyTagResult represents a single tag apply result.
@@ -67,6 +71,9 @@ type StagingApplyTagResult struct {
 	AddTags    map[string]string `json:"addTags,omitempty"`
 	RemoveTags []string          `json:"removeTags,omitempty"`
 	Error      string            `json:"error,omitempty"`
+	// UnstageError is set when the cloud tag apply succeeded but clearing the
+	// staged tag afterwards failed (see StagingApplyEntryResult.UnstageError).
+	UnstageError string `json:"unstageError,omitempty"`
 }
 
 // StagingApplyResult represents the result of applying staged changes.
@@ -328,6 +335,14 @@ func (a *App) StagingApply(service string, ignoreConflicts bool) (*StagingApplyR
 		return nil, err
 	}
 
+	return newStagingApplyResult(result), nil
+}
+
+// newStagingApplyResult maps the apply use case's output into the frontend DTO.
+// A post-apply unstage failure (UnstageError: the cloud write succeeded but the
+// entry/tag could not be cleared from staging) is carried through so the
+// frontend can warn, mirroring the CLI (internal/staging/cli/apply.go).
+func newStagingApplyResult(result *stagingusecase.ApplyOutput) *StagingApplyResult {
 	// Render each conflict's EntryKey with its namespace badge (bare name for the
 	// empty/default namespace, so AWS/GCloud/Key Vault output is unchanged).
 	conflicts := lo.Map(result.Conflicts, func(key staging.EntryKey, _ int) string { return key.Label() })
@@ -350,6 +365,10 @@ func (a *App) StagingApply(service string, ignoreConflicts bool) (*StagingApplyR
 			entry.Error = r.Error.Error()
 		}
 
+		if r.UnstageError != nil {
+			entry.UnstageError = r.UnstageError.Error()
+		}
+
 		output.EntryResults = append(output.EntryResults, entry)
 	}
 
@@ -363,10 +382,14 @@ func (a *App) StagingApply(service string, ignoreConflicts bool) (*StagingApplyR
 			tagResult.Error = r.Error.Error()
 		}
 
+		if r.UnstageError != nil {
+			tagResult.UnstageError = r.UnstageError.Error()
+		}
+
 		output.TagResults = append(output.TagResults, tagResult)
 	}
 
-	return output, nil
+	return output
 }
 
 // StagingReset resets (unstages) all staged changes for a service.

--- a/internal/gui/staging_integration_internal_test.go
+++ b/internal/gui/staging_integration_internal_test.go
@@ -1317,6 +1317,45 @@ func TestApp_StagingApply_ExecuteError(t *testing.T) {
 	assert.Contains(t, err.Error(), "list boom")
 }
 
+// TestNewStagingApplyResult_UnstageError verifies the GUI apply-result mapping
+// carries a post-apply UnstageError (cloud write succeeded but the entry/tag
+// could not be cleared from staging) into the DTO so the frontend can warn,
+// rather than silently dropping it (#447).
+func TestNewStagingApplyResult_UnstageError(t *testing.T) {
+	t.Parallel()
+
+	out := &stagingusecase.ApplyOutput{
+		ServiceName:    "parameter",
+		EntrySucceeded: 1,
+		TagSucceeded:   1,
+		EntryResults: []stagingusecase.ApplyEntryResult{
+			{
+				Name:         "/app/config",
+				Status:       stagingusecase.ApplyResultCreated,
+				UnstageError: errors.New("keychain locked"),
+			},
+		},
+		TagResults: []stagingusecase.ApplyTagResult{
+			{
+				Name:         "/app/tagged",
+				AddTags:      map[string]string{"env": "prod"},
+				UnstageError: errors.New("disk full"),
+			},
+		},
+	}
+
+	result := newStagingApplyResult(out)
+
+	require.Len(t, result.EntryResults, 1)
+	assert.Equal(t, "created", result.EntryResults[0].Status)
+	assert.Empty(t, result.EntryResults[0].Error)
+	assert.Equal(t, "keychain locked", result.EntryResults[0].UnstageError)
+
+	require.Len(t, result.TagResults, 1)
+	assert.Empty(t, result.TagResults[0].Error)
+	assert.Equal(t, "disk full", result.TagResults[0].UnstageError)
+}
+
 // TestApp_StagingApply_NoStagedChanges covers the success return of StagingApply
 // (nothing staged -> the use case returns early with no error), which exercises
 // the EntryKey->label mapping for result.Conflicts on the happy path. With no

--- a/internal/parallel/parallel.go
+++ b/internal/parallel/parallel.go
@@ -28,13 +28,20 @@ func ExecuteMap[K comparable, V any, R any](
 	return ExecuteMapWithLimit(ctx, entries, DefaultLimit, fn)
 }
 
-// ExecuteMapWithLimit is like ExecuteMap but with a custom concurrency limit.
+// ExecuteMapWithLimit is like ExecuteMap but with a custom concurrency limit. A
+// non-positive limit falls back to DefaultLimit: errgroup.SetLimit(0) uses a
+// zero-capacity semaphore that would block the first g.Go forever (a deadlock),
+// so it is never passed through.
 func ExecuteMapWithLimit[K comparable, V any, R any](
 	ctx context.Context,
 	entries map[K]V,
 	limit int,
 	fn func(ctx context.Context, key K, value V) (R, error),
 ) map[K]*Result[R] {
+	if limit <= 0 {
+		limit = DefaultLimit
+	}
+
 	results := make(map[K]*Result[R], len(entries))
 
 	var mu sync.Mutex

--- a/internal/parallel/parallel_test.go
+++ b/internal/parallel/parallel_test.go
@@ -3,6 +3,7 @@ package parallel_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -147,6 +148,39 @@ func TestExecuteMapWithLimit(t *testing.T) {
 		require.Len(t, results, 5)
 		// Should not exceed limit of 2
 		assert.LessOrEqual(t, maxConcurrent, int32(2))
+	})
+
+	t.Run("non-positive limit falls back to default without deadlocking", func(t *testing.T) {
+		t.Parallel()
+
+		for _, limit := range []int{0, -1} {
+			t.Run(fmt.Sprintf("limit=%d", limit), func(t *testing.T) {
+				t.Parallel()
+
+				entries := map[int]string{1: "a", 2: "b", 3: "c"}
+
+				// A non-positive limit used to deadlock on errgroup's zero-capacity
+				// semaphore; guard with a timeout so a regression fails instead of
+				// hanging the suite.
+				done := make(chan map[int]*parallel.Result[string], 1)
+
+				go func() {
+					done <- parallel.ExecuteMapWithLimit(t.Context(), entries, limit, func(_ context.Context, _ int, value string) (string, error) {
+						return value, nil
+					})
+				}()
+
+				select {
+				case results := <-done:
+					require.Len(t, results, 3)
+					assert.Equal(t, "a", results[1].Value)
+					assert.Equal(t, "b", results[2].Value)
+					assert.Equal(t, "c", results[3].Value)
+				case <-time.After(5 * time.Second):
+					t.Fatalf("ExecuteMapWithLimit deadlocked with limit %d", limit)
+				}
+			})
+		}
 	})
 
 	t.Run("limit of 1 is sequential", func(t *testing.T) {

--- a/internal/usecase/staging/diff.go
+++ b/internal/usecase/staging/diff.go
@@ -3,6 +3,7 @@ package staging
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/samber/lo"
 
@@ -156,7 +157,12 @@ func (u *DiffUseCase) Execute(ctx context.Context, input DiffInput) (*DiffOutput
 		// Process results
 		for key, entry := range entries {
 			result := results[key]
-			diffEntry := u.processDiffResult(ctx, key, entry, result)
+
+			diffEntry, err := u.processDiffResult(ctx, key, entry, result)
+			if err != nil {
+				return nil, err
+			}
+
 			output.Entries = append(output.Entries, diffEntry)
 		}
 	}
@@ -202,7 +208,7 @@ func (u *DiffUseCase) Execute(ctx context.Context, input DiffInput) (*DiffOutput
 }
 
 //nolint:lll // function parameters are descriptive for clarity
-func (u *DiffUseCase) processDiffResult(ctx context.Context, key staging.EntryKey, entry staging.Entry, result *parallel.Result[*staging.FetchResult]) DiffEntry {
+func (u *DiffUseCase) processDiffResult(ctx context.Context, key staging.EntryKey, entry staging.Entry, result *parallel.Result[*staging.FetchResult]) (DiffEntry, error) {
 	service := u.Strategy.Service()
 
 	if result.Err != nil {
@@ -223,14 +229,18 @@ func (u *DiffUseCase) processDiffResult(ctx context.Context, key staging.EntryKe
 	// to be the empty string (legal in Azure App Configuration / Key Vault /
 	// Google Cloud), so an empty-valued delete must not be silently cancelled.
 	if entry.Operation != staging.OperationDelete && awsValue == stagedValue {
-		_ = u.Store.UnstageEntry(ctx, service, key)
+		// A failed unstage would leave the entry staged while we report it as
+		// auto-unstaged, so surface the error rather than discarding it.
+		if err := u.Store.UnstageEntry(ctx, service, key); err != nil {
+			return DiffEntry{}, fmt.Errorf("failed to unstage %s: %w", key.Name, err)
+		}
 
 		return DiffEntry{
 			Name:      key.Name,
 			Namespace: key.Namespace,
 			Type:      DiffEntryAutoUnstaged,
 			Warning:   "identical to AWS current",
-		}
+		}, nil
 	}
 
 	return DiffEntry{
@@ -242,10 +252,10 @@ func (u *DiffUseCase) processDiffResult(ctx context.Context, key staging.EntryKe
 		AWSIdentifier: fetchResult.Identifier,
 		StagedValue:   stagedValue,
 		Description:   entry.Description,
-	}
+	}, nil
 }
 
-func (u *DiffUseCase) handleFetchError(ctx context.Context, key staging.EntryKey, entry staging.Entry, err error) DiffEntry {
+func (u *DiffUseCase) handleFetchError(ctx context.Context, key staging.EntryKey, entry staging.Entry, err error) (DiffEntry, error) {
 	service := u.Strategy.Service()
 
 	// Only a genuine "not found" justifies auto-unstaging a staged delete or
@@ -257,14 +267,16 @@ func (u *DiffUseCase) handleFetchError(ctx context.Context, key staging.EntryKey
 	switch entry.Operation {
 	case staging.OperationDelete:
 		if notFound {
-			_ = u.Store.UnstageEntry(ctx, service, key)
+			if uerr := u.Store.UnstageEntry(ctx, service, key); uerr != nil {
+				return DiffEntry{}, fmt.Errorf("failed to unstage %s: %w", key.Name, uerr)
+			}
 
 			return DiffEntry{
 				Name:      key.Name,
 				Namespace: key.Namespace,
 				Type:      DiffEntryAutoUnstaged,
 				Warning:   "already deleted in AWS",
-			}
+			}, nil
 		}
 
 	case staging.OperationCreate:
@@ -275,18 +287,20 @@ func (u *DiffUseCase) handleFetchError(ctx context.Context, key staging.EntryKey
 			Operation:   entry.Operation,
 			StagedValue: lo.FromPtr(entry.Value),
 			Description: entry.Description,
-		}
+		}, nil
 
 	case staging.OperationUpdate:
 		if notFound {
-			_ = u.Store.UnstageEntry(ctx, service, key)
+			if uerr := u.Store.UnstageEntry(ctx, service, key); uerr != nil {
+				return DiffEntry{}, fmt.Errorf("failed to unstage %s: %w", key.Name, uerr)
+			}
 
 			return DiffEntry{
 				Name:      key.Name,
 				Namespace: key.Namespace,
 				Type:      DiffEntryAutoUnstaged,
 				Warning:   "item no longer exists in AWS",
-			}
+			}, nil
 		}
 	}
 
@@ -295,5 +309,5 @@ func (u *DiffUseCase) handleFetchError(ctx context.Context, key staging.EntryKey
 		Namespace: key.Namespace,
 		Type:      DiffEntryWarning,
 		Warning:   err.Error(),
-	}
+	}, nil
 }

--- a/internal/usecase/staging/diff_test.go
+++ b/internal/usecase/staging/diff_test.go
@@ -253,6 +253,57 @@ func TestDiffUseCase_Execute_DeleteEmptyRemoteNotUnstaged(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestDiffUseCase_Execute_UnstageError verifies the auto-unstage branches surface
+// a store write failure instead of reporting the entry as auto-unstaged while it
+// is in fact still staged (#447).
+func TestDiffUseCase_Execute_UnstageError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("identical value", func(t *testing.T) {
+		t.Parallel()
+
+		store := testutil.NewMockStore()
+		require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/same"}, staging.Entry{
+			Operation: staging.OperationUpdate,
+			Value:     lo.ToPtr("same-value"),
+			StagedAt:  time.Now(),
+		}))
+		store.UnstageEntryErr = errors.New("keychain locked")
+
+		strategy := newMockDiffStrategy()
+		strategy.fetchResults["/app/same"] = &staging.FetchResult{Value: "same-value", Identifier: "#1"}
+
+		uc := &usecasestaging.DiffUseCase{Strategy: strategy, Store: store}
+
+		_, err := uc.Execute(t.Context(), usecasestaging.DiffInput{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to unstage /app/same")
+		assert.Contains(t, err.Error(), "keychain locked")
+	})
+
+	t.Run("update no longer exists", func(t *testing.T) {
+		t.Parallel()
+
+		store := testutil.NewMockStore()
+		require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/gone"}, staging.Entry{
+			Operation: staging.OperationUpdate,
+			Value:     lo.ToPtr("v"),
+			StagedAt:  time.Now(),
+		}))
+		store.UnstageEntryErr = errors.New("disk full")
+
+		strategy := newMockDiffStrategy()
+		strategy.fetchErrors["/app/gone"] = fmt.Errorf("%w: not found", provider.ErrNotFound)
+
+		uc := &usecasestaging.DiffUseCase{Strategy: strategy, Store: store}
+
+		_, err := uc.Execute(t.Context(), usecasestaging.DiffInput{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to unstage /app/gone")
+		assert.Contains(t, err.Error(), "disk full")
+	})
+}
+
 func TestDiffUseCase_Execute_FilterByName(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Closes the three error-handling gaps from the concurrency/error audit (#447):

1. **GUI apply dropped `UnstageError`.** `StagingApplyEntryResult` / `StagingApplyTagResult` gain an `unstageError` field, the apply-result mapping copies it from the use case, and the apply-result view renders a warning row — mirroring the CLI (`internal/staging/cli/apply.go`).
2. **`DiffUseCase` swallowed auto-unstage errors.** The three auto-unstage branches in `internal/usecase/staging/diff.go` now propagate the store write failure instead of labelling the entry auto-unstaged while it is in fact still staged. The GUI diff path (`StagingDiff`) surfaces the error automatically.
3. **`parallel.ExecuteMapWithLimit` deadlocked on a non-positive limit.** `errgroup.SetLimit(0)` blocks the first `g.Go` on a zero-capacity semaphore forever; `limit <= 0` now falls back to `DefaultLimit`.

## Why

Each gap silently discarded an error that the CLI already surfaces, causing data-integrity drift (a staged entry surviving a successful apply) or a latent deadlock.

## Tests

- `ExecuteMapWithLimit` with limit `0` and `-1` no longer hangs (timeout-guarded) and behaves as `DefaultLimit`.
- `DiffUseCase` surfaces an unstage failure (identical-value and update-no-longer-exists branches).
- GUI apply-result mapping carries `UnstageError` into the DTO (Go unit) + DTO-contract guard; a Playwright spec asserts the warning row renders.

Closes #447

🤖 Generated with [Claude Code](https://claude.com/claude-code)