### PR TITLE
ci: add deadcode lint gate (fold into required Lint job)

### DIFF
--- a/.github/deadcode-allow.txt
+++ b/.github/deadcode-allow.txt
@@ -1,0 +1,79 @@
+# Allowlist for the deadcode lint gate (.github/scripts/check-deadcode.sh).
+#
+# Each entry waives one finding from `deadcode ./...` (run WITHOUT -test), in the
+# stable "path/file.go: unreachable func: Name" form (line:col stripped). Blank
+# lines and '#' comments are ignored. Only add an entry if it is a genuine
+# test-only helper (mock / test seam) — production logic that merely happens to
+# have a test must be DELETED, not waived.
+
+# providermock.Store: an in-memory provider.Store double used exclusively by
+# tests (package internal/provider/providermock). Its methods are reached only
+# from test code, so they appear dead in a non-test build.
+internal/provider/providermock/mock.go: unreachable func: Store.Resolve
+internal/provider/providermock/mock.go: unreachable func: Store.Get
+internal/provider/providermock/mock.go: unreachable func: Store.History
+internal/provider/providermock/mock.go: unreachable func: Store.List
+internal/provider/providermock/mock.go: unreachable func: Store.Create
+internal/provider/providermock/mock.go: unreachable func: Store.Put
+internal/provider/providermock/mock.go: unreachable func: Store.Delete
+internal/provider/providermock/mock.go: unreachable func: Store.Tag
+internal/provider/providermock/mock.go: unreachable func: Store.Untag
+internal/provider/providermock/mock.go: unreachable func: Store.Restore
+
+# testutil.MockStore: an in-memory staging store double (package
+# internal/staging/store/testutil), plus its constructor and private deep-clone
+# helpers. Used only by tests.
+internal/staging/store/testutil/mock_store.go: unreachable func: NewMockStore
+internal/staging/store/testutil/mock_store.go: unreachable func: MockStore.GetEntry
+internal/staging/store/testutil/mock_store.go: unreachable func: MockStore.GetTag
+internal/staging/store/testutil/mock_store.go: unreachable func: MockStore.StageEntry
+internal/staging/store/testutil/mock_store.go: unreachable func: MockStore.StageTag
+internal/staging/store/testutil/mock_store.go: unreachable func: MockStore.UnstageEntry
+internal/staging/store/testutil/mock_store.go: unreachable func: MockStore.UnstageTag
+internal/staging/store/testutil/mock_store.go: unreachable func: MockStore.UnstageAll
+internal/staging/store/testutil/mock_store.go: unreachable func: MockStore.servicesFor
+internal/staging/store/testutil/mock_store.go: unreachable func: cloneEntry
+internal/staging/store/testutil/mock_store.go: unreachable func: cloneTagEntry
+internal/staging/store/testutil/mock_store.go: unreachable func: cloneEntryMap
+internal/staging/store/testutil/mock_store.go: unreachable func: cloneTagMap
+internal/staging/store/testutil/mock_store.go: unreachable func: clonePtr
+internal/staging/store/testutil/mock_store.go: unreachable func: MockStore.ListEntries
+internal/staging/store/testutil/mock_store.go: unreachable func: MockStore.ListTags
+internal/staging/store/testutil/mock_store.go: unreachable func: MockStore.AddEntry
+internal/staging/store/testutil/mock_store.go: unreachable func: MockStore.AddTag
+internal/staging/store/testutil/mock_store.go: unreachable func: MockStore.Drain
+internal/staging/store/testutil/mock_store.go: unreachable func: MockStore.WriteState
+internal/staging/store/testutil/mock_store.go: unreachable func: MockStore.Update
+
+# apptest.AWSApp: test-only CLI app builder (package
+# internal/cli/commands/internal/apptest) used across command tests to assemble
+# an app as if AWS were the sole active provider.
+internal/cli/commands/internal/apptest/apptest.go: unreachable func: AWSApp
+
+# crypt randomness / cipher test seams: setters/resetters that let tests inject
+# a deterministic RNG or cipher and restore the production default afterwards.
+internal/staging/store/file/internal/crypt/crypt.go: unreachable func: SetRandReader
+internal/staging/store/file/internal/crypt/crypt.go: unreachable func: ResetRandReader
+internal/staging/store/file/internal/crypt/crypt.go: unreachable func: SetCipherFuncs
+internal/staging/store/file/internal/crypt/crypt.go: unreachable func: ResetCipherFuncs
+
+# file store test seams: constructors that build a file-backed store at an
+# explicit path / passphrase for tests, bypassing the OS keychain resolution the
+# production constructor performs.
+internal/staging/store/file/store.go: unreachable func: NewStoreWithPath
+internal/staging/store/file/store.go: unreachable func: NewStoreWithPassphrase
+
+# timeutil.ResetLocationCache: test seam that clears the cached time.Location so
+# tests can re-exercise the lazy-load path.
+internal/timeutil/timeutil.go: unreachable func: ResetLocationCache
+
+# --- Not test helpers: GUI-only production callers ---------------------------
+# The two entries below are NOT test seams. They are live production code whose
+# only non-test caller is internal/gui (param.go / secret.go, both guarded by
+# `//go:build production || dev`). This gate runs deadcode with the default
+# build tags, which exclude the GUI, so the real callers are invisible and the
+# funcs look dead. Deleting them would break the GUI (`suve --gui`) build. Their
+# reachability from the GUI is already covered by the production golangci-lint
+# step, so they are waived here rather than deleted.
+internal/usecase/param/tag.go: unreachable func: TagUseCase.Execute
+internal/usecase/secret/tag.go: unreachable func: TagUseCase.Execute

