### PR TITLE
fix(param): record per-version fetch errors in log instead of aborting

### DIFF
--- a/internal/cli/commands/param/log.go
+++ b/internal/cli/commands/param/log.go
@@ -24,10 +24,11 @@ import (
 
 // logJSONItem represents a single version entry in JSON output.
 type logJSONItem struct {
-	Version  int64  `json:"version"`
-	Type     string `json:"type"`
-	Modified string `json:"modified,omitempty"`
-	Value    string `json:"value"`
+	Version  int64   `json:"version"`
+	Type     string  `json:"type,omitempty"`
+	Modified string  `json:"modified,omitempty"`
+	Value    *string `json:"value,omitempty"` // nil when error, pointer to distinguish from empty string
+	Error    string  `json:"error,omitempty"`
 }
 
 // logPresenter renders SSM Parameter Store log output byte-for-byte as before.
@@ -69,11 +70,16 @@ func (p *logPresenter) RenderJSON(stdout io.Writer) error {
 	for i, entry := range entries {
 		items[i] = logJSONItem{
 			Version: entry.Version,
-			Type:    paramtype.Display(entry.Type),
-			Value:   entry.Value,
 		}
 		if entry.LastModified != nil {
 			items[i].Modified = timeutil.FormatRFC3339(*entry.LastModified)
+		}
+
+		if entry.Error != nil {
+			items[i].Error = entry.Error.Error()
+		} else {
+			items[i].Type = paramtype.Display(entry.Type)
+			items[i].Value = &entry.Value
 		}
 	}
 
@@ -90,6 +96,9 @@ func (p *logPresenter) RenderOneline(stdout io.Writer, i, maxValueLength int) {
 	}
 
 	value := entry.Value
+	if entry.Error != nil {
+		value = fmt.Sprintf("<error: %v>", entry.Error)
+	}
 	// Determine max length for oneline mode
 	maxLen := maxValueLength
 	if maxLen == 0 {
@@ -139,6 +148,12 @@ func (p *logPresenter) RenderHeader(stdout io.Writer, i int) {
 func (p *logPresenter) RenderValue(stdout io.Writer, i, maxValueLength int) {
 	entry := p.result.Entries[i]
 
+	if entry.Error != nil {
+		output.Printf(stdout, "<error: %v>\n", entry.Error)
+
+		return
+	}
+
 	// Show value preview (unlimited unless --max-value-length specified).
 	// Truncate by runes so multi-byte content is never cut mid-rune (#340).
 	// Newlines are preserved here: normal mode intentionally shows the full
@@ -153,6 +168,11 @@ func (p *logPresenter) RenderPatch(stdout, stderr io.Writer, i int, parseJSON, r
 	parentIdx, oldest := genericlog.PatchParent(i, len(entries), reverse)
 
 	newEntry := entries[i]
+	// A version whose value failed to fetch has no content to diff against.
+	if newEntry.Error != nil {
+		return
+	}
+
 	newValue := newEntry.Value
 
 	var oldValue, oldName string
@@ -173,6 +193,11 @@ func (p *logPresenter) RenderPatch(stdout, stderr io.Writer, i int, parseJSON, r
 		}
 	} else {
 		oldEntry := entries[parentIdx]
+		// Skip the diff when the parent's value could not be fetched.
+		if oldEntry.Error != nil {
+			return
+		}
+
 		oldValue = oldEntry.Value
 		oldName = fmt.Sprintf("%s#%d", p.result.Name, oldEntry.Version)
 

--- a/internal/usecase/param/log.go
+++ b/internal/usecase/param/log.go
@@ -27,6 +27,7 @@ type LogEntry struct {
 	Value        string
 	LastModified *time.Time
 	IsCurrent    bool
+	Error        error // Error from fetching value, if any
 }
 
 // LogOutput holds the result of the log use case.
@@ -49,7 +50,8 @@ type LogUseCase struct {
 // It fetches the version history (newest first) via the provider, applies the
 // date filters, then retrieves each surviving version's value and type. The
 // provider's History exposes only version metadata (id/created), so values are
-// fetched per version via Resolve+Get.
+// fetched per version via Resolve+Get. A per-version fetch failure is recorded
+// on the entry's Error field rather than aborting the whole listing.
 func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, error) {
 	versions, err := u.Reader.History(ctx, input.Name)
 	if err != nil {
@@ -102,18 +104,22 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 	entries := make([]LogEntry, 0, len(filtered))
 
 	for _, v := range filtered {
-		entry, err := u.getVersion(ctx, input.Name, v)
-		if err != nil {
-			return nil, err
-		}
+		entry, fetchErr := u.getVersion(ctx, input.Name, v)
 
-		entries = append(entries, LogEntry{
+		logEntry := LogEntry{
 			Version:      parseVersion(v.ID),
-			Type:         entry.Type,
-			Value:        entry.Value,
 			LastModified: v.Created,
 			IsCurrent:    parseVersion(v.ID) == maxVersionNum,
-		})
+			Error:        fetchErr,
+		}
+		// Record a per-version fetch failure on the entry rather than aborting
+		// the whole listing; entry is nil when fetchErr is non-nil.
+		if fetchErr == nil {
+			logEntry.Type = entry.Type
+			logEntry.Value = entry.Value
+		}
+
+		entries = append(entries, logEntry)
 	}
 
 	// History yields newest first (default). Reverse to oldest first on request.

--- a/internal/usecase/param/log_test.go
+++ b/internal/usecase/param/log_test.go
@@ -24,6 +24,7 @@ type logVer struct {
 	value    string
 	typ      domain.ValueType
 	modified *time.Time
+	getErr   error // when set, Get fails for this version
 }
 
 // newLogStore builds a provider mock whose History returns the given versions
@@ -49,6 +50,10 @@ func newLogStore(oldestFirst []logVer) *providermock.Store {
 		},
 		GetFunc: func(_ context.Context, name string, ref provider.VersionRef) (*domain.Entry, error) {
 			v := byID[ref.ID()]
+
+			if v.getErr != nil {
+				return nil, v.getErr
+			}
 
 			return &domain.Entry{
 				Name:     name,
@@ -115,6 +120,33 @@ func TestLogUseCase_Execute_Error(t *testing.T) {
 
 	_, err := uc.Execute(t.Context(), param.LogInput{Name: "/app/config"})
 	require.Error(t, err)
+}
+
+// TestLogUseCase_Execute_PartialFetchError records a per-version fetch failure
+// on the entry rather than aborting the whole listing.
+func TestLogUseCase_Execute_PartialFetchError(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	store := newLogStore([]logVer{
+		{ver: 1, value: "v1", getErr: errAccessDenied, modified: lo.ToPtr(now.Add(-1 * time.Hour))},
+		{ver: 2, value: "v2", modified: lo.ToPtr(now)},
+	})
+
+	uc := &param.LogUseCase{Reader: store}
+
+	output, err := uc.Execute(t.Context(), param.LogInput{Name: "/app/config"})
+	require.NoError(t, err)
+	require.Len(t, output.Entries, 2)
+
+	// Newest first: v2 succeeds, v1 records its fetch error.
+	require.NoError(t, output.Entries[0].Error)
+	assert.Equal(t, "v2", output.Entries[0].Value)
+	require.Error(t, output.Entries[1].Error)
+	assert.Empty(t, output.Entries[1].Value)
+	// IsCurrent stays correct even for a failed entry (derived from version number).
+	assert.True(t, output.Entries[0].IsCurrent)
+	assert.False(t, output.Entries[1].IsCurrent)
 }
 
 func TestLogUseCase_Execute_Reverse(t *testing.T) {


### PR DESCRIPTION
param log は 1 バージョンの値取得に失敗すると早期 return し、履歴全体の表示を中断していた。

`secret/log.go` に倣い次のように修正した。

- usecase: `LogEntry` に `Error` フィールドを追加し、値取得ループで per-version の失敗を記録して継続する（早期 `return nil, err` を廃止）。`IsCurrent` は `maxVersionNum` から独立算出するため失敗エントリでも正しい。
- presenter: JSON は `error` フィールドを出力し `value` をポインタ化、text / oneline は `<error: ...>` を表示、patch は失敗バージョンの diff をスキップ。
- usecase テストに `TestLogUseCase_Execute_PartialFetchError` を追加。

Closes #532.