### PR TITLE
fix(staging): guard plaintext fallback against existing encrypted state

### DIFF
--- a/internal/staging/store/file/internal/keyprovider/keyprovider.go
+++ b/internal/staging/store/file/internal/keyprovider/keyprovider.go
@@ -67,6 +67,13 @@ var (
 var ErrKeychainKeyNotFound = errors.New(
 	"no staging data key found in the OS keychain (it may have been deleted or reset)")
 
+// ErrNoKeyAvailable signals that no staging encryption key is available on this
+// platform: SUVE_STAGING_KEY is unset and the platform has no keyring backend,
+// so the store would fall back to plaintext. It is the cause reported when that
+// fallback collides with existing encrypted working state.
+var ErrNoKeyAvailable = errors.New(
+	"no staging encryption key is available on this platform; set SUVE_STAGING_KEY")
+
 // KeychainUnavailableError wraps a hard OS-keychain failure — a locked
 // keychain, an unreachable dbus, a corrupted stored key, or a failed store.
 //

--- a/internal/staging/store/file/store.go
+++ b/internal/staging/store/file/store.go
@@ -173,6 +173,19 @@ func NewWorkingStore(scope provider.Scope) (*Store, error) {
 	}
 
 	if plaintext {
+		// No key is available on this platform. Falling back to plaintext is only
+		// safe when no encrypted state exists yet; otherwise reading that state
+		// needs a key, so hard-fail with the real cause instead of silently
+		// degrading (mirrors the keychain-unavailable and lost-key branches above).
+		guardErr, checkErr := s.guardKeyLossWithEncryptedState(keyprovider.ErrNoKeyAvailable)
+		if checkErr != nil {
+			return nil, checkErr
+		}
+
+		if guardErr != nil {
+			return nil, guardErr
+		}
+
 		warnPlaintextOnce(nil)
 
 		return s, nil

--- a/internal/staging/store/file/store_key_internal_test.go
+++ b/internal/staging/store/file/store_key_internal_test.go
@@ -145,6 +145,48 @@ func TestNewWorkingStore_PlaintextFallback(t *testing.T) {
 	assert.Nil(t, s.key)
 }
 
+// TestNewWorkingStore_Plaintext_EncryptedStateExists_Fatal guards #523: when no
+// key is available on this platform (plaintext fallback) but encrypted state
+// already exists, the constructor must hard-fail like the keychain-unavailable
+// and lost-key branches instead of silently degrading to plaintext.
+//
+//nolint:paralleltest // overrides package-level resolveKeyFunc.
+func TestNewWorkingStore_Plaintext_EncryptedStateExists_Fatal(t *testing.T) {
+	origResolve := resolveKeyFunc
+	origHome := userHomeDirFunc
+
+	defer func() {
+		resolveKeyFunc = origResolve
+		userHomeDirFunc = origHome
+	}()
+
+	home := t.TempDir()
+	userHomeDirFunc = func() (string, error) { return home, nil }
+
+	scope := provider.AWSScope("123456789012", "ap-northeast-1")
+
+	// Seed an ENCRYPTED param.json under the scope directory.
+	seed, err := NewStore(scope)
+	require.NoError(t, err)
+
+	seed.key = newTestKey()
+
+	state := staging.NewEmptyState()
+	state.Entries[staging.ServiceParam][staging.EntryKey{Name: "/app/secret"}] = staging.Entry{
+		Operation: staging.OperationCreate,
+		Value:     lo.ToPtr("v"),
+	}
+	require.NoError(t, seed.WriteState(t.Context(), "", state))
+
+	resolveKeyFunc = func() ([]byte, bool, bool, error) { return nil, true, false, nil }
+
+	s, err := NewWorkingStore(scope)
+	require.Error(t, err)
+	assert.Nil(t, s)
+	assert.Contains(t, err.Error(), "encrypted state exists")
+	assert.ErrorIs(t, err, keyprovider.ErrNoKeyAvailable)
+}
+
 // TestNewWorkingStore_ResolveError verifies a provider error propagates.
 //
 //nolint:paralleltest // overrides package-level resolveKeyFunc.


### PR DESCRIPTION
The plaintext-fallback branch of `NewWorkingStore` (when no `SUVE_STAGING_KEY` and no OS keyring backend are available) returned a plaintext store unconditionally, bypassing the encrypted-state guard that the sibling keychain-unavailable and lost-key branches apply. If encrypted working state already existed on disk, the tool would silently operate in plaintext and fail later with a misleading decryption error.

This branch now calls `guardKeyLossWithEncryptedState` too: it hard-fails with the real cause (`keyprovider.ErrNoKeyAvailable`) when encrypted state exists, and only warns/continues when it does not.

Closes #523.