### PR TITLE
fix(staging): field-union tag deltas on import --merge

### DIFF
--- a/internal/staging/stage.go
+++ b/internal/staging/stage.go
@@ -335,8 +335,80 @@ func (s *State) Merge(other *State) {
 			s.Tags[svc] = make(map[EntryKey]TagEntry)
 		}
 
-		maps.Copy(s.Tags[svc], tags)
+		for key, incoming := range tags {
+			if existing, ok := s.Tags[svc][key]; ok {
+				s.Tags[svc][key] = mergeTagEntry(existing, incoming)
+			} else {
+				s.Tags[svc][key] = incoming
+			}
+		}
 	}
+}
+
+// mergeTagEntry field-unions two staged tag deltas for the same key instead of
+// replacing base wholesale. Value entries are complete snapshots and stay
+// wholesale-replaced, but tag deltas are partial edits, so replacing base
+// wholesale silently drops the base side's pending Add/Remove. The incoming
+// (envelope) side wins per tag-key: its Add value overrides, and an
+// Add-vs-Remove clash on the same tag-key resolves to whichever side incoming
+// chose. Tag-keys only present in base are preserved (union). Non-tag fields
+// (StagedAt, BaseModifiedAt) follow the winning envelope.
+func mergeTagEntry(base, incoming TagEntry) TagEntry {
+	tagKeys := maputil.NewSet[string]()
+	for k := range base.Add {
+		tagKeys.Add(k)
+	}
+
+	for k := range incoming.Add {
+		tagKeys.Add(k)
+	}
+
+	for k := range base.Remove {
+		tagKeys.Add(k)
+	}
+
+	for k := range incoming.Remove {
+		tagKeys.Add(k)
+	}
+
+	add := make(map[string]string)
+	remove := make(maputil.Set[string])
+
+	for k := range tagKeys {
+		switch {
+		case hasKey(incoming.Add, k):
+			add[k] = incoming.Add[k]
+		case incoming.Remove.Contains(k):
+			remove.Add(k)
+		case hasKey(base.Add, k):
+			add[k] = base.Add[k]
+		case base.Remove.Contains(k):
+			remove.Add(k)
+		}
+	}
+
+	merged := incoming
+
+	if len(add) == 0 {
+		add = nil
+	}
+
+	if len(remove) == 0 {
+		remove = nil
+	}
+
+	merged.Add = add
+	merged.Remove = remove
+
+	return merged
+}
+
+// hasKey reports whether m contains key, distinguishing an explicit empty-string
+// tag value from an absent tag-key.
+func hasKey(m map[string]string, key string) bool {
+	_, ok := m[key]
+
+	return ok
 }
 
 // NewEmptyState creates a new empty state with initialized maps.

--- a/internal/staging/stage_test.go
+++ b/internal/staging/stage_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mpyw/suve/internal/maputil"
 	"github.com/mpyw/suve/internal/staging"
 )
 
@@ -184,6 +185,68 @@ func TestState_Merge(t *testing.T) {
 
 		assert.NotNil(t, state1.Entries[staging.ServiceParam])
 		assert.Len(t, state1.Entries[staging.ServiceParam], 1)
+	})
+
+	t.Run("merge unions tag deltas for the same key", func(t *testing.T) {
+		t.Parallel()
+
+		key := staging.EntryKey{Name: "/app/config"}
+
+		working := staging.NewEmptyState()
+		working.Tags[staging.ServiceParam][key] = staging.TagEntry{
+			Add:      map[string]string{"env": "prod"},
+			Remove:   maputil.NewSet("old"),
+			StagedAt: time.Now(),
+		}
+
+		envelope := staging.NewEmptyState()
+		envelope.Tags[staging.ServiceParam][key] = staging.TagEntry{
+			Add:      map[string]string{"team": "foo"},
+			StagedAt: time.Now(),
+		}
+
+		working.Merge(envelope)
+
+		merged := working.Tags[staging.ServiceParam][key]
+		assert.Equal(t, "prod", merged.Add["env"])
+		assert.Equal(t, "foo", merged.Add["team"])
+		assert.True(t, merged.Remove.Contains("old"))
+	})
+
+	t.Run("merge lets envelope win per tag-key and on add-vs-remove clash", func(t *testing.T) {
+		t.Parallel()
+
+		key := staging.EntryKey{Name: "/app/config"}
+
+		working := staging.NewEmptyState()
+		working.Tags[staging.ServiceParam][key] = staging.TagEntry{
+			// env:    same tag-key Add in both -> envelope value wins.
+			// keep:   working Add, envelope silent -> preserved.
+			// revive: working Remove, envelope Add -> envelope Add wins.
+			// gone:   working Remove, envelope silent -> preserved.
+			// drop:   working Add, envelope Remove -> envelope Remove wins.
+			Add:      map[string]string{"env": "stage", "keep": "yes", "drop": "no"},
+			Remove:   maputil.NewSet("gone", "revive"),
+			StagedAt: time.Now(),
+		}
+
+		envelope := staging.NewEmptyState()
+		envelope.Tags[staging.ServiceParam][key] = staging.TagEntry{
+			Add:      map[string]string{"env": "prod", "revive": "back"},
+			Remove:   maputil.NewSet("drop"),
+			StagedAt: time.Now(),
+		}
+
+		working.Merge(envelope)
+
+		merged := working.Tags[staging.ServiceParam][key]
+		assert.Equal(t, "prod", merged.Add["env"])     // envelope wins same tag-key
+		assert.Equal(t, "yes", merged.Add["keep"])     // working-only preserved
+		assert.Equal(t, "back", merged.Add["revive"])  // envelope Add beats working Remove
+		assert.True(t, merged.Remove.Contains("gone")) // working-only remove preserved
+		assert.True(t, merged.Remove.Contains("drop")) // envelope Remove beats working Add
+		assert.NotContains(t, merged.Add, "drop")
+		assert.NotContains(t, merged.Remove, "revive")
 	})
 }
 


### PR DESCRIPTION
import --merge replaced staged tag deltas wholesale, silently dropping the working side's pending Add/Remove for a key that also appears in the envelope.

State.Merge now field-unions TagEntry per tag-key:
- Add is unioned; the envelope wins on the same tag-key.
- Remove is unioned.
- An Add-vs-Remove clash on the same tag-key resolves to whichever side the envelope chose (import content wins).
- Value entries remain wholesale-replaced since they are complete snapshots.

Regression tests cover the union and the clash resolution.

Closes #548.