--- a/.github/scripts/check-deadcode.sh
+++ b/.github/scripts/check-deadcode.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+#
+# Fail the build if `deadcode ./...` reports any unreachable (dead) function
+# that is not explicitly waived in .github/deadcode-allow.txt.
+#
+# deadcode (golang.org/x/tools/cmd/deadcode) uses Rapid Type Analysis to find
+# functions unreachable from any main in the module. We run it WITHOUT -test on
+# purpose: with -test, production logic that is reachable only from its own
+# tests would be hidden (a test would keep otherwise-dead code "alive"). We want
+# that surfaced. Genuine test-only helpers (mocks / test seams) are the sole
+# exception and are waived, with a justification each, in the allowlist file —
+# this is the "ignore comment" equivalent for this gate.
+#
+# The default build tags (linux, non-production) exclude internal/gui, so GUI
+# code is not analyzed here; its dead code stays covered by the existing
+# production golangci-lint step.
+set -eu
+
+cd "$(git rev-parse --show-toplevel)"
+
+ALLOWLIST=".github/deadcode-allow.txt"
+
+# Prefer a deadcode binary on PATH (mise installs it in CI); otherwise fall back
+# to a pinned `go run` so the gate is runner-independent and works locally.
+if command -v deadcode >/dev/null 2>&1; then
+  deadcode_cmd="deadcode"
+else
+  deadcode_cmd="go run golang.org/x/tools/cmd/deadcode@v0.48.0"
+fi
+
+# Each finding is "path/file.go:LINE:COL: unreachable func: Name". Strip the
+# volatile ":LINE:COL" so matching is on the stable
+# "path/file.go: unreachable func: Name" form.
+findings=$(
+  $deadcode_cmd ./... \
+    | sed 's/\(\.go\):[0-9][0-9]*:[0-9][0-9]*:/\1:/'
+)
+
+# The allowlist, minus blank lines and '#' comments.
+allow=$(sed -e 's/#.*$//' -e 's/[[:space:]]*$//' "${ALLOWLIST}" | grep -v '^[[:space:]]*$' || true)
+
+offenders=""
+old_ifs=$IFS
+IFS='
+'
+for finding in ${findings}; do
+  [ -n "${finding}" ] || continue
+  if printf '%s\n' "${allow}" | grep -Fxq "${finding}"; then
+    continue
+  fi
+  offenders="${offenders}${finding}
+"
+done
+IFS=$old_ifs
+
+if [ -n "${offenders}" ]; then
+  echo "Dead code found: unreachable func(s) not waived in ${ALLOWLIST}:" >&2
+  printf '%s' "${offenders}" >&2
+  echo "Delete the dead code, or — only if it is a genuine test-only helper —" >&2
+  echo "add its 'path/file.go: unreachable func: Name' line to ${ALLOWLIST} with a justification." >&2
+  exit 1
+fi
+
+echo "Dead code gate OK: no unreachable funcs outside ${ALLOWLIST}."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,11 +230,14 @@ jobs:
       - name: Set up toolchain (mise)
         uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
         with:
