### PR TITLE
feat(gui): carry namespace on apply-result rows

### DIFF
--- a/internal/gui/frontend/src/lib/StagingView.svelte
+++ b/internal/gui/frontend/src/lib/StagingView.svelte
@@ -669,6 +669,9 @@
             <ul class="result-list">
               {#each applyResult.entryResults as result}
                 <li class="result-item" class:failed={result.status === 'failed'}>
+                  {#if result.namespace}
+                    <span class="result-namespace">{result.namespace}</span>
+                  {/if}
                   <span class="result-name">{result.name}</span>
                   <span class="result-status" class:status-created={result.status === 'created'} class:status-updated={result.status === 'updated'} class:status-deleted={result.status === 'deleted'} class:status-failed={result.status === 'failed'}>
                     {result.status}
@@ -692,6 +695,9 @@
             <ul class="result-list">
               {#each applyResult.tagResults as result}
                 <li class="result-item" class:failed={!!result.error}>
+                  {#if result.namespace}
+                    <span class="result-namespace">{result.namespace}</span>
+                  {/if}
                   <span class="result-name">{result.name}</span>
                   <span class="result-status status-updated">tags</span>
                   {#if result.error}
@@ -1328,6 +1334,16 @@
     font-family: monospace;
     font-size: 13px;
     color: #fff;
+  }
+
+  /* App Configuration namespace badge on an apply-result row (empty otherwise). */
+  .result-namespace {
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-size: 11px;
+    background: rgba(120, 120, 120, 0.18);
+    color: #888;
+    white-space: nowrap;
   }
 
   .result-status {

--- a/internal/gui/frontend/wailsjs/go/models.ts
+++ b/internal/gui/frontend/wailsjs/go/models.ts
@@ -649,6 +649,7 @@ export namespace gui {
 	}
 	export class StagingApplyEntryResult {
 	    name: string;
+	    namespace: string;
 	    status: string;
 	    error?: string;
 	    unstageError?: string;
@@ -660,6 +661,7 @@ export namespace gui {
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.name = source["name"];
+	        this.namespace = source["namespace"];
 	        this.status = source["status"];
 	        this.error = source["error"];
 	        this.unstageError = source["unstageError"];
@@ -667,6 +669,7 @@ export namespace gui {
 	}
 	export class StagingApplyTagResult {
 	    name: string;
+	    namespace: string;
 	    addTags?: Record<string, string>;
 	    removeTags?: string[];
 	    error?: string;
@@ -679,6 +682,7 @@ export namespace gui {
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.name = source["name"];
+	        this.namespace = source["namespace"];
 	        this.addTags = source["addTags"];
 	        this.removeTags = source["removeTags"];
 	        this.error = source["error"];

--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -56,9 +56,14 @@ type StagingTagEntry struct {
 
 // StagingApplyEntryResult represents a single entry apply result.
 type StagingApplyEntryResult struct {
-	Name   string `json:"name"`
-	Status string `json:"status"`
-	Error  string `json:"error,omitempty"`
+	Name string `json:"name"`
+	// Namespace is the App Configuration namespace the entry was applied under
+	// (empty for the null/default namespace and every other provider). The
+	// frontend shows it as a badge so multi-namespace App Config results are
+	// distinguishable.
+	Namespace string `json:"namespace"`
+	Status    string `json:"status"`
+	Error     string `json:"error,omitempty"`
 	// UnstageError is set when the cloud apply succeeded but clearing the entry
 	// from the staging store afterwards failed. The entry is still staged, so a
 	// later apply would re-run it; the frontend surfaces this as a warning row.
@@ -67,7 +72,10 @@ type StagingApplyEntryResult struct {
 
 // StagingApplyTagResult represents a single tag apply result.
 type StagingApplyTagResult struct {
-	Name       string            `json:"name"`
+	Name string `json:"name"`
+	// Namespace is the App Configuration namespace the tags were applied under
+	// (empty for the null/default namespace and every other provider).
+	Namespace  string            `json:"namespace"`
 	AddTags    map[string]string `json:"addTags,omitempty"`
 	RemoveTags []string          `json:"removeTags,omitempty"`
 	Error      string            `json:"error,omitempty"`
@@ -365,8 +373,9 @@ func newStagingApplyResult(result *stagingusecase.ApplyOutput) *StagingApplyResu
 
 	for _, r := range result.EntryResults {
 		entry := StagingApplyEntryResult{
-			Name:   r.Name,
-			Status: applyStatusNames[r.Status],
+			Name:      r.Name,
+			Namespace: r.Namespace,
+			Status:    applyStatusNames[r.Status],
 		}
 		if r.Status == stagingusecase.ApplyResultFailed && r.Error != nil {
 			entry.Error = r.Error.Error()
@@ -382,6 +391,7 @@ func newStagingApplyResult(result *stagingusecase.ApplyOutput) *StagingApplyResu
 	for _, r := range result.TagResults {
 		tagResult := StagingApplyTagResult{
 			Name:       r.Name,
+			Namespace:  r.Namespace,
 			AddTags:    r.AddTags,
 			RemoveTags: r.RemoveTag.Values(),
 		}


### PR DESCRIPTION
Apply-result rows dropped the App Configuration namespace, so multi-namespace App Config results were indistinguishable by name alone.

`StagingApplyEntryResult` / `StagingApplyTagResult` now carry the namespace the entry/tag was applied under (copied from the use case output; empty for the null/default namespace and every other provider). The `models.ts` mirror is regenerated and `StagingView` renders a namespace badge on each apply result row.

Closes #559.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwohz3bcExASTpHgiV2dHt