### PR TITLE
fix(stage/apply): detect tag conflicts in global apply

### DIFF
--- a/internal/cli/commands/stage/apply/apply.go
+++ b/internal/cli/commands/stage/apply/apply.go
@@ -405,7 +405,7 @@ func formatTagApplySummary(tagEntry staging.TagEntry) string {
 // distinct items; within one service a key that conflicts on both its value and
 // its tags is reported once.
 func (r *Runner) checkAllConflicts(ctx context.Context, checks []serviceConflictCheck) []conflictItem {
-	var all []conflictItem
+	all := make([]conflictItem, 0, len(checks))
 
 	for _, check := range checks {
 		merged := make(map[staging.EntryKey]struct{})

--- a/internal/cli/commands/stage/apply/apply.go
+++ b/internal/cli/commands/stage/apply/apply.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"strings"
 
 	"github.com/urfave/cli/v3"
@@ -46,12 +47,13 @@ func (s ServiceApply) strategyForNamespace(namespace string) (staging.ApplyStrat
 	return s.StrategyFor(namespace)
 }
 
-// serviceConflictCheck holds entries and the per-namespace strategy resolver for
-// a single service's conflict checking. resolve mirrors the apply path so each
-// entry is probed against its own namespace's remote state.
+// serviceConflictCheck holds the staged entries and tags plus the per-namespace
+// strategy resolver for a single service's conflict checking. resolve mirrors the
+// apply path so each entry/tag is probed against its own namespace's remote state.
 type serviceConflictCheck struct {
 	serviceName string
 	entries     map[staging.EntryKey]staging.Entry
+	tags        map[staging.EntryKey]staging.TagEntry
 	resolve     staging.ApplyStrategyResolver
 }
 
@@ -244,13 +246,18 @@ func (r *Runner) Run(ctx context.Context) error {
 		var checks []serviceConflictCheck
 
 		for _, svc := range r.Services {
-			if len(svc.Entries) > 0 {
-				checks = append(checks, serviceConflictCheck{
-					serviceName: svc.Strategy.ServiceName(),
-					entries:     svc.Entries,
-					resolve:     svc.strategyForNamespace,
-				})
+			// Include a service if it has staged entries OR staged tags, so a
+			// tags-only service is still conflict-checked before apply.
+			if len(svc.Entries) == 0 && len(svc.Tags) == 0 {
+				continue
 			}
+
+			checks = append(checks, serviceConflictCheck{
+				serviceName: svc.Strategy.ServiceName(),
+				entries:     svc.Entries,
+				tags:        svc.Tags,
+				resolve:     svc.strategyForNamespace,
+			})
 		}
 
 		allConflicts := r.checkAllConflicts(ctx, checks)
@@ -392,15 +399,21 @@ func formatTagApplySummary(tagEntry staging.TagEntry) string {
 	return " [" + strings.Join(parts, ", ") + "]"
 }
 
-// checkAllConflicts checks all services for conflicts and returns them qualified
-// by service, in a stable (service order, then sorted key) order. Two services
-// with a conflict on the same (name, namespace) yield two distinct items.
+// checkAllConflicts checks all services for both value and tag conflicts and
+// returns them qualified by service, in a stable (service order, then sorted key)
+// order. Two services with a conflict on the same (name, namespace) yield two
+// distinct items; within one service a key that conflicts on both its value and
+// its tags is reported once.
 func (r *Runner) checkAllConflicts(ctx context.Context, checks []serviceConflictCheck) []conflictItem {
 	var all []conflictItem
 
 	for _, check := range checks {
-		conflicts := staging.CheckConflicts(ctx, check.resolve, check.entries)
-		for _, key := range staging.SortedEntryKeys(conflicts) {
+		merged := make(map[staging.EntryKey]struct{})
+
+		maps.Copy(merged, staging.CheckConflicts(ctx, check.resolve, check.entries))
+		maps.Copy(merged, staging.CheckTagConflicts(ctx, check.resolve, check.tags))
+
+		for _, key := range staging.SortedEntryKeys(merged) {
 			all = append(all, conflictItem{serviceName: check.serviceName, key: key})
 		}
 	}

--- a/internal/cli/commands/stage/apply/apply_test.go
+++ b/internal/cli/commands/stage/apply/apply_test.go
@@ -762,6 +762,51 @@ func TestRun_ConflictDetection_BothServices(t *testing.T) {
 	assert.Contains(t, errBuf.String(), "conflict detected for my-secret")
 }
 
+func TestRun_ConflictDetection_TagConflict(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+
+	baseTime := time.Now().Add(-1 * time.Hour)
+
+	// Stage a tags-only change (no value entry) with a BaseModifiedAt.
+	_ = store.StageTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"}, staging.TagEntry{
+		Add:            map[string]string{"env": "prod"},
+		StagedAt:       time.Now(),
+		BaseModifiedAt: &baseTime,
+	})
+
+	applyTagsCalled := false
+	paramMock := newParamStrategy()
+	// Remote was modified after BaseModifiedAt (conflict).
+	paramMock.fetchLastModifiedVal = time.Now()
+	paramMock.applyTagsFunc = func(_ context.Context, _ string, _ staging.TagEntry) error {
+		applyTagsCalled = true
+
+		return nil
+	}
+
+	var buf, errBuf bytes.Buffer
+
+	r := &apply.Runner{
+		Services:        []apply.ServiceApply{paramApply(paramMock, store)},
+		ProviderLabel:   "AWS",
+		Stdout:          &buf,
+		Stderr:          &errBuf,
+		IgnoreConflicts: false,
+	}
+
+	err := r.Run(t.Context())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflict(s) detected")
+	assert.Contains(t, errBuf.String(), "conflict detected for /app/config")
+	assert.False(t, applyTagsCalled, "ApplyTags must not be called when a tag conflict is detected")
+
+	// Tag must remain staged (apply rejected).
+	_, err = store.GetTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
+	require.NoError(t, err)
+}
+
 func TestRun_ApplyCreate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The global `suve stage apply` (AWS and Azure, both backed by `apply.Runner`) only ran value-conflict detection, so staged tag changes were pushed even when the remote was modified out-of-band after staging — a silent lost update. Tags-only services were also excluded from checking entirely by the `len(svc.Entries) > 0` gate.

## Changes
- Call `staging.CheckTagConflicts` per service alongside `CheckConflicts` in `checkAllConflicts`, merging both key sets before rejecting (unless `--ignore-conflicts`). `internal/staging/conflict.go` is unchanged.
- Include a service in conflict checking if it has staged entries **or** tags, so tags-only services are no longer skipped.
- A key that conflicts on both its value and its tags within one service is reported once.
- Regression test: a Runner-path tag conflict is rejected and `ApplyTags` is never called.

Closes #521.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwohz3bcExASTpHgiV2dHt