### PR TITLE
feat(gui): report working-has-changes from import inspection

### DIFF
--- a/internal/gui/frontend/src/lib/StagingView.svelte
+++ b/internal/gui/frontend/src/lib/StagingView.svelte
@@ -418,7 +418,11 @@
 
   function proceedImportAfterWarn() {
     showImportWarnModal = false;
-    if (serviceHasChanges(importService)) {
+    // Prompt for merge/overwrite only when the working area already holds
+    // changes for this service. The signal comes from the import metadata
+    // (InspectImportFile) rather than the loaded view state, which may be stale
+    // or not yet loaded — matching the CLI, which prompts from the working area.
+    if (importInfo?.workingHasChanges) {
       importMode = 'merge';
       showImportModeModal = true;
       return;

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -1410,12 +1410,19 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
         if (!file) {
           throw new Error('failed to read export file');
         }
+        // Whether the working area for the file's service already holds staged
+        // changes; the frontend prompts for merge/overwrite only when true.
+        const b = currentBucket();
+        const workingHasChanges = file.service === 'param'
+          ? (b.param.length > 0 || b.paramTags.length > 0)
+          : (b.secret.length > 0 || b.secretTags.length > 0);
         return {
           encrypted: file.encrypted,
           provider: file.provider,
           scope: file.scope,
           service: file.service,
           scopeMatches: file.scope === expectedScopeKey(file.service),
+          workingHasChanges,
         };
       },
       // Import ONE concrete service from a per-service envelope into the working

--- a/internal/gui/frontend/wailsjs/go/models.ts
+++ b/internal/gui/frontend/wailsjs/go/models.ts
@@ -44,11 +44,12 @@ export namespace gui {
 	    scope: string;
 	    service: string;
 	    scopeMatches: boolean;
-	
+	    workingHasChanges: boolean;
+
 	    static createFrom(source: any = {}) {
 	        return new EnvelopeInfoResult(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.encrypted = source["encrypted"];
@@ -56,6 +57,7 @@ export namespace gui {
 	        this.scope = source["scope"];
 	        this.service = source["service"];
 	        this.scopeMatches = source["scopeMatches"];
+	        this.workingHasChanges = source["workingHasChanges"];
 	    }
 	}
 	export class ParamDeleteResult {

--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -863,6 +863,13 @@ type EnvelopeInfoResult struct {
 	// ScopeMatches reports whether the envelope's scope matches the scope the
 	// selected service resolves to under the active provider.
 	ScopeMatches bool `json:"scopeMatches"`
+	// WorkingHasChanges reports whether the working staging area for the
+	// envelope's declared service already holds staged entries or tag changes.
+	// The frontend prompts for merge/overwrite only when it is true, deciding
+	// from the import metadata instead of the (possibly stale/unloaded) view
+	// state — matching the CLI, which prompts only when the working area is
+	// non-empty.
+	WorkingHasChanges bool `json:"workingHasChanges"`
 }
 
 // =============================================================================
@@ -1028,13 +1035,56 @@ func (a *App) InspectImportFile(path string) (*EnvelopeInfoResult, error) {
 		return nil, err
 	}
 
+	workingHasChanges, err := a.workingHasChangesForService(env.Service)
+	if err != nil {
+		return nil, err
+	}
+
 	return &EnvelopeInfoResult{
-		Encrypted:    encrypted,
-		Provider:     env.Provider,
-		Scope:        env.Scope,
-		Service:      env.Service,
-		ScopeMatches: env.Scope == scope.Key(),
+		Encrypted:         encrypted,
+		Provider:          env.Provider,
+		Scope:             env.Scope,
+		Service:           env.Service,
+		ScopeMatches:      env.Scope == scope.Key(),
+		WorkingHasChanges: workingHasChanges,
 	}, nil
+}
+
+// workingHasChangesForService reports whether the per-service working staging
+// area holds any staged entries or tag changes for the given service. The GUI
+// uses it (via InspectImportFile) to prompt for merge/overwrite only when the
+// working area is non-empty, mirroring the CLI's import behavior. The working
+// store is file-based, so this makes no network calls. An unrecognized service
+// (a malformed envelope) reports no changes rather than erroring.
+func (a *App) workingHasChangesForService(service string) (bool, error) {
+	// A malformed envelope may name an unknown service; treat that as no working
+	// changes rather than resolving a store for it.
+	if service != string(staging.ServiceParam) && service != string(staging.ServiceSecret) {
+		return false, nil
+	}
+
+	svc := staging.Service(service)
+
+	store, err := a.getStagingStore(kindForService(service))
+	if err != nil {
+		return false, err
+	}
+
+	entries, err := store.ListEntries(a.ctx, svc)
+	if err != nil {
+		return false, err
+	}
+
+	if len(entries[svc]) > 0 {
+		return true, nil
+	}
+
+	tags, err := store.ListTags(a.ctx, svc)
+	if err != nil {
+		return false, err
+	}
+
+	return len(tags[svc]) > 0, nil
 }
 
 // StagingImport reads a per-service envelope file into the working staging area


### PR DESCRIPTION
`InspectImportFile` lacked a signal for whether the working staging area already holds changes, so the GUI decided the merge/overwrite prompt from the loaded view state, which can be stale or not yet loaded.

This adds a per-service `workingHasChanges` flag to `EnvelopeInfoResult`, computed from the working staging store for the envelope's declared service (file-based; no network calls). The frontend now prompts for merge/overwrite from this import metadata, matching the CLI which prompts only when the working area is non-empty. The `models.ts` mirror and the Playwright wails mock are updated accordingly.

Closes #558.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwohz3bcExASTpHgiV2dHt