### PR TITLE
fix(param): color the version in log --oneline

### DIFF
--- a/internal/cli/commands/param/log.go
+++ b/internal/cli/commands/param/log.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 	"unicode"
 
@@ -112,9 +113,8 @@ func (p *logPresenter) RenderOneline(stdout io.Writer, i, maxValueLength int) {
 		currentMark = colors.For(stdout).Current(" (current)")
 	}
 
-	output.Printf(stdout, "%s%d%s  %s  %s\n",
-		colors.For(stdout).Version(""),
-		entry.Version,
+	output.Printf(stdout, "%s%s  %s  %s\n",
+		colors.For(stdout).Version(strconv.FormatInt(entry.Version, 10)),
 		currentMark,
 		colors.For(stdout).FieldLabel(dateStr),
 		value,

--- a/internal/cli/commands/param/log_internal_test.go
+++ b/internal/cli/commands/param/log_internal_test.go
@@ -2,6 +2,7 @@ package param
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 	"time"
 	"unicode/utf8"
@@ -67,6 +68,9 @@ func TestRenderOnelineDateHonorsTZ(t *testing.T) {
 
 	assert.Contains(t, buf.String(), "2024-01-16")
 	assert.NotContains(t, buf.String(), "2024-01-15")
+	// The version number leads the line (no empty prefix segment, #531).
+	assert.True(t, strings.HasPrefix(buf.String(), "1"),
+		"oneline output should start with the version number, got %q", buf.String())
 }
 
 func TestSanitizeControl(t *testing.T) {


### PR DESCRIPTION
In `param log --oneline`, the version was printed via `Version("")` (an empty, colored segment) followed by an uncolored `%d`. This emitted an empty ANSI pair and left the version number itself uncolored.

Color the actual version number instead, matching `RenderHeader` and the other providers.

Closes #531.