### PR TITLE
fix(staging): parse name up front in stage edit

### DIFF
--- a/internal/usecase/staging/edit.go
+++ b/internal/usecase/staging/edit.go
@@ -44,10 +44,18 @@ func (u *EditUseCase) Execute(ctx context.Context, input EditInput) (*EditOutput
 		return nil, ErrValueNotUTF8
 	}
 
+	// Parse and validate name up front (like add/tag); rejects version
+	// specifiers so they surface a clear error instead of a misleading
+	// "resource not found".
+	name, err := u.Strategy.ParseName(input.Key.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	// Check staged state first to avoid unnecessary AWS fetch
 	var stagedEntry *staging.Entry
 
-	key := input.Key
+	key := staging.EntryKey{Name: name, Namespace: input.Key.Namespace}
 
 	entry, err := u.Store.GetEntry(ctx, service, key)
 	if err != nil && !errors.Is(err, staging.ErrNotStaged) {

--- a/internal/usecase/staging/edit_test.go
+++ b/internal/usecase/staging/edit_test.go
@@ -93,6 +93,26 @@ func TestEditUseCase_Execute_RejectsNonUTF8Value(t *testing.T) {
 	assert.ErrorIs(t, err, staging.ErrNotStaged)
 }
 
+func TestEditUseCase_Execute_ParseError(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	strategy := newMockEditStrategy()
+	strategy.parseErr = errors.New("invalid name")
+
+	uc := &usecasestaging.EditUseCase{
+		Strategy: strategy,
+		Store:    store,
+	}
+
+	_, err := uc.Execute(t.Context(), usecasestaging.EditInput{
+		Key:   staging.EntryKey{Name: "/app/config@1"},
+		Value: "value",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid name")
+}
+
 func TestEditUseCase_Execute_PreservesBaseModifiedAt(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Call `Strategy.ParseName(input.Key.Name)` at the start of `EditUseCase.Execute` (mirroring add/tag) and build the entry key from the normalized name.

Previously `stage edit` skipped `ParseName`, so a version specifier was passed through and dead-ended as a misleading "resource not found". It now fails validation with a clear error.

Closes #551.