### PR TITLE
fix(staging): anchor conflict base on reset restore

### DIFF
--- a/internal/usecase/staging/reset.go
+++ b/internal/usecase/staging/reset.go
@@ -157,8 +157,9 @@ func (u *ResetUseCase) restore(ctx context.Context, spec, name, namespace string
 	// Always use the value pointer - empty string is a valid AWS value
 	currentValue := &fetchResult.Value
 
-	// Load current state with AWS value for auto-skip
-	entryState, err := transition.LoadEntryState(ctx, u.Store, service, key, currentValue)
+	// Load current state with AWS value for auto-skip, keeping any existing
+	// staged base so conflict detection is preserved across the restore.
+	entryState, existingBaseModifiedAt, err := transition.LoadEntryStateWithMetadata(ctx, u.Store, service, key, currentValue)
 	if err != nil {
 		return nil, err
 	}
@@ -166,10 +167,23 @@ func (u *ResetUseCase) restore(ctx context.Context, spec, name, namespace string
 	// Check if value matches current AWS (would be auto-skipped)
 	_, wasNotStaged := entryState.StagedState.(transition.EntryStagedStateNotStaged)
 
+	// Anchor the conflict base: reuse an existing staged base when present,
+	// otherwise fall back to the current AWS LastModified (zero-time → nil),
+	// mirroring the edit use case.
+	baseModifiedAt := existingBaseModifiedAt
+	if baseModifiedAt == nil && !fetchResult.LastModified.IsZero() {
+		lastModified := fetchResult.LastModified
+		baseModifiedAt = &lastModified
+	}
+
+	opts := &transition.EntryExecuteOptions{
+		BaseModifiedAt: baseModifiedAt,
+	}
+
 	// Execute the edit transition with the restored value
 	executor := transition.NewExecutor(u.Store)
 
-	result, err := executor.ExecuteEntry(ctx, service, key, entryState, transition.EntryActionEdit{Value: value}, nil)
+	result, err := executor.ExecuteEntry(ctx, service, key, entryState, transition.EntryActionEdit{Value: value}, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usecase/staging/reset_test.go
+++ b/internal/usecase/staging/reset_test.go
@@ -24,6 +24,7 @@ type mockResetStrategy struct {
 	versionLabel      string
 	fetchErr          error
 	currentValue      string
+	currentModified   time.Time
 	fetchCurrentError error
 }
 
@@ -40,7 +41,7 @@ func (m *mockResetStrategy) FetchCurrentValue(_ context.Context, _ string) (*sta
 		return nil, m.fetchCurrentError
 	}
 
-	return &staging.EditFetchResult{Value: m.currentValue}, nil
+	return &staging.EditFetchResult{Value: m.currentValue, LastModified: m.currentModified}, nil
 }
 
 func newMockResetStrategy() *mockResetStrategy {
@@ -514,6 +515,116 @@ func TestResetUseCase_Execute_UnstageAll_WithTags(t *testing.T) {
 	tags, err := store.ListTags(t.Context(), staging.ServiceParam)
 	require.NoError(t, err)
 	assert.Empty(t, tags[staging.ServiceParam])
+}
+
+// stubApplyStrategy is a minimal ApplyStrategy that reports a fixed
+// last-modified time, used to drive CheckConflicts in the restore regression.
+type stubApplyStrategy struct {
+	lastModified time.Time
+}
+
+func (s *stubApplyStrategy) Service() staging.Service { return staging.ServiceParam }
+func (s *stubApplyStrategy) ServiceName() string      { return "Test" }
+func (s *stubApplyStrategy) ItemName() string         { return "item" }
+func (s *stubApplyStrategy) HasDeleteOptions() bool   { return false }
+func (s *stubApplyStrategy) Apply(context.Context, string, staging.Entry) error {
+	return nil
+}
+func (s *stubApplyStrategy) ApplyTags(context.Context, string, staging.TagEntry) error {
+	return nil
+}
+func (s *stubApplyStrategy) FetchLastModified(context.Context, string) (time.Time, error) {
+	return s.lastModified, nil
+}
+
+// TestResetUseCase_Execute_Restore_AnchorsConflictBase guards against the
+// silent lost-update regression (#546): restore must stage the Update with a
+// non-nil BaseModifiedAt so a subsequent apply still detects out-of-band
+// changes instead of overwriting them.
+func TestResetUseCase_Execute_Restore_AnchorsConflictBase(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	store := testutil.NewMockStore()
+	parser := &mockParserWithVersion{
+		mockParser: newMockParser(),
+		hasVersion: true,
+	}
+
+	fetcher := newMockResetStrategy()
+	fetcher.fetchValue = "old-version-value"
+	fetcher.currentValue = testCurrentValue // Different from fetched version -> staged
+	fetcher.currentModified = base
+
+	uc := &usecasestaging.ResetUseCase{
+		Parser:  parser,
+		Fetcher: fetcher,
+		Store:   store,
+	}
+
+	output, err := uc.Execute(t.Context(), usecasestaging.ResetInput{Spec: "/app/config#3"})
+	require.NoError(t, err)
+	require.Equal(t, usecasestaging.ResetResultRestored, output.Type)
+
+	key := staging.EntryKey{Name: "/app/config#3"}
+	entry, err := store.GetEntry(t.Context(), staging.ServiceParam, key)
+	require.NoError(t, err)
+
+	// The restored Update must carry the AWS base time for conflict detection.
+	require.NotNil(t, entry.BaseModifiedAt)
+	assert.Equal(t, base, *entry.BaseModifiedAt)
+
+	// A far-future remote modification must now be flagged as a conflict.
+	strategy := &stubApplyStrategy{lastModified: base.Add(24 * time.Hour)}
+	conflicts := staging.CheckConflicts(
+		t.Context(),
+		func(string) (staging.ApplyStrategy, error) { return strategy, nil },
+		map[staging.EntryKey]staging.Entry{key: *entry},
+	)
+	assert.Contains(t, conflicts, key)
+}
+
+// TestResetUseCase_Execute_Restore_PreservesExistingBase verifies restore keeps
+// a conflict base established by a prior edit rather than dropping it (#546).
+func TestResetUseCase_Execute_Restore_PreservesExistingBase(t *testing.T) {
+	t.Parallel()
+
+	priorBase := time.Date(2023, 6, 1, 0, 0, 0, 0, time.UTC)
+
+	store := testutil.NewMockStore()
+	key := staging.EntryKey{Name: "/app/config#3"}
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, key, staging.Entry{
+		Operation:      staging.OperationUpdate,
+		Value:          lo.ToPtr("prior-edit"),
+		StagedAt:       time.Now(),
+		BaseModifiedAt: lo.ToPtr(priorBase),
+	}))
+
+	parser := &mockParserWithVersion{
+		mockParser: newMockParser(),
+		hasVersion: true,
+	}
+
+	fetcher := newMockResetStrategy()
+	fetcher.fetchValue = "old-version-value"
+	fetcher.currentValue = testCurrentValue
+	fetcher.currentModified = time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	uc := &usecasestaging.ResetUseCase{
+		Parser:  parser,
+		Fetcher: fetcher,
+		Store:   store,
+	}
+
+	_, err := uc.Execute(t.Context(), usecasestaging.ResetInput{Spec: "/app/config#3"})
+	require.NoError(t, err)
+
+	entry, err := store.GetEntry(t.Context(), staging.ServiceParam, key)
+	require.NoError(t, err)
+	require.NotNil(t, entry.BaseModifiedAt)
+	// The prior edit's base survives the restore (not overwritten by AWS time).
+	assert.Equal(t, priorBase, *entry.BaseModifiedAt)
 }
 
 func TestResetUseCase_Execute_ListTagsError(t *testing.T) {


### PR DESCRIPTION
The restore form of reset (`stage <svc> reset <name>#<version>`) staged the old value as an Update with `BaseModifiedAt = nil`, so `CheckConflicts` skipped it and `apply` silently overwrote concurrent out-of-band changes. It also dropped any conflict base a prior `edit` had established.

`restore` now threads `EntryExecuteOptions{BaseModifiedAt}` (mirroring the `edit` use case): it reuses an existing staged base when present, otherwise falls back to the current AWS `FetchCurrentValue.LastModified` (zero-time → nil).

Regression tests cover both: restore stages a non-nil base and a far-future remote `LastModified` is flagged by `CheckConflicts`, and a prior edit's base survives the restore.

Closes #546.