### PR TITLE
fix(gui): keep import passphrase modal open on decrypt error

### DIFF
--- a/internal/gui/frontend/src/lib/StagingView.svelte
+++ b/internal/gui/frontend/src/lib/StagingView.svelte
@@ -440,7 +440,9 @@
   }
 
   function handleImportPassphrase(passphrase: string) {
-    showImportPassphrase = false;
+    // Keep the passphrase modal open across the attempt so a wrong passphrase can
+    // be re-entered inline (via the modal's error prop); runImport closes it on
+    // success. Mirrors the export flow.
     runImport(passphrase);
   }
 
@@ -459,9 +461,14 @@
       await loadStatus();
     } catch (e) {
       importError = parseError(e);
-      // Surface backend errors (e.g. wrong passphrase, service mismatch) in a
-      // modal since the transient chain modals are now closed.
-      showImportErrorModal = true;
+      // When the passphrase prompt is open (encrypted import), keep it open and
+      // show the error inline via the modal's error prop so a wrong passphrase can
+      // be retried without rebuilding the whole import chain (mirrors export).
+      // Only non-passphrase errors (the prompt is closed) fall back to the
+      // standalone Import Failed modal.
+      if (!showImportPassphrase) {
+        showImportErrorModal = true;
+      }
     } finally {
       importLoading = false;
     }


### PR DESCRIPTION
## Summary
Entering a wrong passphrase for an encrypted import dead-ended: `handleImportPassphrase` closed the passphrase modal before `runImport`, and `runImport`'s catch routed to the standalone Import Failed modal (Close only). The user had to restart the whole import (menu → file picker → inspect → scope/mode → passphrase) just to fix a typo. The export flow already keeps its passphrase modal open on error, and the import `PassphraseModal` was already wired with `error={importError}`.

## Fix
- `handleImportPassphrase` no longer closes the modal before the attempt; `runImport` closes it only on success.
- `runImport`'s catch keeps the passphrase modal open and shows the error inline (via the existing `error` prop) when the prompt is open, so a wrong passphrase can be re-entered. Non-passphrase errors (prompt closed, e.g. service mismatch on the unencrypted path) still fall back to the standalone Import Failed modal.

Mirrors the export flow. `svelte-check` passes with 0 errors.

Closes #526.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwohz3bcExASTpHgiV2dHt