### PR TITLE
fix(staging): treat empty/whitespace state file as empty state

### DIFF
--- a/internal/staging/store/file/store.go
+++ b/internal/staging/store/file/store.go
@@ -12,6 +12,7 @@
 package file
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -306,6 +307,14 @@ func (s *Store) readFile(path string) (*staging.State, error) {
 		}
 
 		return nil, fmt.Errorf("failed to read state file: %w", err)
+	}
+
+	// A trimmed-empty file (zero bytes or only whitespace) is treated like a
+	// missing file: an external truncation or an editor leaving an empty file
+	// behind must not hard-fail every command with a parse error. Genuinely
+	// non-empty garbage still surfaces a corruption error below.
+	if len(bytes.TrimSpace(data)) == 0 {
+		return staging.NewEmptyState(), nil
 	}
 
 	// Decrypt if encrypted. Reading an unencrypted (plaintext/legacy) file is

--- a/internal/staging/store/file/store_internal_test.go
+++ b/internal/staging/store/file/store_internal_test.go
@@ -335,6 +335,50 @@ func TestWriteState_EncryptionError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to encrypt state")
 }
 
+// TestReadFile_EmptyOrWhitespaceTreatedAsEmpty guards #562: a state file that is
+// zero bytes or contains only whitespace (e.g. an external truncation) must be
+// read as an empty state instead of hard-failing every command with a parse
+// error, mirroring how a missing file is handled.
+func TestReadFile_EmptyOrWhitespaceTreatedAsEmpty(t *testing.T) {
+	t.Parallel()
+
+	for name, content := range map[string]string{
+		"zero bytes":       "",
+		"single newline":   "\n",
+		"spaces and tabs":  "  \t  ",
+		"crlf and spaces":  " \r\n\t ",
+		"trailing newline": "\n\n\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(t.TempDir(), "stage.json")
+			require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+			store := NewStoreWithPath(path)
+
+			state, err := store.Drain(t.Context(), "", true)
+			require.NoError(t, err)
+			assert.True(t, state.IsEmpty(), "trimmed-empty file should read as empty state")
+		})
+	}
+}
+
+// TestReadFile_NonEmptyGarbageStillErrors verifies the empty-file tolerance does
+// not swallow genuinely corrupt (non-empty) content.
+func TestReadFile_NonEmptyGarbageStillErrors(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "stage.json")
+	require.NoError(t, os.WriteFile(path, []byte("not json at all"), 0o600))
+
+	store := NewStoreWithPath(path)
+
+	_, err := store.Drain(t.Context(), "", true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse state file")
+}
+
 // errorReader is an io.Reader that returns an error.
 type errorReader struct {
 	err error


### PR DESCRIPTION
An external truncation or an editor leaving an empty file behind currently makes every staging command hard-fail with a JSON parse error.

`readFile` now returns `NewEmptyState()` when the file is zero bytes or contains only whitespace (`len(bytes.TrimSpace(data)) == 0`), mirroring how a missing file is already handled. Genuinely non-empty garbage still surfaces the corruption error.

Closes #562.