### PR TITLE
fix(provider): fold Azure vault/store names to lower case in Scope.Key

### DIFF
--- a/internal/provider/scope.go
+++ b/internal/provider/scope.go
@@ -1,6 +1,9 @@
 package provider
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // Scope identifies a provider-specific namespace for staging state. The set of
 // meaningful fields depends on Provider:
@@ -47,16 +50,18 @@ func (s Scope) Key() string {
 	case ProviderAzure:
 		// Key Vault and App Configuration names are globally unique DNS labels
 		// (*.vault.azure.net / *.azconfig.io), so the name alone identifies the
-		// resource — no subscription/resource-group needed.
+		// resource — no subscription/resource-group needed. DNS labels are
+		// case-insensitive, so fold to lower case to keep the key stable across
+		// mixed-case spellings of the same resource.
 		if s.VaultName != "" {
-			return fmt.Sprintf("azure/keyvault/%s", s.VaultName)
+			return fmt.Sprintf("azure/keyvault/%s", strings.ToLower(s.VaultName))
 		}
 
 		// App Configuration staging is per-STORE, not per-namespace: all of a
 		// store's staged settings share one param.json, and each entry carries
 		// its own namespace as part of its identity (see staging.CompositeEntryKey).
 		// The namespace is deliberately NOT in the key.
-		return fmt.Sprintf("azure/appconfig/%s", s.StoreName)
+		return fmt.Sprintf("azure/appconfig/%s", strings.ToLower(s.StoreName))
 	default:
 		return ""
 	}

--- a/internal/provider/scope_test.go
+++ b/internal/provider/scope_test.go
@@ -33,9 +33,23 @@ func TestScope_Key(t *testing.T) {
 			want:  "azure/keyvault/vault1",
 		},
 		{
+			// Vault names are case-insensitive DNS labels, so mixed-case spellings
+			// of the same vault must fold to one stable key.
+			name:  "azure keyvault mixed case folds to lower",
+			scope: provider.AzureKeyVaultScope("MyVault"),
+			want:  "azure/keyvault/myvault",
+		},
+		{
 			name:  "azure appconfig",
 			scope: provider.AzureAppConfigScope("store1"),
 			want:  "azure/appconfig/store1",
+		},
+		{
+			// Store names are case-insensitive DNS labels, so mixed-case spellings
+			// of the same store must fold to one stable key.
+			name:  "azure appconfig mixed case folds to lower",
+			scope: provider.AzureAppConfigScope("MyStore"),
+			want:  "azure/appconfig/mystore",
 		},
 		{
 			// Staging is per-STORE, not per-namespace: the namespace is NOT in the


### PR DESCRIPTION
Azure Key Vault and App Configuration names are case-insensitive DNS labels. Mixed-case spellings of the same resource previously produced distinct staging keys (e.g. `MyVault` vs `myvault`), splitting staging state. `Scope.Key` now lowercases `VaultName`/`StoreName` so the on-disk key is stable regardless of case.

Existing mixed-case staging directories may orphan; migration is out of scope per the approved 実装方針 and handled via release notes.

Closes #564.