### PR TITLE
fix(azure/appconfig): preserve content-type on every write

### DIFF
--- a/internal/provider/azure/appconfig/appconfig.go
+++ b/internal/provider/azure/appconfig/appconfig.go
@@ -18,12 +18,16 @@
 //     the aznamespace subpackage): List forwards the raw value as a LabelFilter;
 //     single-key ops decode it to one literal label; empty is the null/default
 //     namespace. A label is never exposed as a version.
-//   - App Configuration's PUT replaces the whole key-value, so tags must always
-//     be re-sent or they are cleared. Value writes (Put) therefore GET the
-//     current tags and re-send them; Tag/Untag are GET-merge-PUT with an
-//     OnlyIfUnchanged (ETag) precondition and a small retry on a 412 conflict.
-//     This is unblocked by azappconfig/v2, whose SetSettingOptions carries Tags
-//     (map[string]*string) and OnlyIfUnchanged.
+//   - App Configuration's PUT replaces the whole key-value, so tags AND the
+//     content-type must always be re-sent or they are cleared. Value writes
+//     (Put) therefore GET the current tags and content-type and re-send them;
+//     Tag/Untag are GET-merge-PUT with an OnlyIfUnchanged (ETag) precondition
+//     and a small retry on a 412 conflict, re-sending the unchanged value and
+//     content-type. The content-type is held opaquely (the domain model has no
+//     content-type field) purely to survive a write; a Key Vault reference's
+//     content-type, for instance, must not be dropped by a tag-only edit. This
+//     is unblocked by azappconfig/v2, whose SetSettingOptions carries
+//     ContentType, Tags (map[string]*string) and OnlyIfUnchanged.
 package appconfig
 
 import (
@@ -52,16 +56,17 @@ const tagWriteMaxAttempts = 3
 
 // Client is the narrow App Configuration surface this adapter needs. Single-key
 // methods take a resolved literal label ("" = the null/default label); the list
-// method takes a LabelFilter. SetSetting additionally carries the tags to write
-// (App Config's PUT replaces the whole key-value, so tags are always re-sent)
-// and an optional ETag precondition (nil = unconditional). The list method
+// method takes a LabelFilter. SetSetting additionally carries the tags and
+// content-type to write (App Config's PUT replaces the whole key-value, so both
+// are always re-sent) and an optional ETag precondition (nil = unconditional).
+// The list method
 // returns a drained slice rather than the SDK's pager so tests can mock the
 // interface trivially; the production adapter (see Wrap) confines the pager
 // draining and the concrete *azappconfig.Client to this package.
 type Client interface {
 	GetSetting(ctx context.Context, key, label string) (azappconfig.GetSettingResponse, error)
 	SetSetting(
-		ctx context.Context, key, value, label string, tags map[string]*string, etag *azcore.ETag,
+		ctx context.Context, key, value, label string, tags map[string]*string, contentType *string, etag *azcore.ETag,
 	) (azappconfig.SetSettingResponse, error)
 	AddSetting(ctx context.Context, key, value, label string) (azappconfig.AddSettingResponse, error)
 	DeleteSetting(ctx context.Context, key, label string) (azappconfig.DeleteSettingResponse, error)
@@ -261,9 +266,9 @@ func (s *Store) Create(
 
 // Put creates or updates a setting (upsert) via SetSetting and returns an empty
 // version (App Configuration is unversioned). Because App Configuration's PUT
-// replaces the whole key-value, the current tags are read first and re-sent so
-// the value write does not clear them (a not-yet-existing setting has none).
-// The valueType and description are ignored.
+// replaces the whole key-value, the current tags and content-type are read
+// first and re-sent so the value write does not clear them (a not-yet-existing
+// setting has neither). The valueType and description are ignored.
 func (s *Store) Put(
 	ctx context.Context, name, value string, _ domain.ValueType, _ string, _ ...provider.WriteOption,
 ) (domain.Version, error) {
@@ -272,12 +277,12 @@ func (s *Store) Put(
 		return domain.Version{}, err
 	}
 
-	tags, err := s.currentTags(ctx, name, label)
+	tags, contentType, err := s.currentTagsAndContentType(ctx, name, label)
 	if err != nil {
 		return domain.Version{}, err
 	}
 
-	if _, err := s.client.SetSetting(ctx, name, value, label, tags, nil); err != nil {
+	if _, err := s.client.SetSetting(ctx, name, value, label, tags, contentType, nil); err != nil {
 		return domain.Version{}, fmt.Errorf("failed to set setting: %w", err)
 	}
 
@@ -331,9 +336,11 @@ func (s *Store) Untag(ctx context.Context, name string, keys []string) error {
 // mutateTags applies merge to the setting's current tags and writes them back
 // with an OnlyIfUnchanged (ETag) precondition. App Configuration has no partial
 // tag update, so the whole key-value is re-PUT with the merged tags and the
-// unchanged value. If a concurrent writer changes the setting between the GET
-// and the PUT the service returns 412; the loop re-GETs and re-merges up to
-// tagWriteMaxAttempts times before surfacing the conflict.
+// unchanged value and content-type — a tag-only edit must never alter the value
+// semantics (e.g. clear a Key Vault reference's content-type). If a concurrent
+// writer changes the setting between the GET and the PUT the service returns
+// 412; the loop re-GETs and re-merges up to tagWriteMaxAttempts times before
+// surfacing the conflict.
 func (s *Store) mutateTags(ctx context.Context, name string, merge func(map[string]*string)) error {
 	label, err := aznamespace.Literal(s.namespace)
 	if err != nil {
@@ -351,7 +358,7 @@ func (s *Store) mutateTags(ctx context.Context, name string, merge func(map[stri
 		tags := cloneTags(resp.Tags)
 		merge(tags)
 
-		_, err = s.client.SetSetting(ctx, name, lo.FromPtr(resp.Value), label, tags, resp.ETag)
+		_, err = s.client.SetSetting(ctx, name, lo.FromPtr(resp.Value), label, tags, resp.ContentType, resp.ETag)
 		if err == nil {
 			return nil
 		}
@@ -369,20 +376,23 @@ func (s *Store) mutateTags(ctx context.Context, name string, merge func(map[stri
 	)
 }
 
-// currentTags returns the setting's current tags (for re-sending on a value
-// write). A not-found setting has no tags to preserve, so a 404 maps to nil
-// rather than an error (the ensuing Put creates the setting fresh).
-func (s *Store) currentTags(ctx context.Context, name, label string) (map[string]*string, error) {
+// currentTagsAndContentType returns the setting's current tags and content-type
+// (for re-sending on a value write, since App Configuration's PUT replaces the
+// whole key-value). A not-found setting has nothing to preserve, so a 404 maps
+// to nil/nil rather than an error (the ensuing Put creates the setting fresh).
+func (s *Store) currentTagsAndContentType(
+	ctx context.Context, name, label string,
+) (map[string]*string, *string, error) {
 	resp, err := s.client.GetSetting(ctx, name, label)
 	if err != nil {
 		if isNotFound(err) {
-			return nil, nil //nolint:nilnil // intentional: a missing setting has no tags to preserve
+			return nil, nil, nil
 		}
 
-		return nil, mapError(err, name, "get setting")
+		return nil, nil, mapError(err, name, "get setting")
 	}
 
-	return resp.Tags, nil
+	return resp.Tags, resp.ContentType, nil
 }
 
 // cloneTags copies a tags map so a merge does not mutate the value read off the

--- a/internal/provider/azure/appconfig/appconfig_test.go
+++ b/internal/provider/azure/appconfig/appconfig_test.go
@@ -38,7 +38,7 @@ func serverError() error {
 type mockClient struct {
 	getFunc func(ctx context.Context, key, label string) (azappconfig.GetSettingResponse, error)
 	setFunc func(
-		ctx context.Context, key, value, label string, tags map[string]*string, etag *azcore.ETag,
+		ctx context.Context, key, value, label string, tags map[string]*string, contentType *string, etag *azcore.ETag,
 	) (azappconfig.SetSettingResponse, error)
 	addFunc    func(ctx context.Context, key, value, label string) (azappconfig.AddSettingResponse, error)
 	deleteFunc func(ctx context.Context, key, label string) (azappconfig.DeleteSettingResponse, error)
@@ -50,9 +50,9 @@ func (m *mockClient) GetSetting(ctx context.Context, key, label string) (azappco
 }
 
 func (m *mockClient) SetSetting(
-	ctx context.Context, key, value, label string, tags map[string]*string, etag *azcore.ETag,
+	ctx context.Context, key, value, label string, tags map[string]*string, contentType *string, etag *azcore.ETag,
 ) (azappconfig.SetSettingResponse, error) {
-	return m.setFunc(ctx, key, value, label, tags, etag)
+	return m.setFunc(ctx, key, value, label, tags, contentType, etag)
 }
 
 func (m *mockClient) AddSetting(
@@ -524,7 +524,7 @@ func TestPut(t *testing.T) {
 			return azappconfig.GetSettingResponse{}, notFound()
 		},
 		setFunc: func(
-			_ context.Context, key, value, label string, _ map[string]*string, _ *azcore.ETag,
+			_ context.Context, key, value, label string, _ map[string]*string, _ *string, _ *azcore.ETag,
 		) (azappconfig.SetSettingResponse, error) {
 			setKey, setVal, setLabel = key, value, label
 
@@ -558,7 +558,7 @@ func TestPut_PreservesExistingTags(t *testing.T) {
 			}}, nil
 		},
 		setFunc: func(
-			_ context.Context, _, value, _ string, tags map[string]*string, _ *azcore.ETag,
+			_ context.Context, _, value, _ string, tags map[string]*string, _ *string, _ *azcore.ETag,
 		) (azappconfig.SetSettingResponse, error) {
 			sentTags = tags
 
@@ -574,6 +574,39 @@ func TestPut_PreservesExistingTags(t *testing.T) {
 	assert.Equal(t, map[string]*string{"env": lo.ToPtr("prod"), "team": lo.ToPtr("core")}, sentTags)
 }
 
+// TestPut_PreservesContentType asserts a value edit re-sends the setting's
+// current content-type so the PUT (a whole-key-value replace) does not strip it
+// — a Key Vault reference must stay a reference after its value is edited.
+func TestPut_PreservesContentType(t *testing.T) {
+	t.Parallel()
+
+	const kvRef = "application/vnd.microsoft.appconfig.keyvaultref+json"
+
+	var sentContentType *string
+
+	m := &mockClient{
+		getFunc: func(_ context.Context, key, _ string) (azappconfig.GetSettingResponse, error) {
+			return azappconfig.GetSettingResponse{Setting: azappconfig.Setting{
+				Key:         lo.ToPtr(key),
+				Value:       lo.ToPtr("old"),
+				ContentType: lo.ToPtr(kvRef),
+			}}, nil
+		},
+		setFunc: func(
+			_ context.Context, _, _, _ string, _ map[string]*string, contentType *string, _ *azcore.ETag,
+		) (azappconfig.SetSettingResponse, error) {
+			sentContentType = contentType
+
+			return azappconfig.SetSettingResponse{}, nil
+		},
+	}
+	store := appconfig.New(m, "")
+
+	_, err := store.Put(t.Context(), "db-password", "new", domain.ValueTypePlaintext, "")
+	require.NoError(t, err)
+	assert.Equal(t, kvRef, lo.FromPtr(sentContentType))
+}
+
 func TestPut_Error(t *testing.T) {
 	t.Parallel()
 
@@ -582,7 +615,7 @@ func TestPut_Error(t *testing.T) {
 			return azappconfig.GetSettingResponse{}, notFound()
 		},
 		setFunc: func(
-			_ context.Context, _, _, _ string, _ map[string]*string, _ *azcore.ETag,
+			_ context.Context, _, _, _ string, _ map[string]*string, _ *string, _ *azcore.ETag,
 		) (azappconfig.SetSettingResponse, error) {
 			return azappconfig.SetSettingResponse{}, serverError()
 		},
@@ -600,7 +633,7 @@ func TestPut_RejectsFilterNamespace(t *testing.T) {
 	called := false
 	m := &mockClient{
 		setFunc: func(
-			_ context.Context, _, _, _ string, _ map[string]*string, _ *azcore.ETag,
+			_ context.Context, _, _, _ string, _ map[string]*string, _ *string, _ *azcore.ETag,
 		) (azappconfig.SetSettingResponse, error) {
 			called = true
 
@@ -732,7 +765,7 @@ func TestTag_MergesAndPreservesValue(t *testing.T) {
 			}}, nil
 		},
 		setFunc: func(
-			_ context.Context, _, value, label string, tags map[string]*string, e *azcore.ETag,
+			_ context.Context, _, value, label string, tags map[string]*string, _ *string, e *azcore.ETag,
 		) (azappconfig.SetSettingResponse, error) {
 			gotValue, gotLabel, gotTags, gotETag = value, label, tags, e
 
@@ -746,6 +779,39 @@ func TestTag_MergesAndPreservesValue(t *testing.T) {
 	assert.Equal(t, "dev", gotLabel)
 	assert.Equal(t, &etag, gotETag)
 	assert.Equal(t, map[string]string{"env": "prod", "keep": "yes", "team": "core"}, derefTags(gotTags))
+}
+
+// TestTag_PreservesContentType asserts a tag-only edit re-sends the setting's
+// current content-type so the GET-merge-PUT does not strip it — a tag change
+// must never alter the value semantics (e.g. turn a Key Vault reference into a
+// plain literal).
+func TestTag_PreservesContentType(t *testing.T) {
+	t.Parallel()
+
+	const kvRef = "application/vnd.microsoft.appconfig.keyvaultref+json"
+
+	var sentContentType *string
+
+	m := &mockClient{
+		getFunc: func(_ context.Context, key, _ string) (azappconfig.GetSettingResponse, error) {
+			return azappconfig.GetSettingResponse{Setting: azappconfig.Setting{
+				Key:         lo.ToPtr(key),
+				Value:       lo.ToPtr("keep-me"),
+				ContentType: lo.ToPtr(kvRef),
+			}}, nil
+		},
+		setFunc: func(
+			_ context.Context, _, _, _ string, _ map[string]*string, contentType *string, _ *azcore.ETag,
+		) (azappconfig.SetSettingResponse, error) {
+			sentContentType = contentType
+
+			return azappconfig.SetSettingResponse{}, nil
+		},
+	}
+	store := appconfig.New(m, "")
+
+	require.NoError(t, store.Tag(t.Context(), "db-password", map[string]string{"team": "payments"}))
+	assert.Equal(t, kvRef, lo.FromPtr(sentContentType))
 }
 
 // TestUntag_RemovesKeys asserts Untag deletes the given keys from the current
@@ -764,7 +830,7 @@ func TestUntag_RemovesKeys(t *testing.T) {
 			}}, nil
 		},
 		setFunc: func(
-			_ context.Context, _, _, _ string, tags map[string]*string, _ *azcore.ETag,
+			_ context.Context, _, _, _ string, tags map[string]*string, _ *string, _ *azcore.ETag,
 		) (azappconfig.SetSettingResponse, error) {
 			gotTags = tags
 
@@ -795,7 +861,7 @@ func TestTag_RetriesOn412ThenSucceeds(t *testing.T) {
 			}}, nil
 		},
 		setFunc: func(
-			_ context.Context, _, _, _ string, _ map[string]*string, _ *azcore.ETag,
+			_ context.Context, _, _, _ string, _ map[string]*string, _ *string, _ *azcore.ETag,
 		) (azappconfig.SetSettingResponse, error) {
 			sets++
 			if sets == 1 {
@@ -827,7 +893,7 @@ func TestTag_SurfacesPersistentConflict(t *testing.T) {
 			}}, nil
 		},
 		setFunc: func(
-			_ context.Context, _, _, _ string, _ map[string]*string, _ *azcore.ETag,
+			_ context.Context, _, _, _ string, _ map[string]*string, _ *string, _ *azcore.ETag,
 		) (azappconfig.SetSettingResponse, error) {
 			sets++
 

--- a/internal/provider/azure/appconfig/client.go
+++ b/internal/provider/azure/appconfig/client.go
@@ -41,14 +41,16 @@ func (a *apiClient) GetSetting(ctx context.Context, key, label string) (azappcon
 	return a.c.GetSetting(ctx, key, opts)
 }
 
-// SetSetting upserts key=value under label, carrying the given tags and (when
-// etag is non-nil) an OnlyIfUnchanged precondition. App Configuration's PUT
-// replaces the whole key-value, so tags must always be re-sent to be preserved;
-// a nil etag makes the write unconditional.
+// SetSetting upserts key=value under label, carrying the given tags, the given
+// content-type, and (when etag is non-nil) an OnlyIfUnchanged precondition. App
+// Configuration's PUT replaces the whole key-value, so both tags and
+// content-type must always be re-sent to be preserved (a nil content-type
+// leaves it unset); a nil etag makes the write unconditional.
 func (a *apiClient) SetSetting(
-	ctx context.Context, key, value, label string, tags map[string]*string, etag *azcore.ETag,
+	ctx context.Context, key, value, label string, tags map[string]*string, contentType *string, etag *azcore.ETag,
 ) (azappconfig.SetSettingResponse, error) {
 	opts := &azappconfig.SetSettingOptions{
+		ContentType:     contentType,
 		Tags:            tags,
 		OnlyIfUnchanged: etag,
 	}


### PR DESCRIPTION
Azure App Config's PUT is a whole-key-value replace, so a nil content-type was omitted and the service reset it to null on every write — a value edit or even a tag-only edit turned a Key Vault reference into a plain literal. This reads the existing content-type and re-sends it on every write, mirroring the tag re-send; the content-type is held opaquely (no domain field).

Regression tests cover value-edit apply and tag-only apply both preserving a keyvaultref content-type.

Closes #545.