### PR TITLE
fix(azure/param): show values under a wildcard namespace with --hide-ns

### DIFF
--- a/internal/cli/commands/azure/param/list.go
+++ b/internal/cli/commands/azure/param/list.go
@@ -2,7 +2,9 @@ package param
 
 import (
 	"context"
+	"errors"
 	"io"
+	"slices"
 
 	"github.com/samber/lo"
 	"github.com/urfave/cli/v3"
@@ -30,6 +32,10 @@ type ListOptions struct {
 	Show   bool
 	HideNS bool
 	Output output.Format
+	// Namespace is the raw --namespace value (the label axis). It is needed only
+	// to tell a single literal namespace (per-key Get can fetch values) from a
+	// wildcard/OR/prefix one (it cannot — see runKeyOnly).
+	Namespace string
 }
 
 // ListRunner renders the Azure App Configuration listing. When Namespace is set
@@ -59,22 +65,8 @@ func (r *ListRunner) Run(ctx context.Context, opts ListOptions) error {
 // runKeyOnly reuses the shared generic list renderer so --hide-namespace output
 // is byte-for-byte the neutral listing.
 func (r *ListRunner) runKeyOnly(ctx context.Context, opts ListOptions) error {
-	input := azure.ListInput{Prefix: opts.Prefix, Filter: opts.Filter, WithValue: opts.Show}
-
 	runner := &genericlist.Runner{
-		List: func(ctx context.Context) ([]genericlist.Entry, error) {
-			result, err := r.KeyOnly.Execute(ctx, input)
-			if err != nil {
-				return nil, err
-			}
-
-			entries := make([]genericlist.Entry, len(result.Entries))
-			for i, e := range result.Entries {
-				entries[i] = genericlist.Entry{Name: e.Name, Value: e.Value, Error: e.Error}
-			}
-
-			return entries, nil
-		},
+		List:    r.keyOnlyEntries(opts),
 		Options: genericlist.Options{Show: opts.Show, Output: opts.Output},
 		Stdout:  r.Stdout,
 		Stderr:  r.Stderr,
@@ -82,6 +74,106 @@ func (r *ListRunner) runKeyOnly(ctx context.Context, opts ListOptions) error {
 
 	return runner.Run(ctx)
 }
+
+// keyOnlyEntries picks how the key-only rows are produced. Values (with --show)
+// are normally fetched per key via the neutral use case, but that needs a
+// single literal namespace: under a wildcard/OR/prefix --namespace every per-key
+// Get fails (Get cannot address all/multiple namespaces), so the whole listing
+// would be error rows. In that case source the values from the namespaced list
+// — whose response already carries them — and collapse it to key-only rows.
+func (r *ListRunner) keyOnlyEntries(opts ListOptions) func(context.Context) ([]genericlist.Entry, error) {
+	if opts.Show && r.Namespace != nil {
+		if _, err := aznamespace.Literal(opts.Namespace); err != nil {
+			return r.keyOnlyEntriesFromNamespaced(opts)
+		}
+	}
+
+	return r.keyOnlyEntriesFromReader(opts)
+}
+
+// keyOnlyEntriesFromReader is the neutral path: keys (and, with --show, values)
+// come from the provider-neutral use case, byte-for-byte the shared listing.
+func (r *ListRunner) keyOnlyEntriesFromReader(opts ListOptions) func(context.Context) ([]genericlist.Entry, error) {
+	return func(ctx context.Context) ([]genericlist.Entry, error) {
+		result, err := r.KeyOnly.Execute(ctx, azure.ListInput{
+			Prefix: opts.Prefix, Filter: opts.Filter, WithValue: opts.Show,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		entries := make([]genericlist.Entry, len(result.Entries))
+		for i, e := range result.Entries {
+			entries[i] = genericlist.Entry{Name: e.Name, Value: e.Value, Error: e.Error}
+		}
+
+		return entries, nil
+	}
+}
+
+// keyOnlyEntriesFromNamespaced sources values from the namespaced list (which
+// already carries them) and collapses the per-(key, namespace) rows to the
+// deduped key-only rows the --hide-namespace listing shows.
+func (r *ListRunner) keyOnlyEntriesFromNamespaced(opts ListOptions) func(context.Context) ([]genericlist.Entry, error) {
+	return func(ctx context.Context) ([]genericlist.Entry, error) {
+		result, err := r.Namespace.Execute(ctx, azure.ListNamespacesInput{
+			Prefix: opts.Prefix, Filter: opts.Filter, WithValue: true,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		return collapseToKeyOnly(result.Entries), nil
+	}
+}
+
+// collapseToKeyOnly reduces per-(key, namespace) rows to the deduped, sorted
+// key-only rows the --hide-namespace listing shows, carrying each key's value.
+// A key that resolves to different values across namespaces cannot be shown as
+// one value, so it becomes an error row rather than an arbitrary pick.
+func collapseToKeyOnly(rows []azure.ListNamespacesEntry) []genericlist.Entry {
+	type collapsed struct {
+		value     string
+		ambiguous bool
+	}
+
+	byName := make(map[string]*collapsed, len(rows))
+
+	names := make([]string, 0, len(rows))
+
+	for _, row := range rows {
+		value := lo.FromPtr(row.Value)
+
+		if existing, ok := byName[row.Name]; ok {
+			if existing.value != value {
+				existing.ambiguous = true
+			}
+
+			continue
+		}
+
+		byName[row.Name] = &collapsed{value: value}
+		names = append(names, row.Name)
+	}
+
+	slices.Sort(names)
+
+	entries := make([]genericlist.Entry, 0, len(names))
+
+	for _, name := range names {
+		if c := byName[name]; c.ambiguous {
+			entries = append(entries, genericlist.Entry{Name: name, Error: errAmbiguousValue})
+		} else {
+			entries = append(entries, genericlist.Entry{Name: name, Value: lo.ToPtr(c.value)})
+		}
+	}
+
+	return entries
+}
+
+// errAmbiguousValue marks a key whose value differs across the namespaces a
+// wildcard --namespace matched, so --hide-namespace cannot show one value.
+var errAmbiguousValue = errors.New("value differs across namespaces; drop --hide-namespace to see each")
 
 // runNamespaced renders the NAMESPACE column (text: <namespace>TAB<key>[TAB<value>];
 // json: {namespace, name, value?}). The null namespace shows as "(NULL)" in text
@@ -202,11 +294,12 @@ EXAMPLES:
 			}
 
 			return runner.Run(ctx, ListOptions{
-				Prefix: cmd.Args().First(),
-				Filter: cmd.String("filter"),
-				Show:   cmd.Bool("show"),
-				HideNS: cmd.Bool("hide-namespace"),
-				Output: outputFormat,
+				Prefix:    cmd.Args().First(),
+				Filter:    cmd.String("filter"),
+				Show:      cmd.Bool("show"),
+				HideNS:    cmd.Bool("hide-namespace"),
+				Output:    outputFormat,
+				Namespace: cliinternal.AzureAppConfigNamespace(ctx),
 			})
 		},
 	}

--- a/internal/cli/commands/azure/param/param_test.go
+++ b/internal/cli/commands/azure/param/param_test.go
@@ -266,6 +266,78 @@ func TestListRunner_HideNamespace(t *testing.T) {
 	assert.Equal(t, "app/a\napp/b\n", buf.String())
 }
 
+// TestListRunner_HideNamespaceShowWildcard asserts --hide-namespace --show under
+// a non-literal namespace (wildcard/OR/prefix) sources values from the
+// namespaced list — which already carries them — instead of per-key Get (which
+// cannot address all/multiple namespaces and would make every row an error).
+// The neutral reader must not be touched at all.
+func TestListRunner_HideNamespaceShowWildcard(t *testing.T) {
+	t.Parallel()
+
+	rows := []appconfig.KeyNamespace{
+		{Key: "a", Namespace: "dev", Value: "1"},
+		{Key: "b", Namespace: "prod", Value: "2"},
+	}
+
+	for _, ns := range []string{"*", "dev,prod", "dev*"} {
+		t.Run(ns, func(t *testing.T) {
+			t.Parallel()
+
+			var buf, errBuf bytes.Buffer
+
+			// An unconfigured neutral reader errors on any call, proving the
+			// diverted path never falls back to it.
+			r := nsListRunner(rows, &providermock.Store{}, &buf, &errBuf)
+			require.NoError(t, r.Run(t.Context(), param.ListOptions{Show: true, HideNS: true, Namespace: ns}))
+			assert.Equal(t, "a\t1\nb\t2\n", buf.String())
+		})
+	}
+}
+
+// TestListRunner_HideNamespaceShowWildcardAmbiguous asserts a key that resolves
+// to different values across the matched namespaces becomes an error row rather
+// than an arbitrary pick, while unambiguous keys still show their value.
+func TestListRunner_HideNamespaceShowWildcardAmbiguous(t *testing.T) {
+	t.Parallel()
+
+	rows := []appconfig.KeyNamespace{
+		{Key: "dup", Namespace: "dev", Value: "1"},
+		{Key: "dup", Namespace: "prod", Value: "2"},
+		{Key: "uniq", Namespace: "dev", Value: "ok"},
+	}
+
+	var buf, errBuf bytes.Buffer
+
+	r := nsListRunner(rows, &providermock.Store{}, &buf, &errBuf)
+	require.NoError(t, r.Run(t.Context(), param.ListOptions{Show: true, HideNS: true, Namespace: "*"}))
+	assert.Equal(t, "dup\t<error: value differs across namespaces; drop --hide-namespace to see each>\nuniq\tok\n", buf.String())
+}
+
+// TestListRunner_HideNamespaceShowLiteral asserts a single literal namespace with
+// --show keeps using the neutral per-key path (Reader.List + Get), unaffected by
+// the wildcard diversion.
+func TestListRunner_HideNamespaceShowLiteral(t *testing.T) {
+	t.Parallel()
+
+	reader := &providermock.Store{
+		ListFunc: func(_ context.Context) ([]string, error) {
+			return []string{"k"}, nil
+		},
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{Name: name, Value: "v"}, nil
+		},
+	}
+
+	var buf, errBuf bytes.Buffer
+
+	// Namespaced rows would resolve to a different value; the literal path must
+	// win, proving it did not divert.
+	rows := []appconfig.KeyNamespace{{Key: "k", Namespace: "dev", Value: "WRONG"}}
+	r := nsListRunner(rows, reader, &buf, &errBuf)
+	require.NoError(t, r.Run(t.Context(), param.ListOptions{Show: true, HideNS: true, Namespace: "dev"}))
+	assert.Equal(t, "k\tv\n", buf.String())
+}
+
 func TestListRunner_NonAppConfigNoColumn(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`azure param list --hide-namespace --show` under a wildcard/OR/prefix namespace rendered every value as an error, because the key-only path fetches values per key via `Reader.Get`, which needs one literal namespace. This diverts that case to source values from the namespaced list (which already carries them), collapsing per-(key, namespace) rows to deduped key-only rows; a key whose value differs across namespaces becomes an error row instead of an arbitrary pick.

Closes #528.