### PR TITLE
fix(staging): fetch each remote once in conflict pre-check

### DIFF
--- a/internal/staging/conflict.go
+++ b/internal/staging/conflict.go
@@ -2,7 +2,6 @@ package staging
 
 import (
 	"context"
-	"maps"
 	"time"
 
 	"github.com/mpyw/suve/internal/parallel"
@@ -13,6 +12,10 @@ import (
 // provider (Azure App Configuration) probes each entry against the remote state
 // of its OWN namespace rather than the default one.
 type ApplyStrategyResolver func(namespace string) (ApplyStrategy, error)
+
+// lastModifiedResults maps each probed EntryKey to its fetched last-modified
+// time (or the fetch error).
+type lastModifiedResults = map[EntryKey]*parallel.Result[time.Time]
 
 // CheckConflicts checks if remote resources were modified after staging.
 // Returns the set of EntryKeys that have conflicts.
@@ -26,84 +29,7 @@ type ApplyStrategyResolver func(namespace string) (ApplyStrategy, error)
 // For Create operations: conflicts if resource now exists (someone else created it).
 // For Update/Delete operations with BaseModifiedAt: conflicts if the remote was modified after base.
 func CheckConflicts(ctx context.Context, resolve ApplyStrategyResolver, entries map[EntryKey]Entry) map[EntryKey]struct{} {
-	conflicts := make(map[EntryKey]struct{})
-
-	// Separate entries by check type:
-	// - Create: check if resource now exists (someone else created it)
-	// - Update/Delete with BaseModifiedAt: check if modified after base
-	toCheckCreate := make(map[EntryKey]Entry)
-	toCheckModified := make(map[EntryKey]Entry)
-
-	for key, entry := range entries {
-		switch {
-		case entry.Operation == OperationCreate:
-			toCheckCreate[key] = entry
-		case (entry.Operation == OperationUpdate || entry.Operation == OperationDelete) && entry.BaseModifiedAt != nil:
-			toCheckModified[key] = entry
-		}
-	}
-
-	if len(toCheckCreate) == 0 && len(toCheckModified) == 0 {
-		return conflicts
-	}
-
-	// Combine all entries for parallel fetch
-	allToCheck := make(map[EntryKey]Entry)
-
-	maps.Copy(allToCheck, toCheckCreate)
-	maps.Copy(allToCheck, toCheckModified)
-
-	// Fetch last modified times in parallel. Resolve the strategy per entry so the
-	// probe targets the entry's own namespace (App Configuration); other providers
-	// resolve the same single strategy under the empty namespace.
-	results := parallel.ExecuteMap(ctx, allToCheck, func(ctx context.Context, key EntryKey, _ Entry) (time.Time, error) {
-		strategy, err := resolve(key.Namespace)
-		if err != nil {
-			return time.Time{}, err
-		}
-
-		return strategy.FetchLastModified(ctx, key.Name)
-	})
-
-	// Check for conflicts - Create operations
-	for key := range toCheckCreate {
-		result := results[key]
-		if result.Err != nil {
-			// If we can't fetch, assume no conflict (will fail on apply anyway)
-			continue
-		}
-
-		// For Create: if resource now exists (non-zero time), someone else created it
-		if !result.Value.IsZero() {
-			conflicts[key] = struct{}{}
-		}
-	}
-
-	// Check for conflicts - Update/Delete operations
-	for key, entry := range toCheckModified {
-		result := results[key]
-		if result.Err != nil {
-			// If we can't fetch, assume no conflict (will fail on apply anyway)
-			continue
-		}
-
-		awsModified := result.Value
-
-		// Zero time means resource doesn't exist - no conflict for delete (already gone)
-		if awsModified.IsZero() {
-			continue
-		}
-
-		// If AWS was modified after the base value was fetched, it's a conflict.
-		// Strict After: on second-granular providers (e.g. Azure Key Vault) an
-		// out-of-band write in the same wall-clock second compares as equal and
-		// escapes detection. See docs/staging-state-transitions.md.
-		if awsModified.After(*entry.BaseModifiedAt) {
-			conflicts[key] = struct{}{}
-		}
-	}
-
-	return conflicts
+	return CheckEntryAndTagConflicts(ctx, resolve, entries, nil)
 }
 
 // CheckTagConflicts checks if the remote resource behind each staged tag change
@@ -121,8 +47,79 @@ func CheckConflicts(ctx context.Context, resolve ApplyStrategyResolver, entries 
 // A remote that no longer exists (zero time) is skipped too — the tag apply will
 // fail on its own.
 func CheckTagConflicts(ctx context.Context, resolve ApplyStrategyResolver, tags map[EntryKey]TagEntry) map[EntryKey]struct{} {
+	return CheckEntryAndTagConflicts(ctx, resolve, nil, tags)
+}
+
+// CheckEntryAndTagConflicts checks both staged value changes and staged tag
+// changes for conflicts and returns the merged set of conflicting EntryKeys.
+//
+// It fetches each remote's last-modified time at most once, even when the same
+// key carries both a value change and a tag change: the two probes previously
+// double-fetched the same remote, wasting I/O and widening the window in which
+// the two timestamps could disagree on second-granular providers. The value and
+// tag comparisons now share that single fetch.
+func CheckEntryAndTagConflicts(
+	ctx context.Context,
+	resolve ApplyStrategyResolver,
+	entries map[EntryKey]Entry,
+	tags map[EntryKey]TagEntry,
+) map[EntryKey]struct{} {
 	conflicts := make(map[EntryKey]struct{})
 
+	toCheckCreate, toCheckModified := classifyEntries(entries)
+	toCheckTags := tagsWithBase(tags)
+
+	if len(toCheckCreate) == 0 && len(toCheckModified) == 0 && len(toCheckTags) == 0 {
+		return conflicts
+	}
+
+	// Merge the key sets so each remote is fetched exactly once, then share the
+	// results across the create, modified and tag comparisons below.
+	keys := make(map[EntryKey]struct{}, len(toCheckCreate)+len(toCheckModified)+len(toCheckTags))
+	addKeys(keys, toCheckCreate)
+	addKeys(keys, toCheckModified)
+	addKeys(keys, toCheckTags)
+
+	results := fetchLastModified(ctx, resolve, keys)
+
+	// Create: conflict if the resource now exists (someone else created it).
+	for key := range toCheckCreate {
+		result := results[key]
+		if result.Err == nil && !result.Value.IsZero() {
+			conflicts[key] = struct{}{}
+		}
+	}
+
+	// Update/Delete and tag changes: conflict if the remote was modified after
+	// the staged base time.
+	markModifiedAfterBase(toCheckModified, func(e Entry) time.Time { return *e.BaseModifiedAt }, results, conflicts)
+	markModifiedAfterBase(toCheckTags, func(t TagEntry) time.Time { return *t.BaseModifiedAt }, results, conflicts)
+
+	return conflicts
+}
+
+// classifyEntries splits entries into those checked for a Create conflict (the
+// resource now exists) and those checked for a modified-after-base conflict.
+// Entries without a check type (Update/Delete lacking BaseModifiedAt) are dropped.
+func classifyEntries(entries map[EntryKey]Entry) (create, modified map[EntryKey]Entry) {
+	create = make(map[EntryKey]Entry)
+	modified = make(map[EntryKey]Entry)
+
+	for key, entry := range entries {
+		switch {
+		case entry.Operation == OperationCreate:
+			create[key] = entry
+		case (entry.Operation == OperationUpdate || entry.Operation == OperationDelete) && entry.BaseModifiedAt != nil:
+			modified[key] = entry
+		}
+	}
+
+	return create, modified
+}
+
+// tagsWithBase returns the tag changes that carry a BaseModifiedAt and can
+// therefore be conflict-checked; the rest are never conflicts.
+func tagsWithBase(tags map[EntryKey]TagEntry) map[EntryKey]TagEntry {
 	toCheck := make(map[EntryKey]TagEntry)
 
 	for key, tag := range tags {
@@ -131,13 +128,21 @@ func CheckTagConflicts(ctx context.Context, resolve ApplyStrategyResolver, tags 
 		}
 	}
 
-	if len(toCheck) == 0 {
-		return conflicts
-	}
+	return toCheck
+}
 
-	// Fetch last modified times in parallel, resolving the strategy per entry so
-	// the probe targets the tagged item's own namespace.
-	results := parallel.ExecuteMap(ctx, toCheck, func(ctx context.Context, key EntryKey, _ TagEntry) (time.Time, error) {
+// addKeys copies the keys of src into dst.
+func addKeys[V any](dst map[EntryKey]struct{}, src map[EntryKey]V) {
+	for key := range src {
+		dst[key] = struct{}{}
+	}
+}
+
+// fetchLastModified fetches each key's remote last-modified time in parallel,
+// resolving the strategy for the key's own namespace so a namespaced provider
+// probes each entry against the right remote.
+func fetchLastModified(ctx context.Context, resolve ApplyStrategyResolver, keys map[EntryKey]struct{}) lastModifiedResults {
+	return parallel.ExecuteMap(ctx, keys, func(ctx context.Context, key EntryKey, _ struct{}) (time.Time, error) {
 		strategy, err := resolve(key.Namespace)
 		if err != nil {
 			return time.Time{}, err
@@ -145,27 +150,30 @@ func CheckTagConflicts(ctx context.Context, resolve ApplyStrategyResolver, tags 
 
 		return strategy.FetchLastModified(ctx, key.Name)
 	})
+}
 
-	for key, tag := range toCheck {
+// markModifiedAfterBase adds to conflicts every key whose remote was modified
+// strictly after its staged base time. A fetch error or a zero time (the remote
+// no longer exists) is skipped — the apply will fail on its own. base extracts
+// each item's staged base time.
+//
+// Strict After: on second-granular providers (e.g. Azure Key Vault) an
+// out-of-band write in the same wall-clock second compares as equal and escapes
+// detection. See docs/staging-state-transitions.md.
+func markModifiedAfterBase[V any](
+	items map[EntryKey]V,
+	base func(V) time.Time,
+	results lastModifiedResults,
+	conflicts map[EntryKey]struct{},
+) {
+	for key, item := range items {
 		result := results[key]
-		if result.Err != nil {
-			// If we can't fetch, assume no conflict (will fail on apply anyway)
+		if result.Err != nil || result.Value.IsZero() {
 			continue
 		}
 
-		awsModified := result.Value
-
-		// Zero time means the resource no longer exists - the tag apply will fail
-		// on its own, so don't report it as a conflict here.
-		if awsModified.IsZero() {
-			continue
-		}
-
-		// If the remote was modified after the tags were fetched, it's a conflict.
-		if awsModified.After(*tag.BaseModifiedAt) {
+		if result.Value.After(base(item)) {
 			conflicts[key] = struct{}{}
 		}
 	}
-
-	return conflicts
 }

--- a/internal/staging/conflict_test.go
+++ b/internal/staging/conflict_test.go
@@ -384,6 +384,51 @@ func TestCheckTagConflicts(t *testing.T) {
 	})
 }
 
+// TestCheckEntryAndTagConflicts_SingleFetch is a regression for #555: when a key
+// carries both a staged value change and a staged tag change, the remote's
+// last-modified time must be fetched only once and shared between the two
+// comparisons, not fetched separately for each.
+func TestCheckEntryAndTagConflicts_SingleFetch(t *testing.T) {
+	t.Parallel()
+
+	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	laterTime := time.Date(2024, 1, 1, 13, 0, 0, 0, time.UTC)
+
+	var (
+		mu     sync.Mutex
+		counts = map[string]int{}
+	)
+
+	strategy := &mockApplyStrategy{
+		fetchLastModifiedFunc: func(_ context.Context, name string) (time.Time, error) {
+			mu.Lock()
+			counts[name]++
+			mu.Unlock()
+
+			return laterTime, nil // modified after base -> conflict
+		},
+	}
+
+	entries := map[staging.EntryKey]staging.Entry{
+		{Name: "item"}: {Operation: staging.OperationUpdate, Value: lo.ToPtr("v"), BaseModifiedAt: &baseTime},
+	}
+	tags := map[staging.EntryKey]staging.TagEntry{
+		{Name: "item"}: {Add: map[string]string{"env": "prod"}, BaseModifiedAt: &baseTime},
+	}
+
+	conflicts := staging.CheckEntryAndTagConflicts(t.Context(), resolverFor(strategy), entries, tags)
+
+	// The key is reported once despite conflicting on both its value and its tags.
+	assert.Len(t, conflicts, 1)
+	assert.Contains(t, conflicts, staging.EntryKey{Name: "item"})
+
+	// The shared remote was fetched exactly once, not once per check.
+	mu.Lock()
+	defer mu.Unlock()
+
+	assert.Equal(t, 1, counts["item"])
+}
+
 // TestCheckConflicts_ResolverError verifies that a per-namespace resolver which
 // fails to resolve a strategy is treated like a fetch error: the entry is
 // skipped (no conflict) and the failure surfaces later on the apply attempt.

--- a/internal/usecase/staging/apply.go
+++ b/internal/usecase/staging/apply.go
@@ -153,13 +153,10 @@ func (u *ApplyUseCase) Execute(ctx context.Context, input ApplyInput) (*ApplyOut
 
 	// Check for conflicts. Both value entries and tag changes carry a
 	// BaseModifiedAt; a remote modified after that base time is a conflict for
-	// either kind. Merge both sets so a resource staged with both a value change
-	// and a tag change is reported once.
+	// either kind. The merged check fetches each remote once — even when a key
+	// has both a value and a tag change — and reports that key once.
 	if !input.IgnoreConflicts {
-		conflicts := staging.CheckConflicts(ctx, u.strategyForNamespace, entries)
-		for key := range staging.CheckTagConflicts(ctx, u.strategyForNamespace, tags) {
-			conflicts[key] = struct{}{}
-		}
+		conflicts := staging.CheckEntryAndTagConflicts(ctx, u.strategyForNamespace, entries, tags)
 
 		if len(conflicts) > 0 {
 			// Report the full EntryKey (sorted for determinism) so callers can


### PR DESCRIPTION
When a resource had both a staged value change and a staged tag change, `ApplyUseCase` fetched the remote's `LastModified` twice for the same key — once in `CheckConflicts`, once in `CheckTagConflicts`. Redundant network I/O, plus a slightly wider window in which the two probes could disagree on second-granular providers.

## Changes
- Add `staging.CheckEntryAndTagConflicts`, which merges the entry and tag key sets, fetches each remote once, and shares the timestamp between the value and tag comparisons.
- Refactor `CheckConflicts` / `CheckTagConflicts` to delegate to it via shared helpers (classify / fetch / mark), removing the duplicated fetch-and-evaluate logic.
- `ApplyUseCase.Execute` now calls the merged check.
- Regression test asserting a single fetch for a key that conflicts on both its value and its tags.

Closes #555.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwohz3bcExASTpHgiV2dHt