### PR TITLE
fix(gui): resolve per-provider scope defaults from env for any selected provider

### DIFF
--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -246,6 +246,19 @@ func (a *App) GetCurrentScope() *ScopeSelection {
 	return selectionFromScope(a.currentScope())
 }
 
+// EnvScope returns the env-derived scope defaults for an ARBITRARY provider,
+// hydrated from the ambient environment (GOOGLE_CLOUD_PROJECT / AZURE_KEYVAULT_NAME
+// / AZURE_APPCONFIG_NAME / AZURE_APPCONFIG_NAMESPACE). It is the direct analog of
+// the CLI's per-provider env resolution: each provider group reads its own env
+// independently of detect, so an explicitly-selected provider always resolves its
+// scope from env even in a mixed-env shell. GetCurrentScope only surfaces the
+// launch provider's env-derived scope; the frontend calls this to fill the scope
+// form for any OTHER provider it switches to. An unknown provider yields the AWS
+// default (hydrateScope's fallback).
+func (a *App) EnvScope(providerName string) *ScopeSelection {
+	return selectionFromScope(hydrateScope(provider.Scope{Provider: provider.Provider(providerName)}))
+}
+
 // selectionFromScope is the inverse of scopeFromSelection: it projects a
 // provider.Scope back to the frontend DTO. Fields irrelevant to the provider
 // stay empty.

