### PR TITLE
fix(staging): name reset as remedy when deleting a staged update with vanished remote

### DIFF
--- a/internal/staging/transition/reducer.go
+++ b/internal/staging/transition/reducer.go
@@ -9,10 +9,15 @@ var (
 	ErrCannotAddToExisting  = errors.New("cannot add: resource already exists, use edit instead")
 	ErrCannotEditDelete     = errors.New("cannot edit: staged for deletion, reset first")
 	ErrCannotDeleteNotFound = errors.New("cannot delete: resource not found")
-	ErrCannotTagNotFound    = errors.New("cannot tag: resource not found")
-	ErrCannotTagDelete      = errors.New("cannot tag: resource staged for deletion")
-	ErrCannotUntagNotFound  = errors.New("cannot untag: resource not found")
-	ErrCannotUntagDelete    = errors.New("cannot untag: resource staged for deletion")
+	// ErrCannotDeleteStagedUpdateNotFound is returned when a staged Update points
+	// at a remote that was deleted out-of-band. The Update can never apply and
+	// delete cannot help, so the message names reset as the way out instead of a
+	// generic not-found that dead-ends the user.
+	ErrCannotDeleteStagedUpdateNotFound = errors.New("cannot delete: staged update targets a resource that no longer exists; use reset to discard it")
+	ErrCannotTagNotFound                = errors.New("cannot tag: resource not found")
+	ErrCannotTagDelete                  = errors.New("cannot tag: resource staged for deletion")
+	ErrCannotUntagNotFound              = errors.New("cannot untag: resource not found")
+	ErrCannotUntagDelete                = errors.New("cannot untag: resource staged for deletion")
 )
 
 // EntryTransitionResult holds the result of an entry state transition.
@@ -127,7 +132,7 @@ func reduceEdit(state EntryState, action EntryActionEdit) EntryTransitionResult 
 // Transition rules:
 //   - CurrentValue=nil + NotStaged → ERROR      (resource not found)
 //   - CurrentValue=nil + Create    → NotStaged  (unstage, also unstage tags)
-//   - CurrentValue=nil + Update    → ERROR      (should not happen)
+//   - CurrentValue=nil + Update    → ERROR      (remote vanished out-of-band; names reset)
 //   - CurrentValue=nil + Delete    → ERROR      (should not happen)
 //   - CurrentValue!=nil + NotStaged → Delete    (stage for deletion, also unstage tags)
 //   - CurrentValue!=nil + Create    → NotStaged (unstage, also unstage tags) - should not happen
@@ -143,6 +148,13 @@ func reduceDelete(state EntryState) EntryTransitionResult {
 	// Check if resource exists on AWS or is staged for CREATE
 	_, isCreate := state.StagedState.(EntryStagedStateCreate)
 	if state.CurrentValue == nil && !isCreate {
+		// A staged Update whose remote was deleted out-of-band can never apply;
+		// point the user at reset rather than a generic not-found so they aren't
+		// dead-ended (delete refuses, apply keeps failing).
+		if _, isUpdate := state.StagedState.(EntryStagedStateUpdate); isUpdate {
+			return EntryTransitionResult{NewState: state, Error: ErrCannotDeleteStagedUpdateNotFound}
+		}
+
 		return EntryTransitionResult{NewState: state, Error: ErrCannotDeleteNotFound}
 	}
 

--- a/internal/staging/transition/reducer_internal_test.go
+++ b/internal/staging/transition/reducer_internal_test.go
@@ -687,6 +687,22 @@ func TestReduceEntry_Delete_NotFound(t *testing.T) {
 	assert.Equal(t, EntryStagedStateNotStaged{}, result.NewState.StagedState)
 }
 
+func TestReduceEntry_Delete_StagedUpdateRemoteVanished(t *testing.T) {
+	t.Parallel()
+
+	// Test case: CurrentValue=nil + Update -> ERROR naming reset as the remedy.
+	// The staged Update can never apply once the remote is gone, so delete must
+	// point at reset instead of the generic not-found (#552).
+	state := EntryState{
+		CurrentValue: nil,
+		StagedState:  EntryStagedStateUpdate{DraftValue: "v2"},
+	}
+	result := ReduceEntry(state, EntryActionDelete{})
+	assert.Equal(t, ErrCannotDeleteStagedUpdateNotFound, result.Error)
+	assert.Contains(t, result.Error.Error(), "reset")
+	assert.Equal(t, EntryStagedStateUpdate{DraftValue: "v2"}, result.NewState.StagedState)
+}
+
 func TestReduceEntry_Delete_InconsistentState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/usecase/staging/delete_test.go
+++ b/internal/usecase/staging/delete_test.go
@@ -179,6 +179,38 @@ func TestDeleteUseCase_Execute_ResourceNotFound(t *testing.T) {
 	assert.Contains(t, err.Error(), "resource not found")
 }
 
+func TestDeleteUseCase_Execute_StagedUpdate_RemoteVanished(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	// A value was staged as an Update, then the remote was deleted out-of-band.
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/gone"}, staging.Entry{
+		Operation: staging.OperationUpdate,
+		Value:     lo.ToPtr("v2"),
+		StagedAt:  time.Now(),
+	}))
+
+	strategy := newMockDeleteStrategy(false)
+	strategy.fetchErr = &staging.ResourceNotFoundError{} // Remote no longer exists
+
+	uc := &usecasestaging.DeleteUseCase{
+		Strategy: strategy,
+		Store:    store,
+	}
+
+	// Delete must not dead-end silently: it errors and names reset as the remedy.
+	_, err := uc.Execute(t.Context(), usecasestaging.DeleteInput{
+		Key: staging.EntryKey{Name: "/app/gone"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "reset")
+
+	// The staged Update must be left intact so reset can still discard it.
+	entry, err := store.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/gone", Namespace: ""})
+	require.NoError(t, err)
+	assert.Equal(t, staging.OperationUpdate, entry.Operation)
+}
+
 func TestDeleteUseCase_Execute_ZeroLastModified_ResourceExists(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
When a resource with a staged **Update** was deleted out-of-band on the remote, `stage delete <name>` failed with the generic "cannot delete: resource not found" and left the staged Update in place. That Update could never apply (apply-side Get errors), so the user was dead-ended and the error never mentioned the actual remedy.

`reduceDelete` now returns a distinct `ErrCannotDeleteStagedUpdateNotFound` for the `CurrentValue == nil` + staged-Update case, whose message names `reset` as the way out. The genuine not-found path (nothing staged) keeps the original generic message. Per the approved 実装方針 this errors-and-hints rather than implicitly discarding, so the user consciously resets.

Regression tests added at the reducer and delete use case levels.

Closes #552.