### PR TITLE
fix(gui): guard StagingView loadStatus with a request sequence

### DIFF
--- a/internal/gui/frontend/src/lib/StagingView.svelte
+++ b/internal/gui/frontend/src/lib/StagingView.svelte
@@ -89,7 +89,14 @@
   let importError = $state('');
   let importResult: gui.StagingImportResult | null = $state(null);
 
+  // Monotonic request id: loadStatus is fired from onMount, Refresh, and every
+  // action handler's finally block, so two runs can overlap. Only the latest run
+  // may assign state / fire oncountchange, otherwise a slow earlier snapshot
+  // resolving last could resurrect a just-unstaged entry and stale the badge (#566).
+  let loadSeq = 0;
+
   async function loadStatus() {
+    const seq = ++loadSeq;
     loading = true;
     error = '';
     try {
@@ -97,6 +104,7 @@
         paramSvc ? withRetry(() => StagingDiff('param', '')) : Promise.resolve(null),
         secretSvc ? withRetry(() => StagingDiff('secret', '')) : Promise.resolve(null),
       ]);
+      if (seq !== loadSeq) return; // superseded by a newer reload
       paramEntries = paramResult?.entries?.filter(e => e.type !== 'autoUnstaged') || [];
       secretEntries = secretResult?.entries?.filter(e => e.type !== 'autoUnstaged') || [];
       paramTagEntries = paramResult?.tagEntries || [];
@@ -105,6 +113,7 @@
       const totalCount = paramEntries.length + secretEntries.length + paramTagEntries.length + secretTagEntries.length;
       oncountchange?.(totalCount);
     } catch (e) {
+      if (seq !== loadSeq) return; // superseded by a newer reload
       error = parseError(e);
       paramEntries = [];
       secretEntries = [];
@@ -112,7 +121,7 @@
       secretTagEntries = [];
       oncountchange?.(0);
     } finally {
-      loading = false;
+      if (seq === loadSeq) loading = false;
     }
   }
 


### PR DESCRIPTION
## Summary
`StagingView.loadStatus` had no request-sequence guard. It fires from `onMount`, the Refresh button, and every action handler's `finally` block, and each run unconditionally assigned the entry/tag lists and fired `oncountchange`. Two overlapping runs raced: if the earlier snapshot resolved last, a just-unstaged entry reappeared and the badge count went stale until the next reload (same class as #539).

## Fix
Capture a monotonic request id at the start of each call; only the latest run may assign state, fire `oncountchange`, and clear `loading`. Superseded runs return early in both the success and catch paths.

`svelte-check` passes with 0 errors.

Closes #566.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwohz3bcExASTpHgiV2dHt