### PR TITLE
chore(dev): comprehensive local seeding + clean local volumes + reconcile demo scripts

### DIFF
--- a/demo/cli-record.sh
+++ b/demo/cli-record.sh
@@ -18,18 +18,25 @@ export AWS_ENDPOINT_URL="http://localhost:${SUVE_LOCALSTACK_EXTERNAL_PORT:-4566}
 export AWS_ACCESS_KEY_ID="test"
 export AWS_SECRET_ACCESS_KEY="test"
 export AWS_DEFAULT_REGION="us-east-1"
+# Pin a deterministic staging data key so the staging steps never block on the
+# macOS keychain (matches `mise test` and scripts/seed.sh).
+export SUVE_STAGING_KEY="${SUVE_STAGING_KEY:-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=}"
+
+# This demo owns the /demo/* namespace, kept deliberately separate from the
+# `mise run seed-*` fixtures (/suve-demo/*), so recording and manual seeding
+# never clobber each other.
 
 echo "=== Setting up demo environment ==="
 
-# Build suve if needed
-if [[ ! -f bin/suve ]]; then
-    echo "Building suve..."
-    mise build
-fi
+# Always build the full GUI binary (bin/suve) so it matches the current bindings
+# and API arity — a stale or CLI-only binary can drift out of sync.
+echo "Building suve (GUI)..."
+mise build-gui
 
-# Reset LocalStack (clean slate)
+# Reset LocalStack (clean slate). --profile "*" so the profile-gated localstack
+# service is actually torn down (a bare `down` leaves profiled services running).
 echo "Resetting LocalStack..."
-docker compose down -v
+docker compose --profile "*" down -v
 docker compose --profile aws up -d
 echo "Waiting for LocalStack to be ready..."
 sleep 3

--- a/demo/gui-record.sh
+++ b/demo/gui-record.sh
@@ -24,8 +24,6 @@ cleanup() {
         echo "Stopping wails dev..."
         kill "$WAILS_PID" 2>/dev/null || true
     fi
-    echo "Stopping staging agent..."
-    "$PROJECT_DIR/bin/suve" stage agent stop 2>/dev/null || true
 }
 trap cleanup EXIT
 
@@ -36,18 +34,26 @@ export AWS_ENDPOINT_URL="http://localhost:${SUVE_LOCALSTACK_EXTERNAL_PORT:-4566}
 export AWS_ACCESS_KEY_ID="test"
 export AWS_SECRET_ACCESS_KEY="test"
 export AWS_DEFAULT_REGION="us-east-1"
+# Pin a deterministic staging data key so both the setup CLI and the GUI (wails
+# dev, launched below with this env inherited) share one staging store without a
+# macOS keychain prompt (matches `mise test` and scripts/seed.sh).
+export SUVE_STAGING_KEY="${SUVE_STAGING_KEY:-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=}"
+
+# This demo owns the /demo/* namespace, kept deliberately separate from the
+# `mise run seed-*` fixtures (/suve-demo/*), so recording and manual seeding
+# never clobber each other.
 
 echo "=== Setting up demo environment ==="
 
-# Build suve if needed
-if [[ ! -f bin/suve ]]; then
-    echo "Building suve..."
-    mise build
-fi
+# Always build the full GUI binary (bin/suve) so it matches the current bindings
+# and API arity — a stale or CLI-only binary can drift out of sync.
+echo "Building suve (GUI)..."
+mise build-gui
 
-# Reset LocalStack (clean slate)
+# Reset LocalStack (clean slate). --profile "*" so the profile-gated localstack
+# service is actually torn down (a bare `down` leaves profiled services running).
 echo "Resetting LocalStack..."
-docker compose down -v
+docker compose --profile "*" down -v
 docker compose --profile aws up -d
 echo "Waiting for LocalStack to be ready..."
 sleep 3
@@ -77,17 +83,9 @@ echo "=== Starting wails dev ==="
 # Clean up previous test artifacts
 rm -rf "$FRONTEND_DIR/test-results-recording" 2>/dev/null || true
 