--- a/internal/gui/frontend/src/App.svelte
+++ b/internal/gui/frontend/src/App.svelte
@@ -3,6 +3,7 @@
   import {
     Capabilities,
     DetectProviders,
+    EnvScope,
     GetAWSIdentity,
     GetCurrentScope,
     InitialProvider,
@@ -144,18 +145,19 @@
 
   // buildSelection assembles the auto-apply candidate for provider p.
   //
-  // Launch wins, cache fills gaps: the launch-derived backend scope (from --gui
-  // flags + env, via GetCurrentScope) takes precedence PER FIELD, and the
-  // localStorage cache only supplies fields the launch left empty. This keeps
-  // `AZURE_APPCONFIG_NAMESPACE=dev` / `--namespace dev` (and --vault-name /
-  // --store-name / --project) authoritative over a stale cache, while a bare
-  // `suve --gui` (launch scope has only the provider) still restores the cached
-  // resource fields.
-  function buildSelection(p: string): gui.ScopeSelection {
+  // Per-field precedence is launch/flag > env > cache, mirroring the CLI: an
+  // explicit --gui flag (surfaced via GetCurrentScope as the launch scope) beats
+  // the env, the env (EnvScope resolves GOOGLE_CLOUD_PROJECT / AZURE_* for ANY
+  // provider) beats a stale localStorage cache, and the cache fills whatever is
+  // still empty. The launch scope only carries env for the launch provider, so
+  // EnvScope is what lets a provider switched to in a mixed-env shell resolve its
+  // own scope defaults (e.g. GOOGLE_CLOUD_PROJECT while AWS creds are also set).
+  async function buildSelection(p: string): Promise<gui.ScopeSelection> {
     const cached = readCachedScope(p);
     const launch = scope?.provider === p ? scope : null;
+    const env = await withRetry(() => EnvScope(p)).catch(() => null);
     const pick = (field: keyof gui.ScopeSelection): string =>
-      (launch?.[field] || cached?.[field] || '') as string;
+      (launch?.[field] || env?.[field] || cached?.[field] || '') as string;
     return {
       provider: p,
       projectId: p === 'googlecloud' ? pick('projectId') : '',
@@ -218,7 +220,7 @@
   async function handleSelectProvider(p: string) {
     scopeError = '';
 
-    const sel = buildSelection(p);
+    const sel = await buildSelection(p);
     if (hasRequiredScope(sel)) {
       await applyScope(sel);
     } else {

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -175,6 +175,11 @@ export interface MockState {
   // mirroring the Go App.InitialService binding. Drives the initial view.
   initialService: string;
   currentScope: ScopeSelection;
+  // envScopes holds the per-provider env-derived scope defaults returned by the
+  // EnvScope binding (Go hydrateScope for an ARBITRARY provider). Keyed by
+  // provider; only the fields the environment supplies need be set. Defaults
+  // empty so specs without a mixed env are unaffected.
+  envScopes: Record<string, Partial<ScopeSelection>>;
   detectResult: DetectResult;
   capabilities: ProviderCapability[];
   // Error simulation
@@ -346,6 +351,7 @@ export const defaultMockState: MockState = {
   initialProvider: 'aws',
   initialService: '',
   currentScope: awsScopeSelection,
+  envScopes: {},
   detectResult: awsOnlyDetectResult,
   capabilities: defaultCapabilities,
 };
@@ -806,6 +812,19 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
       InitialProvider: async () => state.initialProvider,
       InitialService: async () => state.initialService,
       GetCurrentScope: async () => state.currentScope,
+      // Per-provider env-derived scope defaults for an ARBITRARY provider,
+      // mirroring the Go hydrateScope: only provider-relevant fields carry env
+      // values (from state.envScopes), the rest are empty.
+      EnvScope: async (p: string) => {
+        const env = state.envScopes?.[p] ?? {};
+        return {
+          provider: p,
+          projectId: env.projectId ?? '',
+          vaultName: env.vaultName ?? '',
+          storeName: env.storeName ?? '',
+          namespace: env.namespace ?? '',
+        };
+      },
       SelectScope: async (sel: any) => {
         calls.push('SelectScope');
         // Record the exact payload so specs can assert it (incl. vault vs store

--- a/internal/gui/frontend/tests/provider-selection.spec.ts
+++ b/internal/gui/frontend/tests/provider-selection.spec.ts
@@ -190,4 +190,34 @@ test.describe('Provider selection', () => {
       await expect(page.locator('.staging-count')).toHaveCount(0);
     });
   });
+
+  test.describe('Per-provider env scope (#518)', () => {
+    // Mixed env: AWS + Google Cloud both active → detection is ambiguous, so the
+    // app preselects nothing. Switching to Google Cloud must still resolve its
+    // project from GOOGLE_CLOUD_PROJECT (via EnvScope) and auto-apply, without
+    // any manual entry — mirroring the CLI's per-provider env resolution.
+    // Before the fix, buildSelection only consulted the launch provider's env,
+    // so a switched-to provider fell back to the (empty) cache and forced the
+    // user to hand-type the project.
+    test('switching to Google Cloud in a mixed env prefills project from env', async ({ page }) => {
+      await setupWailsMocks(page, {
+        ...createAmbiguousProviderState(),
+        envScopes: { googlecloud: { projectId: 'env-project' } },
+      });
+      await page.goto('/');
+
+      // Ambiguous detection → nothing preselected.
+      await expect(page.getByText('Select a provider to begin.')).toBeVisible();
+      await expect(page.locator('#provider-select')).toHaveValue('');
+
+      // Switch to Google Cloud WITHOUT touching the project field.
+      await page.locator('#provider-select').selectOption('googlecloud');
+
+      // Env-derived project auto-applies: the secret view mounts and the sidebar
+      // shows the project — no scope-entry prompt.
+      await waitForItemList(page);
+      await expect(page.getByText('env-project')).toBeVisible();
+      await expect(page.getByText('Enter the required scope in the sidebar to continue.')).toHaveCount(0);
+    });
+  });
 });

--- a/internal/gui/frontend/wailsjs/go/gui/App.d.ts
+++ b/internal/gui/frontend/wailsjs/go/gui/App.d.ts
@@ -6,6 +6,8 @@ export function Capabilities():Promise<Array<gui.ProviderCapability>>;
 
 export function DetectProviders():Promise<gui.DetectResult>;
 
+export function EnvScope(arg1:string):Promise<gui.ScopeSelection>;
+
 export function GetAWSIdentity():Promise<gui.AWSIdentityResult>;
 
 export function GetCurrentScope():Promise<gui.ScopeSelection>;

--- a/internal/gui/frontend/wailsjs/go/gui/App.js
+++ b/internal/gui/frontend/wailsjs/go/gui/App.js
@@ -10,6 +10,10 @@ export function DetectProviders() {
   return window['go']['gui']['App']['DetectProviders']();
 }
 
+export function EnvScope(arg1) {
+  return window['go']['gui']['App']['EnvScope'](arg1);
+}
+
 export function GetAWSIdentity() {
   return window['go']['gui']['App']['GetAWSIdentity']();
 }

--- a/internal/gui/scope_internal_test.go
+++ b/internal/gui/scope_internal_test.go
@@ -233,3 +233,61 @@ func TestApp_GetCurrentScope_EnvDerivedAzure_StoreOnly(t *testing.T) {
 	assert.Empty(t, got.VaultName)
 	assert.Equal(t, "env-store", got.StoreName)
 }
+
+// TestApp_EnvScope verifies EnvScope resolves each provider's scope from env
+// INDEPENDENTLY of the launch provider (#518): the app is launched as AWS, yet
+// EnvScope("googlecloud") / EnvScope("azure") still hydrate their fields from
+// the ambient environment — the direct analog of the CLI resolving each provider
+// group's scope from its own env regardless of detect.
+func TestApp_EnvScope(t *testing.T) {
+	t.Setenv("GOOGLE_CLOUD_PROJECT", "env-project")
+	t.Setenv("AZURE_KEYVAULT_NAME", "env-vault")
+	t.Setenv("AZURE_APPCONFIG_NAME", "env-store")
+	t.Setenv("AZURE_APPCONFIG_NAMESPACE", "env-ns")
+
+	// Launched as AWS — EnvScope must not be gated on the launch provider.
+	app := NewApp(provider.Scope{Provider: provider.ProviderAWS}, "")
+
+	tests := []struct {
+		name     string
+		provider string
+		want     ScopeSelection
+	}{
+		{
+			name:     "googlecloud resolves project from env",
+			provider: "googlecloud",
+			want:     ScopeSelection{Provider: "googlecloud", ProjectID: "env-project"},
+		},
+		{
+			name:     "azure resolves vault/store/namespace from env",
+			provider: "azure",
+			want: ScopeSelection{
+				Provider:  "azure",
+				VaultName: "env-vault",
+				StoreName: "env-store",
+				Namespace: "env-ns",
+			},
+		},
+		{
+			name:     "aws carries no env-derived resource fields",
+			provider: "aws",
+			want:     ScopeSelection{Provider: "aws"},
+		},
+		{
+			// An unknown provider falls back to the AWS default (hydrateScope's
+			// default branch), so the form never prefills bogus fields.
+			name:     "unknown provider falls back to aws default",
+			provider: "oracle",
+			want:     ScopeSelection{Provider: "aws"},
+		},
+	}
+
+	//nolint:paralleltest // parent uses t.Setenv, so subtests cannot run in parallel
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := app.EnvScope(tt.provider)
+			require.NotNil(t, got)
+			assert.Equal(t, &tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
## What
Adds an `EnvScope(providerName string) *ScopeSelection` Wails binding on `App` that reuses the existing `hydrateScope` for an **arbitrary** provider (not just the launch provider), and folds it into the frontend `buildSelection` with per-field precedence **launch/flag > env > cache**.

- Backend (`internal/gui/app.go`): `EnvScope` = `selectionFromScope(hydrateScope(provider.Scope{Provider: ...}))`, mirroring `GetCurrentScope`/`hydrateScope`/`selectionFromScope`. Wails bindings regenerated.
- Frontend (`internal/gui/frontend/src/App.svelte`): `buildSelection` now fetches `EnvScope(p)` for the selected provider and inserts it as the middle precedence tier (`launch?.[f] || env?.[f] || cached?.[f]`).

## Why
In the GUI, per-provider scope defaults (Google Cloud project, Azure Key Vault name, App Configuration store name/namespace) were only populated for the **launch provider**. Switching to another provider forced the user to hand-type values the environment already provided — even though the same env vars work fine on the CLI, which resolves each provider group's scope from its own flags/env independently of `detect`.

The `detect.Resolve` / default-provider tie-break is intentionally **unchanged**; this fix only concerns per-provider scope-default resolution for an explicitly-selected provider.

## Tests (3-layer)
- **Go unit** (`internal/gui/scope_internal_test.go`): `TestApp_EnvScope` asserts `EnvScope` hydrates gcloud/azure fields from env independently of the AWS launch provider (and unknown → AWS default).
- **Playwright** (`internal/gui/frontend/tests/provider-selection.spec.ts`): mixed env (AWS + gcloud active → ambiguous), switching to Google Cloud auto-prefills the project from env with no manual entry (fails before the fix). Fixture mock gains an `EnvScope` binding + `envScopes` state.
- `mise build-gui` builds cleanly with the regenerated bindings.

Closes #518

🤖 Generated with [Claude Code](https://claude.com/claude-code)