### PR TITLE
fix(jsonutil): reject escaped lone surrogates that coerce to U+FFFD

### DIFF
--- a/internal/jsonutil/json.go
+++ b/internal/jsonutil/json.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/mpyw/suve/internal/cli/output"
@@ -63,7 +64,20 @@ func TryFormat(value string) (string, bool) {
 
 	// json.Encoder.Encode appends a trailing newline; strip it to match the
 	// previous json.MarshalIndent behavior.
-	return string(bytes.TrimRight(buf.Bytes(), "\n")), true
+	formatted := string(bytes.TrimRight(buf.Bytes(), "\n"))
+
+	// Reject silent lossy conversions that survive raw-byte UTF-8 validation:
+	// Go's json decoder turns an escaped lone surrogate (e.g. "\ud800") into
+	// U+FFFD, so the input is valid UTF-8 yet its decoded content is mangled.
+	// If formatting introduced a replacement character that the input did not
+	// already contain, fall back to the raw string instead of misrepresenting
+	// the value as a clean round-trip (#525).
+	replacementChar := string(utf8.RuneError)
+	if strings.Count(formatted, replacementChar) > strings.Count(value, replacementChar) {
+		return value, false
+	}
+
+	return formatted, true
 }
 
 // TryFormatOrWarn formats JSON or warns and returns original.

--- a/internal/jsonutil/json_test.go
+++ b/internal/jsonutil/json_test.go
@@ -78,6 +78,23 @@ func TestTryFormat(t *testing.T) {
 			wantStr:  "{\"k\":\"\xff\"}",
 			wantBool: false,
 		},
+		{
+			// An escaped lone surrogate is valid UTF-8 as raw bytes but the
+			// decoder coerces it to U+FFFD; formatting must not silently mutate
+			// it (#525).
+			name:     "escaped lone surrogate is rejected to avoid U+FFFD coercion",
+			input:    `{"k":"\ud800"}`,
+			wantStr:  `{"k":"\ud800"}`,
+			wantBool: false,
+		},
+		{
+			// A replacement character genuinely present in the input is not a
+			// coercion, so formatting proceeds (no new U+FFFD is introduced).
+			name:     "pre-existing replacement character is preserved and formatted",
+			input:    "{\"k\":\"�\"}",
+			wantStr:  "{\n  \"k\": \"�\"\n}",
+			wantBool: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
エスケープされた lone surrogate（例 `"\ud800"`）は raw バイトとしては valid UTF-8 のため `utf8.ValidString` を通過するが、`json.Decode` が U+FFFD へ暗黙変換する。従来はこれを検出できず、値が変質しているのに整形成功として扱っていた。

- `TryFormat` にデコード→再エンコード後の round-trip 検証を追加し、「元入力に無い U+FFFD」が現れた場合は `(value, false)` を返すようにした。
- 元入力に既に含まれる U+FFFD は変換ではないため、整形を継続する。
- これにより show / log の `--parse-json` 表示と stage diff の "formatting のみ差分" 誤判定を解消する。

Closes #525.