### PR TITLE
test(staging): improve MockStore fidelity to the file store

### DIFF
--- a/internal/staging/store/testutil/mock_store.go
+++ b/internal/staging/store/testutil/mock_store.go
@@ -57,7 +57,9 @@ func (m *MockStore) GetEntry(_ context.Context, service staging.Service, key sta
 	}
 
 	if entry, ok := m.entries[service][key]; ok {
-		return &entry, nil
+		cloned := cloneEntry(entry)
+
+		return &cloned, nil
 	}
 
 	return nil, staging.ErrNotStaged
@@ -70,7 +72,9 @@ func (m *MockStore) GetTag(_ context.Context, service staging.Service, key stagi
 	}
 
 	if tag, ok := m.tags[service][key]; ok {
-		return &tag, nil
+		cloned := cloneTagEntry(tag)
+
+		return &cloned, nil
 	}
 
 	return nil, staging.ErrNotStaged
@@ -153,6 +157,65 @@ func (m *MockStore) servicesFor(service staging.Service) []staging.Service {
 	return slices.Sorted(maps.Keys(m.entries))
 }
 
+// cloneEntry returns a deep copy of e. The file store reparses JSON on every
+// read and therefore always hands back independent values; cloning here gives
+// the mock the same fidelity so a caller mutating a returned Entry cannot reach
+// back into the mock's stored state.
+func cloneEntry(e staging.Entry) staging.Entry {
+	e.Value = clonePtr(e.Value)
+	e.Description = clonePtr(e.Description)
+	e.BaseModifiedAt = clonePtr(e.BaseModifiedAt)
+	e.DeleteOptions = clonePtr(e.DeleteOptions)
+
+	return e
+}
+
+// cloneTagEntry returns a deep copy of t (see cloneEntry).
+func cloneTagEntry(t staging.TagEntry) staging.TagEntry {
+	if t.Add != nil {
+		t.Add = maps.Clone(t.Add)
+	}
+
+	if t.Remove != nil {
+		t.Remove = maps.Clone(t.Remove)
+	}
+
+	t.BaseModifiedAt = clonePtr(t.BaseModifiedAt)
+
+	return t
+}
+
+// cloneEntryMap returns a deep copy of a per-service entry map.
+func cloneEntryMap(m map[staging.EntryKey]staging.Entry) map[staging.EntryKey]staging.Entry {
+	out := make(map[staging.EntryKey]staging.Entry, len(m))
+	for k, v := range m {
+		out[k] = cloneEntry(v)
+	}
+
+	return out
+}
+
+// cloneTagMap returns a deep copy of a per-service tag map.
+func cloneTagMap(m map[staging.EntryKey]staging.TagEntry) map[staging.EntryKey]staging.TagEntry {
+	out := make(map[staging.EntryKey]staging.TagEntry, len(m))
+	for k, v := range m {
+		out[k] = cloneTagEntry(v)
+	}
+
+	return out
+}
+
+// clonePtr returns a pointer to a shallow copy of *p, or nil when p is nil.
+func clonePtr[T any](p *T) *T {
+	if p == nil {
+		return nil
+	}
+
+	v := *p
+
+	return &v
+}
+
 // ListEntries returns all staged entries for a service.
 func (m *MockStore) ListEntries(_ context.Context, service staging.Service) (map[staging.Service]map[staging.EntryKey]staging.Entry, error) {
 	if m.ListEntriesErr != nil {
@@ -163,7 +226,7 @@ func (m *MockStore) ListEntries(_ context.Context, service staging.Service) (map
 
 	for _, svc := range m.servicesFor(service) {
 		if len(m.entries[svc]) > 0 {
-			result[svc] = maps.Clone(m.entries[svc])
+			result[svc] = cloneEntryMap(m.entries[svc])
 		}
 	}
 
@@ -180,7 +243,7 @@ func (m *MockStore) ListTags(_ context.Context, service staging.Service) (map[st
 
 	for _, svc := range m.servicesFor(service) {
 		if len(m.tags[svc]) > 0 {
-			result[svc] = maps.Clone(m.tags[svc])
+			result[svc] = cloneTagMap(m.tags[svc])
 		}
 	}
 
@@ -209,19 +272,28 @@ func (m *MockStore) Drain(_ context.Context, service staging.Service, keep bool)
 		}
 	}
 
-	// Copy current state
+	// Copy current state. Entries/tags are deep-cloned so a caller mutating the
+	// returned state cannot reach back into the mock's stored maps, mirroring the
+	// file store's reparse-on-read fidelity.
 	state := staging.NewEmptyState()
+
 	for svc, entries := range m.entries {
-		maps.Copy(state.Entries[svc], entries)
+		for key, entry := range entries {
+			state.Entries[svc][key] = cloneEntry(entry)
+		}
 	}
 
 	for svc, tags := range m.tags {
-		maps.Copy(state.Tags[svc], tags)
+		for key, tag := range tags {
+			state.Tags[svc][key] = cloneTagEntry(tag)
+		}
 	}
 
-	// Clear storage if not keeping
+	// Clear storage if not keeping. Scope the clear to the requested service so a
+	// service-specific drain does not wipe the other service, matching the file
+	// store (which removes only the drained service's file).
 	if !keep {
-		for _, svc := range m.servicesFor("") {
+		for _, svc := range m.servicesFor(service) {
 			m.entries[svc] = make(map[staging.EntryKey]staging.Entry)
 			m.tags[svc] = make(map[staging.EntryKey]staging.TagEntry)
 		}
@@ -247,8 +319,11 @@ func (m *MockStore) WriteState(_ context.Context, service staging.Service, state
 		state = state.ExtractService(service)
 	}
 
-	// Replace all entries and tags
-	for _, svc := range m.servicesFor("") {
+	// Replace entries and tags for the affected service(s) only. Scoping the
+	// clear to the requested service means a service-specific write leaves the
+	// other service intact, matching the file store (which writes only the
+	// requested service's file).
+	for _, svc := range m.servicesFor(service) {
 		m.entries[svc] = make(map[staging.EntryKey]staging.Entry)
 		m.tags[svc] = make(map[staging.EntryKey]staging.TagEntry)
 	}

--- a/internal/staging/store/testutil/mock_store_test.go
+++ b/internal/staging/store/testutil/mock_store_test.go
@@ -71,3 +71,115 @@ func TestListCopyOnRead_Parity(t *testing.T) {
 		assertListCopyOnRead(t, file.NewStoreWithPath(filepath.Join(t.TempDir(), "stage.json")))
 	})
 }
+
+// assertDeepCloneOnRead verifies that mutating the pointer-typed fields of a
+// value returned from GetEntry/GetTag does not leak into stored state. The file
+// store reparses JSON on every read, so MockStore must deep-clone to match.
+func assertDeepCloneOnRead(t *testing.T, rw store.ReadWriteOperator) {
+	t.Helper()
+
+	ctx := context.Background()
+	key := staging.EntryKey{Name: "/a"}
+
+	require.NoError(t, rw.StageEntry(ctx, staging.ServiceParam, key, staging.Entry{
+		Operation:   staging.OperationUpdate,
+		Value:       lo.ToPtr("v1"),
+		Description: lo.ToPtr("d1"),
+		StagedAt:    time.Now(),
+	}))
+	require.NoError(t, rw.StageTag(ctx, staging.ServiceParam, key, staging.TagEntry{
+		Add:      map[string]string{"env": "prod"},
+		StagedAt: time.Now(),
+	}))
+
+	got, err := rw.GetEntry(ctx, staging.ServiceParam, key)
+	require.NoError(t, err)
+
+	*got.Value = "hacked"
+	*got.Description = "hacked"
+
+	gotTag, err := rw.GetTag(ctx, staging.ServiceParam, key)
+	require.NoError(t, err)
+
+	gotTag.Add["env"] = "hacked"
+
+	fresh, err := rw.GetEntry(ctx, staging.ServiceParam, key)
+	require.NoError(t, err)
+	assert.Equal(t, "v1", lo.FromPtr(fresh.Value), "GetEntry must return a deep copy")
+	assert.Equal(t, "d1", lo.FromPtr(fresh.Description), "GetEntry must return a deep copy")
+
+	freshTag, err := rw.GetTag(ctx, staging.ServiceParam, key)
+	require.NoError(t, err)
+	assert.Equal(t, "prod", freshTag.Add["env"], "GetTag must return a deep copy")
+}
+
+// TestDeepCloneOnRead_Parity pins MockStore to the file store's deep-copy
+// semantics for GetEntry/GetTag.
+func TestDeepCloneOnRead_Parity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("mock", func(t *testing.T) {
+		t.Parallel()
+		assertDeepCloneOnRead(t, testutil.NewMockStore())
+	})
+
+	t.Run("file", func(t *testing.T) {
+		t.Parallel()
+		assertDeepCloneOnRead(t, file.NewStoreWithPath(filepath.Join(t.TempDir(), "stage.json")))
+	})
+}
+
+// TestServiceScopedClear verifies that a service-specific Drain or WriteState
+// touches only that service, leaving the other service's staged changes intact —
+// mirroring the split-mode file store, which backs each service with its own
+// file. Previously the mock cleared every tracked service regardless of the
+// service filter.
+func TestServiceScopedClear(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	paramKey := staging.EntryKey{Name: "/p"}
+	secretKey := staging.EntryKey{Name: "/s"}
+
+	entry := func(v string) staging.Entry {
+		return staging.Entry{Operation: staging.OperationUpdate, Value: lo.ToPtr(v), StagedAt: time.Now()}
+	}
+
+	t.Run("drain", func(t *testing.T) {
+		t.Parallel()
+
+		rw := testutil.NewMockStore()
+		require.NoError(t, rw.StageEntry(ctx, staging.ServiceParam, paramKey, entry("p")))
+		require.NoError(t, rw.StageEntry(ctx, staging.ServiceSecret, secretKey, entry("s")))
+
+		_, err := rw.Drain(ctx, staging.ServiceParam, false)
+		require.NoError(t, err)
+
+		secret, err := rw.ListEntries(ctx, staging.ServiceSecret)
+		require.NoError(t, err)
+		assert.Len(t, secret[staging.ServiceSecret], 1, "draining param must not clear secret")
+
+		param, err := rw.ListEntries(ctx, staging.ServiceParam)
+		require.NoError(t, err)
+		assert.Empty(t, param[staging.ServiceParam], "draining param must clear param")
+	})
+
+	t.Run("write", func(t *testing.T) {
+		t.Parallel()
+
+		rw := testutil.NewMockStore()
+		require.NoError(t, rw.StageEntry(ctx, staging.ServiceSecret, secretKey, entry("s")))
+
+		state := staging.NewEmptyState()
+		state.Entries[staging.ServiceParam][paramKey] = entry("p")
+		require.NoError(t, rw.WriteState(ctx, staging.ServiceParam, state))
+
+		secret, err := rw.ListEntries(ctx, staging.ServiceSecret)
+		require.NoError(t, err)
+		assert.Len(t, secret[staging.ServiceSecret], 1, "writing param must not clear secret")
+
+		param, err := rw.ListEntries(ctx, staging.ServiceParam)
+		require.NoError(t, err)
+		assert.Len(t, param[staging.ServiceParam], 1, "writing param must persist param")
+	})
+}


### PR DESCRIPTION
Two fidelity gaps between `MockStore` and the real file store:

- **Deep-clone on read.** `GetEntry`/`GetTag`/`ListEntries`/`ListTags`/`Drain` now deep-clone the pointer/map fields (`Value`, `Description`, `BaseModifiedAt`, `DeleteOptions`, `Add`, `Remove`), so a caller mutating a returned value cannot reach back into the mock's stored state — matching the file store, which reparses JSON on every read.
- **Service-scoped clears.** `Drain`/`WriteState` clears are scoped to `servicesFor(service)` so a service-specific op no longer wipes the other service, matching the split-mode file store (one file per service).

Adds parity/behavior tests covering both.

Closes #563.