### PR TITLE
fix(staging): gate export/import prompts on stdin being a TTY

### DIFF
--- a/internal/cli/terminal/terminal.go
+++ b/internal/cli/terminal/terminal.go
@@ -66,3 +66,16 @@ func IsTerminalWriter(w io.Writer) bool {
 
 	return IsTTY(f.Fd())
 }
+
+// IsTerminalReader returns true if the given reader is a terminal. It mirrors
+// IsTerminalWriter for stdin, so an interactive prompt can require BOTH a
+// terminal to draw on AND a terminal to read the answer from — a piped stdin
+// must never be consumed as if it were a typed reply.
+func IsTerminalReader(r io.Reader) bool {
+	f, ok := r.(Fder)
+	if !ok {
+		return false
+	}
+
+	return IsTTY(f.Fd())
+}

--- a/internal/cli/terminal/terminal_internal_test.go
+++ b/internal/cli/terminal/terminal_internal_test.go
@@ -119,3 +119,41 @@ func TestIsTerminalWriter_NonTTY(t *testing.T) {
 	result := IsTerminalWriter(w)
 	assert.False(t, result)
 }
+
+// mockFdReader implements Fder for reader tests.
+type mockFdReader struct {
+	buf bytes.Buffer
+	fd  uintptr
+}
+
+func (m *mockFdReader) Read(p []byte) (n int, err error) {
+	return m.buf.Read(p)
+}
+
+func (m *mockFdReader) Fd() uintptr {
+	return m.fd
+}
+
+//nolint:paralleltest // Test modifies package globals (IsTTY)
+func TestIsTerminalReader_TTY(t *testing.T) {
+	origIsTTY := IsTTY
+
+	defer func() { IsTTY = origIsTTY }()
+
+	IsTTY = func(_ uintptr) bool { return true }
+
+	r := &mockFdReader{fd: 0}
+	assert.True(t, IsTerminalReader(r))
+}
+
+//nolint:paralleltest // Test modifies package globals (IsTTY)
+func TestIsTerminalReader_NonTTY(t *testing.T) {
+	origIsTTY := IsTTY
+
+	defer func() { IsTTY = origIsTTY }()
+
+	IsTTY = func(_ uintptr) bool { return false }
+
+	r := &mockFdReader{fd: 0}
+	assert.False(t, IsTerminalReader(r))
+}

--- a/internal/cli/terminal/terminal_test.go
+++ b/internal/cli/terminal/terminal_test.go
@@ -53,6 +53,17 @@ func TestIsTerminalWriter_NonFder(t *testing.T) {
 	assert.False(t, result)
 }
 
