### PR TITLE
fix(staging): error on state written by a newer suve

### DIFF
--- a/internal/staging/stage.go
+++ b/internal/staging/stage.go
@@ -217,6 +217,17 @@ func (s *State) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
+	if head.Version > stateVersion {
+		// A newer suve wrote this state in a format this build does not understand.
+		// Silently rewriting it as v3 would strip fields the newer build relies on,
+		// so refuse instead. This mirrors the envelope's two-directional version
+		// check (see file.ReadEnvelopeFile).
+		return fmt.Errorf(
+			"%w: on-disk state is version %d but this build only supports version %d",
+			ErrStateVersionTooNew, head.Version, stateVersion,
+		)
+	}
+
 	var in stateJSON
 	if err := json.Unmarshal(data, &in); err != nil {
 		return err
@@ -420,4 +431,9 @@ const (
 var (
 	// ErrNotStaged is returned when a parameter/secret is not staged.
 	ErrNotStaged = errors.New("not staged")
+	// ErrStateVersionTooNew is returned by UnmarshalJSON when the on-disk staging
+	// state was written by a newer suve than this build can read. The caller must
+	// upgrade suve; the state is left untouched rather than rewritten as an older
+	// version.
+	ErrStateVersionTooNew = errors.New("staging state was written by a newer suve; upgrade suve")
 )

--- a/internal/staging/stage_test.go
+++ b/internal/staging/stage_test.go
@@ -187,6 +187,30 @@ func TestState_Merge(t *testing.T) {
 	})
 }
 
+func TestState_UnmarshalJSON_Version(t *testing.T) {
+	t.Parallel()
+
+	t.Run("older version is dropped as empty", func(t *testing.T) {
+		t.Parallel()
+
+		var state staging.State
+
+		err := json.Unmarshal([]byte(`{"version":2}`), &state)
+		require.NoError(t, err)
+		assert.True(t, state.IsEmpty())
+	})
+
+	t.Run("newer version is an error and is not rewritten", func(t *testing.T) {
+		t.Parallel()
+
+		var state staging.State
+
+		err := json.Unmarshal([]byte(`{"version":4}`), &state)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, staging.ErrStateVersionTooNew)
+	})
+}
+
 func TestState_ExtractService(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
State.UnmarshalJSON silently downgraded a working state written by a newer suve: any version above the current stateVersion was rewritten as v3, stripping fields the newer build relies on.

It now returns ErrStateVersionTooNew when head.Version > stateVersion and leaves the file untouched, mirroring the envelope's two-directional version check. Older versions are still dropped as empty (unchanged).

Regression tests cover both the older-drop and newer-error paths.

Closes #561.