### PR TITLE
fix(staging): cancel tag-only staged changes on named reset

### DIFF
--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -198,6 +198,7 @@ var (
 		stagingusecase.ResetResultNotStaged:     "notStaged",
 		stagingusecase.ResetResultNothingStaged: "nothingStaged",
 		stagingusecase.ResetResultSkipped:       "skipped",
+		stagingusecase.ResetResultUnstagedTag:   "unstagedTag",
 	}
 
 	diffEntryTypeNames = map[stagingusecase.DiffEntryType]string{

--- a/internal/staging/cli/reset.go
+++ b/internal/staging/cli/reset.go
@@ -44,6 +44,8 @@ func (r *ResetRunner) Run(ctx context.Context, opts ResetOptions) error {
 		output.Warn(r.Stdout, "%s is not staged", result.Name)
 	case stagingusecase.ResetResultUnstaged:
 		output.Success(r.Stdout, "Unstaged %s", result.Name)
+	case stagingusecase.ResetResultUnstagedTag:
+		output.Success(r.Stdout, "Unstaged tag changes for %s", result.Name)
 	case stagingusecase.ResetResultRestored:
 		output.Success(r.Stdout, "Restored %s (staged from version %s)", result.Name, result.VersionLabel)
 	case stagingusecase.ResetResultSkipped:

--- a/internal/usecase/staging/reset.go
+++ b/internal/usecase/staging/reset.go
@@ -29,7 +29,8 @@ const (
 	ResetResultRestored
 	ResetResultNotStaged
 	ResetResultNothingStaged
-	ResetResultSkipped // Restore was skipped because value matches current AWS
+	ResetResultSkipped     // Restore was skipped because value matches current AWS
+	ResetResultUnstagedTag // Only staged tag changes were unstaged (entry itself not staged)
 )
 
 // ResetOutput holds the result of the reset use case.
@@ -118,8 +119,28 @@ func (u *ResetUseCase) unstage(ctx context.Context, name, namespace, _, _ string
 
 	// Check if already not staged
 	if _, isNotStaged := entryState.StagedState.(transition.EntryStagedStateNotStaged); isNotStaged {
+		// The entry value is not staged, but a tag-only change may still be
+		// staged. Named reset must cancel it too; otherwise the CLI misreports
+		// "not staged" while the TagEntry survives and is applied on the next
+		// apply.
+		tagEntry, err := u.Store.GetTag(ctx, service, key)
+		if err != nil && !errors.Is(err, staging.ErrNotStaged) {
+			return nil, err
+		}
+
+		if tagEntry == nil {
+			return &ResetOutput{
+				Type: ResetResultNotStaged,
+				Name: name,
+			}, nil
+		}
+
+		if err := u.Store.UnstageTag(ctx, service, key); err != nil {
+			return nil, err
+		}
+
 		return &ResetOutput{
-			Type: ResetResultNotStaged,
+			Type: ResetResultUnstagedTag,
 			Name: name,
 		}, nil
 	}

--- a/internal/usecase/staging/reset_test.go
+++ b/internal/usecase/staging/reset_test.go
@@ -95,6 +95,38 @@ func TestResetUseCase_Execute_NotStaged(t *testing.T) {
 	assert.Equal(t, usecasestaging.ResetResultNotStaged, output.Type)
 }
 
+// TestResetUseCase_Execute_UnstageTagOnly guards #522: named reset of an item
+// whose value is not staged but which carries a staged tag-only change must
+// cancel that tag change and report it, not misreport "not staged" while the
+// TagEntry silently survives to apply.
+func TestResetUseCase_Execute_UnstageTagOnly(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	key := staging.EntryKey{Name: "/app/config"}
+	// Only a tag change is staged; the entry value itself stays NotStaged.
+	require.NoError(t, store.StageTag(t.Context(), staging.ServiceParam, key, staging.TagEntry{
+		Add:      map[string]string{"env": "prod"},
+		StagedAt: time.Now(),
+	}))
+
+	uc := &usecasestaging.ResetUseCase{
+		Parser: newMockParser(),
+		Store:  store,
+	}
+
+	output, err := uc.Execute(t.Context(), usecasestaging.ResetInput{
+		Spec: "/app/config",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, usecasestaging.ResetResultUnstagedTag, output.Type)
+	assert.Equal(t, "/app/config", output.Name)
+
+	// The staged tag change must be gone.
+	_, err = store.GetTag(t.Context(), staging.ServiceParam, key)
+	assert.ErrorIs(t, err, staging.ErrNotStaged)
+}
+
 func TestResetUseCase_Execute_UnstageCreate_DiscardsTags(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Named `stage <svc> reset <name>` returned early with "X is not staged" whenever the entry value was `NotStaged`, without ever consulting `GetTag`. A staged tag-only change therefore could not be cancelled from the CLI: it silently survived and was applied on the next `stage apply`.

`ResetUseCase.unstage` now checks for a staged `TagEntry` when the entry is `NotStaged`, `UnstageTag`s it, and reports the new `ResetResultUnstagedTag` outcome ("Unstaged tag changes for X"). `ResetResultNotStaged` is returned only when both the entry and the tags are absent. The GUI reset type name map gains the matching key.

A regression test covers named reset of a tag-only item.

Closes #522.