### PR TITLE
docs(skills): add engineering skills (add-provider-adapter, add-e2e-emulator, gui-change, refresh-demo-gifs) (#630)

### DIFF
--- a/.claude/skills/add-e2e-emulator/SKILL.md
+++ b/.claude/skills/add-e2e-emulator/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: add-e2e-emulator
+description: Use when adding emulator-backed e2e coverage for a provider — wiring an env-gated emulator seam, a compose.test.yaml service, a mise e2e-<provider> task, and a closed-network CI job. Covers emulator-vs-SDK divergences and coverage upload.
+---
+
+# Adding emulator-backed e2e
+
+suve runs provider e2e against local emulators: Google Cloud (PR #256), Azure
+App Configuration (PR #258), and Azure Key Vault (PR #259).
+
+## Emulator seam
+
+- Add an **env-gated seam in the adapter** that swaps credentials/TLS into
+  emulator mode when set — e.g. `SUVE_AZURE_APPCONFIG_CONNECTION_STRING`,
+  `SUVE_AZURE_KEYVAULT_ENDPOINT`. Document in the code that the variable is for
+  emulator use and must never be pointed at production.
+
+## Compose + task + CI
+
+- Add a `compose.test.yaml` service under the provider's compose profile.
+- Add a `mise e2e-<provider>` task (AWS is `mise e2e-aws`; Google Cloud is
+  `mise e2e-gcloud`; Azure is `mise e2e-azure-appconfig` / `mise e2e-azure-keyvault`).
+- Add a CI job that runs on a **closed compose network with no host ports**
+  (#468) — the suite runs in-container and tears everything down on exit.
+- **e2e CI jobs must upload coverage.**
+
+## Vet the emulator against the real SDK
+
+Upstream emulators break real SDKs — vet with the official SDK, not curl:
+
+- App Configuration (#258) documents three divergences that the fork
+  `ghcr.io/mpyw/azure-app-configuration-emulator` fixes: HMAC auth-header
+  parsing, RFC3339 timestamp offset handling, and a missing `Sync-Token`
+  response header.
+- Key Vault (#259): lowkey-vault has 1-second-granular timestamps, so **space
+  successive writes by 1 second** to keep version ordering deterministic; it
+  returns 405 on an empty-version PATCH, so **cover tag/untag in unit tests**
+  rather than through the emulator.
+
+Document each quirk next to the code that routes around it.
+
+## Assertions
+
+- Assertions must assert **real behavior**, not merely "no panic". Weak
+  error-case subtests (#443) were hardened to assert actual outcomes in #517.
+
+## Local runs
+
+- Keychain-dependent e2e blocks on OS keychain prompts when run locally. Bypass
+  with `SUVE_STAGING_KEY`, or leave those paths to CI.

--- a/.claude/skills/add-provider-adapter/SKILL.md
+++ b/.claude/skills/add-provider-adapter/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: add-provider-adapter
+description: Use when adding a new cloud provider adapter, or extending an existing one with a new service, in internal/provider/<name>/. Covers the Store interface, SDK confinement, error mapping, version-spec parsing, CLI/registry wiring, and staging support.
+---
+
+# Adding or extending a provider adapter
+
+A provider adapter implements the neutral seam in `internal/provider` so the rest
+of suve never sees a cloud SDK. Google Cloud (PR #231), Azure Key Vault + App
+Configuration (PR #239), and the AWS re-implementation (PR #224) all follow the
+same shape.
+
+## Core adapter
+
+- Implement `provider.Store` — the composition of `Reader`, `Writer`, and
+  `Tagger` (`internal/provider/provider.go`) — over a **narrow in-package client
+  wrapper**. Keep the cloud SDK confined to `internal/provider/<name>/**`.
+- Hide SDK paginators and iterators behind a `Wrap()` adapter so the seam
+  returns neutral `domain` types, never SDK types.
+- Map SDK errors to the neutral sentinels in `internal/provider/errors.go`:
+  `provider.ErrNotFound` and `provider.ErrAlreadyExists`. Missed error mappings
+  are a recurring defect source (#318, #481) — enumerate every not-found and
+  already-exists SDK error shape and cover it in unit tests.
+- Do **pagination and deterministic ordering from day one**. List and history
+  operations must page through all results and break timestamp ties with a
+  stable secondary key. Skipping this produced #311, #312, and #314.
+
+## Version-spec parser
+
+- Add a parser package `internal/version/<name>version` (see the existing
+  `gcloudversion`, `azurekvversion`, `azureappconfigversion`). It resolves
+  `#VERSION` / `~SHIFT` / `:LABEL` per the provider's capabilities and **cleanly
+  rejects unsupported specifiers before any API call**. Google Cloud rejects
+  labels with a dedicated error at parse time (`ErrLabelUnsupported`, #231);
+  App Configuration is unversioned and rejects all specifiers.
+
+## Wiring
+
+- Wire a `Factory` (`internal/provider/registry.go`) that returns
+  `provider.ErrUnsupportedKind` for services the provider does not offer.
+- Register the factory in the CLI registry and in `internal/cli/commands/app.go`.
+- Add the provider's scope flag plus its environment-variable fallback.
+
+## SDK confinement guards
+
+- Extend `internal/architecture_test.go` and the `depguard` block in
+  `.golangci.yaml` to gate the new SDK module so it can only be imported from
+  the provider directory. Confinement is enforced across all of `internal/`
+  (#488, #502) — keep that breadth.
+
+## Staging support (separate work)
+
+Staging is a distinct increment on top of read/write (#247 → #261, #262):
+
+- Implement the provider `ScopeResolver`.
+- Add the provider's staging strategy.
+- Register the service spec in `GlobalConfig` (#261).
+
+## PR conventions
+
+- Record any friction with the neutral abstraction in a "Design feedback"
+  section of the PR body (#231 — this feedback fed the seam epic #419).
+- Close against #231's acceptance checklist: every op works, unsupported specs
+  are rejected before the API call, no foreign SDK appears outside the provider
+  directory, and `mise test` + `mise lint` are green.

--- a/.claude/skills/gui-change/SKILL.md
+++ b/.claude/skills/gui-change/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: gui-change
+description: Use when changing the Wails/Svelte GUI in internal/gui/ — backend bindings, capability-driven UI, provider/scope switching, or async loads. Covers the bindings-regenerate-then-rebuild rule, server-side guards, and the recurring async-bug checklist.
+---
+
+# Changing the GUI
+
+The GUI is Wails (Go bindings in `internal/gui/*.go`) plus a Svelte frontend
+(`internal/gui/frontend/src/`). Multi-cloud parity was tracked in #250 and
+landed across #273–#282.
+
+## Bindings: regenerate, then rebuild immediately
+
+- Any backend binding change requires `mise generate-gui-bindings`, then an
+  immediate `mise build-gui`. Stale bindings make every API arity mismatch, so
+  **verification is always `mise build-gui`, never the CLI build**.
+
+## Capability-driven UI
+
+- Drive control visibility from the per-provider capability descriptor
+  (`ProviderCapability` / `ServiceCapability` in `internal/gui/providers.go`,
+  #264/#274). Hide unsupported controls via the descriptor; never hardcode
+  provider conditionals in Svelte.
+- Security-relevant guards live **server-side in the Go bindings**, not only in
+  frontend hiding (#276) — e.g. staging guards and scope validation/readback.
+
+## Provider/scope switching
+
+- A provider or scope switch is a **full view remount** driven by
+  `{#key scopeKey}` (`internal/gui/frontend/src/App.svelte`). Reset badges and
+  cancel pending debounces on switch so no stale state or stray request survives
+  the remount (#266).
+
+## Testing (three-layer rule)
+
+- Playwright coverage is per-feature definition-of-done (#250). Any
+  GUI-visible behavior requires a Playwright test
+  (`internal/gui/frontend/tests/`) in addition to Go unit and CLI e2e coverage.
+
+## Recurring async-bug checklist
+
+Check every GUI change against these classes:
+
+- Stale-response guards on async loads — ignore a resolved load whose request
+  has been superseded by a newer one (#539, #566).
+- Busy-guards against double-fire on repeated clicks/actions (#568).
+- Modal dismissal gating while an operation is mid-flight (#565).
+- Errors must not be swallowed at the binding boundary; surface them to the UI
+  (#550, #447).

--- a/.claude/skills/refresh-demo-gifs/SKILL.md
+++ b/.claude/skills/refresh-demo-gifs/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: refresh-demo-gifs
+description: Use when re-recording the CLI or GUI demo GIFs after a UI change or a user-visible CLI output change. Covers the record scripts, robust Playwright selectors, output-drift triggers, frame verification, and Git LFS.
+---
+
+# Refreshing the demo GIFs
+
+Two demos are recorded and committed as GIFs (PRs #619, #618, #61):
+
+- **CLI demo**: `demo/cli-demo.tape` recorded via `./demo/cli-record.sh` (vhs).
+- **GUI demo**: `demo/gui-demo.spec.ts` recorded via `./demo/gui-record.sh`
+  (Playwright-driven).
+
+## Selector drift is the dominant failure mode
+
+After a UI change the GUI recording breaks on selectors:
+
+- Prefer role/label selectors over positional ones — use
+  `page.getByRole('checkbox', { name: 'Show Values' })`, not `.first()`.
+- Re-check navigation labels against the provider display names in
+  `internal/gui/providers.go` (AWS {Param, Secret}, Google Cloud {Secret},
+  Azure {App Configuration, Key Vault}).
+
+## CLI output drift also invalidates the GIF
+
+- User-visible CLI output changes invalidate the CLI GIF even without a "UI"
+  change — e.g. `param ls` sorting (#480, PR #508). Re-record after such changes.
+
+## Verify and commit
+
+- Verify by **frame inspection** of the produced GIF — confirm each intended
+  step is visible (PR #619 lists per-frame confirmations).
+- The GIFs are tracked as **Git LFS** pointers (`*.gif filter=lfs` in
+  `.gitattributes`). Confirm the committed `demo/cli-demo.gif` /
+  `demo/gui-demo.gif` are LFS pointer files, not raw binaries.


### PR DESCRIPTION
## Summary

Adds four committed ENGINEERING skills under `.claude/skills/<name>/SKILL.md`, extracting recurring workflows mined from issue/PR history into durable, versioned skills (Step 10 of Epic #620). Each skill has YAML frontmatter (`name`, `description` stating WHEN to load) and a current-state-only body.

- `add-provider-adapter` — adding/extending a cloud provider adapter (Store interface, SDK confinement, error mapping, version-spec parser, CLI/registry wiring, staging support).
- `add-e2e-emulator` — adding emulator-backed e2e (env-gated seam, compose.test.yaml service, `mise e2e-<provider>` task, closed-network CI + coverage, emulator-vs-SDK divergences).
- `gui-change` — touching the Wails/Svelte GUI (regenerate-then-rebuild bindings, capability-driven UI, server-side guards, `{#key scopeKey}` remount, three-layer testing, async-bug checklist).
- `refresh-demo-gifs` — re-recording demo GIFs after UI/output changes (record scripts, role/label selectors, output-drift triggers, frame verification, Git LFS).

The AWS e2e task is referenced as `e2e-aws` (its target name after sibling PR #623), and provider tasks as `mise e2e-<provider>`.

## Related

Closes #630
Part of #620

## Changes

- `.claude/skills/add-provider-adapter/SKILL.md`
- `.claude/skills/add-e2e-emulator/SKILL.md`
- `.claude/skills/gui-change/SKILL.md`
- `.claude/skills/refresh-demo-gifs/SKILL.md`

## Verification

- `ls .claude/skills/*/SKILL.md` shows the four files.
- Frontmatter validated: each opens with `---`, has `name:` + `description:`, and every description starts with "Use when".
- Current-state-only prose: `grep -rniE 'removed|no longer|renamed|used to|previously|BREAKING|deprecat' .claude/skills/` → CLEAN.
- All referenced repo paths confirmed present via `git ls-files` (e.g. `internal/provider/{provider,errors,registry}.go`, `internal/gui/providers.go`, `internal/gui/frontend/src/App.svelte`, `demo/{cli-demo.tape,cli-record.sh,gui-demo.spec.ts,gui-record.sh}`, `compose.test.yaml`, `.golangci.yaml`, `internal/architecture_test.go`, `.gitattributes`).
- A sample of cited PRs re-verified via `gh pr view` (#231, #258, #259, #468, #517, #619); #276/#266 confirmed as issues (GUI backend/frontend prep) and cited without mislabeling.
- Context-isolated review subagent checked accuracy vs the #630 spec, path existence, task naming, and the current-state-only rule: no defects.
- Docs-only change (no Go touched). `mise lint` fails only on the pre-existing `internal/gui/assets.go` `all:frontend/dist` embed (a build artifact requiring `mise build-gui`), which this change does not affect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)