-          install_args: "go golangci-lint"
+          install_args: "go golangci-lint go:golang.org/x/tools/cmd/deadcode"
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run golangci-lint (default build)
         run: golangci-lint run --timeout=5m
+
+      - name: Run deadcode
+        run: mise run deadcode
 
       - name: Create dummy frontend dist for production lint
         run: mkdir -p internal/gui/frontend/dist && touch internal/gui/frontend/dist/index.html

--- a/internal/cli/colors/colors.go
+++ b/internal/cli/colors/colors.go
@@ -30,11 +30,6 @@ func For(w io.Writer) Palette {
 	return Palette{enabled: os.Getenv("NO_COLOR") == "" && terminal.IsTerminalWriter(w)}
 }
 
-// Enabled reports whether this palette emits ANSI color.
-func (p Palette) Enabled() bool {
-	return p.enabled
-}
-
 // sprint colorizes the operands with attrs when the palette is enabled, and
 // returns them unformatted otherwise. A fresh color.Color with a forced
 // per-instance setting is used, so palettes for different destinations never

--- a/internal/infra/client.go
+++ b/internal/infra/client.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
-	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/aws/smithy-go/logging"
 	"github.com/samber/lo"
@@ -153,26 +151,6 @@ func logEffectiveConfig(ctx context.Context, d debug.Config, cfg aws.Config) {
 	}
 
 	d.Logf("aws: region=%q profile=%q credentials-source=%s\n", cfg.Region, profile, creds.Source)
