### PR TITLE
fix(staging): reject namespaced entries from namespace-agnostic envelopes

### DIFF
--- a/internal/staging/store/file/envelope.go
+++ b/internal/staging/store/file/envelope.go
@@ -231,9 +231,53 @@ func (e *Envelope) DecodeState(passphrase string) (*staging.State, error) {
 		return nil, fmt.Errorf("%w: %s", ErrInvalidEnvelope, err.Error())
 	}
 
-	// The payload is untrusted input, so return only the entries for the
-	// service the (plaintext) header declares: a mismatched or hostile payload
-	// carrying another service's data is dropped rather than trusted.
-	// ExtractService returns a state with fully initialized maps.
-	return state.ExtractService(staging.Service(e.Service)), nil
+	// The payload is untrusted input, so keep only the service the (plaintext)
+	// header declares: a mismatched or hostile payload carrying another service's
+	// data is dropped rather than trusted. ExtractService returns a state with
+	// fully initialized maps.
+	scoped := state.ExtractService(staging.Service(e.Service))
+
+	// A namespace (Azure App Configuration label) axis exists only for App
+	// Configuration; AWS, Google Cloud and Azure Key Vault are namespace-agnostic.
+	// Reject an envelope for such a provider that still carries namespace-bearing
+	// entries, mirroring the provider-mismatch guard: applying them would push a
+	// namespaced item to a provider that ignores namespaces.
+	if !e.namespaceAllowed() {
+		if key, found := firstNamespacedKey(scoped); found {
+			return nil, fmt.Errorf(
+				"%w: provider %q is namespace-agnostic but the payload carries item %q under namespace %q",
+				ErrInvalidEnvelope, e.Provider, key.Name, key.Namespace)
+		}
+	}
+
+	return scoped, nil
+}
+
+// namespaceAllowed reports whether entries in this envelope may carry a non-empty
+// Namespace. Only Azure App Configuration (provider "azure", param service) has
+// a namespace (label) axis.
+func (e *Envelope) namespaceAllowed() bool {
+	return e.Provider == string(provider.ProviderAzure) && e.Service == string(staging.ServiceParam)
+}
+
+// firstNamespacedKey returns the first entry or tag key in state that carries a
+// non-empty namespace, for reporting a namespace-agnostic violation.
+func firstNamespacedKey(state *staging.State) (staging.EntryKey, bool) {
+	for _, entries := range state.Entries {
+		for key := range entries {
+			if key.Namespace != "" {
+				return key, true
+			}
+		}
+	}
+
+	for _, tags := range state.Tags {
+		for key := range tags {
+			if key.Namespace != "" {
+				return key, true
+			}
+		}
+	}
+
+	return staging.EntryKey{}, false
 }

--- a/internal/staging/store/file/envelope_test.go
+++ b/internal/staging/store/file/envelope_test.go
@@ -182,6 +182,32 @@ func TestDecodeState_ServiceMismatchDropsForeignData(t *testing.T) {
 	assert.Empty(t, got.Entries[staging.ServiceSecret], "foreign service must be dropped")
 }
 
+func TestDecodeState_RejectsNamespaceForAgnosticProvider(t *testing.T) {
+	t.Parallel()
+
+	// An AWS (namespace-agnostic) envelope whose payload smuggles a
+	// namespace-bearing param entry must be rejected, not silently kept.
+	state := staging.NewEmptyState()
+	state.Entries[staging.ServiceParam][staging.EntryKey{Name: "/p", Namespace: "prod"}] = staging.Entry{
+		Operation: staging.OperationCreate, Value: lo.ToPtr("v"),
+	}
+
+	raw, err := json.Marshal(state) //nolint:errchkjson // State has a custom MarshalJSON
+	require.NoError(t, err)
+
+	env := &file.Envelope{
+		Version:  file.EnvelopeVersion,
+		Provider: "aws",
+		Scope:    "aws/1/r",
+		Service:  "param",
+		Payload:  base64.StdEncoding.EncodeToString(raw),
+	}
+
+	_, err = env.DecodeState("")
+	require.ErrorIs(t, err, file.ErrInvalidEnvelope)
+	assert.Contains(t, err.Error(), "namespace")
+}
+
 func TestWriteEnvelopeFile_WriteErrors(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The namespace (Azure App Configuration label) axis exists only for App Configuration. `DecodeState` nonetheless kept namespace-bearing entries from any envelope, so a crafted payload for a namespace-agnostic provider (AWS, Google Cloud, Azure Key Vault) could smuggle a namespaced item into a provider that ignores namespaces.

`DecodeState` now rejects such an envelope with `ErrInvalidEnvelope`, mirroring the provider-mismatch guard. Only `provider == azure` with the `param` service (App Configuration) permits a non-empty namespace.

Closes #556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwohz3bcExASTpHgiV2dHt