### PR TITLE
fix(usecase/staging): sort apply results deterministically

### DIFF
--- a/internal/usecase/staging/apply.go
+++ b/internal/usecase/staging/apply.go
@@ -3,6 +3,8 @@ package staging
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 
 	"github.com/mpyw/suve/internal/maputil"
 	"github.com/mpyw/suve/internal/parallel"
@@ -236,6 +238,17 @@ func (u *ApplyUseCase) applyEntries(ctx context.Context, service staging.Service
 
 		output.EntryResults = append(output.EntryResults, resultEntry)
 	}
+
+	// Results are collected in map iteration order, which is nondeterministic;
+	// sort by (Namespace, Name) so every consumer (including the GUI) renders a
+	// stable order that matches the CLI presenters.
+	slices.SortFunc(output.EntryResults, func(a, b ApplyEntryResult) int {
+		if c := strings.Compare(a.Namespace, b.Namespace); c != 0 {
+			return c
+		}
+
+		return strings.Compare(a.Name, b.Name)
+	})
 }
 
 func (u *ApplyUseCase) applyTags(ctx context.Context, service staging.Service, tags map[staging.EntryKey]staging.TagEntry, output *ApplyOutput) {
@@ -275,4 +288,14 @@ func (u *ApplyUseCase) applyTags(ctx context.Context, service staging.Service, t
 
 		output.TagResults = append(output.TagResults, resultTag)
 	}
+
+	// Sort by (Namespace, Name) for a stable order across consumers (see
+	// applyEntries).
+	slices.SortFunc(output.TagResults, func(a, b ApplyTagResult) int {
+		if c := strings.Compare(a.Namespace, b.Namespace); c != 0 {
+			return c
+		}
+
+		return strings.Compare(a.Name, b.Name)
+	})
 }

--- a/internal/usecase/staging/apply_test.go
+++ b/internal/usecase/staging/apply_test.go
@@ -135,6 +135,51 @@ func TestApplyUseCase_Execute_MultipleOperations(t *testing.T) {
 	assert.Equal(t, 0, output.EntryFailed)
 }
 
+func TestApplyUseCase_Execute_ResultsSorted(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	// Stage in non-sorted name order; results must come back sorted regardless.
+	for _, name := range []string{"/app/charlie", "/app/alpha", "/app/bravo"} {
+		require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: name}, staging.Entry{
+			Operation: staging.OperationUpdate,
+			Value:     lo.ToPtr("v"),
+			StagedAt:  time.Now(),
+		}))
+	}
+
+	for _, name := range []string{"/tag/zulu", "/tag/mike", "/tag/delta"} {
+		require.NoError(t, store.StageTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: name}, staging.TagEntry{
+			Add:      map[string]string{"env": "prod"},
+			StagedAt: time.Now(),
+		}))
+	}
+
+	uc := &usecasestaging.ApplyUseCase{
+		Strategy: newMockApplyStrategy(),
+		Store:    store,
+	}
+
+	output, err := uc.Execute(t.Context(), usecasestaging.ApplyInput{
+		IgnoreConflicts: true,
+	})
+	require.NoError(t, err)
+
+	entryNames := make([]string, len(output.EntryResults))
+	for i, r := range output.EntryResults {
+		entryNames[i] = r.Name
+	}
+
+	assert.Equal(t, []string{"/app/alpha", "/app/bravo", "/app/charlie"}, entryNames)
+
+	tagNames := make([]string, len(output.TagResults))
+	for i, r := range output.TagResults {
+		tagNames[i] = r.Name
+	}
+
+	assert.Equal(t, []string{"/tag/delta", "/tag/mike", "/tag/zulu"}, tagNames)
+}
+
 func TestApplyUseCase_Execute_FilterByName(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
`ApplyUseCase` collected per-entry and per-tag results by ranging over Go maps, so the GUI's Apply Results rows rendered in an unstable order on every run — a drift from the CLI presenter and global Runner, which both re-sort before printing.

## Changes
- Sort `EntryResults` and `TagResults` by (Namespace, Name) inside `ApplyUseCase` so all consumers (including the GUI) get a stable order.
- Regression test asserting sorted output from unsorted staged input.

Closes #554.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwohz3bcExASTpHgiV2dHt