### PR TITLE
fix(demo): repair GUI demo recording + refresh stale CLI demo GIF

### DIFF
--- a/demo/cli-demo.gif
+++ b/demo/cli-demo.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ec5a569537ae5af237bf9c471366f1e288b2cf061a33b2b9f32c9a5dd6ce5077
-size 2766014
+oid sha256:ceb554628756c575e578a12577ef1e1d7ba7eab81123555ccd49e95ada552d74
+size 2936824

--- a/demo/gui-demo.gif
+++ b/demo/gui-demo.gif
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2776686ff6ee21137f8f22017344d8d32d21f56e3a1966fdc262ec56bb3eb074
-size 7828301
+oid sha256:3bdd31f15650ed20a00e666a34dd651557cc98ce752f605861d49fb262fbd6cb
+size 8121512

--- a/demo/gui-demo.spec.ts
+++ b/demo/gui-demo.spec.ts
@@ -54,8 +54,8 @@ test.describe('GUI Demo Recording', () => {
     console.log('Step 1: Viewing existing parameters');
     await pause(PAUSE_MEDIUM);
 
-    // Enable "Show Values"
-    await page.locator('input[type="checkbox"]').first().check();
+    // Enable "Show Values" (target by label — the first checkbox is "Recursive")
+    await page.getByRole('checkbox', { name: 'Show Values' }).check();
     await pause(PAUSE_MEDIUM);
 
     // Click on /demo/api/url to show details with tags
@@ -94,7 +94,7 @@ test.describe('GUI Demo Recording', () => {
     // 4. Stage an update to existing parameter (/demo/api/url)
     // =========================================================================
     console.log('Step 4: Staging update to existing parameter');
-    await navigateTo(page, 'Parameters');
+    await navigateTo(page, 'Param');
     await waitForItemList(page);
     await pause(PAUSE_MEDIUM); // Wait for view transition to complete
 
@@ -197,7 +197,7 @@ test.describe('GUI Demo Recording', () => {
     // 10. Apply all staged changes
     // =========================================================================
     console.log('Step 10: Applying staged changes');
-    await page.getByRole('button', { name: /Apply/i }).first().click();
+    await page.getByRole('button', { name: 'Apply All' }).click();
 
     await pause(PAUSE_LONG); // Show confirm dialog before closing
     await page.locator('.modal-content').getByRole('button').filter({ hasText: /Apply|Confirm/i }).click();
@@ -212,7 +212,7 @@ test.describe('GUI Demo Recording', () => {
     // 11. Verify changes
     // =========================================================================
     console.log('Step 11: Verifying changes');
-    await navigateTo(page, 'Parameters');
+    await navigateTo(page, 'Param');
     await waitForItemList(page);
     await pause(PAUSE_MEDIUM);
 
@@ -221,7 +221,7 @@ test.describe('GUI Demo Recording', () => {
     await waitForItemList(page);
     await pause(PAUSE_MEDIUM);
 
-    const showValues = page.locator('input[type="checkbox"]').first();
+    const showValues = page.getByRole('checkbox', { name: 'Show Values' });
     if (!(await showValues.isChecked())) {
       await showValues.check();
     }


### PR DESCRIPTION
Both demo GIFs had drifted out of sync with current behavior. This PR refreshes them and fixes the GUI recording automation.

## 1. GUI demo (`demo/gui-demo.spec.ts` + `demo/gui-demo.gif`)

The Playwright spec hadn't been touched since #61 (2026-01-06) and broke after the provider-selection / capability-display-name changes, so `./demo/gui-record.sh` no longer produced a correct GIF.

| Step | Problem | Fix |
|------|---------|-----|
| Show Values (Step 1 & 11) | `input[type=checkbox]`.first() now grabs the **Recursive** checkbox (default-on) → no-op, values never displayed | target by label: `getByRole('checkbox', {name: 'Show Values'})` |
| Nav (Step 4 & 11) | `navigateTo(page, 'Parameters')` no longer matches — the AWS param nav label is now **"Param"** (`internal/gui/providers.go:167`) | `'Param'` |
| Apply (Step 10) | `getByRole('button', {name: /Apply/i}).first()` is ambiguous with the per-section **Apply** button | `getByRole('button', {name: 'Apply All'})` |

All other selectors (`.item-list`, `.btn-close`, `#param-name`, `#param-value`, `.modal-backdrop`, `.staging-content`, `.view-toggle`, `#tag-key`/`#tag-value`, `+ New`, `+ Add`, `.btn-tag-remove`, `Stage`/`Stage Tag`/`Stage Remove`/`Stage Delete`) still match and needed no change. AWS auto-connects when the env is present, so no scope/provider handling was needed.

**Verification:** `./demo/gui-record.sh` → Playwright **1 passed (52.1s)**, all 12 steps. Frame inspection confirmed Show Values on, staging area with all 4 changes (delete / update v1→v2 / +Env=Dev / −Version), Apply All success, and verify showing `api/url`=v2 (`Env=Dev`, history v2/v1) and `cache/ttl`=3600.

## 2. CLI demo (`demo/cli-demo.gif`)

The committed CLI GIF predated the change that **sorts `param ls` output**: it showed creation order (`api/url`, `legacy/endpoint`, `config`) while the CLI now lists sorted (`api/url`, `config`, `legacy/endpoint`). Re-recorded so the GIF matches current behavior — no tape/script changes.

---

Both GIFs are Git LFS objects (verified stored as LFS pointers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)