### PR TITLE
docs(skills): add process skills (bug-audit-epic, bug-fix-pr, feature-epic-breakdown, docs-audit) (#629)

### DIFF
--- a/.claude/skills/bug-audit-epic/SKILL.md
+++ b/.claude/skills/bug-audit-epic/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: bug-audit-epic
+description: Use when running a codebase-wide or subsystem bug audit — fan out orthogonal parallel investigators, adversarially verify every Medium+ finding before filing, write bug issues in the standard body, and file a severity-grouped [Epic] with linked sub-issues and an "Areas verified clean" section.
+---
+
+# Bug audit epic
+
+A bug audit produces **verified bug reports only — no code changes**. The fixes come later, one PR per issue (see the `bug-fix-pr` skill). Evidence for this procedure: epics #493 (24 children), #543 (47 children, rounds 2–3), #570 (staging deep-dive); standard child body #545; children #545–569.
+
+## Procedure
+
+### 1. Fix the audit baseline
+
+Pick the commit the audit runs against and record it in the epic verbatim: `Audited at main = <sha>` (#570 audited at `d424c74`; #493 at its round-1 base). Every `file:line` cite in every child must resolve against that SHA. When the audit spans several days and later rounds re-verify cites against a newer SHA, state both bases (#543 records base `98f5b74`, extended to `d424c74`).
+
+### 2. Fan out orthogonal investigators
+
+Run parallel investigators, each with a distinct attack angle so coverage does not overlap:
+
+- **Subsystem audit** (#570, six angles): exhaustive transition-matrix analysis (actions × entry states × tag presence × remote state) with use-case-level reproduction; cross-check every parallel implementation of the same operation for drift (the three apply paths — global Runner / ApplyUseCase / GUI); the persistence/serialization layer; export/import data semantics; the GUI Go layer and its frontend contract; the Svelte view read as a state machine.
+- **Whole-codebase audit** (#493, four rounds): ~11 area investigators (CLI, staging engine, export/import, crypto/key handling, each provider adapter, GUI, concurrency, cross-cutting), then an independent adversarial refutation round, then a completeness-critic pass with gap follow-ups, then a final verification round that declares the audit converged.
+
+### 3. Adversarially verify every Medium+ candidate
+
+Before a Medium-or-higher candidate is filed, an independent agent tries to refute it. Record the outcome in the epic methodology: upgrades (evidence traced deeper — #570 upgraded one to SDK-serializer level), confirmations, and downgrades with corrections (#543 downgraded five to Low). Drop plausible-but-unproven low-severity candidates rather than filing them (#493).
+
+### 4. Deduplicate and exclude prior waves
+
+Merge findings that independent investigators reported for the same root cause. Exclude anything already filed in earlier waves, stated explicitly by issue-number range (#570 excludes everything in #493 and #543 including staging items #521–#542; #543 excludes #493's #447 as tracked). Refute suspected process gaps in writing rather than leaving them implied (#570 refuted a suspected export tag-destruction; #543 dismissed a "closed but unmerged" concern by confirming the PR was merged).
+
+### 5. File each child with the standard body
+
+Body sections, in order (template = #545):
+
+- `## Summary` — what breaks and why, in prose.
+- `## Where` — `file:line` anchors for every implicated site.
+- `## Failure scenario` — a concrete reproduction a fixer can replay.
+- `## Severity` — with justification.
+- `## Suggested fix` — the minimal correct change.
+- Provenance/confidence footer — e.g. `Found during a Fable-coordinated / Opus-executed <scope> audit; adversarially verified (<how>). Confidence: CONFIRMED.`
+
+Labels: `bug` + the area label(s) (`staging`, `param`, `secret`, …) + a `Priority:*` label. Priority definitions: `Critical` = silent data loss or wrong values returned (e.g. #545 — a tag-only write silently corrupts a Key Vault reference into a plain literal).
+
+### 6. File the epic
+
+- Title `[Epic] <scope> bug audit (<date>)`, label `epic` (+ area label for a subsystem audit).
+- A **methodology** paragraph naming the investigators, the adversarial round and its upgrade/downgrade tally, and the convergence criterion.
+- An **"Areas verified clean"** (or "Areas audited clean") paragraph listing what was checked and found sound. This is load-bearing: it stops the next wave from re-auditing the same ground.
+- Children grouped by severity (Critical / High / Medium / Low) as checkbox lists, and also linked as GitHub sub-issues.

--- a/.claude/skills/bug-fix-pr/SKILL.md
+++ b/.claude/skills/bug-fix-pr/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: bug-fix-pr
+description: Use when turning one filed bug issue into a fix PR — reproduce from the issue's Failure-scenario section, fix at the cited site, add a regression test at every layer the three-layer rule names, run the gates, and write a PR whose Verification section shows real command output.
+---
+
+# Bug fix PR
+
+One filed bug = one PR. Evidence for this workflow: the fix-PR waves #363–#408, #494–#517, #571–#613, each closing a single audit child.
+
+## Procedure
+
+### 1. Reproduce first
+
+Read the issue. Its `## Failure scenario` gives the exact reproduction; its `## Where` gives the `file:line` anchors. Replay the failure before touching anything, so the fix is validated against a real reproduction rather than a guess. Confirm the cites still resolve at current `main`.
+
+### 2. Fix at the cited site
+
+Make the minimal correct change at the anchors the issue names. If the true root cause is elsewhere, fix the root cause and say so in the PR body — do not paper over it at the symptom site.
+
+### 3. Regression test at every layer the three-layer rule names
+
+A feature/bug that is visible at multiple layers must be tested at each: **Go unit** test, **CLI e2e** test, and **GUI Playwright** test. Anything visible in the GUI needs Playwright coverage — a Go-only fix for a GUI-visible bug is incomplete (cf. #417 tag-only staged changes made visible in the Staging Area; #606 auto-unstaged notice; #607 inline-row double-fire guard, all with Playwright coverage). Add the regression test at the layer the bug actually lives in, plus any layer that surfaces it.
+
+### 4. Run the gates
+
+- `mise test` and `mise lint` — always.
+- `mise e2e-aws` (and the `-gcloud` / `-azure-appconfig` / `-azure-keyvault` variants for the affected providers) when command behavior changed.
+- `mise build-gui` when GUI code or the wailsjs bindings were touched.
+
+### 5. Write the PR
+
+- Title: `fix(<area>): <imperative summary> (#<issue>)`.
+- Body opens with `Closes #<issue>`.
+- Body ends with a **Verification** section showing real command output (the actual test/gate runs, or a before/after transcript) — not a claim that it passes. #231 and #619 are the exemplars for a Verification section.
+- Before opening the PR, have a context-isolated subagent critically review the change and apply the improvements it surfaces (repo convention).

--- a/.claude/skills/docs-audit/SKILL.md
+++ b/.claude/skills/docs-audit/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: docs-audit
+description: Use when keeping docs in sync with the implementation — sweep command tables/env-vars/paths against the real CLI, keep reference docs current-state-only (migrations go to release notes), enforce identical terminology across CLI help / README / GUI, and track the README install/aqua section against the external aqua-registry.
+---
+
+# Docs audit
+
+Sweep documentation for divergence from the implementation and fix it. Evidence: audit #448 → fix PR #442; self-review sweep PR #245; aqua-version drift #544; export/import docs PR #461; README restructure PR #614; terminology work #409 → PR #412; release/aqua coupling PRs #303, #304, #309.
+
+## Procedure
+
+### 1. Sweep for divergence
+
+Compare docs against the real implementation and file/fix each divergence (#448 catalogued them; #442 fixed them):
+
+- Command tables and flag lists vs the actual `--help` output.
+- Documented env vars, paths, and package names vs the code (missing packages, renamed dirs, drifted interface descriptions).
+- Claims about behavior vs what the code does (e.g. an "E2E is SSM-only" claim the current suite contradicts).
+
+### 2. Reference docs describe current state only
+
+Reference/README bodies describe **the current state only**. Do not write "removed", "no longer", "renamed from", or "BREAKING" in a reference body — describe what the thing *is* now, in the present tense. Migrations and breaking-change narratives go to **release notes**, not reference docs (the #456 / PR #461 pattern: the export/import reference docs describe export/import as they exist; the stash→export/import migration lives in the release note).
+
+### 3. Terminology identical across surfaces
+
+The same concept uses the same word in CLI help, README, and the GUI. Maintain the native→suve term mapping explicitly (#409 / PR #412): Google Cloud "labels" are surfaced as suve **tags**; the Azure App Config "label" axis is surfaced as a **namespace** and is distinct from metadata tags. When one surface changes wording, change all of them in the same PR.
+
+### 4. Track the README install/aqua section against the external registry
+
+The README install/aqua section must track the external aqua-registry package `pkgs/mpyw/suve` (regenerated with `argd gr`; `version_constraint` floor currently `v1.6.1`). This drifts independently of the code, so check it every sweep — #544 was exactly this drift (the aqua section advertised an outdated minimum version). Release-archive and install-method changes couple here too (PRs #303, #304, #309).

--- a/.claude/skills/feature-epic-breakdown/SKILL.md
+++ b/.claude/skills/feature-epic-breakdown/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: feature-epic-breakdown
+description: Use when planning a multi-PR feature or cross-cutting refactor as an epic — write a design-complete epic body, slice into layer-ordered sub-issues that each restate their slice standalone with DELETE/ADD/MODIFY tasks and dependencies, use an integration branch when the change must land coherently, and require a context-isolated review before every PR.
+---
+
+# Feature epic breakdown
+
+Plan a feature so that each sub-issue is a self-contained PR and the whole lands coherently. Evidence: #451 (the gold standard — export/import, sub-issues #452–457), #419 (phased domain→adapters→usecase→CLI→GUI refactor), #410 (integration-branch epic).
+
+## Epic body
+
+Write the epic so a work agent needs nothing else:
+
+- **Summary** → **Motivation**.
+- **Finalized design** — schemas and tables inline, not linked. #451 embeds the full JSON envelope schema and a complete CLI-surface table; #419 tables the per-provider semantics being modeled.
+- **Sub-issues in dependency order**, with the order stated explicitly (`#452 → #453 → #454 → (#455 and #456 in parallel) → #457`; each green under its gates before the next starts).
+- **Edge cases shared across all steps** — called out once, centrally.
+- **Blast radius** — file counts per layer, so scope is legible.
+- **Validation gates** — the concrete `mise` commands.
+- **"Done when"** acceptance criteria (#410 closes with an explicit Done-when list).
+
+## Slicing
+
+Slice by layer, in dependency order:
+
+1. **Storage** (schema, serialization; delete the thing being replaced).
+2. **Usecase** (business logic).
+3. **CLI + e2e** (commands, wiring, e2e coverage).
+4. **GUI** (Go DTO/API, regenerated wailsjs bindings, Svelte view, Playwright).
+5. **Docs + breaking-change note** (reference docs current-state-only; migration to release notes).
+6. **Final integration & comprehensive review** — its own last sub-issue (#457).
+
+Each sub-issue must: restate its slice standalone (a fixer reads only that issue), list **DELETE / ADD / MODIFY** tasks against concrete `file:line` sites, name its gates, and state its dependency (`Do not start until Step 2 (Usecase) is merged` — #454). Link children as GitHub sub-issues and mirror them as a body checklist.
+
+## Integration branch
+
+When the change must land as one coherent concept rather than piecemeal, sub-PRs target an **integration branch** `epic/<name>` and a final PR merges it to `main` (`epic/version-state-vs-staging-labels` in #419; `epic/appconfig-namespace-terminology` in #410). Otherwise each sub-PR targets `main` directly.
+
+## Mandatory review clause
+
+Include this clause verbatim in the epic (and echo it in each sub-issue, as #454 does):
+
+> Before opening the PR, have a **context-isolated subagent** (one that does **not** share this conversation's context) perform a **critical review** of the changes, apply the quality improvements it surfaces, and only then open the pull request.


### PR DESCRIPTION
## Summary

Adds four committed PROCESS skills under `.claude/skills/<name>/SKILL.md`, capturing recurring engineering workflows mined from the repo's issue/PR history so the knowledge is durable and versioned rather than living only in closed issues. Each skill is a YAML-frontmatter (`name` + when-to-use `description`) doc whose body encodes the procedure, with the source issue/PR numbers cited as evidence.

Step 9 of 11 of Epic #620.

## Related

- Closes #629
- Part of #620

## Changes

- `bug-audit-epic` — running a codebase/subsystem bug audit: orthogonal parallel investigators, adversarial verification of every Medium+ finding, standard bug-issue body, severity-grouped `[Epic]` with an "Areas verified clean" section and linked sub-issues (sources: #493, #543, #570; body template #545).
- `bug-fix-pr` — executing one filed bug as a PR: reproduce from the Failure-scenario section, fix at the cited site, regression-test at every layer the three-layer rule names, run the gates, Verification section with real output (sources: fix-PR waves #363–#408, #494–#517, #571–#613; #417/#606/#607; #231/#619).
- `feature-epic-breakdown` — planning a multi-PR feature: design-complete epic body, layer-ordered standalone sub-issues with DELETE/ADD/MODIFY tasks and dependencies, integration branch when needed, verbatim context-isolated-review clause (sources: #451/#452–457, #419, #410).
- `docs-audit` — keeping docs in sync: sweep tables/env-vars/paths vs implementation, current-state-only reference bodies, identical terminology across CLI/README/GUI, README aqua section tracked against the external aqua-registry (sources: #448/#442, #544, #245/#461/#614, #409/#412).

Skill bodies are written in current-state-only prose; every cited number was re-verified with `gh issue view` / `gh pr view` (no transposed numbers). The AWS e2e gate is referenced as `mise e2e-aws` per the #629 spec (its post-rename name from Step 3 / #623).

## Verification

```
$ ls .claude/skills/*/SKILL.md
.claude/skills/bug-audit-epic/SKILL.md
.claude/skills/bug-fix-pr/SKILL.md
.claude/skills/docs-audit/SKILL.md
.claude/skills/feature-epic-breakdown/SKILL.md
```

- All four frontmatter blocks are valid single-line-scalar YAML with `name` + when-to-use `description`.
- These are Markdown skills (not Go-linted); they load as available project skills in a fresh Claude Code session.
- A context-isolated review subagent verified spec fidelity, all cited numbers, and the current-state-only rule — no defects found.
- Pre-existing `mise lint` typecheck failure (`internal/gui/assets.go` embedding an unbuilt `frontend/dist`) is unrelated to these Markdown-only changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)