### PR TITLE
fix(updatecheck): add in-process fallback for unwritable cache path

### DIFF
--- a/internal/updatecheck/updatecheck.go
+++ b/internal/updatecheck/updatecheck.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"golang.org/x/mod/semver"
@@ -61,6 +62,45 @@ type checker struct {
 	lookupEnv   func(string) (string, bool)
 	cachePath   func() (string, error)
 	fetchLatest func(ctx context.Context) (string, error)
+
+	// readMemo / writeMemo are the in-process fallback marker. Production wires
+	// them to a package-level, process-wide store (see defaultChecker); tests
+	// may leave them nil (fallback disabled) or supply isolated closures.
+	readMemo  func() (cacheEntry, bool)
+	writeMemo func(cacheEntry)
+}
+
+// procMemoMu guards the process-wide in-memory fallback below.
+//
+//nolint:gochecknoglobals // process-wide mutex for the in-process fallback marker
+var procMemoMu sync.Mutex
+
+// procMemo is the process-wide in-memory fallback for resolveLatest. It bounds
+// network probing to once per cacheTTL even when the on-disk cache is unusable
+// (e.g. an unwritable ~/.suve), so a failed writeCache does not re-pay the HTTP
+// timeout on every invocation within a single process.
+//
+//nolint:gochecknoglobals // process-wide fallback marker; guarded by procMemoMu
+var procMemo cacheEntry
+
+// procMemoValid reports whether procMemo has been populated in this process.
+//
+//nolint:gochecknoglobals // process-wide fallback marker; guarded by procMemoMu
+var procMemoValid bool
+
+func readProcMemo() (cacheEntry, bool) {
+	procMemoMu.Lock()
+	defer procMemoMu.Unlock()
+
+	return procMemo, procMemoValid
+}
+
+func writeProcMemo(entry cacheEntry) {
+	procMemoMu.Lock()
+	defer procMemoMu.Unlock()
+
+	procMemo = entry
+	procMemoValid = true
 }
 
 // Notice returns a one-line update notice when a newer release of mpyw/suve is
@@ -84,6 +124,8 @@ func defaultChecker() *checker {
 		fetchLatest: func(ctx context.Context) (string, error) {
 			return fetchLatestRelease(ctx, client)
 		},
+		readMemo:  readProcMemo,
+		writeMemo: writeProcMemo,
 	}
 }
 
@@ -142,25 +184,42 @@ func (c *checker) resolveLatest(ctx context.Context) string {
 		}
 	}
 
+	// In-process fallback: when the on-disk cache is unusable (no path, or an
+	// unwritable file whose marker never persisted), a fresh in-memory marker
+	// still bounds probing to once per TTL within this process.
+	if c.readMemo != nil {
+		if entry, ok := c.readMemo(); ok && c.now().Sub(entry.CheckedAt) < cacheTTL {
+			return entry.LatestVersion
+		}
+	}
+
 	latest, err := c.fetchLatest(ctx)
 	if err != nil || latest == "" {
 		// On fetch failure, record a short-lived negative marker (an empty
 		// LatestVersion, treated as "checked, nothing to report") so a failed
 		// probe suppresses retries within the TTL rather than paying the HTTP
 		// timeout on every invocation.
-		if pathErr == nil {
-			_ = writeCache(path, cacheEntry{CheckedAt: c.now()})
-		}
+		c.record(path, pathErr, cacheEntry{CheckedAt: c.now()})
 
 		return ""
 	}
 
-	if pathErr == nil {
-		// Best-effort cache write; errors are ignored on purpose.
-		_ = writeCache(path, cacheEntry{CheckedAt: c.now(), LatestVersion: latest})
-	}
+	c.record(path, pathErr, cacheEntry{CheckedAt: c.now(), LatestVersion: latest})
 
 	return latest