-# Start daemon manually before wails dev to prevent hot-reload loop
-# SUVE_DAEMON_MANUAL_MODE=1 prevents auto-start/stop which causes
-# file changes that trigger wails hot-reload in an infinite loop
-export SUVE_DAEMON_MANUAL_MODE=1
-echo "Starting staging agent manually..."
-# Stop any existing daemon first (from previous runs)
-"$PROJECT_DIR/bin/suve" stage agent stop 2>/dev/null || true
-# Start daemon (auto-backgrounds via launcher)
-"$PROJECT_DIR/bin/suve" stage agent start
-
-# Start wails dev in background (same as mise gui-dev)
+# Start wails dev in background (same as mise gui-dev). The GUI reads and writes
+# the staging store directly — there is no longer a background staging agent to
+# start (the daemon was removed).
 cd "$GUI_DIR"
 wails dev -skipbindings -tags dev &
 WAILS_PID=$!

--- a/mise-tasks/bash
+++ b/mise-tasks/bash
@@ -89,6 +89,18 @@ if $want_keyvault; then
   )
 fi
 
+# Staging (every provider) persists to a keychain-encrypted working store. Pin a
+# deterministic data key — base64 of 32 zero bytes — so that (a) the shell never
+# blocks on an OS keychain prompt, and (b) staged changes written by
+# `mise run seed*` are read back with the SAME key, staying visible here. Without
+# this, seeding writes under the fixed key while this shell would read under the
+# keychain/plaintext key and see NO staged changes (or a decryption error).
+# Respected as an override if already exported. Only set it when a cloud is
+# active, keeping the flagless plain shell truly env-free.
+if [ "${#clouds[@]}" -gt 0 ]; then
+  env_kv+=("SUVE_STAGING_KEY=${SUVE_STAGING_KEY:-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=}")
+fi
+
 if [ "${#services[@]}" -gt 0 ]; then
   profile_args=()
   for p in "${profiles[@]}"; do profile_args+=(--profile "$p"); done

--- a/mise.toml
+++ b/mise.toml
@@ -163,11 +163,16 @@ $compose run --rm --no-deps -e SUVE_AZURE_KEYVAULT_ENDPOINT=https://azure-keyvau
 '''
 
 [tasks.clean]
-description = "Remove build artifacts and stop containers (incl. volumes)"
+description = "Remove build artifacts and stop containers (incl. local-verification + test volumes)"
 shell = "bash -c"
 run = '''
 rm -rf bin/ *.out coverage/
-docker compose down -v 2>/dev/null || true
+# Default compose project: the local dev-verification emulators (started by
+# `mise run bash --aws/--gcloud/--azure`) and the ubuntu-* GUI desktops all sit
+# behind profiles, so --profile "*" is required to actually stop them and drop
+# their named volumes (go-cache / go-build-cache) — a bare `down -v` would leave
+# the profiled emulator containers and their volumes orphaned.
+docker compose --profile "*" down -v 2>/dev/null || true
 # Sweep any leftover closed-test projects (suve-test-*) from crashed runs, plus
 # their shared external caches. --profile "*" so profiled emulator services
 # (localstack/gcloud/azure) are actually removed, not just non-profiled ones.
