### PR TITLE
fix(gui): gate modal dismissal while an operation is in flight

### DIFF
--- a/internal/gui/frontend/src/lib/Modal.svelte
+++ b/internal/gui/frontend/src/lib/Modal.svelte
@@ -6,13 +6,18 @@
   interface Props {
     title: string;
     show?: boolean;
+    // busy suppresses every dismissal path (Escape, backdrop, close button) while
+    // an operation is in flight, so a mid-flight dismiss cannot unmount the modal
+    // and silently discard its pending result/error.
+    busy?: boolean;
     onclose?: () => void;
     children?: Snippet;
   }
 
-  let { title, show = false, onclose, children }: Props = $props();
+  let { title, show = false, busy = false, onclose, children }: Props = $props();
 
   function handleClose() {
+    if (busy) return;
     onclose?.();
   }
 
@@ -29,11 +34,11 @@
 
 {#if show}
   <div class="modal-backdrop">
-    <button type="button" class="modal-backdrop-dismiss" aria-label="Dismiss" onclick={handleClose}></button>
+    <button type="button" class="modal-backdrop-dismiss" aria-label="Dismiss" disabled={busy} onclick={handleClose}></button>
     <div class="modal">
       <div class="modal-header">
         <h3 class="modal-title">{title}</h3>
-        <button class="btn-close" onclick={handleClose}>
+        <button class="btn-close" disabled={busy} onclick={handleClose}>
           <CloseIcon />
         </button>
       </div>

--- a/internal/gui/frontend/src/lib/PassphraseModal.svelte
+++ b/internal/gui/frontend/src/lib/PassphraseModal.svelte
@@ -89,7 +89,7 @@
   }
 </script>
 
-<Modal title={modalTitle} show={show} onclose={handleClose}>
+<Modal title={modalTitle} show={show} busy={loading} onclose={handleClose}>
   {#if showPlaintextWarning}
     <div class="plaintext-warning">
       <div class="warning-icon">!</div>

--- a/internal/gui/frontend/src/lib/StagingView.svelte
+++ b/internal/gui/frontend/src/lib/StagingView.svelte
@@ -635,7 +635,7 @@
 </div>
 
 <!-- Apply Modal -->
-<Modal title="Apply Staged Changes" show={showApplyModal} onclose={closeApplyModal}>
+<Modal title="Apply Staged Changes" show={showApplyModal} busy={modalLoading} onclose={closeApplyModal}>
   <div class="modal-apply">
     {#if modalError}
       <div class="modal-error">{modalError}</div>
@@ -729,7 +729,7 @@
         <span>Ignore conflicts</span>
       </label>
       <div class="form-actions">
-        <button type="button" class="btn-secondary" onclick={closeApplyModal}>Cancel</button>
+        <button type="button" class="btn-secondary" onclick={closeApplyModal} disabled={modalLoading}>Cancel</button>
         <button type="button" class="btn-apply" onclick={handleApply} disabled={modalLoading}>
           {modalLoading ? 'Applying...' : 'Apply'}
         </button>
@@ -739,7 +739,7 @@
 </Modal>
 
 <!-- Reset Modal -->
-<Modal title="Reset Staged Changes" show={showResetModal} onclose={() => showResetModal = false}>
+<Modal title="Reset Staged Changes" show={showResetModal} busy={modalLoading} onclose={() => showResetModal = false}>
   <div class="modal-confirm">
     {#if modalError}
       <div class="modal-error">{modalError}</div>
@@ -747,7 +747,7 @@
     <p>Reset all staged changes for {getServiceName(resetService)}?</p>
     <p class="warning">This will discard all staged changes without applying them.</p>
     <div class="form-actions">
-      <button type="button" class="btn-secondary" onclick={() => showResetModal = false}>Cancel</button>
+      <button type="button" class="btn-secondary" onclick={() => showResetModal = false} disabled={modalLoading}>Cancel</button>
       <button type="button" class="btn-danger" onclick={handleReset} disabled={modalLoading}>
         {modalLoading ? 'Resetting...' : 'Reset'}
       </button>


### PR DESCRIPTION
## Summary
While an Apply/Reset was in flight, the modal's Cancel button, backdrop-dismiss, and window-level Escape all stayed active (only the primary button was gated). Dismissing mid-flight unmounted the modal, so when the promise settled the results/errors were written to hidden state and never rendered — losing per-entry error rows, the conflict list, unstage warnings, and (on reject) the error text. PassphraseModal had the same gap (only its Cancel was gated).

## Fix
- `Modal` gains a `busy` prop that suppresses every dismissal path (Escape, backdrop click, close button) while true.
- The Apply and Reset modals pass `busy={modalLoading}` and disable their Cancel button while busy.
- `PassphraseModal` forwards `busy={loading}` so its backdrop/Escape are gated like its Cancel button already was.

`svelte-check` passes with 0 errors.

Closes #565.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwohz3bcExASTpHgiV2dHt