-}
-
-// NewParamClient creates a new SSM Parameter Store client using the default configuration.
-func NewParamClient(ctx context.Context) (*ssm.Client, error) {
-	cfg, err := LoadConfig(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return ssm.NewFromConfig(cfg), nil
-}
-
-// NewSecretClient creates a new Secrets Manager client using the default configuration.
-func NewSecretClient(ctx context.Context) (*secretsmanager.Client, error) {
-	cfg, err := LoadConfig(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	return secretsmanager.NewFromConfig(cfg), nil
 }
 
 // AWSIdentity contains AWS account ID, region, and profile name.

--- a/internal/provider/azure/azure.go
+++ b/internal/provider/azure/azure.go
@@ -235,11 +235,3 @@ func appConfigStore(ctx context.Context, scope provider.Scope) (provider.Store, 
 func Register(reg *provider.Registry) {
 	reg.Register(provider.ProviderAzure, Factory{})
 }
-
-// NewRegistry returns a provider.Registry with the Azure provider registered.
-func NewRegistry() *provider.Registry {
-	reg := provider.NewRegistry()
-	Register(reg)
-
-	return reg
-}

--- a/internal/provider/gcloud/gcloud.go
+++ b/internal/provider/gcloud/gcloud.go
@@ -146,11 +146,3 @@ func (Factory) Store(ctx context.Context, scope provider.Scope, kind provider.Ki
 func Register(reg *provider.Registry) {
 	reg.Register(provider.ProviderGoogleCloud, Factory{})
 }
-
-// NewRegistry returns a provider.Registry with the Google Cloud provider registered.
-func NewRegistry() *provider.Registry {
-	reg := provider.NewRegistry()
-	Register(reg)
-
-	return reg
-}

--- a/internal/provider/gcloud/gcloud_test.go
+++ b/internal/provider/gcloud/gcloud_test.go
@@ -100,26 +100,3 @@ func TestRegister(t *testing.T) {
 	require.ErrorIs(t, err, provider.ErrUnsupportedKind)
 	assert.NotErrorIs(t, err, provider.ErrNoFactory)
 }
-
-// TestNewRegistry verifies NewRegistry returns a registry with only the Google
-// Cloud provider registered.
-func TestNewRegistry(t *testing.T) {
-	t.Parallel()
-
-	reg := gcloud.NewRegistry()
-
-	t.Run("google cloud is registered", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := reg.Store(t.Context(), provider.GoogleCloudScope("my-project"), provider.KindParam)
-		require.ErrorIs(t, err, provider.ErrUnsupportedKind)
-		assert.NotErrorIs(t, err, provider.ErrNoFactory)
-	})
-
-	t.Run("other providers are not registered", func(t *testing.T) {
-		t.Parallel()
-
-		_, err := reg.Store(t.Context(), provider.AWSScope("123456789012", "us-east-1"), provider.KindSecret)
-		require.ErrorIs(t, err, provider.ErrNoFactory)
-	})
-}

--- a/internal/staging/scope.go
+++ b/internal/staging/scope.go
@@ -32,18 +32,6 @@ type ResolvedScope struct {
 // staging commands, never by read/write commands.
 type ScopeResolver func(ctx context.Context) (ResolvedScope, error)
 
-// ServiceToKind maps a staging Service to the equivalent provider Kind.
-func ServiceToKind(s Service) provider.Kind {
-	switch s {
-	case ServiceParam:
-		return provider.KindParam
-	case ServiceSecret:
-		return provider.KindSecret
-	default:
-		return provider.Kind(s)
-	}
-}
-
 // KindToService maps a provider Kind to the equivalent staging Service.
 func KindToService(k provider.Kind) Service {
 	switch k {

--- a/mise.toml
+++ b/mise.toml
@@ -17,6 +17,8 @@ golangci-lint = "2.12.2"
 goreleaser = "2"
 nfpm = "2.41.1"
 "go:github.com/wailsapp/wails/v2/cmd/wails" = "2.13.0"
+# Reports production dead code; run via the `deadcode` task (deadcode lint gate).
+"go:golang.org/x/tools/cmd/deadcode" = "0.48.0"
 
 # =============================================================================
 # Tasks (run with `mise run <task>`, or `mise <task>` — no name collides with a
@@ -30,6 +32,10 @@ nfpm = "2.41.1"
 [tasks.build-cli]
 description = "Build the CLI binary"
 run = "go build -o bin/suve ./cmd/suve"
+
+[tasks.deadcode]
+description = "Report production dead code (x/tools deadcode; test-only helpers waived in .github/deadcode-allow.txt)"
+run = "bash .github/scripts/check-deadcode.sh"
 
 [tasks.build-gui]
 description = "Build the single CLI+GUI binary (bin/suve), embedding a freshly-built frontend"


### PR DESCRIPTION
## What

Add a runner-independent dead-code gate using `golang.org/x/tools/cmd/deadcode`, wired through mise and **folded into the existing (already required) `Lint` job** rather than added as a new job — so no branch-ruleset change is needed and in-flight PRs are not blocked by a new required check.

## Mechanism

- `.github/scripts/check-deadcode.sh` (POSIX sh) runs `deadcode ./...` **without `-test`**. Running without `-test` is deliberate: it surfaces production logic reachable only from its own tests (dead code that merely has a test), instead of hiding it. The script strips the volatile `:line:col`, and fails (exit 1, printing offenders) on any finding not present in the allowlist; otherwise it prints OK and exits 0. It uses `deadcode` if on `PATH`, else falls back to `go run golang.org/x/tools/cmd/deadcode@v0.48.0`.
- `.github/deadcode-allow.txt` is the waiver list — the "ignore comment" equivalent — of genuine test-only helpers (mocks / test seams), each with a `#` justification.
- Default build tags (linux, non-production) exclude `internal/gui`, so GUI dead code is **not** this gate's concern; it stays covered by the existing production `golangci-lint` step.
- `mise.toml` gains the pinned `deadcode` tool and a `deadcode` task; the `Lint` job installs it via `install_args` and runs `mise run deadcode`.

## Deleted genuinely-dead funcs

No CLI / gui / test caller for any of these (grep-verified); no cascade deletions were needed:

- `internal/cli/colors`: `Palette.Enabled`
- `internal/infra`: `NewParamClient`, `NewSecretClient` (dropped now-unused `ssm` / `secretsmanager` imports)
- `internal/provider/azure`: `NewRegistry` (azure is wired via `Register`, never `NewRegistry`)
- `internal/staging`: `ServiceToKind`
- `internal/provider/gcloud`: `NewRegistry` **and** its only caller `TestNewRegistry` — an unused convenience constructor used solely by that test. `aws.NewRegistry` stays because the CLI uses it.

## Note for reviewers

The allowlist contains **two entries that are not test helpers**: `internal/usecase/param/tag.go` and `internal/usecase/secret/tag.go` — `TagUseCase.Execute`. These are live production functions whose only non-test caller is `internal/gui` (`//go:build production || dev`), which this gate's default build excludes; deleting them would break the GUI build, and their reachability is covered by the production `golangci-lint` step. They are waived with an explicit, distinct justification rather than deleted or silently buried.

`codecov/*` checks are **non-required** and do not block; the `Lint` check (now running deadcode) is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xwohz3bcExASTpHgiV2dHt