### PR TITLE
fix(staging): re-anchor cross-scope import onto the target scope

### DIFF
--- a/internal/cli/commands/stage/command.go
+++ b/internal/cli/commands/stage/command.go
@@ -50,7 +50,7 @@ EXAMPLES:
 			apply.Command(gcfg),
 			reset.Command(gcfg),
 			stgcli.NewGlobalExportCommand(gcfg.ScopeResolver),
-			stgcli.NewGlobalImportCommand(gcfg.ScopeResolver),
+			stgcli.NewGlobalImportCommand(gcfg),
 		},
 		CommandNotFound: cliinternal.CommandNotFound,
 	}

--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -1161,7 +1161,18 @@ func (a *App) StagingImport(path, service, passphrase, mode string, force bool) 
 		Working: working,
 	}
 
-	result, err := uc.Execute(a.ctx, stagingusecase.ImportInput{Service: svc, Mode: importMode})
+	// A forced scope mismatch is a cross-scope import: the envelope's
+	// BaseModifiedAt values track the source scope's timeline, so re-anchor them
+	// against the target scope's current LastModified (mirrors the CLI).
+	reAnchor := force && env.Scope != scope.Key()
+	if reAnchor {
+		uc.ReAnchor, err = a.importReAnchorResolver(service)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	result, err := uc.Execute(a.ctx, stagingusecase.ImportInput{Service: svc, Mode: importMode, ReAnchor: reAnchor})
 	if err != nil {
 		return nil, err
 	}
@@ -1170,5 +1181,26 @@ func (a *App) StagingImport(path, service, passphrase, mode string, force bool) 
 		Merged:     result.Merged,
 		EntryCount: result.EntryCount,
 		TagCount:   result.TagCount,
+	}, nil
+}
+
+// importReAnchorResolver builds the resolver a cross-scope import uses to fetch
+// the target scope's current LastModified. App Configuration (param) keeps all
+// namespaces in one staging store, so it resolves a strategy per namespace like
+// the apply path; every other service resolves a single strategy built once.
+func (a *App) importReAnchorResolver(service string) (stagingusecase.ReAnchorResolver, error) {
+	if service == string(staging.ServiceParam) && a.isAppConfigParam() {
+		return func(_ staging.Service, namespace string) (staging.ApplyStrategy, error) {
+			return a.appConfigParamStrategyForNamespace(namespace)
+		}, nil
+	}
+
+	strategy, err := a.getApplyStrategy(service)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(staging.Service, string) (staging.ApplyStrategy, error) {
+		return strategy, nil
 	}, nil
 }

--- a/internal/staging/cli/import.go
+++ b/internal/staging/cli/import.go
@@ -279,10 +279,53 @@ func importPassphrase(cmd *cli.Command, stdin *bufio.Reader) (string, error) {
 	}
 }
 
