### PR TITLE
fix(gui): surface populated apply result on conflict/partial failure

### DIFF
--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -331,7 +331,14 @@ func (a *App) StagingApply(service string, ignoreConflicts bool) (*StagingApplyR
 	result, err := uc.Execute(a.ctx, stagingusecase.ApplyInput{
 		IgnoreConflicts: ignoreConflicts,
 	})
-	if err != nil {
+	// A conflict rejection or a per-entry/tag failure returns a POPULATED result
+	// alongside the error; the failure detail lives in the result's fields
+	// (Conflicts, EntryFailed, TagFailed, per-entry Error). Surface that result so
+	// the frontend can render the conflict panel and per-entry rows instead of
+	// discarding everything into a bare error message, mirroring the CLI's
+	// apply.go (which prints the result before returning the error). Only a nil
+	// result (e.g. a store read failure) is a hard error with nothing to show.
+	if result == nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
`StagingApply` returned `(nil, err)` whenever `ApplyUseCase.Execute` reported an error, discarding the populated `ApplyOutput` that carries conflicts and per-entry/tag failure detail. As a result the frontend's conflict panel never rendered — a conflict rejection showed only a bare error string.

This returns the mapped result whenever `Execute` yields a non-nil output (conflict rejection or partial failure), so the frontend renders the conflict panel and per-entry rows. Only a nil result (e.g. a store read failure) stays a hard error. Mirrors the CLI apply path, which prints the result before returning the error, and lets the Apply-All loop proceed across every service instead of aborting on the first rejection.

Closes #550.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwohz3bcExASTpHgiV2dHt