### PR TITLE
fix(gui): show a busy modal during import backend call

### DIFF
--- a/internal/gui/frontend/src/lib/StagingView.svelte
+++ b/internal/gui/frontend/src/lib/StagingView.svelte
@@ -440,7 +440,9 @@
   }
 
   function handleImportPassphrase(passphrase: string) {
-    showImportPassphrase = false;
+    // Keep the passphrase modal open across the attempt so a wrong passphrase can
+    // be re-entered inline (via the modal's error prop); runImport closes it on
+    // success. Mirrors the export flow.
     runImport(passphrase);
   }
 
@@ -459,9 +461,14 @@
       await loadStatus();
     } catch (e) {
       importError = parseError(e);
-      // Surface backend errors (e.g. wrong passphrase, service mismatch) in a
-      // modal since the transient chain modals are now closed.
-      showImportErrorModal = true;
+      // When the passphrase prompt is open (encrypted import), keep it open and
+      // show the error inline via the modal's error prop so a wrong passphrase can
+      // be retried without rebuilding the whole import chain (mirrors export).
+      // Only non-passphrase errors (the prompt is closed) fall back to the
+      // standalone Import Failed modal.
+      if (!showImportPassphrase) {
+        showImportErrorModal = true;
+      }
     } finally {
       importLoading = false;
     }

--- a/internal/gui/frontend/src/lib/StagingView.svelte
+++ b/internal/gui/frontend/src/lib/StagingView.svelte
@@ -918,6 +918,17 @@
   error={importError}
 />
 
+<!-- Import Busy Modal: progress feedback + input blocking for the import paths
+     that show no passphrase modal (plaintext, and plaintext into a service with
+     no existing changes). The encrypted path already surfaces progress via the
+     passphrase modal's loading state, so this is suppressed while that is open.
+     It has no onclose, so its backdrop/Escape/× cannot dismiss it mid-flight. -->
+<Modal title="Importing {serviceLabel(importService)}" show={importLoading && !showImportPassphrase}>
+  <div class="modal-confirm">
+    <p>Importing staged changes…</p>
+  </div>
+</Modal>
+
 <!-- Import Result Modal -->
 {#if importResult}
 <Modal title="Import Complete" show={true} onclose={() => importResult = null}>


### PR DESCRIPTION
## Summary
Import gave no busy feedback during the backend call. The plaintext paths fired `runImport` with no modal on screen, so nothing was disabled and the transfer menu could be reopened to start a second import mid-flight during a slow `StagingImport`.

## Fix
Add a lightweight "Importing…" modal bound to `importLoading`, shown while the passphrase modal is not open (the encrypted path already surfaces progress via that modal's loading state, per #526). The busy modal has no `onclose`, so its backdrop covers the UI and cannot be dismissed mid-flight, blocking a concurrent import.

`svelte-check` passes with 0 errors.

## Note
Stacked on #600 (both touch the import flow, which would otherwise conflict), so this PR's diff currently includes #600's retry change until #600 merges. It should merge after #600.

Closes #569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwohz3bcExASTpHgiV2dHt