### PR TITLE
fix(staging): split envelope version message by direction

### DIFF
--- a/internal/staging/store/file/envelope.go
+++ b/internal/staging/store/file/envelope.go
@@ -169,9 +169,20 @@ func ReadEnvelopeFile(path string) (*Envelope, error) {
 		return nil, fmt.Errorf("%w: %s", ErrInvalidEnvelope, err.Error())
 	}
 
-	if env.Version != EnvelopeVersion {
+	if env.Version < EnvelopeVersion {
+		// An older envelope: its format is gone from this build, so re-export it
+		// from a still-staged source with the current suve.
 		return nil, fmt.Errorf(
 			"%w: file is version %d, but this build only reads version %d; re-create it with `stage export`",
+			ErrUnsupportedEnvelopeVersion, env.Version, EnvelopeVersion,
+		)
+	}
+
+	if env.Version > EnvelopeVersion {
+		// A newer envelope: this build cannot know its format, so upgrading suve
+		// is the fix rather than re-exporting.
+		return nil, fmt.Errorf(
+			"%w: file is version %d, but this build only reads version %d; it was written by a newer suve, upgrade suve",
 			ErrUnsupportedEnvelopeVersion, env.Version, EnvelopeVersion,
 		)
 	}

--- a/internal/staging/store/file/envelope_test.go
+++ b/internal/staging/store/file/envelope_test.go
@@ -300,11 +300,19 @@ func TestReadEnvelopeFile_Errors(t *testing.T) {
 	t.Run("unsupported version", func(t *testing.T) {
 		t.Parallel()
 
-		// version 1 is the pre-AAD format that is deliberately no longer readable.
-		for _, ver := range []int{1, 99} {
+		// An older version (e.g. the pre-AAD v1 format) is guided to re-export;
+		// a newer version is guided to upgrade suve.
+		cases := []struct {
+			ver  int
+			want string
+		}{
+			{ver: 1, want: "stage export"},
+			{ver: 99, want: "upgrade suve"},
+		}
+		for _, tc := range cases {
 			path := filepath.Join(t.TempDir(), "old.json")
 			data, err := json.Marshal(file.Envelope{
-				Version:  ver,
+				Version:  tc.ver,
 				Provider: "aws",
 				Scope:    "aws/1/r",
 				Service:  "param",
@@ -315,8 +323,8 @@ func TestReadEnvelopeFile_Errors(t *testing.T) {
 
 			_, err = file.ReadEnvelopeFile(path)
 			require.ErrorIs(t, err, file.ErrUnsupportedEnvelopeVersion)
-			// The error must guide the user to re-create the file.
-			assert.Contains(t, err.Error(), "stage export")
+			// The error must guide the user to the right remedy for the direction.
+			assert.Contains(t, err.Error(), tc.want)
 		}
 	})
 


### PR DESCRIPTION
A version-mismatched export file always got "re-create it with `stage export`". That is correct for an older file but misleading for one written by a newer suve, where re-exporting from an older build cannot produce a readable file.

`ReadEnvelopeFile` now splits the check: `env.Version < EnvelopeVersion` keeps the re-export guidance, while `env.Version > EnvelopeVersion` advises upgrading suve.

Closes #529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwohz3bcExASTpHgiV2dHt