### PR TITLE
fix(staging): honor $TZ for status -v Staged timestamp

### DIFF
--- a/internal/staging/printer.go
+++ b/internal/staging/printer.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mpyw/suve/internal/cli/colors"
 	"github.com/mpyw/suve/internal/cli/output"
+	"github.com/mpyw/suve/internal/timeutil"
 )
 
 // maxValueDisplayLength is the maximum length of a value shown in status output.
@@ -49,7 +50,7 @@ func (p *EntryPrinter) PrintEntry(key EntryKey, entry Entry, verbose, showDelete
 	}
 
 	output.Printf(p.Writer, "\n%s %s%s\n", opColor, key.Name, nsSuffix)
-	output.Printf(p.Writer, "  %s %s\n", pal.FieldLabel("Staged:"), entry.StagedAt.Format("2006-01-02 15:04:05"))
+	output.Printf(p.Writer, "  %s %s\n", pal.FieldLabel("Staged:"), timeutil.FormatDateTime(entry.StagedAt))
 
 	switch entry.Operation {
 	case OperationCreate, OperationUpdate:

--- a/internal/staging/printer_test.go
+++ b/internal/staging/printer_test.go
@@ -10,12 +10,16 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/mpyw/suve/internal/staging"
+	"github.com/mpyw/suve/internal/timeutil"
 )
 
 func TestEntryPrinter_PrintEntry(t *testing.T) {
 	t.Parallel()
 
 	fixedTime := time.Date(2024, 1, 15, 10, 30, 0, 0, time.UTC)
+	// The Staged timestamp is rendered through timeutil so it honors $TZ; assert
+	// against the same TZ-aware representation rather than a hard-coded UTC one.
+	stagedAt := timeutil.FormatDateTime(fixedTime)
 
 	tests := []struct {
 		name              string
@@ -56,7 +60,7 @@ func TestEntryPrinter_PrintEntry(t *testing.T) {
 				StagedAt:  fixedTime,
 			},
 			verbose:      true,
-			wantContains: []string{"M", "/app/config", "Staged:", "2024-01-15 10:30:00", "Value: test-value"},
+			wantContains: []string{"M", "/app/config", "Staged:", stagedAt, "Value: test-value"},
 		},
 		{
 			name:      "update operation verbose with long value",

--- a/internal/timeutil/timeutil.go
+++ b/internal/timeutil/timeutil.go
@@ -55,6 +55,12 @@ func FormatDate(t time.Time) string {
 	return t.In(GetLocation()).Format("2006-01-02")
 }
 
+// FormatDateTime formats the given time as a YYYY-MM-DD HH:MM:SS datetime using
+// the timezone from TZ environment variable.
+func FormatDateTime(t time.Time) string {
+	return t.In(GetLocation()).Format("2006-01-02 15:04:05")
+}
+
 // ResetLocationCache resets the cached location.
 // This is intended for testing purposes only.
 func ResetLocationCache() {


### PR DESCRIPTION
The `status -v` "Staged:" timestamp was rendered with a raw `.Format`, bypassing the `TZ` environment variable that the GUI and log columns respect.

Add a `timeutil.FormatDateTime` helper and render the timestamp through it.

Closes #541.