### PR TITLE
fix(gui): guard param/secret list loaders against stale responses

### DIFF
--- a/internal/gui/frontend/src/lib/ParamView.svelte
+++ b/internal/gui/frontend/src/lib/ParamView.svelte
@@ -60,6 +60,14 @@
   let error = $state('');
   let nextToken = $state('');
 
+  // Monotonic request id. Filter/prefix input is debounced, but debounce only
+  // delays dispatch — it does not serialize in-flight requests. A slow broader
+  // query resolving after a fast narrower one would otherwise overwrite the list
+  // with stale rows. Each loadParams bumps the id and only the latest run may
+  // assign entries/nextToken; loadMore captures the current id and appends only
+  // while it is still current (#539).
+  let loadSeq = 0;
+
   let entries: gui.ParamListEntry[] = $state([]);
   let selectedParam: string | null = $state(null);
   let paramDetail: gui.ParamShowResult | null = $state(null);
@@ -189,30 +197,38 @@
   }
 
   async function loadParams(opts: LoadParamsOptions) {
+    const seq = ++loadSeq;
     loading = true;
     error = '';
     nextToken = '';
     try {
       const result = await ParamList(opts.prefix, opts.recursive, opts.withValue, opts.filter, PAGE_SIZE, '');
+      if (seq !== loadSeq) return; // superseded by a newer query
       entries = result?.entries || [];
       nextToken = result?.nextToken || '';
     } catch (e) {
+      if (seq !== loadSeq) return; // superseded by a newer query
       error = parseError(e);
       entries = [];
     } finally {
-      loading = false;
+      if (seq === loadSeq) loading = false;
     }
   }
 
   async function loadMore(opts: LoadParamsOptions) {
     if (!nextToken || loadingMore || loading) return;
 
+    // Continuation of the current query: capture the id without bumping so a
+    // loadParams starting mid-flight supersedes this append.
+    const seq = loadSeq;
     loadingMore = true;
     try {
       const result = await ParamList(opts.prefix, opts.recursive, opts.withValue, opts.filter, PAGE_SIZE, nextToken);
+      if (seq !== loadSeq) return; // superseded by a newer query
       entries = [...entries, ...(result?.entries || [])];
       nextToken = result?.nextToken || '';
     } catch (e) {
+      if (seq !== loadSeq) return; // superseded by a newer query
       error = parseError(e);
     } finally {
       loadingMore = false;

--- a/internal/gui/frontend/src/lib/SecretView.svelte
+++ b/internal/gui/frontend/src/lib/SecretView.svelte
@@ -83,6 +83,14 @@
   let loading = $state(false);
   let error = $state('');
 
+  // Monotonic request id. Filter/prefix input is debounced, but debounce only
+  // delays dispatch — it does not serialize in-flight requests. A slow broader
+  // query resolving after a fast narrower one would otherwise overwrite the list
+  // with stale rows. Each loadSecrets bumps the id and only the latest run may
+  // assign entries/nextToken; loadMore captures the current id and appends only
+  // while it is still current (#539).
+  let loadSeq = 0;
+
   let entries: gui.SecretListEntry[] = $state([]);
   let selectedSecret: string | null = $state(null);
   let secretDetail: gui.SecretShowResult | null = $state(null);
@@ -132,30 +140,38 @@
   let observer: IntersectionObserver | null = null;
 
   async function loadSecrets(opts: LoadSecretsOptions) {
+    const seq = ++loadSeq;
     loading = true;
     error = '';
     nextToken = '';
     try {
       const result = await SecretList(opts.prefix, opts.withValue, opts.filter, PAGE_SIZE, '');
+      if (seq !== loadSeq) return; // superseded by a newer query
       entries = result?.entries || [];
       nextToken = result?.nextToken || '';
     } catch (e) {
+      if (seq !== loadSeq) return; // superseded by a newer query
       error = parseError(e);
       entries = [];
     } finally {
-      loading = false;
+      if (seq === loadSeq) loading = false;
     }
   }
 
   async function loadMore(opts: LoadSecretsOptions) {
     if (!nextToken || loadingMore || loading) return;
 
+    // Continuation of the current query: capture the id without bumping so a
+    // loadSecrets starting mid-flight supersedes this append.
+    const seq = loadSeq;
     loadingMore = true;
     try {
       const result = await SecretList(opts.prefix, opts.withValue, opts.filter, PAGE_SIZE, nextToken);
+      if (seq !== loadSeq) return; // superseded by a newer query
       entries = [...entries, ...(result?.entries || [])];
       nextToken = result?.nextToken || '';
     } catch (e) {
+      if (seq !== loadSeq) return; // superseded by a newer query
       error = parseError(e);
     } finally {
       loadingMore = false;


### PR DESCRIPTION
## Summary
The GUI param/secret list loaders had no stale-response guard. Filter/prefix input is debounced (300ms), but debounce only delays dispatch — it does not serialize in-flight requests. Each response unconditionally assigned `entries`, so a slow broader query resolving after a fast narrower one overwrote the list with stale rows while the filter box showed the newer text.

## Fix
Add a monotonic request id to `loadParams`/`loadSecrets`: bump per call and assign `entries`/`nextToken` (and clear `loading`) only when the captured id is still the latest. `loadMore` captures the current id without bumping and appends only while it is unchanged, so a filter change mid-page supersedes the append.

`svelte-check` passes with 0 errors.

Closes #539.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwohz3bcExASTpHgiV2dHt