+}
+
+// record persists a resolved marker to the on-disk cache (best-effort; ignored
+// on error) and always to the in-process fallback, so an unwritable cache path
+// still limits probing to once per process.
+func (c *checker) record(path string, pathErr error, entry cacheEntry) {
+	if pathErr == nil {
+		_ = writeCache(path, entry)
+	}
+
+	if c.writeMemo != nil {
+		c.writeMemo(entry)
+	}
 }
 
 // normalize ensures a version tag carries a leading "v" so it is comparable

--- a/internal/updatecheck/updatecheck_test.go
+++ b/internal/updatecheck/updatecheck_test.go
@@ -216,6 +216,83 @@ func TestNotice_FetchError_SuppressesRetriesWithinTTL(t *testing.T) {
 	assert.Equal(t, 1, fetches, "a failed probe must be attempted at most once within the TTL")
 }
 
+func TestNotice_UnwritableCache_InProcessFallbackLimitsProbing(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	// A cache path whose parent is a regular file: writeCache always fails and
+	// readCache never finds a fresh entry, so only the in-process fallback can
+	// bound probing.
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	require.NoError(t, os.WriteFile(blocker, []byte("x"), 0o600))
+	path := filepath.Join(blocker, "update-check.json")
+
+	var (
+		memo      cacheEntry
+		memoValid bool
+	)
+
+	fetches := 0
+	c := &checker{
+		now:       fixedNow(now),
+		lookupEnv: noEnv,
+		cachePath: func() (string, error) { return path, nil },
+		fetchLatest: func(context.Context) (string, error) {
+			fetches++
+
+			return "", errors.New("boom")
+		},
+		readMemo:  func() (cacheEntry, bool) { return memo, memoValid },
+		writeMemo: func(e cacheEntry) { memo, memoValid = e, true },
+	}
+
+	const calls = 5
+	for range calls {
+		assert.Empty(t, c.notice(context.Background(), "v1.2.3"))
+	}
+
+	// The on-disk marker never persisted, but the in-process fallback still
+	// suppresses retries after the first probe.
+	_, ok := readCache(path)
+	assert.False(t, ok, "unwritable cache must not persist a marker")
+	assert.Equal(t, 1, fetches, "in-process fallback must bound probing to once per process")
+}
+
+func TestDefaultChecker_Wired(t *testing.T) {
+	t.Parallel()
+
+	c := defaultChecker()
+	require.NotNil(t, c)
+	assert.NotNil(t, c.now)
+	assert.NotNil(t, c.lookupEnv)
+	assert.NotNil(t, c.cachePath)
+	assert.NotNil(t, c.fetchLatest)
+	assert.NotNil(t, c.readMemo, "production wires the in-process fallback")
+	assert.NotNil(t, c.writeMemo, "production wires the in-process fallback")
+}
+
+func TestProcMemo_RoundTrip(t *testing.T) { //nolint:paralleltest // mutates process-wide procMemo
+	t.Cleanup(func() {
+		procMemoMu.Lock()
+		procMemo, procMemoValid = cacheEntry{}, false
+		procMemoMu.Unlock()
+	})
+
+	if _, ok := readProcMemo(); ok {
+		procMemoMu.Lock()
+		procMemo, procMemoValid = cacheEntry{}, false
+		procMemoMu.Unlock()
+	}
+
+	entry := cacheEntry{CheckedAt: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC), LatestVersion: "v1.2.3"}
+	writeProcMemo(entry)
+
+	got, ok := readProcMemo()
+	require.True(t, ok)
+	assert.Equal(t, entry, got)
+}
+
 func TestNotice_CachePathError_StillFetches(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When `~/.suve` is unwritable, the negative-cache marker written on fetch failure never persists, so every invocation re-pays the HTTP timeout.

This adds a process-wide in-memory fallback: `resolveLatest` records each resolved marker to both the best-effort on-disk cache and an in-process store, so a failed `writeCache` still bounds network probing to once per TTL within a single process. The memo store is injectable on `checker` (nil = disabled) so tests stay isolated.

Closes #537.