### PR TITLE
fix(staging): reject duplicate records and diagnose version-drop

### DIFF
--- a/internal/staging/stage.go
+++ b/internal/staging/stage.go
@@ -210,11 +210,19 @@ func (s *State) UnmarshalJSON(data []byte) error {
 
 	if head.Version < stateVersion {
 		// Pre-v3 state used a different on-disk layout (NUL-composite string map
-		// keys) that is intentionally not migrated. Treat it as empty so a format
-		// bump never crashes commands; stale local working state is dropped.
+		// keys) that is intentionally not migrated. Decode it as empty so a format
+		// bump never crashes commands, but report the drop with a distinct error so
+		// a reader that is NOT a stale-working-state migration (e.g. an envelope
+		// import) can surface "records dropped due to unsupported version" instead
+		// of a silent "nothing imported". The working store treats this sentinel as
+		// a benign reset (see file.Store.readFile).
 		*s = *NewEmptyState()
 
-		return nil
+		return fmt.Errorf(
+			"%w: on-disk state is version %d but this build only supports version %d; "+
+				"records dropped due to unsupported version",
+			ErrStateVersionTooOld, head.Version, stateVersion,
+		)
 	}
 
 	if head.Version > stateVersion {
@@ -240,7 +248,13 @@ func (s *State) UnmarshalJSON(data []byte) error {
 	for svc, recs := range in.Entries {
 		m := make(map[EntryKey]Entry, len(recs))
 		for _, rec := range recs {
-			m[EntryKey{Name: rec.Name, Namespace: rec.Namespace}] = rec.Entry
+			key := EntryKey{Name: rec.Name, Namespace: rec.Namespace}
+			if _, dup := m[key]; dup {
+				return fmt.Errorf(
+					"%w: entry %s appears more than once in service %q", ErrDuplicateRecord, key.Label(), svc)
+			}
+
+			m[key] = rec.Entry
 		}
 
 		s.Entries[svc] = m
@@ -249,7 +263,13 @@ func (s *State) UnmarshalJSON(data []byte) error {
 	for svc, recs := range in.Tags {
 		m := make(map[EntryKey]TagEntry, len(recs))
 		for _, rec := range recs {
-			m[EntryKey{Name: rec.Name, Namespace: rec.Namespace}] = rec.TagEntry
+			key := EntryKey{Name: rec.Name, Namespace: rec.Namespace}
+			if _, dup := m[key]; dup {
+				return fmt.Errorf(
+					"%w: tag change for %s appears more than once in service %q", ErrDuplicateRecord, key.Label(), svc)
+			}
+
+			m[key] = rec.TagEntry
 		}
 
 		s.Tags[svc] = m
@@ -508,4 +528,14 @@ var (
 	// upgrade suve; the state is left untouched rather than rewritten as an older
 	// version.
 	ErrStateVersionTooNew = errors.New("staging state was written by a newer suve; upgrade suve")
+	// ErrStateVersionTooOld is returned by UnmarshalJSON when the state was
+	// written by an older suve whose on-disk layout this build does not migrate.
+	// The state decodes as empty (its records are dropped), but the error makes
+	// that drop explicit so an importer can report it instead of silently
+	// importing nothing. The working store treats it as a benign reset.
+	ErrStateVersionTooOld = errors.New("staging state was written by an older suve and cannot be read; its records were dropped")
+	// ErrDuplicateRecord is returned by UnmarshalJSON when a payload carries two
+	// records for the same (name, namespace). Silently keeping the last one would
+	// hide the ambiguity, so the state is rejected instead.
+	ErrDuplicateRecord = errors.New("duplicate staged record")
 )

--- a/internal/staging/stage_test.go
+++ b/internal/staging/stage_test.go
@@ -253,13 +253,14 @@ func TestState_Merge(t *testing.T) {
 func TestState_UnmarshalJSON_Version(t *testing.T) {
 	t.Parallel()
 
-	t.Run("older version is dropped as empty", func(t *testing.T) {
+	t.Run("older version is dropped as empty with a distinct diagnostic", func(t *testing.T) {
 		t.Parallel()
 
 		var state staging.State
 
 		err := json.Unmarshal([]byte(`{"version":2}`), &state)
-		require.NoError(t, err)
+		require.ErrorIs(t, err, staging.ErrStateVersionTooOld)
+		require.NotErrorIs(t, err, staging.ErrStateVersionTooNew)
 		assert.True(t, state.IsEmpty())
 	})
 
@@ -271,6 +272,52 @@ func TestState_UnmarshalJSON_Version(t *testing.T) {
 		err := json.Unmarshal([]byte(`{"version":4}`), &state)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, staging.ErrStateVersionTooNew)
+	})
+}
+
+func TestState_UnmarshalJSON_Duplicate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("duplicate entry records are rejected", func(t *testing.T) {
+		t.Parallel()
+
+		data := `{"version":3,"entries":{"param":[` +
+			`{"name":"/app/x","operation":"update","staged_at":"2024-01-01T00:00:00Z"},` +
+			`{"name":"/app/x","operation":"delete","staged_at":"2024-01-02T00:00:00Z"}]}}`
+
+		var state staging.State
+
+		err := json.Unmarshal([]byte(data), &state)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, staging.ErrDuplicateRecord)
+	})
+
+	t.Run("duplicate tag records are rejected", func(t *testing.T) {
+		t.Parallel()
+
+		data := `{"version":3,"tags":{"param":[` +
+			`{"name":"/app/x","staged_at":"2024-01-01T00:00:00Z"},` +
+			`{"name":"/app/x","staged_at":"2024-01-02T00:00:00Z"}]}}`
+
+		var state staging.State
+
+		err := json.Unmarshal([]byte(data), &state)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, staging.ErrDuplicateRecord)
+	})
+
+	t.Run("same name under distinct namespaces is not a duplicate", func(t *testing.T) {
+		t.Parallel()
+
+		data := `{"version":3,"entries":{"param":[` +
+			`{"name":"x","namespace":"a","operation":"update","staged_at":"2024-01-01T00:00:00Z"},` +
+			`{"name":"x","namespace":"b","operation":"update","staged_at":"2024-01-02T00:00:00Z"}]}}`
+
+		var state staging.State
+
+		err := json.Unmarshal([]byte(data), &state)
+		require.NoError(t, err)
+		assert.Equal(t, 2, state.EntryCount())
 	})
 }
 

--- a/internal/staging/store/file/store.go
+++ b/internal/staging/store/file/store.go
@@ -327,6 +327,13 @@ func (s *Store) readFile(path string) (*staging.State, error) {
 
 	var state staging.State
 	if err := json.Unmarshal(data, &state); err != nil {
+		// A too-old on-disk layout is intentionally not migrated: it decodes as an
+		// empty state and the stale working area is silently reset (the diagnostic
+		// only matters to an importer, not to this migration path).
+		if errors.Is(err, staging.ErrStateVersionTooOld) {
+			return staging.NewEmptyState(), nil
+		}
+
 		return nil, fmt.Errorf("failed to parse state file: %w", err)
 	}
 


### PR DESCRIPTION
Two payload-parsing gaps in `State.UnmarshalJSON`:

1. Duplicate `(name, namespace)` records collapsed last-wins silently, hiding an ambiguous/corrupt payload. They are now rejected with `ErrDuplicateRecord`.
2. A payload written by an older, unmigratable version decoded as empty and returned `nil`, so an import reported a bland "nothing imported". It now still decodes as empty but returns the distinct `ErrStateVersionTooOld` ("records dropped due to unsupported version") so the drop is surfaced.

The working store's `readFile` treats `ErrStateVersionTooOld` as a benign reset, preserving the intentional stale-working-state migration (an old local state is still silently dropped there).

Closes #557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwohz3bcExASTpHgiV2dHt