### PR TITLE
fix(cli): --value-stdin での確認プロンプト二重消費を明確なエラーに

### DIFF
--- a/internal/cli/commands/azure/param/update.go
+++ b/internal/cli/commands/azure/param/update.go
@@ -72,6 +72,9 @@ func updateAction(ctx context.Context, cmd *cli.Command) error {
 		HasArg:    args.Len() >= 2, //nolint:mnd // arg 0 is the key, arg 1 is the optional value
 		Arg:       args.Get(1),
 		Stdin:     cliinternal.Stdin(cmd),
+		// Without --yes we prompt for confirmation on the same stdin below;
+		// reading the value from stdin would leave nothing for that prompt.
+		ConfirmRequired: !skipConfirm,
 	})
 	if err != nil {
 		return err

--- a/internal/cli/commands/azure/secret/update.go
+++ b/internal/cli/commands/azure/secret/update.go
@@ -72,6 +72,9 @@ func updateAction(ctx context.Context, cmd *cli.Command) error {
 		HasArg:    args.Len() >= 2, //nolint:mnd // arg 0 is the name, arg 1 is the optional value
 		Arg:       args.Get(1),
 		Stdin:     cliinternal.Stdin(cmd),
+		// Without --yes we prompt for confirmation on the same stdin below;
+		// reading the value from stdin would leave nothing for that prompt.
+		ConfirmRequired: !skipConfirm,
 	})
 	if err != nil {
 		return err

--- a/internal/cli/commands/gcloud/update.go
+++ b/internal/cli/commands/gcloud/update.go
@@ -71,6 +71,9 @@ func updateAction(ctx context.Context, cmd *cli.Command) error {
 		HasArg:    args.Len() >= 2, //nolint:mnd // arg 0 is the name, arg 1 is the optional value
 		Arg:       args.Get(1),
 		Stdin:     cliinternal.Stdin(cmd),
+		// Without --yes we prompt for confirmation on the same stdin below;
+		// reading the value from stdin would leave nothing for that prompt.
+		ConfirmRequired: !skipConfirm,
 	})
 	if err != nil {
 		return err

--- a/internal/cli/commands/internal/valueinput.go
+++ b/internal/cli/commands/internal/valueinput.go
@@ -22,6 +22,18 @@ var ErrValueRequired = errors.New(
 		", or run interactively to edit it in $EDITOR",
 )
 
+// ErrValueStdinNeedsYes is returned when the value was read from stdin via
+// --value-stdin but a confirmation prompt would still run afterwards. The
+// prompt reads from the same stdin, which has already been consumed, so it
+// would immediately hit EOF. Rather than fail cryptically, we detect this up
+// front and tell the user to re-run with --yes. We intentionally neither imply
+// --yes nor read the confirmation from /dev/tty, so the acknowledgement stays
+// explicit.
+var ErrValueStdinNeedsYes = errors.New(
+	"--" + FlagValueStdin + " consumes stdin, so the confirmation prompt cannot be read; " +
+		"re-run with --yes to acknowledge the update",
+)
+
 // FlagValueStdin is the name of the flag that reads a create/update value from
 // stdin instead of a positional argument, keeping the secret out of argv (and
 // therefore out of ps/proc/cmdline and shell history).
@@ -70,6 +82,12 @@ type ValueSource struct {
 	Stdin io.Reader
 	// OpenEditor is the editor seam used for the fallback path (nil -> editor.Open).
 	OpenEditor editor.OpenFunc
+	// ConfirmRequired is true when the command would prompt for confirmation on
+	// the same stdin after resolving the value (i.e. an update without --yes).
+	// Combined with FromStdin this is the double-consume case, so ResolveValue
+	// fails with ErrValueStdinNeedsYes instead of letting the later prompt hit
+	// EOF.
+	ConfirmRequired bool
 }
 
 // ResolveValue determines the value for a create/update command. Precedence:
@@ -83,11 +101,19 @@ type ValueSource struct {
 // cancellation (matching the staging add/edit UX). --value-stdin and the
 // positional argument always proceed, even with an empty value, because those
 // are explicit.
+//
+// When ConfirmRequired is set alongside --value-stdin, ResolveValue returns
+// ErrValueStdinNeedsYes instead of reading stdin, because the later
+// confirmation prompt would find stdin already consumed.
 func ResolveValue(ctx context.Context, src ValueSource) (value string, proceed bool, err error) {
 	switch {
 	case src.FromStdin:
 		if src.HasArg {
 			return "", false, errors.New("cannot combine a positional value with --" + FlagValueStdin)
+		}
+
+		if src.ConfirmRequired {
+			return "", false, ErrValueStdinNeedsYes
 		}
 
 		reader := src.Stdin

--- a/internal/cli/commands/internal/valueinput_test.go
+++ b/internal/cli/commands/internal/valueinput_test.go
@@ -63,6 +63,35 @@ func TestResolveValue_FromStdin(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot combine a positional value with --value-stdin")
 	})
+
+	t.Run("errors before reading stdin when a confirmation prompt is required", func(t *testing.T) {
+		t.Parallel()
+
+		reader := strings.NewReader("sk-12345\n")
+
+		_, proceed, err := cliinternal.ResolveValue(t.Context(), cliinternal.ValueSource{
+			FromStdin:       true,
+			ConfirmRequired: true,
+			Stdin:           reader,
+		})
+		require.ErrorIs(t, err, cliinternal.ErrValueStdinNeedsYes)
+		assert.False(t, proceed)
+		// Stdin must be left untouched so a caller could still use it.
+		assert.Equal(t, reader.Len(), len("sk-12345\n"))
+	})
+
+	t.Run("reads stdin when confirmation is skipped via --yes", func(t *testing.T) {
+		t.Parallel()
+
+		value, proceed, err := cliinternal.ResolveValue(t.Context(), cliinternal.ValueSource{
+			FromStdin:       true,
+			ConfirmRequired: false,
+			Stdin:           strings.NewReader("sk-12345\n"),
+		})
+		require.NoError(t, err)
+		assert.True(t, proceed)
+		assert.Equal(t, "sk-12345", value)
+	})
 }
 
 func TestResolveValue_FromArg(t *testing.T) {

--- a/internal/cli/commands/internal/valueinput_test.go
+++ b/internal/cli/commands/internal/valueinput_test.go
@@ -3,6 +3,7 @@ package internal_test
 import (
 	"context"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 
@@ -76,8 +77,10 @@ func TestResolveValue_FromStdin(t *testing.T) {
 		})
 		require.ErrorIs(t, err, cliinternal.ErrValueStdinNeedsYes)
 		assert.False(t, proceed)
-		// Stdin must be left untouched so a caller could still use it.
-		assert.Equal(t, reader.Len(), len("sk-12345\n"))
+		// Stdin must be left untouched so the value is never silently consumed.
+		rest, rerr := io.ReadAll(reader)
+		require.NoError(t, rerr)
+		assert.Equal(t, "sk-12345\n", string(rest))
 	})
 
 	t.Run("reads stdin when confirmation is skipped via --yes", func(t *testing.T) {

--- a/internal/cli/commands/param/update/update.go
+++ b/internal/cli/commands/param/update/update.go
@@ -140,6 +140,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		HasArg:    args.Len() >= 2, //nolint:mnd // arg 0 is the name, arg 1 is the optional value
 		Arg:       args.Get(1),
 		Stdin:     internal.Stdin(cmd),
+		// Without --yes we prompt for confirmation on the same stdin below;
+		// reading the value from stdin would leave nothing for that prompt.
+		ConfirmRequired: !skipConfirm,
 	})
 	if err != nil {
 		return err

--- a/internal/cli/commands/secret/update/update.go
+++ b/internal/cli/commands/secret/update/update.go
@@ -82,6 +82,9 @@ func action(ctx context.Context, cmd *cli.Command) error {
 		HasArg:    args.Len() >= 2, //nolint:mnd // arg 0 is the name, arg 1 is the optional value
 		Arg:       args.Get(1),
 		Stdin:     internal.Stdin(cmd),
+		// Without --yes we prompt for confirmation on the same stdin below;
+		// reading the value from stdin would leave nothing for that prompt.
+		ConfirmRequired: !skipConfirm,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
## 概要

`--value-stdin` で値を stdin から読んだ後に確認プロンプトが必要になる経路 (update 系で `--yes` 無し) では、stdin を二重消費して `failed to read response: EOF` で失敗していた。この二重消費を事前に検知し、actionable なエラーを返すようにする。

## 変更点

- `ResolveValue` の `ValueSource` に `ConfirmRequired` を追加。`FromStdin` と同時に真のとき、stdin を読む前に `ErrValueStdinNeedsYes` を返す。
- 新エラーメッセージ: `--value-stdin consumes stdin, so the confirmation prompt cannot be read; re-run with --yes to acknowledge the update`
- `param` / `secret` / `gcloud` / `azure` の update コマンドで `ConfirmRequired: !skipConfirm` を渡す。
- 方針どおり「暗黙 `--yes`」も「`/dev/tty` からの確認読み」も採らない。`confirm.go` は変更せず、値入力/コマンド層でガードする。
- `valueinput_test.go` にガードのテストを追加。

Closes #542.