@@ -177,6 +182,64 @@ done
 docker compose -f compose.test.yaml --profile "*" down -v 2>/dev/null || true
 docker volume rm suve-test-go-cache suve-test-go-build-cache 2>/dev/null || true
 '''
+
+# -----------------------------------------------------------------------------
+# Seeding: populate the local dev-verification emulators (started by
+# `mise run bash --aws/--gcloud/--azure`) with comprehensive demo data — stacked
+# versions, tags, and a full spread of staged changes — so every CLI/GUI view has
+# something to show. Run these INSIDE a `mise run bash …` shell so the emulator
+# env is injected; a service whose env is absent is skipped with a hint.
+#
+# Leaf tasks do the work; the seed-{aws,gcloud,azure} and seed-all aliases just
+# fan out via depends. All share seed-build so the throwaway CLI binary
+# (bin/suve-seed, kept apart from a GUI-enabled bin/suve) is compiled once.
+# -----------------------------------------------------------------------------
+
+[tasks.seed-build]
+hide = true
+description = "Compile the throwaway CLI binary used by the seed tasks"
+run = "go build -o bin/suve-seed ./cmd/suve"
+
+[tasks.seed-aws-param]
+description = "Seed AWS Parameter Store (versions, tags, staged add/edit/delete/tag changes)"
+depends = ["seed-build"]
+run = "bash scripts/seed.sh aws-param"
+
+[tasks.seed-aws-secret]
+description = "Seed AWS Secrets Manager (versions, tags, staged add/edit/delete/tag changes)"
+depends = ["seed-build"]
+run = "bash scripts/seed.sh aws-secret"
+
+[tasks.seed-aws]
+description = "Seed AWS Parameter Store + Secrets Manager"
+depends = ["seed-aws-param", "seed-aws-secret"]
+
+[tasks.seed-gcloud-secret]
+description = "Seed Google Cloud Secret Manager (versions, labels, staged add/edit/delete/tag changes)"
+depends = ["seed-build"]
+run = "bash scripts/seed.sh gcloud-secret"
+
+[tasks.seed-gcloud]
+description = "Seed Google Cloud (Secret Manager)"
+depends = ["seed-gcloud-secret"]
+
+[tasks.seed-azure-secret]
+description = "Seed Azure Key Vault (versions with per-version tags, staged add/edit/delete/tag changes)"
+depends = ["seed-build"]
+run = "bash scripts/seed.sh azure-secret"
+
+[tasks.seed-azure-param]
+description = "Seed Azure App Configuration ((NULL)/dev/prd labels, per-label tags, staged add/edit/delete/tag changes)"
+depends = ["seed-build"]
+run = "bash scripts/seed.sh azure-param"
+
+[tasks.seed-azure]
+description = "Seed Azure Key Vault + App Configuration"
+depends = ["seed-azure-secret", "seed-azure-param"]
+
+[tasks.seed-all]
+description = "Seed every configured cloud (AWS + Google Cloud + Azure)"
+depends = ["seed-aws", "seed-gcloud", "seed-azure"]
 
 [tasks.coverage]
 description = "Run unit tests with coverage"

--- a/scripts/seed.sh
+++ b/scripts/seed.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+#
+# Seed the local emulators with comprehensive demo data for manual verification
+# (CLI or GUI). It is driven by the `mise run seed-*` tasks — see mise.toml — but
+# `bash scripts/seed.sh <service>` works standalone too.
+#
+#   <service> = aws-param | aws-secret | gcloud-secret | azure-secret | azure-param
+#
+# It expects the target emulator's environment to be present (exactly what
+# `mise run bash --aws/--gcloud/--azure` injects); a service whose env is absent
+# is skipped with a hint rather than failing, so `seed-all` inside a partial dev
+# shell just seeds whatever is running.
+#
+# What it lays down per service (breadth over depth, so every read/stage view has
+# something to show):
+#   - applied resources with several versions stacked up (for show/log/diff and
+#     the #VERSION / ~SHIFT / :LABEL specs), some carrying tags;
+#   - a working staging area holding one of every staged shape: a fresh add, an
+#     edit, a delete, and a tag add / change / removal.
+set -eo pipefail
+
+root="${MISE_PROJECT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+cd "$root"
+
+# A throwaway CLI binary kept out of bin/suve so seeding never clobbers a
+# GUI-enabled build. The seed-build mise task compiles it once up front; building
+# here too keeps a direct `bash scripts/seed.sh ...` self-contained.
+suve_bin="$root/bin/suve-seed"
+if [ ! -x "$suve_bin" ]; then
+  echo "==> Building $suve_bin"
+  go build -o "$suve_bin" ./cmd/suve
+fi
+
+# Staging writes go through the keychain-encrypted file store; pin a deterministic
+# data key (base64 of 32 zero bytes) so seeding never blocks on an OS keychain
+# prompt, exactly like `mise test` / `mise coverage`. This MUST match the key the
+# `mise run bash` dev shell injects (see mise-tasks/bash) — otherwise the shell
+# would read the working store under a different key and the staged changes below
+# would be invisible there. Honor an override if one is already exported.
+export SUVE_STAGING_KEY="${SUVE_STAGING_KEY:-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=}"
+
+# run echoes the command, then executes it tolerating failure: seeding is
+# best-effort and re-runnable, so an "already exists" create (or a service the
+# emulator does not implement) is a skip, not a hard stop.
+run() {
+  printf '   $ suve %s\n' "$*"
+  if ! "$suve_bin" "$@" </dev/null >/dev/null 2>&1; then
+    printf '     ! skipped (already present, or unsupported by this emulator)\n' >&2
+  fi
+}
+
+# run_stdin feeds $1 to the command over stdin via --value-stdin. Needed whenever
+# a value would otherwise be misread as a flag (e.g. a PEM block beginning with
+# "-----BEGIN"), and also mirrors how secrets are meant to be piped in practice.
+run_stdin() {
+  local value="$1"
+  shift
+  printf '   $ printf … | suve %s --value-stdin\n' "$*"
+  if ! printf '%s' "$value" | "$suve_bin" "$@" --value-stdin >/dev/null 2>&1; then
+    printf '     ! skipped (already present, or unsupported by this emulator)\n' >&2
+  fi
+}
+
+# require_env VAR "human name" "mise run bash flag" — returns non-zero (so the
+# caller can `|| return 0`) when the emulator env is not injected.
+require_env() {
+  if [ -z "${!1:-}" ]; then
+    # The literal "$NAME" is shown to the user on purpose (not a shell expansion).
+    # shellcheck disable=SC2016
+    printf '==> %s: $%s not set — skipping. Start it with `mise run bash %s`,\n' "$2" "$1" "$3"
+    printf '    then re-run this inside that shell.\n'
+    return 1
+  fi
+  return 0
+}
+
+# ---------------------------------------------------------------------------
+# AWS Parameter Store
+# ---------------------------------------------------------------------------
+seed_aws_param() {
+  require_env AWS_ENDPOINT_URL "AWS Parameter Store" "--aws" || return 0
+  echo "==> Seeding AWS Parameter Store…"
+
+  # Applied baseline: multiple versions stacked, a spread of value types, tags.
+  run aws param create /suve-demo/app/database-url "postgres://db.internal:5432/app?sslmode=require" --description "Primary database DSN"
+  run aws param update --yes /suve-demo/app/database-url "postgres://db.internal:5432/app?sslmode=verify-full"
+  run aws param update --yes /suve-demo/app/database-url "postgres://db-primary.internal:5432/app?sslmode=verify-full"
+  run aws param tag /suve-demo/app/database-url env=production team=payments managed-by=suve
+
+  run aws param create /suve-demo/app/database-password "correct-horse-battery-staple" --secure --description "DB password (rotated quarterly)"
+  run aws param update --yes /suve-demo/app/database-password "Tr0ub4dour-and-3-more"
+  run aws param tag /suve-demo/app/database-password rotation=90d env=production
+
+  run aws param create /suve-demo/app/feature-flags "beta,dark-mode" --type StringList --description "Enabled feature flags"
+  run aws param update --yes /suve-demo/app/feature-flags "beta,dark-mode,new-checkout"
+
+  run aws param create /suve-demo/app/config '{"timeout":30,"retries":3}' --description "App tuning knobs"
+  run aws param update --yes /suve-demo/app/config '{"timeout":60,"retries":5,"backoff":"exponential"}'
+  run aws param tag /suve-demo/app/config format=json
+
+  run aws param create /suve-demo/shared/region "us-east-1"
+
+  # Applied resources that back the staged scenarios below.
+  run aws param create /suve-demo/staging/edit-me "live-value-v1"
+  run aws param update --yes /suve-demo/staging/edit-me "live-value-v2"
+  run aws param create /suve-demo/staging/delete-me "obsolete, staged for deletion"
+  run aws param create /suve-demo/staging/tag-add "value"
+  run aws param tag /suve-demo/staging/tag-add existing=kept
+  run aws param create /suve-demo/staging/tag-change "value"
+  run aws param tag /suve-demo/staging/tag-change env=staging
+  run aws param create /suve-demo/staging/tag-remove "value"
+  run aws param tag /suve-demo/staging/tag-remove temporary=yes keep=yes
+
+  # Working-area staged changes, deliberately left un-applied for stage status/diff.
+  run aws stage param add /suve-demo/staging/new-param "created via staging, not yet applied"
+  run aws stage param edit /suve-demo/staging/edit-me "edited via staging (v3 pending)"
+  run aws stage param delete /suve-demo/staging/delete-me
+  run aws stage param tag /suve-demo/staging/tag-add owner=team-a      # stage a NEW tag
+  run aws stage param tag /suve-demo/staging/tag-change env=production # stage a CHANGED tag value
+  run aws stage param untag /suve-demo/staging/tag-remove temporary    # stage a tag REMOVAL
+}
+
+# ---------------------------------------------------------------------------
+# AWS Secrets Manager
+# ---------------------------------------------------------------------------
+seed_aws_secret() {
+  require_env AWS_ENDPOINT_URL "AWS Secrets Manager" "--aws" || return 0
+  echo "==> Seeding AWS Secrets Manager…"
+
+  run aws secret create suve-demo/db-credentials '{"username":"app","password":"p@ss-v1"}' --description "Service DB credentials"
+  run aws secret update --yes suve-demo/db-credentials '{"username":"app","password":"p@ss-v2"}'
+  run aws secret update --yes suve-demo/db-credentials '{"username":"app","password":"p@ss-v3"}'
+  run aws secret tag suve-demo/db-credentials env=production team=payments
+
+  run aws secret create suve-demo/api-key "ak_live_0001"
+  run aws secret update --yes suve-demo/api-key "ak_live_0002"
+
+  # Piped over stdin: the value leads with "-----", which would otherwise be
+  # parsed as a flag (and it is how you would feed a real cert anyway).
+  run_stdin "$(printf -- '-----BEGIN CERTIFICATE-----\nMIIB-demo-not-a-real-cert\nQU5ETUlORw==\n-----END CERTIFICATE-----')" aws secret create suve-demo/tls-cert --description "PEM certificate (multiline)"
+
+  # Applied resources that back the staged scenarios below.
+  run aws secret create suve-demo/staging/edit-me "live-secret-v1"
+  run aws secret update --yes suve-demo/staging/edit-me "live-secret-v2"
+  run aws secret create suve-demo/staging/delete-me "obsolete secret"
+  run aws secret create suve-demo/staging/tag-add "value"
+  run aws secret tag suve-demo/staging/tag-add existing=kept
+  run aws secret create suve-demo/staging/tag-change "value"
+  run aws secret tag suve-demo/staging/tag-change env=staging
+  run aws secret create suve-demo/staging/tag-remove "value"
+  run aws secret tag suve-demo/staging/tag-remove temporary=yes keep=yes
+
+  # Working-area staged changes.
+  run aws stage secret add suve-demo/staging/new-secret "created via staging, not yet applied"
+  run aws stage secret edit suve-demo/staging/edit-me "edited via staging"
+  run aws stage secret delete suve-demo/staging/delete-me
+  run aws stage secret tag suve-demo/staging/tag-add owner=team-a
+  run aws stage secret tag suve-demo/staging/tag-change env=production
+  run aws stage secret untag suve-demo/staging/tag-remove temporary
+}
+
+# ---------------------------------------------------------------------------
+# Google Cloud Secret Manager (secret-only; names are [A-Za-z0-9_-], labels lowercase)
+# ---------------------------------------------------------------------------
+seed_gcloud_secret() {
+  require_env SUVE_GCLOUD_SECRETMANAGER_ENDPOINT "Google Cloud Secret Manager" "--gcloud" || return 0
+  echo "==> Seeding Google Cloud Secret Manager…"
+
+  run gcloud secret create suve-demo-db-password "db-pass-v1"
+  run gcloud secret update --yes suve-demo-db-password "db-pass-v2"
+  run gcloud secret update --yes suve-demo-db-password "db-pass-v3"
+  run gcloud secret tag suve-demo-db-password env=production team=payments
+
+  run gcloud secret create suve-demo-api-token "token-v1"
+  run gcloud secret update --yes suve-demo-api-token "token-v2"
+
+  run gcloud secret create suve-demo-config '{"region":"us","tier":"gold"}'
+
+  # Applied resources that back the staged scenarios below.
+  run gcloud secret create suve-demo-stage-edit "live-v1"
+  run gcloud secret update --yes suve-demo-stage-edit "live-v2"
+  run gcloud secret create suve-demo-stage-delete "obsolete"
+  run gcloud secret create suve-demo-stage-tag-add "value"
+  run gcloud secret tag suve-demo-stage-tag-add existing=kept
+  run gcloud secret create suve-demo-stage-tag-change "value"
+  run gcloud secret tag suve-demo-stage-tag-change env=staging
+  run gcloud secret create suve-demo-stage-tag-remove "value"
+  run gcloud secret tag suve-demo-stage-tag-remove temporary=yes keep=yes
+
+  # Working-area staged changes.
+  run gcloud stage add suve-demo-stage-new "created via staging, not yet applied"
+  run gcloud stage edit suve-demo-stage-edit "edited via staging"
+  run gcloud stage delete suve-demo-stage-delete
+  run gcloud stage tag suve-demo-stage-tag-add owner=team-a
+  run gcloud stage tag suve-demo-stage-tag-change env=production
+  run gcloud stage untag suve-demo-stage-tag-remove temporary
+}
+
+# ---------------------------------------------------------------------------
+# Azure Key Vault (secret; names are [0-9A-Za-z-], opaque-versioned)
+# ---------------------------------------------------------------------------
+seed_azure_secret() {
+  require_env SUVE_AZURE_KEYVAULT_ENDPOINT "Azure Key Vault" "--azure-keyvault" || return 0
+  echo "==> Seeding Azure Key Vault…"
+
+  # Key Vault tags live on a secret *version* (read-modify-write against the
+  # current one), and each update mints a fresh version with no tags. Tag v1 and
+  # the latest v3 but not the middle v2, so the per-version nature is visible in
+  # `azure secret log`: v1 → tagged, v2 → bare, v3 (current) → tagged.
+  run azure secret create suve-demo-db-password "db-pass-v1"
+  run azure secret tag suve-demo-db-password imported=legacy
+  run azure secret update --yes suve-demo-db-password "db-pass-v2"
+  run azure secret update --yes suve-demo-db-password "db-pass-v3"
+  run azure secret tag suve-demo-db-password env=production team=payments
+
+  run azure secret create suve-demo-api-key "ak-live-0001"
+  run azure secret update --yes suve-demo-api-key "ak-live-0002"
+
+  # Applied resources that back the staged scenarios below.
+  run azure secret create suve-demo-stage-edit "live-v1"
+  run azure secret update --yes suve-demo-stage-edit "live-v2"
+  run azure secret create suve-demo-stage-delete "obsolete"
+  run azure secret create suve-demo-stage-tag-add "value"
+  run azure secret tag suve-demo-stage-tag-add existing=kept
+  run azure secret create suve-demo-stage-tag-change "value"
+  run azure secret tag suve-demo-stage-tag-change env=staging
+  run azure secret create suve-demo-stage-tag-remove "value"
+  run azure secret tag suve-demo-stage-tag-remove temporary=yes keep=yes
+
+  # Working-area staged changes.
+  run azure stage secret add suve-demo-stage-new "created via staging, not yet applied"
+  run azure stage secret edit suve-demo-stage-edit "edited via staging"
+  run azure stage secret delete suve-demo-stage-delete
+  run azure stage secret tag suve-demo-stage-tag-add owner=team-a
+  run azure stage secret tag suve-demo-stage-tag-change env=production
+  run azure stage secret untag suve-demo-stage-tag-remove temporary
+}
+
+# ---------------------------------------------------------------------------
+# Azure App Configuration (param; UNVERSIONED, keys may contain slashes,
+# namespace = the label axis)
+# ---------------------------------------------------------------------------
+seed_azure_param() {
+  require_env SUVE_AZURE_APPCONFIG_CONNECTION_STRING "Azure App Configuration" "--azure-appconfig" || return 0
+  echo "==> Seeding Azure App Configuration…"
+
+  # No version history here (last-write-wins); updates overwrite in place.
+  run azure param create suve-demo/app/database-url "postgres://db.internal:5432/app"
+  run azure param update --yes suve-demo/app/database-url "postgres://db-primary.internal:5432/app"
+  run azure param tag suve-demo/app/database-url env=production team=payments
+
+  run azure param create suve-demo/app/feature-flags "beta,dark-mode"
+
+  # The label axis (Azure calls it a "label"; suve exposes it as --namespace).
+  # Same key under the default (NULL) label plus dev / prd, with a distinct value
+  # each. Tags are per-(key, label): tag the default and prd rows, leave dev bare.
+  run azure param create suve-demo/app/log-level "info"                     # (NULL) label
+  run azure param --namespace dev create suve-demo/app/log-level "debug"
+  run azure param --namespace prd create suve-demo/app/log-level "warn"
+  run azure param tag suve-demo/app/log-level owner=platform
+  run azure param --namespace prd tag suve-demo/app/log-level owner=platform change-ticket=CHG-1024
+
+  # Applied settings that back the staged scenarios below (default namespace).
+  run azure param create suve-demo/staging/edit-me "live-value"
+  run azure param create suve-demo/staging/delete-me "obsolete setting"
+  run azure param create suve-demo/staging/tag-add "value"
+  run azure param tag suve-demo/staging/tag-add existing=kept
+  run azure param create suve-demo/staging/tag-change "value"
+  run azure param tag suve-demo/staging/tag-change env=staging
+  run azure param create suve-demo/staging/tag-remove "value"
+  run azure param tag suve-demo/staging/tag-remove temporary=yes keep=yes
+
+  # Working-area staged changes.
+  run azure stage param add suve-demo/staging/new-setting "created via staging, not yet applied"
+  run azure stage param edit suve-demo/staging/edit-me "edited via staging"
+  run azure stage param delete suve-demo/staging/delete-me
+  run azure stage param tag suve-demo/staging/tag-add owner=team-a
+  run azure stage param tag suve-demo/staging/tag-change env=production
+  run azure stage param untag suve-demo/staging/tag-remove temporary
+}
+
+case "${1:-}" in
+  aws-param) seed_aws_param ;;
+  aws-secret) seed_aws_secret ;;
+  gcloud-secret) seed_gcloud_secret ;;
+  azure-secret) seed_azure_secret ;;
+  azure-param) seed_azure_param ;;
+  *)
+    echo "usage: bash scripts/seed.sh {aws-param|aws-secret|gcloud-secret|azure-secret|azure-param}" >&2
+    exit 2
+    ;;
+esac


### PR DESCRIPTION
Local dev-verification tooling and demo upkeep. No product code changes. Split from #617 (the staging plaintext-guard bug fix), which this shares no files with.

## Seeding (`mise run seed-*`)

Comprehensive fixtures for manual CLI/GUI verification, run inside a `mise run bash --…` shell:

- Leaf tasks `seed-{aws,gcloud,azure}-{param,secret}` plus `seed-aws` / `seed-gcloud` / `seed-azure` / `seed-all` aggregate aliases (fan out via `depends`; a hidden `seed-build` compiles `bin/suve-seed` once). Logic in `scripts/seed.sh`.
- Each service lays down applied resources with **stacked versions** and **tags**, plus a full **working staging area** — one of every staged shape: add, edit, delete, and tag add / change / remove.
- Azure reflects its version-scoped model: **Key Vault** tags land on *some* versions including the latest; **App Configuration** seeds the `(NULL)`/`dev`/`prd` label axis with per-`(key,label)` tags.
- A service whose emulator env is absent is skipped with a hint, so `seed-all` in a partial dev shell just seeds what is running.

Verified end-to-end against localstack (param+secret: 3 versions, `stage status` shows A/M/D + tag ±) and the Azure emulators (per-version KV tags, per-label App Config).

## `clean`

`docker compose down -v` omitted `--profile "*"`, so the profile-gated local-verification emulators (localstack/gcloud/azure) and their volumes were left orphaned. Added `--profile "*"` — verified a running localstack goes to 0 containers.

## Dev shell (`mise-tasks/bash`)

Inject `SUVE_STAGING_KEY` when a cloud is active, so staged changes written by `seed*` are read back with the **same** key and stay visible. Without it the shell read the working store under a different key and saw nothing staged ("everything looks applied").

## Demo scripts

Reconcile `demo/cli-record.sh` / `demo/gui-record.sh` with reality: `mise build` → `mise build-cli`; drop the removed staging agent / `SUVE_DAEMON_MANUAL_MODE`; `--profile "*"` on the reset `down`; pin `SUVE_STAGING_KEY`; and keep the demo's `/demo/*` namespace separate from the seed fixtures' `/suve-demo/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)