+func TestIsTerminalReader_NonFder(t *testing.T) {
+	t.Parallel()
+
+	// bytes.Buffer doesn't implement Fder, so a piped/buffered stdin is never
+	// mistaken for an interactive terminal.
+	var buf bytes.Buffer
+
+	result := terminal.IsTerminalReader(&buf)
+	assert.False(t, result)
+}
+
 func TestDefaultWidth(t *testing.T) {
 	t.Parallel()
 

--- a/internal/staging/cli/export.go
+++ b/internal/staging/cli/export.go
@@ -79,7 +79,7 @@ func exportPassphrase(cmd *cli.Command, stdin *bufio.Reader) (pass string, cance
 		}
 
 		return pass, false, nil
-	case terminal.IsTerminalWriter(cmd.Root().ErrWriter):
+	case terminal.IsTerminalWriter(cmd.Root().ErrWriter) && terminal.IsTerminalReader(cmd.Root().Reader):
 		pass, err = prompter.PromptForEncrypt()
 		if err != nil {
 			if errors.Is(err, passphrase.ErrCancelled) {
@@ -91,6 +91,9 @@ func exportPassphrase(cmd *cli.Command, stdin *bufio.Reader) (pass string, cance
 
 		return pass, false, nil
 	default:
+		// No interactive session (stderr not a TTY, or stdin is piped): do not
+		// prompt — reading a piped stdin here would consume a line meant as data.
+		// Fall back to plaintext with a warning, as in the fully non-TTY case.
 		prompter.WarnNonTTY()
 
 		return "", false, nil
@@ -139,9 +142,13 @@ func confirmExportOverwrite(cmd *cli.Command, paths []string, stdin *bufio.Reade
 
 	// With --passphrase-stdin, stdin carries the passphrase, not an interactive
 	// answer: prompting here would consume the passphrase line as the y/N reply
-	// and silently cancel (#471). Require --yes explicitly, mirroring the non-TTY
-	// branch, so a scripted overwrite fails loudly instead of no-op'ing at exit 0.
-	if cmd.Bool(flagPassphraseStdin) || !terminal.IsTerminalWriter(cmd.Root().ErrWriter) {
+	// and silently cancel (#471). Likewise a non-TTY stderr or a piped stdin has
+	// no interactive answer to read. Require --yes explicitly in all these cases,
+	// so a scripted overwrite fails loudly instead of no-op'ing at exit 0 or
+	// swallowing a piped data line.
+	if cmd.Bool(flagPassphraseStdin) ||
+		!terminal.IsTerminalWriter(cmd.Root().ErrWriter) ||
+		!terminal.IsTerminalReader(cmd.Root().Reader) {
 		return false, fmt.Errorf(
 			"export file(s) already exist: %v; re-run with --yes to overwrite",
 			existing,

--- a/internal/staging/cli/import.go
+++ b/internal/staging/cli/import.go
@@ -267,7 +267,7 @@ func importPassphrase(cmd *cli.Command, stdin *bufio.Reader) (string, error) {
 		}
 
 		return pass, nil
-	case terminal.IsTerminalWriter(cmd.Root().ErrWriter):
+	case terminal.IsTerminalWriter(cmd.Root().ErrWriter) && terminal.IsTerminalReader(cmd.Root().Reader):
 		pass, err := prompter.PromptForDecrypt()
 		if err != nil {
 			return "", fmt.Errorf("failed to get passphrase: %w", err)
@@ -275,6 +275,9 @@ func importPassphrase(cmd *cli.Command, stdin *bufio.Reader) (string, error) {
 
 		return pass, nil
 	default:
+		// Prompting needs both a terminal to draw on and a terminal to read from:
+		// a piped stdin would be consumed as the passphrase instead of the data it
+		// carries. Refuse and point at the non-interactive flag.
 		return "", errors.New("encrypted file cannot be decrypted in non-TTY environment; use --passphrase-stdin")
 	}
 }
@@ -371,7 +374,10 @@ func importAction(service staging.Service, resolver staging.ScopeResolver) func(
 			PassphraseStdin: cmd.Bool(flagPassphraseStdin),
 			HasChanges:      !existing.IsEmpty(),
 			ItemCount:       existing.TotalCount(),
-			IsTTY:           terminal.IsTerminalWriter(cmd.Root().ErrWriter),
+			// Interactive only when there is both a terminal to draw the prompt on
+			// and a terminal to read the answer from; a piped stdin must not be
+			// consumed as the Merge/Overwrite reply.
+			IsTTY: terminal.IsTerminalWriter(cmd.Root().ErrWriter) && terminal.IsTerminalReader(cmd.Root().Reader),
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
The interactive export/import prompts (encryption/decryption passphrase, overwrite confirmation, and the merge/overwrite chooser) decided to prompt based only on stderr being a TTY. When stderr is a TTY but stdin is piped, they still prompted and read stdin, consuming a line meant as piped data (e.g. a passphrase or the next command's input) as the answer.

Prompting now also requires stdin to be a TTY (new `terminal.IsTerminalReader`). When stdin is not interactive, the code takes the same branch as the fully non-TTY case: it refuses with the `--yes` / `--passphrase-stdin` guidance (or falls back to plaintext with a warning on export) rather than swallowing a piped line.

Closes #536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwohz3bcExASTpHgiV2dHt