### PR TITLE
fix(staging): reject non-UTF-8 values at ingestion

### DIFF
--- a/internal/usecase/staging/add.go
+++ b/internal/usecase/staging/add.go
@@ -3,6 +3,7 @@ package staging
 import (
 	"context"
 	"errors"
+	"unicode/utf8"
 
 	"github.com/samber/lo"
 
@@ -10,6 +11,13 @@ import (
 	"github.com/mpyw/suve/internal/staging/store"
 	"github.com/mpyw/suve/internal/staging/transition"
 )
+
+// ErrValueNotUTF8 is returned when a value to be staged is not valid UTF-8.
+// The staging state stores values as UTF-8 strings (mirroring jsonutil, which
+// refuses to format invalid UTF-8 to avoid U+FFFD coercion), so binary values
+// cannot be staged. This covers every ingestion path: positional argv, the
+// $EDITOR fallback, and provider prefill.
+var ErrValueNotUTF8 = errors.New("value is not valid UTF-8: binary values cannot be staged")
 
 // AddInput holds input for the add use case. Key identifies the item by name and
 // (Azure App Configuration) namespace; the namespace is empty for the
@@ -34,6 +42,11 @@ type AddUseCase struct {
 // Execute runs the add use case.
 func (u *AddUseCase) Execute(ctx context.Context, input AddInput) (*AddOutput, error) {
 	service := u.Strategy.Service()
+
+	// Reject non-UTF-8 values at ingestion (argv, $EDITOR, provider prefill)
+	if !utf8.ValidString(input.Value) {
+		return nil, ErrValueNotUTF8
+	}
 
 	// Parse and validate name
 	name, err := u.Strategy.ParseName(input.Key.Name)

--- a/internal/usecase/staging/add_test.go
+++ b/internal/usecase/staging/add_test.go
@@ -87,6 +87,26 @@ func TestAddUseCase_Execute_RejectsWhenResourceExists(t *testing.T) {
 	assert.ErrorIs(t, err, transition.ErrCannotAddToExisting)
 }
 
+func TestAddUseCase_Execute_RejectsNonUTF8Value(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	uc := &usecasestaging.AddUseCase{
+		Strategy: newMockEditStrategyNotFound(),
+		Store:    store,
+	}
+
+	_, err := uc.Execute(t.Context(), usecasestaging.AddInput{
+		Key:   staging.EntryKey{Name: "/app/new-param"},
+		Value: "\xff\xfe",
+	})
+	require.ErrorIs(t, err, usecasestaging.ErrValueNotUTF8)
+
+	// Nothing should have been staged
+	_, err = store.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/new-param", Namespace: ""})
+	assert.ErrorIs(t, err, staging.ErrNotStaged)
+}
+
 func TestAddUseCase_Execute_MinimalInput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/usecase/staging/edit.go
+++ b/internal/usecase/staging/edit.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"time"
+	"unicode/utf8"
 
 	"github.com/samber/lo"
 
@@ -37,6 +38,11 @@ type EditUseCase struct {
 // Execute runs the edit use case.
 func (u *EditUseCase) Execute(ctx context.Context, input EditInput) (*EditOutput, error) {
 	service := u.Strategy.Service()
+
+	// Reject non-UTF-8 values at ingestion (argv, $EDITOR, provider prefill)
+	if !utf8.ValidString(input.Value) {
+		return nil, ErrValueNotUTF8
+	}
 
 	// Check staged state first to avoid unnecessary AWS fetch
 	var stagedEntry *staging.Entry

--- a/internal/usecase/staging/edit_test.go
+++ b/internal/usecase/staging/edit_test.go
@@ -73,6 +73,26 @@ func TestEditUseCase_Execute(t *testing.T) {
 	assert.NotNil(t, entry.BaseModifiedAt)
 }
 
+func TestEditUseCase_Execute_RejectsNonUTF8Value(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	uc := &usecasestaging.EditUseCase{
+		Strategy: newMockEditStrategy(),
+		Store:    store,
+	}
+
+	_, err := uc.Execute(t.Context(), usecasestaging.EditInput{
+		Key:   staging.EntryKey{Name: "/app/config"},
+		Value: "\xff\xfe",
+	})
+	require.ErrorIs(t, err, usecasestaging.ErrValueNotUTF8)
+
+	// Nothing should have been staged
+	_, err = store.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config", Namespace: ""})
+	assert.ErrorIs(t, err, staging.ErrNotStaged)
+}
+
 func TestEditUseCase_Execute_PreservesBaseModifiedAt(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Validate the resolved value with `utf8.ValidString` in the add and edit use cases so non-UTF-8 (binary) values are rejected with a clear `ErrValueNotUTF8` error.

- Covers every ingestion path: positional argv, the `$EDITOR` fallback, and provider prefill (all resolve to `input.Value`).
- Mirrors `jsonutil`, which refuses to format invalid UTF-8 to avoid silent U+FFFD coercion. Binary value support is out of scope for now.

Closes #547.