+// reAnchorSpec carries the per-service strategy plumbing needed to fetch the
+// target scope's current LastModified when re-anchoring a cross-scope import.
+type reAnchorSpec struct {
+	factory              staging.StrategyFactory
+	strategyForNamespace func(ctx context.Context, namespace string) (staging.FullStrategy, error)
+}
+
+// newReAnchorResolver adapts per-service strategy plumbing to the import use
+// case's ReAnchorResolver. The single non-namespaced strategy is built once and
+// cached (re-anchoring runs sequentially, so no locking is needed); namespaced
+// providers resolve a strategy per namespace like the apply/diff paths do.
+func newReAnchorResolver(ctx context.Context, specs map[staging.Service]reAnchorSpec) usestaging.ReAnchorResolver {
+	cache := make(map[staging.Service]staging.FullStrategy)
+
+	return func(svc staging.Service, namespace string) (staging.ApplyStrategy, error) {
+		spec, ok := specs[svc]
+		if !ok {
+			return nil, fmt.Errorf("no strategy configured for service %q", svc)
+		}
+
+		if spec.strategyForNamespace != nil {
+			return spec.strategyForNamespace(ctx, namespace)
+		}
+
+		if strategy, ok := cache[svc]; ok {
+			return strategy, nil
+		}
+
+		strategy, err := spec.factory(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		cache[svc] = strategy
+
+		return strategy, nil
+	}
+}
+
 // importAction builds the action for the import commands. dest is the single
 // source file for a service-specific import (service != "") or the source
-// directory for a global import (service == "").
-func importAction(service staging.Service, resolver staging.ScopeResolver) func(context.Context, *cli.Command) error {
+// directory for a global import (service == ""). reAnchorSpecs supplies the
+// per-service strategies used to re-base conflict-detection timestamps on a
+// cross-scope import; a nil map disables re-anchoring.
+func importAction(
+	service staging.Service, resolver staging.ScopeResolver, reAnchorSpecs map[staging.Service]reAnchorSpec,
+) func(context.Context, *cli.Command) error {
 	return func(ctx context.Context, cmd *cli.Command) error {
 		if cmd.Args().Len() < 1 {
 			if service != "" {
@@ -320,6 +363,20 @@ func importAction(service staging.Service, resolver staging.ScopeResolver) func(
 			}
 
 			return err
+		}
+
+		// A present envelope whose scope differs from the current scope means this
+		// is a cross-scope import (only reached under --allow-scope-mismatch, since
+		// collectImportEnvelopes refuses a mismatch otherwise). Its BaseModifiedAt
+		// values belong to the source scope's timeline, so re-anchor them.
+		crossScope := false
+
+		for _, p := range present {
+			if p.env.Scope != scope.Key() {
+				crossScope = true
+
+				break
+			}
 		}
 
 		encrypted, err := anyEncrypted(present)
@@ -391,7 +448,14 @@ func importAction(service staging.Service, resolver staging.ScopeResolver) func(
 			Working: working,
 		}
 
-		result, err := uc.Execute(ctx, usestaging.ImportInput{Service: service, Mode: mode.Mode})
+		// Re-anchor only for a genuine cross-scope import, and only when the
+		// command wired per-service strategies to fetch the target LastModified.
+		reAnchor := crossScope && len(reAnchorSpecs) > 0
+		if reAnchor {
+			uc.ReAnchor = newReAnchorResolver(ctx, reAnchorSpecs)
+		}
+
+		result, err := uc.Execute(ctx, usestaging.ImportInput{Service: service, Mode: mode.Mode, ReAnchor: reAnchor})
 		if err != nil {
 			if errors.Is(err, usestaging.ErrNothingToImport) {
 				output.Info(cmd.Root().Writer, "No staged changes to import.")
@@ -400,6 +464,10 @@ func importAction(service staging.Service, resolver staging.ScopeResolver) func(
 			}
 
 			return err
+		}
+
+		for _, warning := range result.Warnings {
+			output.Warning(cmd.Root().ErrWriter, "%s", warning)
 		}
 
 		if result.Merged {
@@ -412,11 +480,26 @@ func importAction(service staging.Service, resolver staging.ScopeResolver) func(
 	}
 }
 
+// globalReAnchorSpecs builds the per-service strategy plumbing for re-anchoring
+// a global cross-scope import from the provider's GlobalConfig.
+func globalReAnchorSpecs(gcfg GlobalConfig) map[staging.Service]reAnchorSpec {
+	specs := make(map[staging.Service]reAnchorSpec, len(gcfg.Services))
+	for _, svc := range gcfg.Services {
+		specs[svc.Service] = reAnchorSpec{factory: svc.Factory, strategyForNamespace: svc.StrategyForNamespace}
+	}
+
+	return specs
+}
+
 // NewGlobalImportCommand creates the global `stage import <dir>` command. It
 // reads <dir>/param.json and <dir>/secret.json (missing files are skipped; an
-// error only when neither exists) into the working staging area. The resolver
-// determines the provider staging scope (nil defaults to AWS).
-func NewGlobalImportCommand(resolver staging.ScopeResolver) *cli.Command {
+// error only when neither exists) into the working staging area. The config's
+// ScopeResolver determines the provider staging scope (nil defaults to AWS); its
+// per-service factories re-anchor conflict-detection timestamps on a cross-scope
+// import.
+func NewGlobalImportCommand(gcfg GlobalConfig) *cli.Command {
+	resolver := gcfg.ScopeResolver
+
 	return &cli.Command{
 		Name:      "import",
 		Usage:     "Import staged changes from a directory (one file per service)",
@@ -439,7 +522,7 @@ EXAMPLES:
    echo "secret" | suve stage import ./backup --passphrase-stdin   Decrypt with passphrase from stdin`,
 		Flags:                  importFlags(),
 		MutuallyExclusiveFlags: importMutuallyExclusiveFlags(),
-		Action:                 importAction("", resolver),
+		Action:                 importAction("", resolver, globalReAnchorSpecs(gcfg)),
 	}
 }
 
@@ -477,6 +560,8 @@ EXAMPLES:
 			cfg.CommandName),
 		Flags:                  importFlags(),
 		MutuallyExclusiveFlags: importMutuallyExclusiveFlags(),
-		Action:                 importAction(service, cfg.ScopeResolver),
+		Action: importAction(service, cfg.ScopeResolver, map[staging.Service]reAnchorSpec{
+			service: {factory: cfg.Factory, strategyForNamespace: cfg.StrategyForNamespace},
+		}),
 	}
 }

--- a/internal/staging/cli/import_test.go
+++ b/internal/staging/cli/import_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/cli/confirm"
 	"github.com/mpyw/suve/internal/provider"
@@ -14,6 +15,14 @@ import (
 	stgcli "github.com/mpyw/suve/internal/staging/cli"
 	usestaging "github.com/mpyw/suve/internal/usecase/staging"
 )
+
+// globalImportCmd builds the global import command for a fixed scope resolver.
+// The global command re-anchors via the config's per-service factories; these
+// tests exercise same-scope and refused cross-scope paths, so a bare resolver
+// (no factories) is enough.
+func globalImportCmd(resolver staging.ScopeResolver) *cli.Command {
+	return stgcli.NewGlobalImportCommand(stgcli.GlobalConfig{ScopeResolver: resolver})
+}
 
 // exportDir stages the given entries, exports them to a fresh directory (which
 // clears the working area), and returns the directory. It is the setup shared by
@@ -41,7 +50,7 @@ func TestGlobalImport(t *testing.T) {
 
 		require.True(t, workingState(t, scope).IsEmpty())
 
-		stdout, _, err := runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scope)), nil, dir)
+		stdout, _, err := runLeafCmd(t, globalImportCmd(fixedResolver(scope)), nil, dir)
 		require.NoError(t, err)
 		assert.Contains(t, stdout, "imported")
 
@@ -59,7 +68,7 @@ func TestGlobalImport(t *testing.T) {
 		// New change in the working area.
 		stageEntry(t, scope, staging.ServiceParam, "/app/param2", "v2")
 
-		stdout, _, err := runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scope)), nil, dir, "--merge")
+		stdout, _, err := runLeafCmd(t, globalImportCmd(fixedResolver(scope)), nil, dir, "--merge")
 		require.NoError(t, err)
 		assert.Contains(t, stdout, "merged")
 
@@ -76,7 +85,7 @@ func TestGlobalImport(t *testing.T) {
 
 		stageEntry(t, scope, staging.ServiceParam, "/app/param2", "v2")
 
-		_, _, err := runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scope)), nil, dir, "--overwrite")
+		_, _, err := runLeafCmd(t, globalImportCmd(fixedResolver(scope)), nil, dir, "--overwrite")
 		require.NoError(t, err)
 
 		entries := workingState(t, scope).Entries[staging.ServiceParam]
@@ -91,7 +100,7 @@ func TestGlobalImport(t *testing.T) {
 		})
 
 		// Only param.json exists in the dir.
-		stdout, _, err := runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scope)), nil, dir)
+		stdout, _, err := runLeafCmd(t, globalImportCmd(fixedResolver(scope)), nil, dir)
 		require.NoError(t, err)
 		assert.Contains(t, stdout, "imported")
 
@@ -110,7 +119,7 @@ func TestGlobalImport(t *testing.T) {
 		_, _, err := runLeafCmd(t, stgcli.NewExportCommand(secretExportImportConfig(fixedResolver(scope))), nil, fpath)
 		require.NoError(t, err)
 
-		_, _, err = runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scope)), nil, dir)
+		_, _, err = runLeafCmd(t, globalImportCmd(fixedResolver(scope)), nil, dir)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "expected")
 	})
@@ -119,7 +128,7 @@ func TestGlobalImport(t *testing.T) {
 		scope := setupExportImportEnv(t)
 		dir := t.TempDir()
 
-		stdout, _, err := runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scope)), nil, dir)
+		stdout, _, err := runLeafCmd(t, globalImportCmd(fixedResolver(scope)), nil, dir)
 		require.NoError(t, err)
 		assert.Contains(t, stdout, "No staged changes to import.")
 	})
@@ -127,7 +136,7 @@ func TestGlobalImport(t *testing.T) {
 	t.Run("missing dir argument", func(t *testing.T) {
 		scope := setupExportImportEnv(t)
 
-		_, _, err := runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scope)), nil)
+		_, _, err := runLeafCmd(t, globalImportCmd(fixedResolver(scope)), nil)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "usage")
 	})
@@ -140,13 +149,13 @@ func TestGlobalImport(t *testing.T) {
 
 		scopeB := provider.AWSScope("999999999999", "eu-west-1")
 
-		_, _, err := runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scopeB)), nil, dir)
+		_, _, err := runLeafCmd(t, globalImportCmd(fixedResolver(scopeB)), nil, dir)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), scopeA.Key())
 		assert.Contains(t, err.Error(), scopeB.Key())
 
 		// --allow-scope-mismatch overrides.
-		_, _, err = runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scopeB)), nil, dir, "--allow-scope-mismatch")
+		_, _, err = runLeafCmd(t, globalImportCmd(fixedResolver(scopeB)), nil, dir, "--allow-scope-mismatch")
 		require.NoError(t, err)
 		assert.False(t, workingState(t, scopeB).ExtractService(staging.ServiceParam).IsEmpty())
 	})
@@ -157,7 +166,7 @@ func TestGlobalImport(t *testing.T) {
 			stageEntry(t, scope, staging.ServiceParam, "/app/config", "pval")
 		})
 
-		_, _, err := runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scope)), nil, dir, "--force")
+		_, _, err := runLeafCmd(t, globalImportCmd(fixedResolver(scope)), nil, dir, "--force")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "force")
 	})
@@ -171,7 +180,7 @@ func TestGlobalImport(t *testing.T) {
 		require.NoError(t, err)
 
 		// No --passphrase-stdin and a non-TTY writer: cannot prompt.
-		_, _, err = runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scope)), nil, dir)
+		_, _, err = runLeafCmd(t, globalImportCmd(fixedResolver(scope)), nil, dir)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "non-TTY")
 	})
@@ -184,7 +193,7 @@ func TestGlobalImport(t *testing.T) {
 		_, _, err := runLeafCmd(t, stgcli.NewGlobalExportCommand(fixedResolver(scope)), bytes.NewBufferString("right-pw\n"), dir, "--passphrase-stdin")
 		require.NoError(t, err)
 
-		_, _, err = runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scope)), bytes.NewBufferString("wrong-pw\n"), dir, "--passphrase-stdin")
+		_, _, err = runLeafCmd(t, globalImportCmd(fixedResolver(scope)), bytes.NewBufferString("wrong-pw\n"), dir, "--passphrase-stdin")
 		require.Error(t, err)
 	})
 
@@ -204,7 +213,7 @@ func TestGlobalImport(t *testing.T) {
 		stageEntry(t, scope, staging.ServiceParam, "/app/param2", "v2")
 
 		// Only the passphrase is on stdin (no merge/overwrite answer line).
-		stdout, _, err := runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scope)), bytes.NewBufferString("pw123\n"), dir, "--passphrase-stdin")
+		stdout, _, err := runLeafCmd(t, globalImportCmd(fixedResolver(scope)), bytes.NewBufferString("pw123\n"), dir, "--passphrase-stdin")
 		require.NoError(t, err)
 		assert.Contains(t, stdout, "merged")
 
@@ -222,7 +231,7 @@ func TestGlobalImport(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, workingState(t, scope).IsEmpty())
 
-		_, _, err = runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(scope)), bytes.NewBufferString("pw123\n"), dir, "--passphrase-stdin")
+		_, _, err = runLeafCmd(t, globalImportCmd(fixedResolver(scope)), bytes.NewBufferString("pw123\n"), dir, "--passphrase-stdin")
 		require.NoError(t, err)
 		assert.False(t, workingState(t, scope).ExtractService(staging.ServiceParam).IsEmpty())
 	})
@@ -248,7 +257,7 @@ func TestGlobalImport_ProviderMismatch(t *testing.T) {
 
 	// --allow-scope-mismatch bypasses the scope check but the provider guard
 	// still refuses.
-	_, _, err := runLeafCmd(t, stgcli.NewGlobalImportCommand(fixedResolver(awsScope)), nil, dir, "--allow-scope-mismatch")
+	_, _, err := runLeafCmd(t, globalImportCmd(fixedResolver(awsScope)), nil, dir, "--allow-scope-mismatch")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "provider")
 	assert.Contains(t, err.Error(), string(provider.ProviderAzure))

--- a/internal/usecase/staging/import.go
+++ b/internal/usecase/staging/import.go
@@ -3,6 +3,8 @@ package staging
 import (
 	"context"
 	"errors"
+	"fmt"
+	"time"
 
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store"
@@ -17,6 +19,14 @@ const (
 	ImportOpWrite       ImportOp = "write"
 	ImportOpReadWorking ImportOp = "read-working"
 )
+
+// ReAnchorResolver resolves the ApplyStrategy that can fetch a resource's
+// current LastModified in the TARGET (current) scope, for a service and
+// namespace. It mirrors the apply/conflict resolver so a cross-scope import can
+// re-base each staged item's conflict-detection timestamp against the scope it
+// is imported INTO rather than the foreign scope it was exported FROM. For
+// namespace-agnostic providers the namespace is always empty.
+type ReAnchorResolver func(svc staging.Service, namespace string) (staging.ApplyStrategy, error)
 
 // EnvelopeReader reads a single service's staged state from an import source
 // (typically a per-service envelope file). Adapters bind the source path, scope
@@ -36,6 +46,13 @@ type ImportInput struct {
 	// ImportModeMerge combines the imported state with the working area.
 	// ImportModeOverwrite replaces the working area with the imported state.
 	Mode ImportMode
+	// ReAnchor requests re-basing each staged item's BaseModifiedAt against the
+	// target scope's current LastModified. It is set for a cross-scope import
+	// (CLI --allow-scope-mismatch / GUI force), where the envelope's
+	// BaseModifiedAt belongs to a foreign scope's timeline and would make apply's
+	// conflict detection meaningless. It is a no-op unless the use case also has
+	// a ReAnchor resolver configured.
+	ReAnchor bool
 }
 
 // ImportOutput holds the result of the import use case.
@@ -47,6 +64,10 @@ type ImportOutput struct {
 	EntryCount int
 	// TagCount is the number of tag entries in the final working state.
 	TagCount int
+	// Warnings holds non-fatal diagnostics produced during import, e.g. an item
+	// left unanchored because its LastModified could not be fetched from the
+	// target scope during a cross-scope re-anchor.
+	Warnings []string
 }
 
 // ImportUseCase reads an export source into the working staging area. It keeps
@@ -58,6 +79,11 @@ type ImportUseCase struct {
 	Source EnvelopeReader
 	// Working is the working staging area (param.json/secret.json).
 	Working store.WorkingStore
+	// ReAnchor, when set, resolves a strategy that fetches the target scope's
+	// current LastModified so a cross-scope import (ImportInput.ReAnchor) re-bases
+	// each staged item's conflict-detection timestamp. Nil disables re-anchoring
+	// even when ImportInput.ReAnchor is set (same-scope import needs none).
+	ReAnchor ReAnchorResolver
 }
 
 // Execute runs the import use case.
@@ -73,6 +99,14 @@ func (u *ImportUseCase) Execute(ctx context.Context, input ImportInput) (*Import
 	}
 
 	output := &ImportOutput{}
+
+	// For a cross-scope import, the envelope's BaseModifiedAt values track a
+	// foreign scope's timeline; re-base them against the target scope's current
+	// LastModified BEFORE reconciling so apply's conflict detection is meaningful
+	// for the scope the items land in.
+	if input.ReAnchor && u.ReAnchor != nil {
+		u.reAnchorState(ctx, sourceState, output)
+	}
 
 	// Reconcile the source into the working area as a single atomic
 	// read-modify-write. Update re-reads the working state fresh under the store
@@ -100,6 +134,73 @@ func (u *ImportUseCase) Execute(ctx context.Context, input ImportInput) (*Import
 	}
 
 	return output, nil
+}
+
+// reAnchorState re-bases every staged item that carries a BaseModifiedAt onto
+// the target scope's current LastModified, mutating sourceState in place. A
+// Create entry carries no base and is left untouched. When the target resource
+// does not exist (or reports no modification time) the item is left unanchored
+// (BaseModifiedAt = nil) so it never trips a spurious conflict against a
+// timeline it never belonged to; a genuine fetch failure is recorded as a
+// warning and likewise unanchors the item rather than aborting the whole import.
+func (u *ImportUseCase) reAnchorState(ctx context.Context, sourceState *staging.State, output *ImportOutput) {
+	for svc, entries := range sourceState.Entries {
+		for key, entry := range entries {
+			if entry.BaseModifiedAt == nil {
+				continue
+			}
+
+			entry.BaseModifiedAt = u.currentBase(ctx, svc, key, output)
+			entries[key] = entry
+		}
+	}
+
+	for svc, tags := range sourceState.Tags {
+		for key, tag := range tags {
+			if tag.BaseModifiedAt == nil {
+				continue
+			}
+
+			tag.BaseModifiedAt = u.currentBase(ctx, svc, key, output)
+			tags[key] = tag
+		}
+	}
+}
+
+// currentBase fetches key's current LastModified in the target scope and returns
+// it as a conflict-detection base, or nil when the resource is missing, reports
+// no modification time, or cannot be fetched. A fetch failure (anything other
+// than a not-found) appends a warning to output.
+func (u *ImportUseCase) currentBase(
+	ctx context.Context, svc staging.Service, key staging.EntryKey, output *ImportOutput,
+) *time.Time {
+	strategy, err := u.ReAnchor(svc, key.Namespace)
+	if err != nil {
+		output.Warnings = append(output.Warnings, fmt.Sprintf(
+			"could not re-anchor %s: %v; left unanchored (conflict detection skipped)", key.Label(), err))
+
+		return nil
+	}
+
+	lastModified, err := strategy.FetchLastModified(ctx, key.Name)
+	if err != nil {
+		// A missing resource has no base to anchor to; leave it unanchored without
+		// a warning. Any other error is surfaced so the unanchored item is visible.
+		if notFound := (*staging.ResourceNotFoundError)(nil); !errors.As(err, &notFound) {
+			output.Warnings = append(output.Warnings, fmt.Sprintf(
+				"could not re-anchor %s: %v; left unanchored (conflict detection skipped)", key.Label(), err))
+		}
+
+		return nil
+	}
+
+	if lastModified.IsZero() {
+		// The resource exists but carries no modification time (or the provider
+		// disables conflict detection): there is nothing to anchor to.
+		return nil
+	}
+
+	return &lastModified
 }
 
 // reconcileImport merges sourceState into workingState in place per the import

--- a/internal/usecase/staging/import_test.go
+++ b/internal/usecase/staging/import_test.go
@@ -48,6 +48,155 @@ func sourceState(svc staging.Service, name, value string) *staging.State {
 	return s
 }
 
+// reAnchorSourceState builds a ServiceParam state carrying one Update entry and
+// one tag change, both anchored to foreignBase (the source scope's timeline), so
+// a re-anchor test can assert the base is rewritten.
+func reAnchorSourceState(name string, foreignBase time.Time) *staging.State {
+	s := staging.NewEmptyState()
+	s.Entries[staging.ServiceParam][staging.EntryKey{Name: name}] = staging.Entry{
+		Operation:      staging.OperationUpdate,
+		Value:          lo.ToPtr("v"),
+		StagedAt:       time.Now(),
+		BaseModifiedAt: lo.ToPtr(foreignBase),
+	}
+	s.Tags[staging.ServiceParam][staging.EntryKey{Name: name}] = staging.TagEntry{
+		Add:            map[string]string{"env": "prod"},
+		StagedAt:       time.Now(),
+		BaseModifiedAt: lo.ToPtr(foreignBase),
+	}
+
+	return s
+}
+
+func TestImportUseCase_ReAnchor(t *testing.T) {
+	t.Parallel()
+
+	foreignBase := time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	name := "/app/config"
+
+	t.Run("cross-scope import re-bases BaseModifiedAt onto the target scope", func(t *testing.T) {
+		t.Parallel()
+
+		targetBase := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+
+		reader := &cannedReader{states: map[staging.Service]*staging.State{
+			staging.ServiceParam: reAnchorSourceState(name, foreignBase),
+		}}
+		working := testutil.NewMockStore()
+
+		strategy := newMockApplyStrategy()
+		strategy.lastModified[name] = targetBase
+
+		usecase := &stagingusecase.ImportUseCase{
+			Source:  reader,
+			Working: working,
+			ReAnchor: func(_ staging.Service, _ string) (staging.ApplyStrategy, error) {
+				return strategy, nil
+			},
+		}
+
+		output, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{ReAnchor: true})
+		require.NoError(t, err)
+		assert.Empty(t, output.Warnings)
+
+		entry, err := working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: name})
+		require.NoError(t, err)
+		require.NotNil(t, entry.BaseModifiedAt)
+		assert.Equal(t, targetBase, *entry.BaseModifiedAt)
+
+		tag, err := working.GetTag(t.Context(), staging.ServiceParam, staging.EntryKey{Name: name})
+		require.NoError(t, err)
+		require.NotNil(t, tag.BaseModifiedAt)
+		assert.Equal(t, targetBase, *tag.BaseModifiedAt)
+	})
+
+	t.Run("missing target resource leaves the item unanchored without a warning", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &cannedReader{states: map[staging.Service]*staging.State{
+			staging.ServiceParam: reAnchorSourceState(name, foreignBase),
+		}}
+		working := testutil.NewMockStore()
+
+		strategy := newMockApplyStrategy()
+		strategy.fetchModifiedErr = &staging.ResourceNotFoundError{}
+
+		usecase := &stagingusecase.ImportUseCase{
+			Source:  reader,
+			Working: working,
+			ReAnchor: func(_ staging.Service, _ string) (staging.ApplyStrategy, error) {
+				return strategy, nil
+			},
+		}
+
+		output, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{ReAnchor: true})
+		require.NoError(t, err)
+		assert.Empty(t, output.Warnings)
+
+		entry, err := working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: name})
+		require.NoError(t, err)
+		assert.Nil(t, entry.BaseModifiedAt)
+	})
+
+	t.Run("fetch failure warns and leaves the item unanchored", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &cannedReader{states: map[staging.Service]*staging.State{
+			staging.ServiceParam: reAnchorSourceState(name, foreignBase),
+		}}
+		working := testutil.NewMockStore()
+
+		strategy := newMockApplyStrategy()
+		strategy.fetchModifiedErr = errors.New("network down")
+
+		usecase := &stagingusecase.ImportUseCase{
+			Source:  reader,
+			Working: working,
+			ReAnchor: func(_ staging.Service, _ string) (staging.ApplyStrategy, error) {
+				return strategy, nil
+			},
+		}
+
+		output, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{ReAnchor: true})
+		require.NoError(t, err)
+		assert.NotEmpty(t, output.Warnings)
+
+		entry, err := working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: name})
+		require.NoError(t, err)
+		assert.Nil(t, entry.BaseModifiedAt)
+	})
+
+	t.Run("without ReAnchor input the foreign base is kept", func(t *testing.T) {
+		t.Parallel()
+
+		reader := &cannedReader{states: map[staging.Service]*staging.State{
+			staging.ServiceParam: reAnchorSourceState(name, foreignBase),
+		}}
+		working := testutil.NewMockStore()
+
+		strategy := newMockApplyStrategy()
+		strategy.lastModified[name] = time.Now()
+
+		usecase := &stagingusecase.ImportUseCase{
+			Source:  reader,
+			Working: working,
+			ReAnchor: func(_ staging.Service, _ string) (staging.ApplyStrategy, error) {
+				return strategy, nil
+			},
+		}
+
+		// ReAnchor is false: the resolver must not be consulted and the foreign
+		// base survives untouched.
+		_, err := usecase.Execute(t.Context(), stagingusecase.ImportInput{})
+		require.NoError(t, err)
+
+		entry, err := working.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: name})
+		require.NoError(t, err)
+		require.NotNil(t, entry.BaseModifiedAt)
+		assert.Equal(t, foreignBase, *entry.BaseModifiedAt)
+	})
+}
+
 //nolint:funlen // Many subtests covering merge/overwrite and service/global cases
 func TestImportUseCase_Execute(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
On a cross-scope import (CLI `--allow-scope-mismatch` / GUI force), the imported envelope kept its foreign `BaseModifiedAt` values, which belong to the source scope's timeline. Apply's conflict detection then compared the target scope's remote against a timestamp from a different scope, making it meaningless.

This re-bases each staged item that carries a base (Update/Delete entries and tag changes) onto the target scope's current `LastModified` before reconciling into the working area:

- `ImportUseCase` gains an optional `ReAnchor` resolver; `ImportInput.ReAnchor` gates it so a same-scope import is unaffected.
- A missing target resource is left unanchored silently (no base to anchor to); a genuine fetch failure warns and leaves the item unanchored rather than aborting the whole import.
- The resolver is wired from the existing per-service strategies in the CLI (global + per-service import) and the GUI.

Closes #549.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwohz3bcExASTpHgiV2dHt