### PR TITLE
refactor(e2e): carry the aws marker in AWS e2e files and test functions (#622)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,7 +207,7 @@ mise generate-gui-bindings # Regenerate the GUI wailsjs bindings
 ## Testing Strategy
 
 - **Unit tests**: Each command package has `*_test.go` with provider-neutral mocking via `internal/provider/providermock`
-- **E2E tests**: `e2e/e2e_test.go` runs against localstack (SSM only, SM requires Pro)
+- **E2E tests**: `e2e/aws_*_test.go` runs against localstack (SSM only, SM requires Pro)
 - **GUI tests**: `internal/gui/frontend/tests/` uses Playwright for component/integration testing
 - **Test dependencies**: Uses `github.com/samber/lo` for pointer helpers and `github.com/stretchr/testify` for assertions
 

--- a/e2e/aws_param_test.go
+++ b/e2e/aws_param_test.go
@@ -28,9 +28,9 @@ import (
 // SSM Parameter Store Basic Commands Tests
 // =============================================================================
 
-// TestParam_FullWorkflow tests the complete SSM Parameter Store workflow:
+// TestAWSParam_FullWorkflow tests the complete SSM Parameter Store workflow:
 // create → show → show --raw → update → log → diff → list → delete → verify deletion.
-func TestParam_FullWorkflow(t *testing.T) {
+func TestAWSParam_FullWorkflow(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-test/basic/param"
@@ -160,8 +160,8 @@ func TestParam_FullWorkflow(t *testing.T) {
 	})
 }
 
-// TestParam_VersionSpecifiers tests SSM Parameter Store version specifier syntax.
-func TestParam_VersionSpecifiers(t *testing.T) {
+// TestAWSParam_VersionSpecifiers tests SSM Parameter Store version specifier syntax.
+func TestAWSParam_VersionSpecifiers(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-test/version/param"
@@ -223,8 +223,8 @@ func TestParam_VersionSpecifiers(t *testing.T) {
 	})
 }
 
-// TestParam_ParseJSONFlag tests the --parse-json/-j flag for formatting.
-func TestParam_ParseJSONFlag(t *testing.T) {
+// TestAWSParam_ParseJSONFlag tests the --parse-json/-j flag for formatting.
+func TestAWSParam_ParseJSONFlag(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-test/json/param"
@@ -265,8 +265,8 @@ func TestParam_ParseJSONFlag(t *testing.T) {
 // SSM Parameter Store Staging Workflow Tests
 // =============================================================================
 
-// TestParam_StagingWorkflow tests the complete SSM Parameter Store staging workflow.
-func TestParam_StagingWorkflow(t *testing.T) {
+// TestAWSParam_StagingWorkflow tests the complete SSM Parameter Store staging workflow.
+func TestAWSParam_StagingWorkflow(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -373,11 +373,11 @@ func TestParam_StagingWorkflow(t *testing.T) {
 	})
 }
 
-// TestParam_StagingTagThenDeleteApply reproduces the #470 wedge: staging a tag
+// TestAWSParam_StagingTagThenDeleteApply reproduces the #470 wedge: staging a tag
 // on an existing parameter and then staging its deletion must NOT leave an
 // orphan tag change. Applying must delete the parameter and finish clean rather
 // than persistently failing when ApplyTags runs against the deleted resource.
-func TestParam_StagingTagThenDeleteApply(t *testing.T) {
+func TestAWSParam_StagingTagThenDeleteApply(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -427,8 +427,8 @@ func TestParam_StagingTagThenDeleteApply(t *testing.T) {
 	})
 }
 
-// TestParam_StagingAdd tests staging a new parameter (create operation).
-func TestParam_StagingAdd(t *testing.T) {
+// TestAWSParam_StagingAdd tests staging a new parameter (create operation).
+func TestAWSParam_StagingAdd(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -474,8 +474,8 @@ func TestParam_StagingAdd(t *testing.T) {
 	})
 }
 
-// TestParam_StagingResetWithVersion tests resetting to a specific version.
-func TestParam_StagingResetWithVersion(t *testing.T) {
+// TestAWSParam_StagingResetWithVersion tests resetting to a specific version.
+func TestAWSParam_StagingResetWithVersion(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -533,8 +533,8 @@ func TestParam_StagingResetWithVersion(t *testing.T) {
 	})
 }
 
-// TestParam_StagingResetAll tests resetting all staged changes.
-func TestParam_StagingResetAll(t *testing.T) {
+// TestAWSParam_StagingResetAll tests resetting all staged changes.
+func TestAWSParam_StagingResetAll(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -592,8 +592,8 @@ func TestParam_StagingResetAll(t *testing.T) {
 	})
 }
 
-// TestParam_StagingApplySingle tests applying a single parameter.
-func TestParam_StagingApplySingle(t *testing.T) {
+// TestAWSParam_StagingApplySingle tests applying a single parameter.
+func TestAWSParam_StagingApplySingle(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -654,8 +654,8 @@ func TestParam_StagingApplySingle(t *testing.T) {
 // Edge Cases and Error Handling Tests
 // =============================================================================
 
-// TestParam_ErrorCases tests various error scenarios.
-func TestParam_ErrorCases(t *testing.T) {
+// TestAWSParam_ErrorCases tests various error scenarios.
+func TestAWSParam_ErrorCases(t *testing.T) {
 	setupEnv(t)
 
 	// Show non-existent parameter
@@ -698,8 +698,8 @@ func TestParam_ErrorCases(t *testing.T) {
 // Special Scenarios
 // =============================================================================
 
-// TestParam_SpecialCharactersInValue tests values with special characters.
-func TestParam_SpecialCharactersInValue(t *testing.T) {
+// TestAWSParam_SpecialCharactersInValue tests values with special characters.
+func TestAWSParam_SpecialCharactersInValue(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-test/special/param"
@@ -736,8 +736,8 @@ func TestParam_SpecialCharactersInValue(t *testing.T) {
 	}
 }
 
-// TestParam_LongValue tests handling of long parameter values.
-func TestParam_LongValue(t *testing.T) {
+// TestAWSParam_LongValue tests handling of long parameter values.
+func TestAWSParam_LongValue(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-test/long/param"
@@ -763,8 +763,8 @@ func TestParam_LongValue(t *testing.T) {
 // Staging CLI Commands Tests (add/edit via CLI)
 // =============================================================================
 
-// TestParam_StagingAddViaCLI tests the stage add command via CLI (with value argument).
-func TestParam_StagingAddViaCLI(t *testing.T) {
+// TestAWSParam_StagingAddViaCLI tests the stage add command via CLI (with value argument).
+func TestAWSParam_StagingAddViaCLI(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -806,8 +806,8 @@ func TestParam_StagingAddViaCLI(t *testing.T) {
 	})
 }
 
-// TestParam_StagingAddWithOptions tests stage add with description and stage tag for tags.
-func TestParam_StagingAddWithOptions(t *testing.T) {
+// TestAWSParam_StagingAddWithOptions tests stage add with description and stage tag for tags.
+func TestAWSParam_StagingAddWithOptions(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -886,8 +886,8 @@ func TestParam_StagingAddWithOptions(t *testing.T) {
 	})
 }
 
-// TestParam_StagingEditViaCLI tests re-adding (editing) a staged value via CLI.
-func TestParam_StagingEditViaCLI(t *testing.T) {
+// TestAWSParam_StagingEditViaCLI tests re-adding (editing) a staged value via CLI.
+func TestAWSParam_StagingEditViaCLI(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -924,8 +924,8 @@ func TestParam_StagingEditViaCLI(t *testing.T) {
 	})
 }
 
-// TestParam_StagingDiffViaCLI tests the stage diff command via CLI for various operations.
-func TestParam_StagingDiffViaCLI(t *testing.T) {
+// TestAWSParam_StagingDiffViaCLI tests the stage diff command via CLI for various operations.
+func TestAWSParam_StagingDiffViaCLI(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -966,8 +966,8 @@ func TestParam_StagingDiffViaCLI(t *testing.T) {
 	})
 }
 
-// TestParam_GlobalDiffWithJSON tests global diff with JSON formatting.
-func TestParam_GlobalDiffWithJSON(t *testing.T) {
+// TestAWSParam_GlobalDiffWithJSON tests global diff with JSON formatting.
+func TestAWSParam_GlobalDiffWithJSON(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -1001,8 +1001,8 @@ func TestParam_GlobalDiffWithJSON(t *testing.T) {
 	assert.Contains(t, stdout, "a")
 }
 
-// TestParam_OutputOption tests --output=json option on various commands.
-func TestParam_OutputOption(t *testing.T) {
+// TestAWSParam_OutputOption tests --output=json option on various commands.
+func TestAWSParam_OutputOption(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-output/param"
@@ -1066,8 +1066,8 @@ func TestParam_OutputOption(t *testing.T) {
 	})
 }
 
-// TestParam_FilterOption tests --filter option on list command.
-func TestParam_FilterOption(t *testing.T) {
+// TestAWSParam_FilterOption tests --filter option on list command.
+func TestAWSParam_FilterOption(t *testing.T) {
 	setupEnv(t)
 
 	prefix := "/suve-e2e-filter"
@@ -1108,8 +1108,8 @@ func TestParam_FilterOption(t *testing.T) {
 	})
 }
 
-// TestParam_ShowOption tests --show option on list command.
-func TestParam_ShowOption(t *testing.T) {
+// TestAWSParam_ShowOption tests --show option on list command.
+func TestAWSParam_ShowOption(t *testing.T) {
 	setupEnv(t)
 
 	prefix := "/suve-e2e-show"
@@ -1154,8 +1154,8 @@ func TestParam_ShowOption(t *testing.T) {
 // Resource Existence Check Tests
 // =============================================================================
 
-// TestParam_StagingAddExistingResourceFails tests that adding an existing resource fails.
-func TestParam_StagingAddExistingResourceFails(t *testing.T) {
+// TestAWSParam_StagingAddExistingResourceFails tests that adding an existing resource fails.
+func TestAWSParam_StagingAddExistingResourceFails(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -1180,8 +1180,8 @@ func TestParam_StagingAddExistingResourceFails(t *testing.T) {
 	})
 }
 
-// TestParam_StagingDeleteNonExistingResourceFails tests that deleting a non-existing resource fails.
-func TestParam_StagingDeleteNonExistingResourceFails(t *testing.T) {
+// TestAWSParam_StagingDeleteNonExistingResourceFails tests that deleting a non-existing resource fails.
+func TestAWSParam_StagingDeleteNonExistingResourceFails(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -1199,8 +1199,8 @@ func TestParam_StagingDeleteNonExistingResourceFails(t *testing.T) {
 	})
 }
 
-// TestParam_StagingTagNonExistingResourceFails tests that tagging a non-existing resource fails.
-func TestParam_StagingTagNonExistingResourceFails(t *testing.T) {
+// TestAWSParam_StagingTagNonExistingResourceFails tests that tagging a non-existing resource fails.
+func TestAWSParam_StagingTagNonExistingResourceFails(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -1218,8 +1218,8 @@ func TestParam_StagingTagNonExistingResourceFails(t *testing.T) {
 	})
 }
 
-// TestParam_StagingUntagNonExistingResourceFails tests that untagging a non-existing resource fails.
-func TestParam_StagingUntagNonExistingResourceFails(t *testing.T) {
+// TestAWSParam_StagingUntagNonExistingResourceFails tests that untagging a non-existing resource fails.
+func TestAWSParam_StagingUntagNonExistingResourceFails(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -1237,8 +1237,8 @@ func TestParam_StagingUntagNonExistingResourceFails(t *testing.T) {
 	})
 }
 
-// TestParam_StagingDeleteStagedCreateSucceeds tests that deleting a staged CREATE unstages it.
-func TestParam_StagingDeleteStagedCreateSucceeds(t *testing.T) {
+// TestAWSParam_StagingDeleteStagedCreateSucceeds tests that deleting a staged CREATE unstages it.
+func TestAWSParam_StagingDeleteStagedCreateSucceeds(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -1281,8 +1281,8 @@ func TestParam_StagingDeleteStagedCreateSucceeds(t *testing.T) {
 	})
 }
 
-// TestParam_StagingTagStagedCreateSucceeds tests that tagging a staged CREATE succeeds.
-func TestParam_StagingTagStagedCreateSucceeds(t *testing.T) {
+// TestAWSParam_StagingTagStagedCreateSucceeds tests that tagging a staged CREATE succeeds.
+func TestAWSParam_StagingTagStagedCreateSucceeds(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -1334,8 +1334,8 @@ func TestParam_StagingTagStagedCreateSucceeds(t *testing.T) {
 // Tag/Untag Command Tests
 // =============================================================================
 
-// TestParam_TagAndUntag tests the param tag and untag commands.
-func TestParam_TagAndUntag(t *testing.T) {
+// TestAWSParam_TagAndUntag tests the param tag and untag commands.
+func TestAWSParam_TagAndUntag(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-tag/test-param"
@@ -1385,8 +1385,8 @@ func TestParam_TagAndUntag(t *testing.T) {
 	})
 }
 
-// TestParam_TagInvalidFormat tests error handling for invalid tag formats.
-func TestParam_TagInvalidFormat(t *testing.T) {
+// TestAWSParam_TagInvalidFormat tests error handling for invalid tag formats.
+func TestAWSParam_TagInvalidFormat(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-tag/invalid-format"
@@ -1409,8 +1409,8 @@ func TestParam_TagInvalidFormat(t *testing.T) {
 	})
 }
 
-// TestParam_TagNonExistent tests tagging a non-existent parameter.
-func TestParam_TagNonExistent(t *testing.T) {
+// TestAWSParam_TagNonExistent tests tagging a non-existent parameter.
+func TestAWSParam_TagNonExistent(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-tag/non-existent"
@@ -1424,8 +1424,8 @@ func TestParam_TagNonExistent(t *testing.T) {
 	t.Logf("expected error: %v", err)
 }
 
-// TestParam_UntagNonExistent tests untagging a non-existent parameter.
-func TestParam_UntagNonExistent(t *testing.T) {
+// TestAWSParam_UntagNonExistent tests untagging a non-existent parameter.
+func TestAWSParam_UntagNonExistent(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-untag/non-existent"
@@ -1443,8 +1443,8 @@ func TestParam_UntagNonExistent(t *testing.T) {
 // Update Command Edge Cases
 // =============================================================================
 
-// TestParam_UpdateWithType tests param update with --type flag.
-func TestParam_UpdateWithType(t *testing.T) {
+// TestAWSParam_UpdateWithType tests param update with --type flag.
+func TestAWSParam_UpdateWithType(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-update/type-test"
@@ -1483,8 +1483,8 @@ func TestParam_UpdateWithType(t *testing.T) {
 	})
 }
 
-// TestParam_UpdateConflictingFlags tests error handling for conflicting flags.
-func TestParam_UpdateConflictingFlags(t *testing.T) {
+// TestAWSParam_UpdateConflictingFlags tests error handling for conflicting flags.
+func TestAWSParam_UpdateConflictingFlags(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-update/conflicting-flags"
@@ -1507,8 +1507,8 @@ func TestParam_UpdateConflictingFlags(t *testing.T) {
 	})
 }
 
-// TestParam_UpdateWithDescription tests param update with description.
-func TestParam_UpdateWithDescription(t *testing.T) {
+// TestAWSParam_UpdateWithDescription tests param update with description.
+func TestAWSParam_UpdateWithDescription(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-update/description-test"
@@ -1531,8 +1531,8 @@ func TestParam_UpdateWithDescription(t *testing.T) {
 	})
 }
 
-// TestParam_UpdateNonExistent tests updating a non-existent parameter.
-func TestParam_UpdateNonExistent(t *testing.T) {
+// TestAWSParam_UpdateNonExistent tests updating a non-existent parameter.
+func TestAWSParam_UpdateNonExistent(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-update/non-existent"
@@ -1545,8 +1545,8 @@ func TestParam_UpdateNonExistent(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestParam_UpdateMissingArgs tests error handling for missing arguments.
-func TestParam_UpdateMissingArgs(t *testing.T) {
+// TestAWSParam_UpdateMissingArgs tests error handling for missing arguments.
+func TestAWSParam_UpdateMissingArgs(t *testing.T) {
 	setupEnv(t)
 
 	// No arguments at all
@@ -1568,8 +1568,8 @@ func TestParam_UpdateMissingArgs(t *testing.T) {
 // Log Command Edge Cases
 // =============================================================================
 
-// TestParam_LogWithNumber tests param log with --number flag.
-func TestParam_LogWithNumber(t *testing.T) {
+// TestAWSParam_LogWithNumber tests param log with --number flag.
+func TestAWSParam_LogWithNumber(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-log/num-flag-test"
@@ -1611,8 +1611,8 @@ func TestParam_LogWithNumber(t *testing.T) {
 	assert.Equal(t, 1, versionCount)
 }
 
-// TestParam_LogNonExistent tests log for non-existent parameter.
-func TestParam_LogNonExistent(t *testing.T) {
+// TestAWSParam_LogNonExistent tests log for non-existent parameter.
+func TestAWSParam_LogNonExistent(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-log/non-existent"
@@ -1625,8 +1625,8 @@ func TestParam_LogNonExistent(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestParam_LogWithFormat tests param log with different output formats.
-func TestParam_LogWithFormat(t *testing.T) {
+// TestAWSParam_LogWithFormat tests param log with different output formats.
+func TestAWSParam_LogWithFormat(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-log/format-test"
@@ -1657,8 +1657,8 @@ func TestParam_LogWithFormat(t *testing.T) {
 	})
 }
 
-// TestParam_LogWithPatch tests param log with --patch flag.
-func TestParam_LogWithPatch(t *testing.T) {
+// TestAWSParam_LogWithPatch tests param log with --patch flag.
+func TestAWSParam_LogWithPatch(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-log/patch-test"
@@ -1687,8 +1687,8 @@ func TestParam_LogWithPatch(t *testing.T) {
 	})
 }
 
-// TestParam_LogWithOneline tests param log with --oneline flag.
-func TestParam_LogWithOneline(t *testing.T) {
+// TestAWSParam_LogWithOneline tests param log with --oneline flag.
+func TestAWSParam_LogWithOneline(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-log/oneline-test"
@@ -1718,8 +1718,8 @@ func TestParam_LogWithOneline(t *testing.T) {
 	})
 }
 
-// TestParam_LogWithReverse tests param log with --reverse flag.
-func TestParam_LogWithReverse(t *testing.T) {
+// TestAWSParam_LogWithReverse tests param log with --reverse flag.
+func TestAWSParam_LogWithReverse(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-log/reverse-test"
@@ -1744,8 +1744,8 @@ func TestParam_LogWithReverse(t *testing.T) {
 	})
 }
 
-// TestParam_LogFlagWarnings tests param log warning messages for conflicting flags.
-func TestParam_LogFlagWarnings(t *testing.T) {
+// TestAWSParam_LogFlagWarnings tests param log warning messages for conflicting flags.
+func TestAWSParam_LogFlagWarnings(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-log/warnings-test"
@@ -1791,8 +1791,8 @@ func TestParam_LogFlagWarnings(t *testing.T) {
 	})
 }
 
-// TestParam_LogWithParseJson tests param log with --parse-json flag.
-func TestParam_LogWithParseJson(t *testing.T) {
+// TestAWSParam_LogWithParseJson tests param log with --parse-json flag.
+func TestAWSParam_LogWithParseJson(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-log/parsejson-test"
@@ -1819,8 +1819,8 @@ func TestParam_LogWithParseJson(t *testing.T) {
 // Diff Command Edge Cases
 // =============================================================================
 
-// TestParam_DiffVersions tests param diff between specific versions.
-func TestParam_DiffVersions(t *testing.T) {
+// TestAWSParam_DiffVersions tests param diff between specific versions.
+func TestAWSParam_DiffVersions(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-diff/versions-test"
@@ -1853,8 +1853,8 @@ func TestParam_DiffVersions(t *testing.T) {
 	})
 }
 
-// TestParam_DiffNonExistent tests diff for non-existent parameter.
-func TestParam_DiffNonExistent(t *testing.T) {
+// TestAWSParam_DiffNonExistent tests diff for non-existent parameter.
+func TestAWSParam_DiffNonExistent(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-diff/non-existent"
@@ -1867,8 +1867,8 @@ func TestParam_DiffNonExistent(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestParam_DiffNoChanges tests diff when there are no changes.
-func TestParam_DiffNoChanges(t *testing.T) {
+// TestAWSParam_DiffNoChanges tests diff when there are no changes.
+func TestAWSParam_DiffNoChanges(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-diff/no-changes"
@@ -1894,8 +1894,8 @@ func TestParam_DiffNoChanges(t *testing.T) {
 // Show Command Edge Cases
 // =============================================================================
 
-// TestParam_ShowRaw tests param show with --raw flag.
-func TestParam_ShowRaw(t *testing.T) {
+// TestAWSParam_ShowRaw tests param show with --raw flag.
+func TestAWSParam_ShowRaw(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-show/raw-test"
@@ -1930,8 +1930,8 @@ func TestParam_ShowRaw(t *testing.T) {
 	})
 }
 
-// TestParam_ShowWithVersion tests param show with version specifier.
-func TestParam_ShowWithVersion(t *testing.T) {
+// TestAWSParam_ShowWithVersion tests param show with version specifier.
+func TestAWSParam_ShowWithVersion(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-show/version-test"
@@ -1961,8 +1961,8 @@ func TestParam_ShowWithVersion(t *testing.T) {
 	})
 }
 
-// TestParam_ShowNonExistent tests show for non-existent parameter.
-func TestParam_ShowNonExistent(t *testing.T) {
+// TestAWSParam_ShowNonExistent tests show for non-existent parameter.
+func TestAWSParam_ShowNonExistent(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-show/non-existent"
@@ -1979,8 +1979,8 @@ func TestParam_ShowNonExistent(t *testing.T) {
 // Create Command Edge Cases
 // =============================================================================
 
-// TestParam_CreateAndTag tests creating a param and adding tags after.
-func TestParam_CreateAndTag(t *testing.T) {
+// TestAWSParam_CreateAndTag tests creating a param and adding tags after.
+func TestAWSParam_CreateAndTag(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-create/and-tag"
@@ -2007,8 +2007,8 @@ func TestParam_CreateAndTag(t *testing.T) {
 	assert.Contains(t, stdout, "team: suve")
 }
 
-// TestParam_CreateWithDescription tests param create with description.
-func TestParam_CreateWithDescription(t *testing.T) {
+// TestAWSParam_CreateWithDescription tests param create with description.
+func TestAWSParam_CreateWithDescription(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-create/with-description"
@@ -2025,8 +2025,8 @@ func TestParam_CreateWithDescription(t *testing.T) {
 	assert.Contains(t, stdout, "Created")
 }
 
-// TestParam_CreateDuplicate tests creating a duplicate parameter.
-func TestParam_CreateDuplicate(t *testing.T) {
+// TestAWSParam_CreateDuplicate tests creating a duplicate parameter.
+func TestAWSParam_CreateDuplicate(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-create/duplicate"
@@ -2046,8 +2046,8 @@ func TestParam_CreateDuplicate(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestParam_CreateMissingArgs tests error handling for missing arguments.
-func TestParam_CreateMissingArgs(t *testing.T) {
+// TestAWSParam_CreateMissingArgs tests error handling for missing arguments.
+func TestAWSParam_CreateMissingArgs(t *testing.T) {
 	setupEnv(t)
 
 	// No arguments at all
@@ -2069,8 +2069,8 @@ func TestParam_CreateMissingArgs(t *testing.T) {
 // Delete Command Edge Cases
 // =============================================================================
 
-// TestParam_DeleteNonExistent tests deleting a non-existent parameter.
-func TestParam_DeleteNonExistent(t *testing.T) {
+// TestAWSParam_DeleteNonExistent tests deleting a non-existent parameter.
+func TestAWSParam_DeleteNonExistent(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-delete/non-existent"
@@ -2087,8 +2087,8 @@ func TestParam_DeleteNonExistent(t *testing.T) {
 // List Command Edge Cases
 // =============================================================================
 
-// TestParam_ListWithPath tests param list with specific path.
-func TestParam_ListWithPath(t *testing.T) {
+// TestAWSParam_ListWithPath tests param list with specific path.
+func TestAWSParam_ListWithPath(t *testing.T) {
 	setupEnv(t)
 
 	basePath := "/suve-e2e-list/path-test"
@@ -2126,8 +2126,8 @@ func TestParam_ListWithPath(t *testing.T) {
 	})
 }
 
-// TestParam_ListWithFilter tests param list with filter.
-func TestParam_ListWithFilter(t *testing.T) {
+// TestAWSParam_ListWithFilter tests param list with filter.
+func TestAWSParam_ListWithFilter(t *testing.T) {
 	setupEnv(t)
 
 	basePath := "/suve-e2e-list/filter-test"
@@ -2151,8 +2151,8 @@ func TestParam_ListWithFilter(t *testing.T) {
 	assert.NotContains(t, stdout, "db-config")
 }
 
-// TestParam_ListJSON tests param list with JSON output.
-func TestParam_ListJSON(t *testing.T) {
+// TestAWSParam_ListJSON tests param list with JSON output.
+func TestAWSParam_ListJSON(t *testing.T) {
 	setupEnv(t)
 
 	basePath := "/suve-e2e-list/json-test"
@@ -2176,15 +2176,15 @@ func TestParam_ListJSON(t *testing.T) {
 // Service-Specific Export / Import Tests
 //
 // These restore the round-trip coverage that the removed service-specific stash
-// tests (TestParam_StashPushAndPop / StashPushWithKeep / StashPopWithMerge)
+// tests (TestAWSParam_StashPushAndPop / StashPushWithKeep / StashPopWithMerge)
 // provided, expressed through `stage param export <file>` / `import <file>`.
 // Each test runs against an isolated temp HOME, so the on-disk working staging
 // area is empty at the start and no cross-test cleanup is required.
 // =============================================================================
 
-// TestParam_ExportImport tests the service-specific export -> clear -> import
+// TestAWSParam_ExportImport tests the service-specific export -> clear -> import
 // round-trip for parameters.
-func TestParam_ExportImport(t *testing.T) {
+func TestAWSParam_ExportImport(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -2226,8 +2226,8 @@ func TestParam_ExportImport(t *testing.T) {
 	})
 }
 
-// TestParam_ExportKeep tests that `export --keep` retains the working area.
-func TestParam_ExportKeep(t *testing.T) {
+// TestAWSParam_ExportKeep tests that `export --keep` retains the working area.
+func TestAWSParam_ExportKeep(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -2251,9 +2251,9 @@ func TestParam_ExportKeep(t *testing.T) {
 	assert.Contains(t, stdout, paramName)
 }
 
-// TestParam_ImportMerge tests that `import --merge` combines the imported file
+// TestAWSParam_ImportMerge tests that `import --merge` combines the imported file
 // with an existing working entry.
-func TestParam_ImportMerge(t *testing.T) {
+func TestAWSParam_ImportMerge(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -2282,10 +2282,10 @@ func TestParam_ImportMerge(t *testing.T) {
 	assert.Contains(t, stdout, paramName2)
 }
 
-// TestParam_ExportImportEncrypted tests a service-level encrypted round-trip via
+// TestAWSParam_ExportImportEncrypted tests a service-level encrypted round-trip via
 // --passphrase-stdin: the payload is encrypted on export and decrypted with the
 // same passphrase on import.
-func TestParam_ExportImportEncrypted(t *testing.T) {
+func TestAWSParam_ExportImportEncrypted(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -2329,9 +2329,9 @@ func TestParam_ExportImportEncrypted(t *testing.T) {
 	assert.Equal(t, "secret-value", strings.TrimSpace(stdout))
 }
 
-// TestParam_ImportMissingFile tests that a service-specific import of a
+// TestAWSParam_ImportMissingFile tests that a service-specific import of a
 // non-existent file is a hard error.
-func TestParam_ImportMissingFile(t *testing.T) {
+func TestAWSParam_ImportMissingFile(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -2342,11 +2342,11 @@ func TestParam_ImportMissingFile(t *testing.T) {
 	assert.Contains(t, err.Error(), "not found")
 }
 
-// TestParam_ValueStdin proves the direct create/update commands accept the
+// TestAWSParam_ValueStdin proves the direct create/update commands accept the
 // value from stdin (--value-stdin) instead of a positional argument, so the
 // secret never lands in argv/ps or shell history (issue #478). It verifies the
 // value round-trips end to end and that no positional value is required.
-func TestParam_ValueStdin(t *testing.T) {
+func TestAWSParam_ValueStdin(t *testing.T) {
 	setupEnv(t)
 
 	paramName := "/suve-e2e-test/value-stdin/param"

--- a/e2e/aws_secret_test.go
+++ b/e2e/aws_secret_test.go
@@ -27,8 +27,8 @@ import (
 // Secrets Manager Basic Commands Tests
 // =============================================================================
 
-// TestSecret_FullWorkflow tests the complete Secrets Manager workflow.
-func TestSecret_FullWorkflow(t *testing.T) {
+// TestAWSSecret_FullWorkflow tests the complete Secrets Manager workflow.
+func TestAWSSecret_FullWorkflow(t *testing.T) {
 	setupEnv(t)
 
 	secretName := "suve-e2e-test/basic/secret"
@@ -160,8 +160,8 @@ func TestSecret_FullWorkflow(t *testing.T) {
 	})
 }
 
-// TestSecret_VersionSpecifiers tests Secrets Manager version specifier syntax.
-func TestSecret_VersionSpecifiers(t *testing.T) {
+// TestAWSSecret_VersionSpecifiers tests Secrets Manager version specifier syntax.
+func TestAWSSecret_VersionSpecifiers(t *testing.T) {
 	setupEnv(t)
 
 	secretName := "suve-e2e-test/version/secret"
@@ -224,8 +224,8 @@ func TestSecret_VersionSpecifiers(t *testing.T) {
 // Secrets Manager Staging Workflow Tests
 // =============================================================================
 
-// TestSecret_StagingWorkflow tests the complete Secrets Manager staging workflow.
-func TestSecret_StagingWorkflow(t *testing.T) {
+// TestAWSSecret_StagingWorkflow tests the complete Secrets Manager staging workflow.
+func TestAWSSecret_StagingWorkflow(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -312,8 +312,8 @@ func TestSecret_StagingWorkflow(t *testing.T) {
 	})
 }
 
-// TestSecret_StagingDeleteOptions tests Secrets Manager staging with delete options.
-func TestSecret_StagingDeleteOptions(t *testing.T) {
+// TestAWSSecret_StagingDeleteOptions tests Secrets Manager staging with delete options.
+func TestAWSSecret_StagingDeleteOptions(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -343,8 +343,8 @@ func TestSecret_StagingDeleteOptions(t *testing.T) {
 	})
 }
 
-// TestSecret_ErrorCases tests various Secrets Manager error scenarios.
-func TestSecret_ErrorCases(t *testing.T) {
+// TestAWSSecret_ErrorCases tests various Secrets Manager error scenarios.
+func TestAWSSecret_ErrorCases(t *testing.T) {
 	setupEnv(t)
 
 	// Show non-existent secret
@@ -369,8 +369,8 @@ func TestSecret_ErrorCases(t *testing.T) {
 	})
 }
 
-// TestSecret_SpecialCharactersInName tests secret names with special characters.
-func TestSecret_SpecialCharactersInName(t *testing.T) {
+// TestAWSSecret_SpecialCharactersInName tests secret names with special characters.
+func TestAWSSecret_SpecialCharactersInName(t *testing.T) {
 	setupEnv(t)
 
 	testCases := []struct {
@@ -400,8 +400,8 @@ func TestSecret_SpecialCharactersInName(t *testing.T) {
 	}
 }
 
-// TestSecret_StagingAddViaCLI tests the Secrets Manager stage add command via CLI.
-func TestSecret_StagingAddViaCLI(t *testing.T) {
+// TestAWSSecret_StagingAddViaCLI tests the Secrets Manager stage add command via CLI.
+func TestAWSSecret_StagingAddViaCLI(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -443,8 +443,8 @@ func TestSecret_StagingAddViaCLI(t *testing.T) {
 	})
 }
 
-// TestSecret_StagingAddExistingResourceFails tests that adding an existing secret fails.
-func TestSecret_StagingAddExistingResourceFails(t *testing.T) {
+// TestAWSSecret_StagingAddExistingResourceFails tests that adding an existing secret fails.
+func TestAWSSecret_StagingAddExistingResourceFails(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -469,8 +469,8 @@ func TestSecret_StagingAddExistingResourceFails(t *testing.T) {
 	})
 }
 
-// TestSecret_TagAndUntag tests the secret tag and untag commands.
-func TestSecret_TagAndUntag(t *testing.T) {
+// TestAWSSecret_TagAndUntag tests the secret tag and untag commands.
+func TestAWSSecret_TagAndUntag(t *testing.T) {
 	setupEnv(t)
 
 	secretName := "suve-e2e-tag/test-secret"
@@ -520,8 +520,8 @@ func TestSecret_TagAndUntag(t *testing.T) {
 	})
 }
 
-// TestSecret_TagInvalidFormat tests error handling for invalid tag formats.
-func TestSecret_TagInvalidFormat(t *testing.T) {
+// TestAWSSecret_TagInvalidFormat tests error handling for invalid tag formats.
+func TestAWSSecret_TagInvalidFormat(t *testing.T) {
 	setupEnv(t)
 
 	secretName := "suve-e2e-tag/invalid-format"
@@ -544,8 +544,8 @@ func TestSecret_TagInvalidFormat(t *testing.T) {
 	})
 }
 
-// TestSecret_TagNonExistent tests tagging a non-existent secret.
-func TestSecret_TagNonExistent(t *testing.T) {
+// TestAWSSecret_TagNonExistent tests tagging a non-existent secret.
+func TestAWSSecret_TagNonExistent(t *testing.T) {
 	setupEnv(t)
 
 	secretName := "suve-e2e-tag/non-existent"
@@ -559,8 +559,8 @@ func TestSecret_TagNonExistent(t *testing.T) {
 	t.Logf("expected error: %v", err)
 }
 
-// TestSecret_UntagNonExistent tests untagging a non-existent secret.
-func TestSecret_UntagNonExistent(t *testing.T) {
+// TestAWSSecret_UntagNonExistent tests untagging a non-existent secret.
+func TestAWSSecret_UntagNonExistent(t *testing.T) {
 	setupEnv(t)
 
 	secretName := "suve-e2e-untag/non-existent"
@@ -574,8 +574,8 @@ func TestSecret_UntagNonExistent(t *testing.T) {
 	t.Logf("expected error: %v", err)
 }
 
-// TestSecret_UpdateNonExistent tests updating a non-existent secret.
-func TestSecret_UpdateNonExistent(t *testing.T) {
+// TestAWSSecret_UpdateNonExistent tests updating a non-existent secret.
+func TestAWSSecret_UpdateNonExistent(t *testing.T) {
 	setupEnv(t)
 
 	secretName := "suve-e2e-update/non-existent"
@@ -588,8 +588,8 @@ func TestSecret_UpdateNonExistent(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestSecret_UpdateMissingArgs tests error handling for missing arguments.
-func TestSecret_UpdateMissingArgs(t *testing.T) {
+// TestAWSSecret_UpdateMissingArgs tests error handling for missing arguments.
+func TestAWSSecret_UpdateMissingArgs(t *testing.T) {
 	setupEnv(t)
 
 	// No arguments at all
@@ -607,8 +607,8 @@ func TestSecret_UpdateMissingArgs(t *testing.T) {
 	})
 }
 
-// TestSecret_LogNonExistent tests log for non-existent secret.
-func TestSecret_LogNonExistent(t *testing.T) {
+// TestAWSSecret_LogNonExistent tests log for non-existent secret.
+func TestAWSSecret_LogNonExistent(t *testing.T) {
 	setupEnv(t)
 
 	secretName := "suve-e2e-log/non-existent"
@@ -621,8 +621,8 @@ func TestSecret_LogNonExistent(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestSecret_DiffNonExistent tests diff for non-existent secret.
-func TestSecret_DiffNonExistent(t *testing.T) {
+// TestAWSSecret_DiffNonExistent tests diff for non-existent secret.
+func TestAWSSecret_DiffNonExistent(t *testing.T) {
 	setupEnv(t)
 
 	secretName := "suve-e2e-diff/non-existent"
@@ -635,8 +635,8 @@ func TestSecret_DiffNonExistent(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestSecret_ShowRaw tests secret show with --raw flag.
-func TestSecret_ShowRaw(t *testing.T) {
+// TestAWSSecret_ShowRaw tests secret show with --raw flag.
+func TestAWSSecret_ShowRaw(t *testing.T) {
 	setupEnv(t)
 
 	secretName := "suve-e2e-show/raw-test"
@@ -660,8 +660,8 @@ func TestSecret_ShowRaw(t *testing.T) {
 	})
 }
 
-// TestSecret_ShowNonExistent tests show for non-existent secret.
-func TestSecret_ShowNonExistent(t *testing.T) {
+// TestAWSSecret_ShowNonExistent tests show for non-existent secret.
+func TestAWSSecret_ShowNonExistent(t *testing.T) {
 	setupEnv(t)
 
 	secretName := "suve-e2e-show/non-existent"
@@ -674,8 +674,8 @@ func TestSecret_ShowNonExistent(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestSecret_CreateAndTag tests creating a secret and adding tags after.
-func TestSecret_CreateAndTag(t *testing.T) {
+// TestAWSSecret_CreateAndTag tests creating a secret and adding tags after.
+func TestAWSSecret_CreateAndTag(t *testing.T) {
 	setupEnv(t)
 
 	secretName := "suve-e2e-create/and-tag"
@@ -702,8 +702,8 @@ func TestSecret_CreateAndTag(t *testing.T) {
 	assert.Contains(t, stdout, "team: suve")
 }
 
-// TestSecret_CreateDuplicate tests creating a duplicate secret.
-func TestSecret_CreateDuplicate(t *testing.T) {
+// TestAWSSecret_CreateDuplicate tests creating a duplicate secret.
+func TestAWSSecret_CreateDuplicate(t *testing.T) {
 	setupEnv(t)
 
 	secretName := "suve-e2e-create/duplicate"
@@ -723,8 +723,8 @@ func TestSecret_CreateDuplicate(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestSecret_CreateMissingArgs tests error handling for missing arguments.
-func TestSecret_CreateMissingArgs(t *testing.T) {
+// TestAWSSecret_CreateMissingArgs tests error handling for missing arguments.
+func TestAWSSecret_CreateMissingArgs(t *testing.T) {
 	setupEnv(t)
 
 	// No arguments at all
@@ -742,8 +742,8 @@ func TestSecret_CreateMissingArgs(t *testing.T) {
 	})
 }
 
-// TestSecret_DeleteNonExistent tests deleting a non-existent secret.
-func TestSecret_DeleteNonExistent(t *testing.T) {
+// TestAWSSecret_DeleteNonExistent tests deleting a non-existent secret.
+func TestAWSSecret_DeleteNonExistent(t *testing.T) {
 	setupEnv(t)
 	// Use a unique name that definitely doesn't exist
 	secretName := "suve-e2e-delete/definitely-non-existent-secret-xyz"
@@ -757,8 +757,8 @@ func TestSecret_DeleteNonExistent(t *testing.T) {
 	}
 }
 
-// TestSecret_DeleteWithRecoveryWindow tests secret delete with recovery window.
-func TestSecret_DeleteWithRecoveryWindow(t *testing.T) {
+// TestAWSSecret_DeleteWithRecoveryWindow tests secret delete with recovery window.
+func TestAWSSecret_DeleteWithRecoveryWindow(t *testing.T) {
 	setupEnv(t)
 
 	secretName := "suve-e2e-delete/scheduled"
@@ -782,8 +782,8 @@ func TestSecret_DeleteWithRecoveryWindow(t *testing.T) {
 	_, _, _ = runCommand(t, secretrestore.Command(), "--yes", secretName)
 }
 
-// TestSecret_ListJSON tests secret list with JSON output.
-func TestSecret_ListJSON(t *testing.T) {
+// TestAWSSecret_ListJSON tests secret list with JSON output.
+func TestAWSSecret_ListJSON(t *testing.T) {
 	setupEnv(t)
 
 	secretName := "suve-e2e-list/json-test"
@@ -807,11 +807,11 @@ func TestSecret_ListJSON(t *testing.T) {
 // Service-Specific Export / Import Tests
 // =============================================================================
 
-// TestSecret_ExportImport restores the round-trip coverage previously provided
-// by TestSecret_StashPushAndPop, expressed through `stage secret export <file>`
+// TestAWSSecret_ExportImport restores the round-trip coverage previously provided
+// by TestAWSSecret_StashPushAndPop, expressed through `stage secret export <file>`
 // / `import <file>`. It runs against an isolated temp HOME so the working
 // staging area starts empty.
-func TestSecret_ExportImport(t *testing.T) {
+func TestAWSSecret_ExportImport(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 

--- a/e2e/aws_stage_test.go
+++ b/e2e/aws_stage_test.go
@@ -43,8 +43,8 @@ func awsStageGlobalConfig() stgcli.GlobalConfig {
 // Global Stage Commands Tests
 // =============================================================================
 
-// TestGlobal_StageWorkflow tests the global stage commands that work across services.
-func TestGlobal_StageWorkflow(t *testing.T) {
+// TestAWSGlobal_StageWorkflow tests the global stage commands that work across services.
+func TestAWSGlobal_StageWorkflow(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -128,8 +128,8 @@ func TestGlobal_StageWorkflow(t *testing.T) {
 	})
 }
 
-// TestGlobal_StageResetAll tests global reset --all.
-func TestGlobal_StageResetAll(t *testing.T) {
+// TestAWSGlobal_StageResetAll tests global reset --all.
+func TestAWSGlobal_StageResetAll(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -194,8 +194,8 @@ func TestGlobal_StageResetAll(t *testing.T) {
 	})
 }
 
-// TestGlobal_StageCommand tests the global stage parent command structure.
-func TestGlobal_StageCommand(t *testing.T) {
+// TestAWSGlobal_StageCommand tests the global stage parent command structure.
+func TestAWSGlobal_StageCommand(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -216,8 +216,8 @@ func TestGlobal_StageCommand(t *testing.T) {
 	})
 }
 
-// TestStaging_ErrorCases tests staging error scenarios.
-func TestStaging_ErrorCases(t *testing.T) {
+// TestAWSStaging_ErrorCases tests staging error scenarios.
+func TestAWSStaging_ErrorCases(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -259,8 +259,8 @@ func TestStaging_ErrorCases(t *testing.T) {
 	})
 }
 
-// TestGlobal_StagingWithTags tests the global stage commands (diff, apply, reset) with tag entries.
-func TestGlobal_StagingWithTags(t *testing.T) {
+// TestAWSGlobal_StagingWithTags tests the global stage commands (diff, apply, reset) with tag entries.
+func TestAWSGlobal_StagingWithTags(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -320,13 +320,13 @@ func TestGlobal_StagingWithTags(t *testing.T) {
 	})
 }
 
-// TestGlobal_TagConflictDetection covers #483: a staged tag whose remote was
+// TestAWSGlobal_TagConflictDetection covers #483: a staged tag whose remote was
 // modified after the recorded BaseModifiedAt is rejected as a conflict at apply
 // time, and --ignore-conflicts forces it through. Staging the tag with a
 // BaseModifiedAt in the past simulates the remote being changed out-of-band
 // since the tags were fetched — the real FetchLastModified returns the
 // parameter's actual (newer) modified time.
-func TestGlobal_TagConflictDetection(t *testing.T) {
+func TestAWSGlobal_TagConflictDetection(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -378,8 +378,8 @@ func TestGlobal_TagConflictDetection(t *testing.T) {
 	})
 }
 
-// TestGlobal_ResetWithTags tests the global reset command with tag entries.
-func TestGlobal_ResetWithTags(t *testing.T) {
+// TestAWSGlobal_ResetWithTags tests the global reset command with tag entries.
+func TestAWSGlobal_ResetWithTags(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -431,8 +431,8 @@ func TestGlobal_ResetWithTags(t *testing.T) {
 // Export and Import Tests
 // =============================================================================
 
-// TestGlobal_ExportImport tests the export -> clear -> import round-trip.
-func TestGlobal_ExportImport(t *testing.T) {
+// TestAWSGlobal_ExportImport tests the export -> clear -> import round-trip.
+func TestAWSGlobal_ExportImport(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -480,8 +480,8 @@ func TestGlobal_ExportImport(t *testing.T) {
 	})
 }
 
-// TestGlobal_ExportKeep tests export --keep retains the working area.
-func TestGlobal_ExportKeep(t *testing.T) {
+// TestAWSGlobal_ExportKeep tests export --keep retains the working area.
+func TestAWSGlobal_ExportKeep(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -507,8 +507,8 @@ func TestGlobal_ExportKeep(t *testing.T) {
 	assert.Contains(t, stdout, paramName)
 }
 
-// TestGlobal_ImportMerge tests import --merge combines with the working area.
-func TestGlobal_ImportMerge(t *testing.T) {
+// TestAWSGlobal_ImportMerge tests import --merge combines with the working area.
+func TestAWSGlobal_ImportMerge(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -543,9 +543,9 @@ func TestGlobal_ImportMerge(t *testing.T) {
 	assert.Contains(t, stdout, paramName2)
 }
 
-// TestGlobal_ImportScopeMismatch tests that a scope mismatch is refused unless
+// TestAWSGlobal_ImportScopeMismatch tests that a scope mismatch is refused unless
 // --force is given.
-func TestGlobal_ImportScopeMismatch(t *testing.T) {
+func TestAWSGlobal_ImportScopeMismatch(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -595,8 +595,8 @@ func TestGlobal_ImportScopeMismatch(t *testing.T) {
 	})
 }
 
-// TestGlobal_ExportEmpty tests export when nothing is staged.
-func TestGlobal_ExportEmpty(t *testing.T) {
+// TestAWSGlobal_ExportEmpty tests export when nothing is staged.
+func TestAWSGlobal_ExportEmpty(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -612,9 +612,9 @@ func TestGlobal_ExportEmpty(t *testing.T) {
 	assert.True(t, os.IsNotExist(statErr))
 }
 
-// TestGlobal_ExportImportEncrypted tests an encrypted export/import round-trip
+// TestAWSGlobal_ExportImportEncrypted tests an encrypted export/import round-trip
 // via --passphrase-stdin.
-func TestGlobal_ExportImportEncrypted(t *testing.T) {
+func TestAWSGlobal_ExportImportEncrypted(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -653,8 +653,8 @@ func TestGlobal_ExportImportEncrypted(t *testing.T) {
 // Agent Store Direct Tests (for IPC coverage)
 // =============================================================================
 
-// TestAgentStore_DirectMethods tests agent store methods directly to improve IPC coverage.
-func TestAgentStore_DirectMethods(t *testing.T) {
+// TestAWSAgentStore_DirectMethods tests agent store methods directly to improve IPC coverage.
+func TestAWSAgentStore_DirectMethods(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -706,8 +706,8 @@ func TestAgentStore_DirectMethods(t *testing.T) {
 	})
 }
 
-// TestAgentStore_TagMethods tests tag-related methods on the agent store.
-func TestAgentStore_TagMethods(t *testing.T) {
+// TestAWSAgentStore_TagMethods tests tag-related methods on the agent store.
+func TestAWSAgentStore_TagMethods(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -760,8 +760,8 @@ func TestAgentStore_TagMethods(t *testing.T) {
 	})
 }
 
-// TestAgentStore_LoadAndWriteState tests Load and WriteState methods.
-func TestAgentStore_LoadAndWriteState(t *testing.T) {
+// TestAWSAgentStore_LoadAndWriteState tests Load and WriteState methods.
+func TestAWSAgentStore_LoadAndWriteState(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -813,8 +813,8 @@ func TestAgentStore_LoadAndWriteState(t *testing.T) {
 	})
 }
 
-// TestAgentStore_DrainMethod tests the Drain method.
-func TestAgentStore_DrainMethod(t *testing.T) {
+// TestAWSAgentStore_DrainMethod tests the Drain method.
+func TestAWSAgentStore_DrainMethod(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -867,8 +867,8 @@ func TestAgentStore_DrainMethod(t *testing.T) {
 	})
 }
 
-// TestAgentStore_UnstageAll tests UnstageAll with different service filters.
-func TestAgentStore_UnstageAll(t *testing.T) {
+// TestAWSAgentStore_UnstageAll tests UnstageAll with different service filters.
+func TestAWSAgentStore_UnstageAll(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -929,8 +929,8 @@ func TestAgentStore_UnstageAll(t *testing.T) {
 	})
 }
 
-// TestAgentStore_ListMethods tests ListEntries and ListTags with various states.
-func TestAgentStore_ListMethods(t *testing.T) {
+// TestAWSAgentStore_ListMethods tests ListEntries and ListTags with various states.
+func TestAWSAgentStore_ListMethods(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -1011,8 +1011,8 @@ func TestAgentStore_ListMethods(t *testing.T) {
 // Store Sequential Operation Tests
 // =============================================================================
 
-// TestStore_SequentialOperations exercises the store through repeated operations.
-func TestStore_SequentialOperations(t *testing.T) {
+// TestAWSStore_SequentialOperations exercises the store through repeated operations.
+func TestAWSStore_SequentialOperations(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -1067,8 +1067,8 @@ func TestStore_SequentialOperations(t *testing.T) {
 	})
 }
 
-// TestStore_SeparateAccounts verifies that stores for different accounts are isolated.
-func TestStore_SeparateAccounts(t *testing.T) {
+// TestAWSStore_SeparateAccounts verifies that stores for different accounts are isolated.
+func TestAWSStore_SeparateAccounts(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -1093,9 +1093,9 @@ func TestStore_SeparateAccounts(t *testing.T) {
 // Empty-State Command Tests - Commands report empty state without side effects
 // =============================================================================
 
-// TestAgentLifecycle_StatusDoesNotStartAgent verifies that status command
+// TestAWSAgentLifecycle_StatusDoesNotStartAgent verifies that status command
 // returns "No changes staged" without starting the agent when nothing is staged.
-func TestAgentLifecycle_StatusDoesNotStartAgent(t *testing.T) {
+func TestAWSAgentLifecycle_StatusDoesNotStartAgent(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -1125,9 +1125,9 @@ func TestAgentLifecycle_StatusDoesNotStartAgent(t *testing.T) {
 	})
 }
 
-// TestAgentLifecycle_DiffDoesNotStartAgent verifies that diff command
+// TestAWSAgentLifecycle_DiffDoesNotStartAgent verifies that diff command
 // returns warning without starting the agent when nothing is staged.
-func TestAgentLifecycle_DiffDoesNotStartAgent(t *testing.T) {
+func TestAWSAgentLifecycle_DiffDoesNotStartAgent(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -1153,9 +1153,9 @@ func TestAgentLifecycle_DiffDoesNotStartAgent(t *testing.T) {
 	})
 }
 
-// TestAgentLifecycle_ApplyDoesNotStartAgent verifies that apply command
+// TestAWSAgentLifecycle_ApplyDoesNotStartAgent verifies that apply command
 // returns "No changes staged" without starting the agent when nothing is staged.
-func TestAgentLifecycle_ApplyDoesNotStartAgent(t *testing.T) {
+func TestAWSAgentLifecycle_ApplyDoesNotStartAgent(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 
@@ -1179,9 +1179,9 @@ func TestAgentLifecycle_ApplyDoesNotStartAgent(t *testing.T) {
 	})
 }
 
-// TestAgentLifecycle_ResetDoesNotStartAgent verifies that reset command
+// TestAWSAgentLifecycle_ResetDoesNotStartAgent verifies that reset command
 // returns "No changes staged" without starting the agent when nothing is staged.
-func TestAgentLifecycle_ResetDoesNotStartAgent(t *testing.T) {
+func TestAWSAgentLifecycle_ResetDoesNotStartAgent(t *testing.T) {
 	setupEnv(t)
 	setupTempHome(t)
 

--- a/e2e/aws_test.go
+++ b/e2e/aws_test.go
@@ -1,0 +1,70 @@
+//go:build e2e
+
+// AWS e2e setup. These tests run against localstack, an AWS-compatible service.
+//
+// Environment variables:
+//   - SUVE_LOCALSTACK_ENDPOINT: Full localstack URL (default:
+//     http://localhost:4566). Host runs use the default; the in-container
+//     (compose.test.yaml) runner points it at http://localstack:4566.
+
+package e2e_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/staging/store/file"
+)
+
+func getEndpoint() string {
+	// Single full-URL knob. Host/manual runs get the default localhost URL; the
+	// in-container (compose.test.yaml) runner sets it to http://localstack:4566
+	// to reach the emulator by service name over the closed compose network.
+	if endpoint := os.Getenv("SUVE_LOCALSTACK_ENDPOINT"); endpoint != "" {
+		return endpoint
+	}
+
+	return "http://localhost:4566"
+}
+
+// setupEnv sets up environment variables for localstack.
+func setupEnv(t *testing.T) {
+	t.Helper()
+
+	endpoint := getEndpoint()
+
+	// Set AWS environment variables for localstack
+	t.Setenv("AWS_ENDPOINT_URL", endpoint)
+	t.Setenv("AWS_ACCESS_KEY_ID", "test")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+	t.Setenv("AWS_DEFAULT_REGION", "us-east-1")
+}
+
+// newStore creates a new staging store for E2E tests.
+// localstack uses account ID "000000000000" and region "us-east-1".
+//
+// It uses NewWorkingStore (not NewStore) so the read path shares the exact key
+// resolution the CLI uses when it writes: SUVE_STAGING_KEY env var -> OS
+// keychain -> plaintext. Both the Dockerized runner and the CI e2e jobs set
+// SUVE_STAGING_KEY, so the working store is encrypted and this must decrypt with
+// the same key. (A keychain-less runner with no key would otherwise fall back to
+// plaintext, which is now refused for non-interactive writes without consent.)
+func newStore() *file.Store {
+	s, err := file.NewWorkingStore(provider.AWSScope("000000000000", "us-east-1"))
+	if err != nil {
+		panic(err)
+	}
+
+	return s
+}
+
+// newStoreForAccount creates a staging store for a specific account and region.
+func newStoreForAccount(accountID, region string) *file.Store {
+	s, err := file.NewWorkingStore(provider.AWSScope(accountID, region))
+	if err != nil {
+		panic(err)
+	}
+
+	return s
+}

--- a/e2e/main_test.go
+++ b/e2e/main_test.go
@@ -2,15 +2,10 @@
 
 // Package e2e contains end-to-end tests for the suve CLI.
 //
-// These tests run against a real AWS-compatible service (localstack) and verify
-// the complete workflow of each command using the actual CLI commands.
-//
-// Run with: make e2e
-//
-// Environment variables:
-//   - SUVE_LOCALSTACK_ENDPOINT: Full localstack URL (default:
-//     http://localhost:4566). Host runs use the default; the in-container
-//     (compose.test.yaml) runner points it at http://localstack:4566.
+// These tests run against real cloud-compatible emulators and verify the
+// complete workflow of each command using the actual CLI commands. Each
+// provider's setup lives in its own file (e.g. aws_test.go); this file holds
+// only the provider-neutral harness.
 package e2e_test
 
 import (
@@ -22,8 +17,6 @@ import (
 	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/cli/output"
-	"github.com/mpyw/suve/internal/provider"
-	"github.com/mpyw/suve/internal/staging/store/file"
 )
 
 // TestMain sets up the environment before running tests.
@@ -55,62 +48,10 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func getEndpoint() string {
-	// Single full-URL knob. Host/manual runs get the default localhost URL; the
-	// in-container (compose.test.yaml) runner sets it to http://localstack:4566
-	// to reach the emulator by service name over the closed compose network.
-	if endpoint := os.Getenv("SUVE_LOCALSTACK_ENDPOINT"); endpoint != "" {
-		return endpoint
-	}
-
-	return "http://localhost:4566"
-}
-
-// setupEnv sets up environment variables for localstack and returns a cleanup function.
-func setupEnv(t *testing.T) {
-	t.Helper()
-
-	endpoint := getEndpoint()
-
-	// Set AWS environment variables for localstack
-	t.Setenv("AWS_ENDPOINT_URL", endpoint)
-	t.Setenv("AWS_ACCESS_KEY_ID", "test")
-	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
-	t.Setenv("AWS_DEFAULT_REGION", "us-east-1")
-}
-
 // setupTempHome sets up a temporary HOME directory for isolated staging tests.
 func setupTempHome(t *testing.T) {
 	t.Helper()
 	t.Setenv("HOME", t.TempDir())
-}
-
-// newStore creates a new staging store for E2E tests.
-// localstack uses account ID "000000000000" and region "us-east-1".
-//
-// It uses NewWorkingStore (not NewStore) so the read path shares the exact key
-// resolution the CLI uses when it writes: SUVE_STAGING_KEY env var -> OS
-// keychain -> plaintext. Both the Dockerized runner and the CI e2e jobs set
-// SUVE_STAGING_KEY, so the working store is encrypted and this must decrypt with
-// the same key. (A keychain-less runner with no key would otherwise fall back to
-// plaintext, which is now refused for non-interactive writes without consent.)
-func newStore() *file.Store {
-	s, err := file.NewWorkingStore(provider.AWSScope("000000000000", "us-east-1"))
-	if err != nil {
-		panic(err)
-	}
-
-	return s
-}
-
-// newStoreForAccount creates a staging store for a specific account and region.
-func newStoreForAccount(accountID, region string) *file.Store {
-	s, err := file.NewWorkingStore(provider.AWSScope(accountID, region))
-	if err != nil {
-		panic(err)
-	}
-
-	return s
 }
 
 // runCommand executes a CLI command and returns stdout, stderr, and error.


### PR DESCRIPTION
## Summary

Removes the historical "unmarked = AWS" naming privilege in the e2e suite. Google Cloud / Azure e2e artifacts are already provider-marked (`gcloud_*_test.go`, `TestAzureKeyVault_*`); this brings the AWS ones into parity by carrying the `aws` marker in file names and test-function names, and by splitting the mixed harness file into a provider-neutral part and an AWS-specific part.

Pure refactor — no behavior change. All e2e files are `package e2e_test` with `//go:build e2e`, so file renames have zero import fallout.

## Related

- Closes #622
- Part of #620 (Step 2 of 11)

## Changes

File renames (`git mv`, history preserved):

| Old | New |
|---|---|
| `e2e/param_test.go` | `e2e/aws_param_test.go` |
| `e2e/secret_test.go` | `e2e/aws_secret_test.go` |
| `e2e/staging_test.go` | `e2e/aws_stage_test.go` |

`e2e/e2e_test.go` split into:
- `e2e/main_test.go` (provider-neutral): `TestMain`, `setupTempHome`, and the generic `runCommand`/`runCommandWithStdin`/`runSubCommand`/`runSubCommandWithStdin` helpers + package doc.
- `e2e/aws_test.go` (AWS): `setupEnv`, `getEndpoint` (`SUVE_LOCALSTACK_ENDPOINT` handling), `newStore`/`newStoreForAccount`, and the localstack doc comment.

Function renames (insert `AWS` after `Test`, mirroring `TestGoogleCloud*` / `TestAzure*`): `TestParam_`→`TestAWSParam_`, `TestSecret_`→`TestAWSSecret_`, `TestGlobal_`→`TestAWSGlobal_`, `TestStaging_`→`TestAWSStaging_`, `TestAgentStore_`→`TestAWSAgentStore_`, `TestStore_`→`TestAWSStore_`, `TestAgentLifecycle_`→`TestAWSAgentLifecycle_` (113 top-level funcs).

Not touched (out of scope): `gcloud_*_test.go`, `azure_*_test.go`, the compose `localstack` service, the `SUVE_LOCALSTACK_ENDPOINT` env var. `CLAUDE.md` has a one-line straggler fix (`e2e/e2e_test.go` → `e2e/aws_*_test.go`).

## Verification

`mise test` — all pass. `golangci-lint run --allow-parallel-runners ./...` (and `--build-tags e2e ./e2e/...`) — `0 issues`. `go vet -tags e2e ./e2e/...` — clean.

`mise e2e` (dockerized localstack) — 113 top-level `TestAWS*` funcs ran, 0 skipped, 0 failed; `ok github.com/mpyw/suve/e2e`.

CI `-run` regexes do NOT match the renamed AWS funcs (critical constraint):

```
$ go test -tags e2e ./e2e/... -list 'TestGoogleCloud'
TestGoogleCloudSecret_FullWorkflow
TestGoogleCloudStage_Workflow
TestGoogleCloudStage_FlatAliasReachesEmulator
TestGoogleCloudStage_ExportImport
ok  	github.com/mpyw/suve/e2e

$ go test -tags e2e ./e2e/... -list 'TestAzureAppConfig|TestAzureKeyVault'
TestAzureAppConfig_FullWorkflow
TestAzureAppConfig_TagWrite
TestAzureAppConfig_Namespace
TestAzureKeyVaultStage_ConflictDetected
... (Azure only) ...
ok  	github.com/mpyw/suve/e2e
```

Neither regex list contains any `TestAWS*` name (grep for `TestAWS` in both outputs → no match). The AWS CI job runs the whole package with no `-run` filter, so it picks up the renamed funcs automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)