### PR TITLE
fix(staging): correct guidance for add over a staged delete

### DIFF
--- a/internal/staging/transition/reducer.go
+++ b/internal/staging/transition/reducer.go
@@ -5,7 +5,7 @@ import "errors"
 // Error definitions for transition failures.
 var (
 	ErrCannotAddToUpdate    = errors.New("cannot add: already staged for update")
-	ErrCannotAddToDelete    = errors.New("cannot add: already staged for deletion")
+	ErrCannotAddToDelete    = errors.New("cannot add: already staged for deletion, reset first")
 	ErrCannotAddToExisting  = errors.New("cannot add: resource already exists, use edit instead")
 	ErrCannotEditDelete     = errors.New("cannot edit: staged for deletion, reset first")
 	ErrCannotDeleteNotFound = errors.New("cannot delete: resource not found")
@@ -63,13 +63,21 @@ func ReduceTag(entryState EntryState, stagedTags StagedTags, action TagAction) T
 // reduceAdd handles the ADD action.
 //
 // Transition rules:
+//   - Delete (any CurrentValue)    → ERROR      (staged for deletion; reset first)
 //   - CurrentValue!=nil            → ERROR      (resource already exists)
 //   - CurrentValue=nil + NotStaged → Create     (stage as create)
 //   - CurrentValue=nil + Create    → Create     (update draft value)
 //   - CurrentValue=nil + Update    → ERROR      (cannot add to update)
-//   - CurrentValue=nil + Delete    → ERROR      (cannot add to delete)
 func reduceAdd(state EntryState, action EntryActionAdd) EntryTransitionResult {
 	var err error
+
+	// A staged Delete is checked before the CurrentValue guard: an existing
+	// remote would otherwise make add report "already exists, use edit instead",
+	// but editing a staged delete is refused too. Surface the accurate remedy
+	// (reset first) regardless of whether the remote still exists.
+	if _, isDelete := state.StagedState.(EntryStagedStateDelete); isDelete {
+		return EntryTransitionResult{NewState: state, Error: ErrCannotAddToDelete}
+	}
 
 	// Check if resource already exists on AWS
 	if state.CurrentValue != nil {

--- a/internal/staging/transition/reducer_internal_test.go
+++ b/internal/staging/transition/reducer_internal_test.go
@@ -70,6 +70,18 @@ func TestReduceEntry_Add(t *testing.T) {
 			wantState: EntryStagedStateNotStaged{},
 			wantError: ErrCannotAddToExisting,
 		},
+		{
+			// #553: staged Delete with the remote still present must report the
+			// delete-specific remedy (reset first), not "already exists, use edit".
+			name: "Delete with remote present -> ERROR (reset first, not use edit)",
+			state: EntryState{
+				CurrentValue: lo.ToPtr("current"),
+				StagedState:  EntryStagedStateDelete{},
+			},
+			action:    EntryActionAdd{Value: "new-value"},
+			wantState: EntryStagedStateDelete{},
+			wantError: ErrCannotAddToDelete,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
`stage add` over a staged **Delete** reported "cannot add: resource already exists, use edit instead" — the wrong remedy, since editing a staged delete is also refused. `reduceAdd` checked `CurrentValue != nil` before the staged-state switch, leaving the delete-specific `ErrCannotAddToDelete` near-unreachable.

`reduceAdd` now judges the staged-Delete state before the `CurrentValue` guard, so add-over-staged-delete consistently reports the accurate remedy. The message is extended to name reset ("already staged for deletion, reset first"), matching the `ErrCannotEditDelete` wording.

A reducer test covers a staged Delete with the remote still present.

Closes #553.