### PR TITLE
refactor(staging): provider-mark AWS staging strategies and factories (#625)

### DIFF
--- a/internal/cli/commands/aws/stage/apply/gather_internal_test.go
+++ b/internal/cli/commands/aws/stage/apply/gather_internal_test.go
@@ -62,8 +62,8 @@ func TestGatherServices_SkipsUnconfigured(t *testing.T) {
 	cfg := stgcli.GlobalConfig{
 		ProviderLabel: "Azure",
 		Services: []stgcli.GlobalServiceSpec{
-			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: notConfiguredResolver},
-			{Service: staging.ServiceSecret, ParserFactory: staging.SecretParserFactory, ScopeResolver: notConfiguredResolver},
+			{Service: staging.ServiceParam, ParserFactory: staging.AWSParamParserFactory, ScopeResolver: notConfiguredResolver},
+			{Service: staging.ServiceSecret, ParserFactory: staging.AWSSecretParserFactory, ScopeResolver: notConfiguredResolver},
 		},
 	}
 
@@ -80,9 +80,13 @@ func TestGatherServices_ResolverErrorPropagates(t *testing.T) {
 	wantErr := errors.New("boom")
 	cfg := stgcli.GlobalConfig{
 		Services: []stgcli.GlobalServiceSpec{
-			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: func(_ context.Context) (staging.ResolvedScope, error) {
-				return staging.ResolvedScope{}, wantErr
-			}},
+			{
+				Service:       staging.ServiceParam,
+				ParserFactory: staging.AWSParamParserFactory,
+				ScopeResolver: func(_ context.Context) (staging.ResolvedScope, error) {
+					return staging.ResolvedScope{}, wantErr
+				},
+			},
 		},
 	}
 
@@ -100,7 +104,7 @@ func TestGatherServices_ListEntriesErrorPropagates(t *testing.T) {
 
 	cfg := stgcli.GlobalConfig{
 		Services: []stgcli.GlobalServiceSpec{
-			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: targetResolver("t")},
+			{Service: staging.ServiceParam, ParserFactory: staging.AWSParamParserFactory, ScopeResolver: targetResolver("t")},
 		},
 	}
 
@@ -118,7 +122,7 @@ func TestGatherServices_ListTagsErrorPropagates(t *testing.T) {
 
 	cfg := stgcli.GlobalConfig{
 		Services: []stgcli.GlobalServiceSpec{
-			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: targetResolver("t")},
+			{Service: staging.ServiceParam, ParserFactory: staging.AWSParamParserFactory, ScopeResolver: targetResolver("t")},
 		},
 	}
 
@@ -146,8 +150,8 @@ func TestGatherServices_PerServiceStores(t *testing.T) {
 
 	cfg := stgcli.GlobalConfig{
 		Services: []stgcli.GlobalServiceSpec{
-			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: targetResolver("store"), Factory: nilFactory},
-			{Service: staging.ServiceSecret, ParserFactory: staging.SecretParserFactory, ScopeResolver: targetResolver("vault"), Factory: nilFactory},
+			{Service: staging.ServiceParam, ParserFactory: staging.AWSParamParserFactory, ScopeResolver: targetResolver("store"), Factory: nilFactory},
+			{Service: staging.ServiceSecret, ParserFactory: staging.AWSSecretParserFactory, ScopeResolver: targetResolver("vault"), Factory: nilFactory},
 		},
 	}
 

--- a/internal/cli/commands/aws/stage/diff/diff_perns_test.go
+++ b/internal/cli/commands/aws/stage/diff/diff_perns_test.go
@@ -39,9 +39,9 @@ func TestRun_DiffsEntriesUnderTheirNamespace(t *testing.T) {
 	svc := stagediff.ServiceStrategy{
 		Service:  staging.ServiceParam,
 		Store:    st,
-		Strategy: staging.NewParamStrategy(storeReturning("cur-a", "1")),
+		Strategy: staging.NewAWSParamStrategy(storeReturning("cur-a", "1")),
 		StrategyFor: func(ns string) (staging.DiffStrategy, error) {
-			return staging.NewParamStrategy(storeReturning(nsCurrent[ns], "1")), nil
+			return staging.NewAWSParamStrategy(storeReturning(nsCurrent[ns], "1")), nil
 		},
 		Entries: entries[staging.ServiceParam],
 	}

--- a/internal/cli/commands/aws/stage/diff/diff_test.go
+++ b/internal/cli/commands/aws/stage/diff/diff_test.go
@@ -130,7 +130,7 @@ func TestRun_ParamOnly(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(storeReturning("old-value", "1")), store)},
+		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewAWSParamStrategy(storeReturning("old-value", "1")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -162,7 +162,7 @@ func TestRun_SecretOnly(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewSecretStrategy(storeReturning("old-secret", "abc123def456")), store)},
+		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewAWSSecretStrategy(storeReturning("old-secret", "abc123def456")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -201,8 +201,8 @@ func TestRun_BothServices(t *testing.T) {
 
 	r := &stagediff.Runner{
 		Services: []stagediff.ServiceStrategy{
-			paramDiff(staging.NewParamStrategy(storeReturning("param-old", "1")), store),
-			secretDiff(staging.NewSecretStrategy(storeReturning("secret-old", "abc123def456")), store),
+			paramDiff(staging.NewAWSParamStrategy(storeReturning("param-old", "1")), store),
+			secretDiff(staging.NewAWSSecretStrategy(storeReturning("secret-old", "abc123def456")), store),
 		},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
@@ -244,8 +244,8 @@ func TestRun_DeleteOperations(t *testing.T) {
 
 	r := &stagediff.Runner{
 		Services: []stagediff.ServiceStrategy{
-			paramDiff(staging.NewParamStrategy(storeReturning("existing-value", "1")), store),
-			secretDiff(staging.NewSecretStrategy(storeReturning("existing-secret", "abc123def456")), store),
+			paramDiff(staging.NewAWSParamStrategy(storeReturning("existing-value", "1")), store),
+			secretDiff(staging.NewAWSSecretStrategy(storeReturning("existing-secret", "abc123def456")), store),
 		},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
@@ -277,7 +277,7 @@ func TestRun_IdenticalValues(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(storeReturning("same-value", "1")), store)},
+		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewAWSParamStrategy(storeReturning("same-value", "1")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -310,7 +310,7 @@ func TestRun_ParseJSON(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(storeReturning(`{"key":"old"}`, "1")), store)},
+		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewAWSParamStrategy(storeReturning(`{"key":"old"}`, "1")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -340,7 +340,7 @@ func TestRun_ParamUpdateAutoUnstageWhenDeleted(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(storeGetError("parameter not found")), store)},
+		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewAWSParamStrategy(storeGetError("parameter not found")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -372,7 +372,7 @@ func TestRun_SecretUpdateAutoUnstageWhenDeleted(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewSecretStrategy(storeGetError("secret not found")), store)},
+		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewAWSSecretStrategy(storeGetError("secret not found")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -404,7 +404,7 @@ func TestRun_SecretIdenticalValues(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewSecretStrategy(storeReturning("same-value", "abc123def456")), store)},
+		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewAWSSecretStrategy(storeReturning("same-value", "abc123def456")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -437,7 +437,7 @@ func TestRun_SecretParseJSON(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewSecretStrategy(storeReturning(`{"key":"old"}`, "abc123def456")), store)},
+		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewAWSSecretStrategy(storeReturning(`{"key":"old"}`, "abc123def456")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -467,7 +467,7 @@ func TestRun_SecretParseJSONMixed(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewSecretStrategy(storeReturning(`{"key":"old"}`, "abc123def456")), store)},
+		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewAWSSecretStrategy(storeReturning(`{"key":"old"}`, "abc123def456")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -502,7 +502,7 @@ func TestRun_ParamCreateOperation(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(storeGetError("parameter not found")), store)},
+		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewAWSParamStrategy(storeGetError("parameter not found")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -543,7 +543,7 @@ func TestRun_SecretCreateOperation(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewSecretStrategy(storeGetError("secret not found")), store)},
+		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewAWSSecretStrategy(storeGetError("secret not found")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -577,7 +577,7 @@ func TestRun_CreateWithParseJSON(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(storeGetError("parameter not found")), store)},
+		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewAWSParamStrategy(storeGetError("parameter not found")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -607,7 +607,7 @@ func TestRun_DeleteAutoUnstageWhenAlreadyDeleted(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(storeGetError("parameter not found")), store)},
+		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewAWSParamStrategy(storeGetError("parameter not found")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -645,7 +645,7 @@ func TestRun_KeptStagedOnTransientFetchError(t *testing.T) {
 			var stdout, stderr bytes.Buffer
 
 			r := &stagediff.Runner{
-				Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(storeGetTransientError("throttled")), store)},
+				Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewAWSParamStrategy(storeGetTransientError("throttled")), store)},
 				ProviderLabel: "AWS",
 				Stdout:        &stdout,
 				Stderr:        &stderr,
@@ -678,7 +678,7 @@ func TestRun_DeleteEmptyRemoteNotUnstaged(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(storeReturning("", "1")), store)},
+		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewAWSParamStrategy(storeReturning("", "1")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -709,7 +709,7 @@ func TestRun_ParseJSONReformatOnlyUpdateKeptStaged(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(storeReturning(`{"a":1,"b":2}`, "1")), store)},
+		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewAWSParamStrategy(storeReturning(`{"a":1,"b":2}`, "1")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -739,7 +739,7 @@ func TestRun_SecretDeleteAutoUnstageWhenAlreadyDeleted(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewSecretStrategy(storeGetError("secret not found")), store)},
+		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewAWSSecretStrategy(storeGetError("secret not found")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -772,7 +772,7 @@ func TestRun_MetadataWithDescription(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(storeReturning("old-value", "1")), store)},
+		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewAWSParamStrategy(storeReturning("old-value", "1")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -808,7 +808,7 @@ func TestRun_MetadataWithTags(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(storeReturning("old-value", "1")), store)},
+		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewAWSParamStrategy(storeReturning("old-value", "1")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -942,7 +942,7 @@ func TestRun_SecretCreateWithParseJSON(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewSecretStrategy(storeGetError("secret not found")), store)},
+		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewAWSSecretStrategy(storeGetError("secret not found")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -982,7 +982,7 @@ func TestRun_BothEntriesAndTags(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(storeReturning("old-value", "1")), store)},
+		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewAWSParamStrategy(storeReturning("old-value", "1")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -1024,7 +1024,7 @@ func TestRun_ParamTagDiffWithValues(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(paramStore), store)},
+		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewAWSParamStrategy(paramStore), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -1059,7 +1059,7 @@ func TestRun_SecretTagDiffWithValues(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewSecretStrategy(secretStore), store)},
+		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewAWSSecretStrategy(secretStore), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -1090,7 +1090,7 @@ func TestRun_ParamTagDiffAPIError(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(storeGetError("API error")), store)},
+		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewAWSParamStrategy(storeGetError("API error")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -1121,7 +1121,7 @@ func TestRun_SecretTagDiffAPIError(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewSecretStrategy(storeGetError("API error")), store)},
+		Services:      []stagediff.ServiceStrategy{secretDiff(staging.NewAWSSecretStrategy(storeGetError("API error")), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,
@@ -1155,7 +1155,7 @@ func TestRun_TagDiffWithMissingValue(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 
 	r := &stagediff.Runner{
-		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewParamStrategy(paramStore), store)},
+		Services:      []stagediff.ServiceStrategy{paramDiff(staging.NewAWSParamStrategy(paramStore), store)},
 		ProviderLabel: "AWS",
 		Stdout:        &stdout,
 		Stderr:        &stderr,

--- a/internal/cli/commands/aws/stage/diff/gather_internal_test.go
+++ b/internal/cli/commands/aws/stage/diff/gather_internal_test.go
@@ -51,8 +51,8 @@ func TestGatherServices_SkipsUnconfigured(t *testing.T) {
 
 	cfg := stgcli.GlobalConfig{
 		Services: []stgcli.GlobalServiceSpec{
-			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: notConfiguredResolver},
-			{Service: staging.ServiceSecret, ParserFactory: staging.SecretParserFactory, ScopeResolver: notConfiguredResolver},
+			{Service: staging.ServiceParam, ParserFactory: staging.AWSParamParserFactory, ScopeResolver: notConfiguredResolver},
+			{Service: staging.ServiceSecret, ParserFactory: staging.AWSSecretParserFactory, ScopeResolver: notConfiguredResolver},
 		},
 	}
 
@@ -67,9 +67,13 @@ func TestGatherServices_ResolverErrorPropagates(t *testing.T) {
 	wantErr := errors.New("boom")
 	cfg := stgcli.GlobalConfig{
 		Services: []stgcli.GlobalServiceSpec{
-			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: func(_ context.Context) (staging.ResolvedScope, error) {
-				return staging.ResolvedScope{}, wantErr
-			}},
+			{
+				Service:       staging.ServiceParam,
+				ParserFactory: staging.AWSParamParserFactory,
+				ScopeResolver: func(_ context.Context) (staging.ResolvedScope, error) {
+					return staging.ResolvedScope{}, wantErr
+				},
+			},
 		},
 	}
 
@@ -86,7 +90,7 @@ func TestGatherServices_ListEntriesErrorPropagates(t *testing.T) {
 
 	cfg := stgcli.GlobalConfig{
 		Services: []stgcli.GlobalServiceSpec{
-			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: targetResolver("t")},
+			{Service: staging.ServiceParam, ParserFactory: staging.AWSParamParserFactory, ScopeResolver: targetResolver("t")},
 		},
 	}
 
@@ -103,7 +107,7 @@ func TestGatherServices_ListTagsErrorPropagates(t *testing.T) {
 
 	cfg := stgcli.GlobalConfig{
 		Services: []stgcli.GlobalServiceSpec{
-			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: targetResolver("t")},
+			{Service: staging.ServiceParam, ParserFactory: staging.AWSParamParserFactory, ScopeResolver: targetResolver("t")},
 		},
 	}
 
@@ -128,8 +132,8 @@ func TestGatherServices_PerServiceStores(t *testing.T) {
 
 	cfg := stgcli.GlobalConfig{
 		Services: []stgcli.GlobalServiceSpec{
-			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: targetResolver("store"), Factory: nilFactory},
-			{Service: staging.ServiceSecret, ParserFactory: staging.SecretParserFactory, ScopeResolver: targetResolver("vault"), Factory: nilFactory},
+			{Service: staging.ServiceParam, ParserFactory: staging.AWSParamParserFactory, ScopeResolver: targetResolver("store"), Factory: nilFactory},
+			{Service: staging.ServiceSecret, ParserFactory: staging.AWSSecretParserFactory, ScopeResolver: targetResolver("vault"), Factory: nilFactory},
 		},
 	}
 

--- a/internal/cli/commands/aws/stage/param/command.go
+++ b/internal/cli/commands/aws/stage/param/command.go
@@ -13,8 +13,8 @@ import (
 var config = stgcli.CommandConfig{
 	CommandName:   "param",
 	ItemName:      "parameter",
-	Factory:       cliinternal.ParamStrategyFactory,
-	ParserFactory: staging.ParamParserFactory,
+	Factory:       cliinternal.AWSParamStrategyFactory,
+	ParserFactory: staging.AWSParamParserFactory,
 }
 
 // Config returns the AWS SSM Parameter Store staging command config. It is used

--- a/internal/cli/commands/aws/stage/reset/reset_test.go
+++ b/internal/cli/commands/aws/stage/reset/reset_test.go
@@ -325,8 +325,8 @@ func TestRun_UnstageAllError(t *testing.T) {
 // provider-wide reset command.
 func awsServices() []stgcli.GlobalServiceSpec {
 	return []stgcli.GlobalServiceSpec{
-		{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory},
-		{Service: staging.ServiceSecret, ParserFactory: staging.SecretParserFactory},
+		{Service: staging.ServiceParam, ParserFactory: staging.AWSParamParserFactory},
+		{Service: staging.ServiceSecret, ParserFactory: staging.AWSSecretParserFactory},
 	}
 }
 
@@ -346,8 +346,8 @@ func TestRun_SkipUnconfiguredService(t *testing.T) {
 
 	r := &reset.Runner{
 		Services: []stgcli.GlobalServiceSpec{
-			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: notConfiguredResolver},
-			{Service: staging.ServiceSecret, ParserFactory: staging.SecretParserFactory, ScopeResolver: notConfiguredResolver},
+			{Service: staging.ServiceParam, ParserFactory: staging.AWSParamParserFactory, ScopeResolver: notConfiguredResolver},
+			{Service: staging.ServiceSecret, ParserFactory: staging.AWSSecretParserFactory, ScopeResolver: notConfiguredResolver},
 		},
 		Stdout: &buf,
 		Stderr: &bytes.Buffer{},
@@ -369,9 +369,13 @@ func TestRun_ResolverErrorPropagates(t *testing.T) {
 
 	r := &reset.Runner{
 		Services: []stgcli.GlobalServiceSpec{
-			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: func(_ context.Context) (staging.ResolvedScope, error) {
-				return staging.ResolvedScope{}, wantErr
-			}},
+			{
+				Service:       staging.ServiceParam,
+				ParserFactory: staging.AWSParamParserFactory,
+				ScopeResolver: func(_ context.Context) (staging.ResolvedScope, error) {
+					return staging.ResolvedScope{}, wantErr
+				},
+			},
 		},
 		Stdout: &buf,
 		Stderr: &bytes.Buffer{},

--- a/internal/cli/commands/aws/stage/secret/command.go
+++ b/internal/cli/commands/aws/stage/secret/command.go
@@ -16,8 +16,8 @@ const nounSecret = "secret"
 var config = stgcli.CommandConfig{
 	CommandName:   nounSecret,
 	ItemName:      nounSecret,
-	Factory:       cliinternal.SecretStrategyFactory,
-	ParserFactory: staging.SecretParserFactory,
+	Factory:       cliinternal.AWSSecretStrategyFactory,
+	ParserFactory: staging.AWSSecretParserFactory,
 }
 
 // Config returns the AWS Secrets Manager staging command config. It is used by

--- a/internal/cli/commands/aws/stage/status/status_test.go
+++ b/internal/cli/commands/aws/stage/status/status_test.go
@@ -447,8 +447,8 @@ func TestCommand_TagOnlyChangesNoEntries(t *testing.T) {
 // provider-wide status command.
 func awsServices() []stgcli.GlobalServiceSpec {
 	return []stgcli.GlobalServiceSpec{
-		{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory},
-		{Service: staging.ServiceSecret, ParserFactory: staging.SecretParserFactory},
+		{Service: staging.ServiceParam, ParserFactory: staging.AWSParamParserFactory},
+		{Service: staging.ServiceSecret, ParserFactory: staging.AWSSecretParserFactory},
 	}
 }
 
@@ -469,8 +469,8 @@ func TestRun_SkipUnconfiguredService(t *testing.T) {
 
 	r := &status.Runner{
 		Services: []stgcli.GlobalServiceSpec{
-			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: notConfiguredResolver},
-			{Service: staging.ServiceSecret, ParserFactory: staging.SecretParserFactory, ScopeResolver: notConfiguredResolver},
+			{Service: staging.ServiceParam, ParserFactory: staging.AWSParamParserFactory, ScopeResolver: notConfiguredResolver},
+			{Service: staging.ServiceSecret, ParserFactory: staging.AWSSecretParserFactory, ScopeResolver: notConfiguredResolver},
 		},
 		Stdout: &buf,
 		Stderr: &bytes.Buffer{},
@@ -492,9 +492,13 @@ func TestRun_ResolverErrorPropagates(t *testing.T) {
 
 	r := &status.Runner{
 		Services: []stgcli.GlobalServiceSpec{
-			{Service: staging.ServiceParam, ParserFactory: staging.ParamParserFactory, ScopeResolver: func(_ context.Context) (staging.ResolvedScope, error) {
-				return staging.ResolvedScope{}, wantErr
-			}},
+			{
+				Service:       staging.ServiceParam,
+				ParserFactory: staging.AWSParamParserFactory,
+				ScopeResolver: func(_ context.Context) (staging.ResolvedScope, error) {
+					return staging.ResolvedScope{}, wantErr
+				},
+			},
 		},
 		Stdout: &buf,
 		Stderr: &bytes.Buffer{},

--- a/internal/cli/commands/internal/client.go
+++ b/internal/cli/commands/internal/client.go
@@ -181,28 +181,28 @@ func storeForKind(ctx context.Context, kind provider.Kind) (provider.Store, erro
 	return store, nil
 }
 
-// ParamStrategyFactory builds a staging FullStrategy for the parameter service,
+// AWSParamStrategyFactory builds a staging FullStrategy for the parameter service,
 // wrapping a provider.Store resolved through the registry. It satisfies
 // staging.StrategyFactory.
-func ParamStrategyFactory(ctx context.Context) (staging.FullStrategy, error) {
+func AWSParamStrategyFactory(ctx context.Context) (staging.FullStrategy, error) {
 	store, err := ParamStore(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return staging.NewParamStrategy(store), nil
+	return staging.NewAWSParamStrategy(store), nil
 }
 
-// SecretStrategyFactory builds a staging FullStrategy for the secret service,
+// AWSSecretStrategyFactory builds a staging FullStrategy for the secret service,
 // wrapping a provider.Store resolved through the registry. It satisfies
 // staging.StrategyFactory.
-func SecretStrategyFactory(ctx context.Context) (staging.FullStrategy, error) {
+func AWSSecretStrategyFactory(ctx context.Context) (staging.FullStrategy, error) {
 	store, err := SecretStore(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return staging.NewSecretStrategy(store), nil
+	return staging.NewAWSSecretStrategy(store), nil
 }
 
 // GoogleCloudSecretStrategyFactory builds a staging FullStrategy for Google Cloud Secret

--- a/internal/gui/app.go
+++ b/internal/gui/app.go
@@ -523,7 +523,7 @@ func (a *App) getParserScoped(sc provider.Scope, service string) (staging.Parser
 			return &staging.AzureAppConfigParamStrategy{}, nil
 		}
 
-		return &staging.ParamStrategy{}, nil
+		return &staging.AWSParamStrategy{}, nil
 	case string(staging.ServiceSecret):
 		switch sc.Provider {
 		case provider.ProviderGoogleCloud:
@@ -531,7 +531,7 @@ func (a *App) getParserScoped(sc provider.Scope, service string) (staging.Parser
 		case provider.ProviderAzure:
 			return &staging.AzureKeyVaultSecretStrategy{}, nil
 		default:
-			return &staging.SecretStrategy{}, nil
+			return &staging.AWSSecretStrategy{}, nil
 		}
 	default:
 		return nil, errInvalidService
@@ -557,7 +557,7 @@ func (a *App) serviceStrategyScoped(sc provider.Scope, service string) (staging.
 			return staging.NewAzureAppConfigParamStrategy(s), nil
 		}
 
-		return staging.NewParamStrategy(s), nil
+		return staging.NewAWSParamStrategy(s), nil
 	case string(staging.ServiceSecret):
 		s, err := a.secretStoreScoped(sc)
 		if err != nil {
@@ -570,7 +570,7 @@ func (a *App) serviceStrategyScoped(sc provider.Scope, service string) (staging.
 		case provider.ProviderAzure:
 			return staging.NewAzureKeyVaultSecretStrategy(s), nil
 		default:
-			return staging.NewSecretStrategy(s), nil
+			return staging.NewAWSSecretStrategy(s), nil
 		}
 	default:
 		return nil, errInvalidService
@@ -579,7 +579,7 @@ func (a *App) serviceStrategyScoped(sc provider.Scope, service string) (staging.
 
 // strategyAsScoped resolves the service strategy for an already-snapshotted scope
 // and narrows it to the requested staging strategy interface T. The concrete
-// *ParamStrategy / *SecretStrategy satisfy every staging strategy interface, so
+// *AWSParamStrategy / *AWSSecretStrategy satisfy every staging strategy interface, so
 // this succeeds for the Edit, Apply and Diff interfaces (which FullStrategy
 // embeds) as well as for DeleteStrategy (which it does not embed but the concrete
 // types implement). It is a free function because Go methods cannot declare type

--- a/internal/gui/staging_multiprovider_internal_test.go
+++ b/internal/gui/staging_multiprovider_internal_test.go
@@ -58,8 +58,8 @@ func TestApp_getParser_PerProvider(t *testing.T) {
 		service  string
 		want     staging.Parser
 	}{
-		{"aws param", provider.ProviderAWS, "param", &staging.ParamStrategy{}},
-		{"aws secret", provider.ProviderAWS, "secret", &staging.SecretStrategy{}},
+		{"aws param", provider.ProviderAWS, "param", &staging.AWSParamStrategy{}},
+		{"aws secret", provider.ProviderAWS, "secret", &staging.AWSSecretStrategy{}},
 		{"google cloud secret", provider.ProviderGoogleCloud, "secret", &staging.GoogleCloudSecretStrategy{}},
 		{"azure param", provider.ProviderAzure, "param", &staging.AzureAppConfigParamStrategy{}},
 		{"azure secret", provider.ProviderAzure, "secret", &staging.AzureKeyVaultSecretStrategy{}},

--- a/internal/staging/aws_param.go
+++ b/internal/staging/aws_param.go
@@ -15,41 +15,41 @@ import (
 	"github.com/mpyw/suve/internal/version/paramversion"
 )
 
-// ParamStrategy implements ServiceStrategy for SSM Parameter Store. It is backed
+// AWSParamStrategy implements ServiceStrategy for SSM Parameter Store. It is backed
 // by a provider.Store rather than an AWS SDK client, so it carries no cloud SDK
 // dependency. A nil store yields a parser-only strategy (ParseName/ParseSpec).
-type ParamStrategy struct {
+type AWSParamStrategy struct {
 	store provider.Store
 }
 
-// NewParamStrategy creates a new SSM Parameter Store strategy over the given
+// NewAWSParamStrategy creates a new SSM Parameter Store strategy over the given
 // provider store. A nil store is allowed for parser-only use.
-func NewParamStrategy(store provider.Store) *ParamStrategy {
-	return &ParamStrategy{store: store}
+func NewAWSParamStrategy(store provider.Store) *AWSParamStrategy {
+	return &AWSParamStrategy{store: store}
 }
 
 // Service returns the service type.
-func (s *ParamStrategy) Service() Service {
+func (s *AWSParamStrategy) Service() Service {
 	return ServiceParam
 }
 
 // ServiceName returns the user-friendly service name.
-func (s *ParamStrategy) ServiceName() string {
+func (s *AWSParamStrategy) ServiceName() string {
 	return "SSM Parameter Store"
 }
 
 // ItemName returns the item name for messages.
-func (s *ParamStrategy) ItemName() string {
+func (s *AWSParamStrategy) ItemName() string {
 	return "parameter"
 }
 
 // HasDeleteOptions returns false as SSM Parameter Store doesn't have delete options.
-func (s *ParamStrategy) HasDeleteOptions() bool {
+func (s *AWSParamStrategy) HasDeleteOptions() bool {
 	return false
 }
 
 // Apply applies a staged operation to SSM Parameter Store.
-func (s *ParamStrategy) Apply(ctx context.Context, name string, entry Entry) error {
+func (s *AWSParamStrategy) Apply(ctx context.Context, name string, entry Entry) error {
 	switch entry.Operation {
 	case OperationCreate:
 		return s.applyCreate(ctx, name, entry)
@@ -62,7 +62,7 @@ func (s *ParamStrategy) Apply(ctx context.Context, name string, entry Entry) err
 	}
 }
 
-func (s *ParamStrategy) applyCreate(ctx context.Context, name string, entry Entry) error {
+func (s *AWSParamStrategy) applyCreate(ctx context.Context, name string, entry Entry) error {
 	if entry.Value == nil {
 		return nil
 	}
@@ -76,7 +76,7 @@ func (s *ParamStrategy) applyCreate(ctx context.Context, name string, entry Entr
 	return nil
 }
 
-func (s *ParamStrategy) applyUpdate(ctx context.Context, name string, entry Entry) error {
+func (s *AWSParamStrategy) applyUpdate(ctx context.Context, name string, entry Entry) error {
 	if entry.Value == nil {
 		return nil
 	}
@@ -99,7 +99,7 @@ func (s *ParamStrategy) applyUpdate(ctx context.Context, name string, entry Entr
 	return nil
 }
 
-func (s *ParamStrategy) applyDelete(ctx context.Context, name string) error {
+func (s *AWSParamStrategy) applyDelete(ctx context.Context, name string) error {
 	if err := s.store.Delete(ctx, name); err != nil {
 		// Already deleted is considered success.
 		if errors.Is(err, provider.ErrNotFound) {
@@ -113,7 +113,7 @@ func (s *ParamStrategy) applyDelete(ctx context.Context, name string) error {
 }
 
 // ApplyTags applies staged tag changes to SSM Parameter Store.
-func (s *ParamStrategy) ApplyTags(ctx context.Context, name string, tagEntry TagEntry) error {
+func (s *AWSParamStrategy) ApplyTags(ctx context.Context, name string, tagEntry TagEntry) error {
 	if len(tagEntry.Add) > 0 {
 		if err := s.store.Tag(ctx, name, tagEntry.Add); err != nil {
 			return err
@@ -133,7 +133,7 @@ func (s *ParamStrategy) ApplyTags(ctx context.Context, name string, tagEntry Tag
 // a *ResourceNotFoundError when the parameter does not exist, so callers can
 // tell "missing" apart from "exists but has no modification time" (the latter
 // returns a zero time with a nil error).
-func (s *ParamStrategy) FetchLastModified(ctx context.Context, name string) (time.Time, error) {
+func (s *AWSParamStrategy) FetchLastModified(ctx context.Context, name string) (time.Time, error) {
 	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
 	if err != nil {
 		if errors.Is(err, provider.ErrNotFound) {
@@ -151,7 +151,7 @@ func (s *ParamStrategy) FetchLastModified(ctx context.Context, name string) (tim
 }
 
 // FetchCurrent fetches the current value from SSM Parameter Store for diffing.
-func (s *ParamStrategy) FetchCurrent(ctx context.Context, name string) (*FetchResult, error) {
+func (s *AWSParamStrategy) FetchCurrent(ctx context.Context, name string) (*FetchResult, error) {
 	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
 	if err != nil {
 		return nil, err
@@ -164,7 +164,7 @@ func (s *ParamStrategy) FetchCurrent(ctx context.Context, name string) (*FetchRe
 }
 
 // FetchCurrentTags fetches the current tags from SSM Parameter Store.
-func (s *ParamStrategy) FetchCurrentTags(ctx context.Context, name string) (map[string]string, error) {
+func (s *AWSParamStrategy) FetchCurrentTags(ctx context.Context, name string) (map[string]string, error) {
 	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
 	if err != nil {
 		// Parameter not found - return nil (no tags available)
@@ -188,7 +188,7 @@ func (s *ParamStrategy) FetchCurrentTags(ctx context.Context, name string) (map[
 }
 
 // ParseName parses and validates a name for editing.
-func (s *ParamStrategy) ParseName(input string) (string, error) {
+func (s *AWSParamStrategy) ParseName(input string) (string, error) {
 	spec, err := paramversion.Parse(input)
 	if err != nil {
 		return "", err
@@ -203,7 +203,7 @@ func (s *ParamStrategy) ParseName(input string) (string, error) {
 
 // FetchCurrentValue fetches the current value from SSM Parameter Store for editing.
 // Returns *ResourceNotFoundError if the parameter doesn't exist.
-func (s *ParamStrategy) FetchCurrentValue(ctx context.Context, name string) (*EditFetchResult, error) {
+func (s *AWSParamStrategy) FetchCurrentValue(ctx context.Context, name string) (*EditFetchResult, error) {
 	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
 	if err != nil {
 		if errors.Is(err, provider.ErrNotFound) {
@@ -225,7 +225,7 @@ func (s *ParamStrategy) FetchCurrentValue(ctx context.Context, name string) (*Ed
 }
 
 // ParseSpec parses a version spec string for reset.
-func (s *ParamStrategy) ParseSpec(input string) (name string, hasVersion bool, err error) {
+func (s *AWSParamStrategy) ParseSpec(input string) (name string, hasVersion bool, err error) {
 	spec, err := paramversion.Parse(input)
 	if err != nil {
 		return "", false, err
@@ -237,7 +237,7 @@ func (s *ParamStrategy) ParseSpec(input string) (name string, hasVersion bool, e
 }
 
 // FetchVersion fetches the value for a specific version.
-func (s *ParamStrategy) FetchVersion(ctx context.Context, input string) (value string, versionLabel string, err error) {
+func (s *AWSParamStrategy) FetchVersion(ctx context.Context, input string) (value string, versionLabel string, err error) {
 	spec, err := paramversion.Parse(input)
 	if err != nil {
 		return "", "", err
@@ -274,8 +274,8 @@ func paramSpecSuffix(spec *paramversion.Spec) string {
 	return b.String()
 }
 
-// ParamParserFactory creates a Parser without provider access.
+// AWSParamParserFactory creates a Parser without provider access.
 // Use this for operations that don't need AWS access (e.g., status, parsing).
-func ParamParserFactory() Parser {
-	return NewParamStrategy(nil)
+func AWSParamParserFactory() Parser {
+	return NewAWSParamStrategy(nil)
 }

--- a/internal/staging/aws_param_test.go
+++ b/internal/staging/aws_param_test.go
@@ -25,7 +25,7 @@ func paramNotFound(name string) error {
 func TestParamStrategy_BasicMethods(t *testing.T) {
 	t.Parallel()
 
-	s := staging.NewParamStrategy(nil)
+	s := staging.NewAWSParamStrategy(nil)
 
 	t.Run("Service", func(t *testing.T) {
 		t.Parallel()
@@ -67,7 +67,7 @@ func TestParamStrategy_Apply(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		err := s.Apply(t.Context(), "/app/param", staging.Entry{
 			Operation: staging.OperationCreate,
 			Value:     lo.ToPtr("new-value"),
@@ -92,7 +92,7 @@ func TestParamStrategy_Apply(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		err := s.Apply(t.Context(), "/app/param", staging.Entry{
 			Operation: staging.OperationUpdate,
 			Value:     lo.ToPtr("updated-value"),
@@ -111,7 +111,7 @@ func TestParamStrategy_Apply(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		err := s.Apply(t.Context(), "/app/param", staging.Entry{
 			Operation: staging.OperationDelete,
 		})
@@ -121,7 +121,7 @@ func TestParamStrategy_Apply(t *testing.T) {
 	t.Run("unknown operation", func(t *testing.T) {
 		t.Parallel()
 
-		s := staging.NewParamStrategy(&providermock.Store{})
+		s := staging.NewAWSParamStrategy(&providermock.Store{})
 		err := s.Apply(t.Context(), "/app/param", staging.Entry{
 			Operation: staging.Operation("unknown"),
 		})
@@ -138,7 +138,7 @@ func TestParamStrategy_Apply(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		err := s.Apply(t.Context(), "/app/param", staging.Entry{
 			Operation: staging.OperationUpdate,
 			Value:     lo.ToPtr("value"),
@@ -156,7 +156,7 @@ func TestParamStrategy_Apply(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		err := s.Apply(t.Context(), "/app/param", staging.Entry{
 			Operation: staging.OperationUpdate,
 			Value:     lo.ToPtr("value"),
@@ -176,7 +176,7 @@ func TestParamStrategy_Apply(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		err := s.Apply(t.Context(), "/app/param", staging.Entry{
 			Operation: staging.OperationCreate,
 			Value:     lo.ToPtr("value"),
@@ -199,7 +199,7 @@ func TestParamStrategy_Apply(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		err := s.Apply(t.Context(), "/app/param", staging.Entry{
 			Operation: staging.OperationUpdate,
 			Value:     lo.ToPtr("value"),
@@ -217,7 +217,7 @@ func TestParamStrategy_Apply(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		err := s.Apply(t.Context(), "/app/param", staging.Entry{
 			Operation: staging.OperationDelete,
 		})
@@ -238,7 +238,7 @@ func TestParamStrategy_FetchCurrent(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		result, err := s.FetchCurrent(t.Context(), "/app/param")
 		require.NoError(t, err)
 		assert.Equal(t, "current-value", result.Value)
@@ -254,7 +254,7 @@ func TestParamStrategy_FetchCurrent(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		_, err := s.FetchCurrent(t.Context(), "/app/param")
 		require.Error(t, err)
 	})
@@ -263,7 +263,7 @@ func TestParamStrategy_FetchCurrent(t *testing.T) {
 func TestParamStrategy_ParseName(t *testing.T) {
 	t.Parallel()
 
-	s := staging.NewParamStrategy(nil)
+	s := staging.NewAWSParamStrategy(nil)
 
 	t.Run("valid name", func(t *testing.T) {
 		t.Parallel()
@@ -319,7 +319,7 @@ func TestParamStrategy_FetchCurrentValue(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		result, err := s.FetchCurrentValue(t.Context(), "/app/param")
 		require.NoError(t, err)
 		assert.Equal(t, "fetched-value", result.Value)
@@ -335,7 +335,7 @@ func TestParamStrategy_FetchCurrentValue(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		_, err := s.FetchCurrentValue(t.Context(), "/app/param")
 		require.Error(t, err)
 
@@ -352,7 +352,7 @@ func TestParamStrategy_FetchCurrentValue(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		_, err := s.FetchCurrentValue(t.Context(), "/app/param")
 		require.Error(t, err)
 	})
@@ -361,7 +361,7 @@ func TestParamStrategy_FetchCurrentValue(t *testing.T) {
 func TestParamStrategy_ParseSpec(t *testing.T) {
 	t.Parallel()
 
-	s := staging.NewParamStrategy(nil)
+	s := staging.NewAWSParamStrategy(nil)
 
 	t.Run("name only", func(t *testing.T) {
 		t.Parallel()
@@ -418,7 +418,7 @@ func TestParamStrategy_FetchVersion(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		value, label, err := s.FetchVersion(t.Context(), "/app/param#2")
 		require.NoError(t, err)
 		assert.Equal(t, "v2", value)
@@ -440,7 +440,7 @@ func TestParamStrategy_FetchVersion(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		value, label, err := s.FetchVersion(t.Context(), "/app/param~1")
 		require.NoError(t, err)
 		assert.Equal(t, "v2", value)
@@ -450,7 +450,7 @@ func TestParamStrategy_FetchVersion(t *testing.T) {
 	t.Run("parse error - invalid version format", func(t *testing.T) {
 		t.Parallel()
 
-		s := staging.NewParamStrategy(&providermock.Store{})
+		s := staging.NewAWSParamStrategy(&providermock.Store{})
 		_, _, err := s.FetchVersion(t.Context(), "/app/param#abc")
 		require.Error(t, err)
 	})
@@ -464,7 +464,7 @@ func TestParamStrategy_FetchVersion(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		_, _, err := s.FetchVersion(t.Context(), "/app/param#2")
 		require.Error(t, err)
 	})
@@ -473,7 +473,7 @@ func TestParamStrategy_FetchVersion(t *testing.T) {
 func TestParamParserFactory(t *testing.T) {
 	t.Parallel()
 
-	parser := staging.ParamParserFactory()
+	parser := staging.AWSParamParserFactory()
 	require.NotNil(t, parser)
 	assert.Equal(t, staging.ServiceParam, parser.Service())
 }
@@ -492,7 +492,7 @@ func TestParamStrategy_FetchLastModified(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		result, err := s.FetchLastModified(t.Context(), "/app/param")
 		require.NoError(t, err)
 		assert.Equal(t, now, result)
@@ -507,7 +507,7 @@ func TestParamStrategy_FetchLastModified(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		_, err := s.FetchLastModified(t.Context(), "/app/param")
 		notFoundErr := (*staging.ResourceNotFoundError)(nil)
 		require.ErrorAs(t, err, &notFoundErr)
@@ -523,7 +523,7 @@ func TestParamStrategy_FetchLastModified(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		_, err := s.FetchLastModified(t.Context(), "/app/param")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to get parameter")
@@ -538,7 +538,7 @@ func TestParamStrategy_FetchLastModified(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		result, err := s.FetchLastModified(t.Context(), "/app/param")
 		require.NoError(t, err)
 		assert.True(t, result.IsZero())
@@ -561,7 +561,7 @@ func TestParamStrategy_Apply_WithDescription(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		err := s.Apply(t.Context(), "/app/param", staging.Entry{
 			Operation:   staging.OperationCreate,
 			Value:       lo.ToPtr("value"),
@@ -586,7 +586,7 @@ func TestParamStrategy_Apply_WithDescription(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		err := s.Apply(t.Context(), "/app/param", staging.Entry{
 			Operation:   staging.OperationUpdate,
 			Value:       lo.ToPtr("value"),
@@ -605,7 +605,7 @@ func TestParamStrategy_Apply_DeleteAlreadyDeleted(t *testing.T) {
 		},
 	}
 
-	s := staging.NewParamStrategy(mock)
+	s := staging.NewAWSParamStrategy(mock)
 	err := s.Apply(t.Context(), "/app/param", staging.Entry{
 		Operation: staging.OperationDelete,
 	})
@@ -629,7 +629,7 @@ func TestParamStrategy_ApplyTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		err := s.ApplyTags(t.Context(), "/app/param", staging.TagEntry{
 			Add: map[string]string{"env": "prod"},
 		})
@@ -651,7 +651,7 @@ func TestParamStrategy_ApplyTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		err := s.ApplyTags(t.Context(), "/app/param", staging.TagEntry{
 			Remove: maputil.NewSet("old-tag"),
 		})
@@ -681,7 +681,7 @@ func TestParamStrategy_ApplyTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		err := s.ApplyTags(t.Context(), "/app/param", staging.TagEntry{
 			Add:    map[string]string{"env": "prod"},
 			Remove: maputil.NewSet("deprecated"),
@@ -700,7 +700,7 @@ func TestParamStrategy_ApplyTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		err := s.ApplyTags(t.Context(), "/app/param", staging.TagEntry{
 			Add: map[string]string{"env": "test"},
 		})
@@ -716,7 +716,7 @@ func TestParamStrategy_ApplyTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		err := s.ApplyTags(t.Context(), "/app/param", staging.TagEntry{
 			Remove: maputil.NewSet("old-tag"),
 		})
@@ -733,7 +733,7 @@ func TestParamStrategy_FetchCurrentValue_NoLastModified(t *testing.T) {
 		},
 	}
 
-	s := staging.NewParamStrategy(mock)
+	s := staging.NewAWSParamStrategy(mock)
 	result, err := s.FetchCurrentValue(t.Context(), "/app/param")
 	require.NoError(t, err)
 	assert.Equal(t, "value", result.Value)
@@ -757,7 +757,7 @@ func TestParamStrategy_FetchCurrentTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		tags, err := s.FetchCurrentTags(t.Context(), "/app/param")
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{"env": "prod", "team": "backend"}, tags)
@@ -772,7 +772,7 @@ func TestParamStrategy_FetchCurrentTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		tags, err := s.FetchCurrentTags(t.Context(), "/app/nonexistent")
 		require.NoError(t, err)
 		assert.Nil(t, tags)
@@ -787,7 +787,7 @@ func TestParamStrategy_FetchCurrentTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		tags, err := s.FetchCurrentTags(t.Context(), "/app/param")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to get tags")
@@ -803,7 +803,7 @@ func TestParamStrategy_FetchCurrentTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewParamStrategy(mock)
+		s := staging.NewAWSParamStrategy(mock)
 		tags, err := s.FetchCurrentTags(t.Context(), "/app/param")
 		require.NoError(t, err)
 		assert.Nil(t, tags)

--- a/internal/staging/aws_secret.go
+++ b/internal/staging/aws_secret.go
@@ -16,41 +16,41 @@ import (
 	"github.com/mpyw/suve/internal/version/secretversion"
 )
 
-// SecretStrategy implements ServiceStrategy for Secrets Manager. It is backed by
+// AWSSecretStrategy implements ServiceStrategy for Secrets Manager. It is backed by
 // a provider.Store rather than an AWS SDK client, so it carries no cloud SDK
 // dependency of its own. A nil store yields a parser-only strategy.
-type SecretStrategy struct {
+type AWSSecretStrategy struct {
 	store provider.Store
 }
 
-// NewSecretStrategy creates a new Secrets Manager strategy over the given
+// NewAWSSecretStrategy creates a new Secrets Manager strategy over the given
 // provider store. A nil store is allowed for parser-only use.
-func NewSecretStrategy(store provider.Store) *SecretStrategy {
-	return &SecretStrategy{store: store}
+func NewAWSSecretStrategy(store provider.Store) *AWSSecretStrategy {
+	return &AWSSecretStrategy{store: store}
 }
 
 // Service returns the service type.
-func (s *SecretStrategy) Service() Service {
+func (s *AWSSecretStrategy) Service() Service {
 	return ServiceSecret
 }
 
 // ServiceName returns the user-friendly service name.
-func (s *SecretStrategy) ServiceName() string {
+func (s *AWSSecretStrategy) ServiceName() string {
 	return "Secrets Manager"
 }
 
 // ItemName returns the item name for messages.
-func (s *SecretStrategy) ItemName() string {
+func (s *AWSSecretStrategy) ItemName() string {
 	return itemNameSecret
 }
 
 // HasDeleteOptions returns true as Secrets Manager has delete options.
-func (s *SecretStrategy) HasDeleteOptions() bool {
+func (s *AWSSecretStrategy) HasDeleteOptions() bool {
 	return true
 }
 
 // Apply applies a staged operation to Secrets Manager.
-func (s *SecretStrategy) Apply(ctx context.Context, name string, entry Entry) error {
+func (s *AWSSecretStrategy) Apply(ctx context.Context, name string, entry Entry) error {
 	switch entry.Operation {
 	case OperationCreate:
 		return s.applyCreate(ctx, name, entry)
@@ -63,7 +63,7 @@ func (s *SecretStrategy) Apply(ctx context.Context, name string, entry Entry) er
 	}
 }
 
-func (s *SecretStrategy) applyCreate(ctx context.Context, name string, entry Entry) error {
+func (s *AWSSecretStrategy) applyCreate(ctx context.Context, name string, entry Entry) error {
 	if _, err := s.store.Create(ctx, name, lo.FromPtr(entry.Value), domain.ValueTypeSecret, lo.FromPtr(entry.Description)); err != nil {
 		return fmt.Errorf("failed to create secret: %w", err)
 	}
@@ -71,7 +71,7 @@ func (s *SecretStrategy) applyCreate(ctx context.Context, name string, entry Ent
 	return nil
 }
 
-func (s *SecretStrategy) applyUpdate(ctx context.Context, name string, entry Entry) error {
+func (s *AWSSecretStrategy) applyUpdate(ctx context.Context, name string, entry Entry) error {
 	if entry.Value == nil {
 		return nil
 	}
@@ -94,7 +94,7 @@ func (s *SecretStrategy) applyUpdate(ctx context.Context, name string, entry Ent
 	return nil
 }
 
-func (s *SecretStrategy) applyDelete(ctx context.Context, name string, entry Entry) error {
+func (s *AWSSecretStrategy) applyDelete(ctx context.Context, name string, entry Entry) error {
 	opts := deleteOptions(entry.DeleteOptions)
 
 	if err := s.store.Delete(ctx, name, opts...); err != nil {
@@ -126,7 +126,7 @@ func deleteOptions(o *DeleteOptions) []provider.DeleteOption {
 }
 
 // ApplyTags applies staged tag changes to Secrets Manager.
-func (s *SecretStrategy) ApplyTags(ctx context.Context, name string, tagEntry TagEntry) error {
+func (s *AWSSecretStrategy) ApplyTags(ctx context.Context, name string, tagEntry TagEntry) error {
 	if len(tagEntry.Add) > 0 {
 		if err := s.store.Tag(ctx, name, tagEntry.Add); err != nil {
 			return err
@@ -146,7 +146,7 @@ func (s *SecretStrategy) ApplyTags(ctx context.Context, name string, tagEntry Ta
 // *ResourceNotFoundError when the secret does not exist, so callers can tell
 // "missing" apart from "exists but has no modification time" (the latter returns
 // a zero time with a nil error).
-func (s *SecretStrategy) FetchLastModified(ctx context.Context, name string) (time.Time, error) {
+func (s *AWSSecretStrategy) FetchLastModified(ctx context.Context, name string) (time.Time, error) {
 	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
 	if err != nil {
 		if errors.Is(err, provider.ErrNotFound) {
@@ -164,7 +164,7 @@ func (s *SecretStrategy) FetchLastModified(ctx context.Context, name string) (ti
 }
 
 // FetchCurrent fetches the current value from Secrets Manager for diffing.
-func (s *SecretStrategy) FetchCurrent(ctx context.Context, name string) (*FetchResult, error) {
+func (s *AWSSecretStrategy) FetchCurrent(ctx context.Context, name string) (*FetchResult, error) {
 	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
 	if err != nil {
 		return nil, err
@@ -177,7 +177,7 @@ func (s *SecretStrategy) FetchCurrent(ctx context.Context, name string) (*FetchR
 }
 
 // FetchCurrentTags fetches the current tags from Secrets Manager.
-func (s *SecretStrategy) FetchCurrentTags(ctx context.Context, name string) (map[string]string, error) {
+func (s *AWSSecretStrategy) FetchCurrentTags(ctx context.Context, name string) (map[string]string, error) {
 	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
 	if err != nil {
 		// Secret not found - return nil (no tags available)
@@ -201,7 +201,7 @@ func (s *SecretStrategy) FetchCurrentTags(ctx context.Context, name string) (map
 }
 
 // ParseName parses and validates a name for editing.
-func (s *SecretStrategy) ParseName(input string) (string, error) {
+func (s *AWSSecretStrategy) ParseName(input string) (string, error) {
 	spec, err := secretversion.Parse(input)
 	if err != nil {
 		return "", err
@@ -216,7 +216,7 @@ func (s *SecretStrategy) ParseName(input string) (string, error) {
 
 // FetchCurrentValue fetches the current value from Secrets Manager for editing.
 // Returns *ResourceNotFoundError if the secret doesn't exist.
-func (s *SecretStrategy) FetchCurrentValue(ctx context.Context, name string) (*EditFetchResult, error) {
+func (s *AWSSecretStrategy) FetchCurrentValue(ctx context.Context, name string) (*EditFetchResult, error) {
 	entry, err := s.store.Get(ctx, name, provider.VersionRef{})
 	if err != nil {
 		if errors.Is(err, provider.ErrNotFound) {
@@ -238,7 +238,7 @@ func (s *SecretStrategy) FetchCurrentValue(ctx context.Context, name string) (*E
 }
 
 // ParseSpec parses a version spec string for reset.
-func (s *SecretStrategy) ParseSpec(input string) (name string, hasVersion bool, err error) {
+func (s *AWSSecretStrategy) ParseSpec(input string) (name string, hasVersion bool, err error) {
 	spec, err := secretversion.Parse(input)
 	if err != nil {
 		return "", false, err
@@ -250,7 +250,7 @@ func (s *SecretStrategy) ParseSpec(input string) (name string, hasVersion bool, 
 }
 
 // FetchVersion fetches the value for a specific version.
-func (s *SecretStrategy) FetchVersion(ctx context.Context, input string) (value string, versionLabel string, err error) {
+func (s *AWSSecretStrategy) FetchVersion(ctx context.Context, input string) (value string, versionLabel string, err error) {
 	spec, err := secretversion.Parse(input)
 	if err != nil {
 		return "", "", err
@@ -291,8 +291,8 @@ func secretSpecSuffix(spec *secretversion.Spec) string {
 	return b.String()
 }
 
-// SecretParserFactory creates a Parser without provider access.
+// AWSSecretParserFactory creates a Parser without provider access.
 // Use this for operations that don't need AWS access (e.g., status, parsing).
-func SecretParserFactory() Parser {
-	return NewSecretStrategy(nil)
+func AWSSecretParserFactory() Parser {
+	return NewAWSSecretStrategy(nil)
 }

--- a/internal/staging/aws_secret_test.go
+++ b/internal/staging/aws_secret_test.go
@@ -26,7 +26,7 @@ func secretNotFound(name string) error {
 func TestSecretStrategy_BasicMethods(t *testing.T) {
 	t.Parallel()
 
-	s := staging.NewSecretStrategy(nil)
+	s := staging.NewAWSSecretStrategy(nil)
 
 	t.Run("Service", func(t *testing.T) {
 		t.Parallel()
@@ -67,7 +67,7 @@ func TestSecretStrategy_Apply(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		err := s.Apply(t.Context(), "my-secret", staging.Entry{
 			Operation: staging.OperationCreate,
 			Value:     lo.ToPtr("secret-value"),
@@ -86,7 +86,7 @@ func TestSecretStrategy_Apply(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		err := s.Apply(t.Context(), "my-secret", staging.Entry{
 			Operation: staging.OperationCreate,
 			Value:     lo.ToPtr("secret-value"),
@@ -110,7 +110,7 @@ func TestSecretStrategy_Apply(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		err := s.Apply(t.Context(), "my-secret", staging.Entry{
 			Operation: staging.OperationUpdate,
 			Value:     lo.ToPtr("updated-value"),
@@ -129,7 +129,7 @@ func TestSecretStrategy_Apply(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		err := s.Apply(t.Context(), "my-secret", staging.Entry{
 			Operation: staging.OperationUpdate,
 			Value:     lo.ToPtr("updated-value"),
@@ -150,7 +150,7 @@ func TestSecretStrategy_Apply(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		err := s.Apply(t.Context(), "my-secret", staging.Entry{
 			Operation: staging.OperationDelete,
 		})
@@ -169,7 +169,7 @@ func TestSecretStrategy_Apply(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		err := s.Apply(t.Context(), "my-secret", staging.Entry{
 			Operation: staging.OperationDelete,
 			DeleteOptions: &staging.DeleteOptions{
@@ -193,7 +193,7 @@ func TestSecretStrategy_Apply(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		err := s.Apply(t.Context(), "my-secret", staging.Entry{
 			Operation: staging.OperationDelete,
 			DeleteOptions: &staging.DeleteOptions{
@@ -212,7 +212,7 @@ func TestSecretStrategy_Apply(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		err := s.Apply(t.Context(), "my-secret", staging.Entry{
 			Operation: staging.OperationDelete,
 		})
@@ -223,7 +223,7 @@ func TestSecretStrategy_Apply(t *testing.T) {
 	t.Run("unknown operation", func(t *testing.T) {
 		t.Parallel()
 
-		s := staging.NewSecretStrategy(&providermock.Store{})
+		s := staging.NewAWSSecretStrategy(&providermock.Store{})
 		err := s.Apply(t.Context(), "my-secret", staging.Entry{
 			Operation: staging.Operation("unknown"),
 		})
@@ -256,7 +256,7 @@ func TestSecretStrategy_Apply_RefusesBinaryOverwrite(t *testing.T) {
 		},
 	}
 
-	s := staging.NewSecretStrategy(mock)
+	s := staging.NewAWSSecretStrategy(mock)
 	err := s.Apply(t.Context(), "my-secret", staging.Entry{
 		Operation: staging.OperationUpdate,
 		Value:     lo.ToPtr("string-value"),
@@ -282,7 +282,7 @@ func TestSecretStrategy_FetchCurrent(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		result, err := s.FetchCurrent(t.Context(), "my-secret")
 		require.NoError(t, err)
 		assert.Equal(t, "secret-value", result.Value)
@@ -298,7 +298,7 @@ func TestSecretStrategy_FetchCurrent(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		_, err := s.FetchCurrent(t.Context(), "my-secret")
 		require.Error(t, err)
 	})
@@ -307,7 +307,7 @@ func TestSecretStrategy_FetchCurrent(t *testing.T) {
 func TestSecretStrategy_ParseName(t *testing.T) {
 	t.Parallel()
 
-	s := staging.NewSecretStrategy(nil)
+	s := staging.NewAWSSecretStrategy(nil)
 
 	t.Run("valid name", func(t *testing.T) {
 		t.Parallel()
@@ -370,7 +370,7 @@ func TestSecretStrategy_FetchCurrentValue(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		result, err := s.FetchCurrentValue(t.Context(), "my-secret")
 		require.NoError(t, err)
 		assert.Equal(t, "fetched-secret", result.Value)
@@ -386,7 +386,7 @@ func TestSecretStrategy_FetchCurrentValue(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		_, err := s.FetchCurrentValue(t.Context(), "my-secret")
 		require.Error(t, err)
 
@@ -403,7 +403,7 @@ func TestSecretStrategy_FetchCurrentValue(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		_, err := s.FetchCurrentValue(t.Context(), "my-secret")
 		require.Error(t, err)
 	})
@@ -412,7 +412,7 @@ func TestSecretStrategy_FetchCurrentValue(t *testing.T) {
 func TestSecretStrategy_ParseSpec(t *testing.T) {
 	t.Parallel()
 
-	s := staging.NewSecretStrategy(nil)
+	s := staging.NewAWSSecretStrategy(nil)
 
 	t.Run("name only", func(t *testing.T) {
 		t.Parallel()
@@ -486,7 +486,7 @@ func TestSecretStrategy_FetchVersion(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		value, label, err := s.FetchVersion(t.Context(), "my-secret:AWSPREVIOUS")
 		require.NoError(t, err)
 		assert.Equal(t, "previous-value", value)
@@ -511,7 +511,7 @@ func TestSecretStrategy_FetchVersion(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		value, label, err := s.FetchVersion(t.Context(), "my-secret~1")
 		require.NoError(t, err)
 		assert.Equal(t, "shifted-value", value)
@@ -521,7 +521,7 @@ func TestSecretStrategy_FetchVersion(t *testing.T) {
 	t.Run("parse error", func(t *testing.T) {
 		t.Parallel()
 
-		s := staging.NewSecretStrategy(&providermock.Store{})
+		s := staging.NewAWSSecretStrategy(&providermock.Store{})
 		_, _, err := s.FetchVersion(t.Context(), "")
 		require.Error(t, err)
 	})
@@ -535,7 +535,7 @@ func TestSecretStrategy_FetchVersion(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		_, _, err := s.FetchVersion(t.Context(), "my-secret:AWSCURRENT")
 		require.Error(t, err)
 	})
@@ -544,7 +544,7 @@ func TestSecretStrategy_FetchVersion(t *testing.T) {
 func TestSecretParserFactory(t *testing.T) {
 	t.Parallel()
 
-	parser := staging.SecretParserFactory()
+	parser := staging.AWSSecretParserFactory()
 	require.NotNil(t, parser)
 	assert.Equal(t, staging.ServiceSecret, parser.Service())
 }
@@ -563,7 +563,7 @@ func TestSecretStrategy_FetchLastModified(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		result, err := s.FetchLastModified(t.Context(), "my-secret")
 		require.NoError(t, err)
 		assert.Equal(t, now, result)
@@ -578,7 +578,7 @@ func TestSecretStrategy_FetchLastModified(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		_, err := s.FetchLastModified(t.Context(), "my-secret")
 		notFoundErr := (*staging.ResourceNotFoundError)(nil)
 		require.ErrorAs(t, err, &notFoundErr)
@@ -594,7 +594,7 @@ func TestSecretStrategy_FetchLastModified(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		_, err := s.FetchLastModified(t.Context(), "my-secret")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to get secret")
@@ -609,7 +609,7 @@ func TestSecretStrategy_FetchLastModified(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		result, err := s.FetchLastModified(t.Context(), "my-secret")
 		require.NoError(t, err)
 		assert.True(t, result.IsZero())
@@ -632,7 +632,7 @@ func TestSecretStrategy_Apply_WithOptions(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		err := s.Apply(t.Context(), "my-secret", staging.Entry{
 			Operation:   staging.OperationCreate,
 			Value:       lo.ToPtr("secret-value"),
@@ -659,7 +659,7 @@ func TestSecretStrategy_Apply_WithOptions(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		err := s.Apply(t.Context(), "my-secret", staging.Entry{
 			Operation:   staging.OperationUpdate,
 			Value:       lo.ToPtr("updated-value"),
@@ -680,7 +680,7 @@ func TestSecretStrategy_Apply_WithOptions(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		err := s.Apply(t.Context(), "my-secret", staging.Entry{
 			Operation:   staging.OperationUpdate,
 			Value:       lo.ToPtr("updated-value"),
@@ -699,7 +699,7 @@ func TestSecretStrategy_Apply_WithOptions(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		err := s.Apply(t.Context(), "my-secret", staging.Entry{
 			Operation: staging.OperationDelete,
 		})
@@ -716,7 +716,7 @@ func TestSecretStrategy_FetchCurrentValue_NoCreatedDate(t *testing.T) {
 		},
 	}
 
-	s := staging.NewSecretStrategy(mock)
+	s := staging.NewAWSSecretStrategy(mock)
 	result, err := s.FetchCurrentValue(t.Context(), "my-secret")
 	require.NoError(t, err)
 	assert.Equal(t, "secret-value", result.Value)
@@ -741,7 +741,7 @@ func TestSecretStrategy_ApplyTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		err := s.ApplyTags(t.Context(), "my-secret", staging.TagEntry{
 			Add: map[string]string{"env": "prod"},
 		})
@@ -764,7 +764,7 @@ func TestSecretStrategy_ApplyTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		err := s.ApplyTags(t.Context(), "my-secret", staging.TagEntry{
 			Remove: maputil.NewSet("old-tag"),
 		})
@@ -794,7 +794,7 @@ func TestSecretStrategy_ApplyTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		err := s.ApplyTags(t.Context(), "my-secret", staging.TagEntry{
 			Add:    map[string]string{"env": "prod"},
 			Remove: maputil.NewSet("deprecated"),
@@ -813,7 +813,7 @@ func TestSecretStrategy_ApplyTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		err := s.ApplyTags(t.Context(), "my-secret", staging.TagEntry{
 			Add: map[string]string{"env": "test"},
 		})
@@ -829,7 +829,7 @@ func TestSecretStrategy_ApplyTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		err := s.ApplyTags(t.Context(), "my-secret", staging.TagEntry{
 			Remove: maputil.NewSet("old-tag"),
 		})
@@ -854,7 +854,7 @@ func TestSecretStrategy_FetchCurrentTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		tags, err := s.FetchCurrentTags(t.Context(), "my-secret")
 		require.NoError(t, err)
 		assert.Equal(t, map[string]string{"env": "prod", "team": "backend"}, tags)
@@ -869,7 +869,7 @@ func TestSecretStrategy_FetchCurrentTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		tags, err := s.FetchCurrentTags(t.Context(), "nonexistent-secret")
 		require.NoError(t, err)
 		assert.Nil(t, tags)
@@ -884,7 +884,7 @@ func TestSecretStrategy_FetchCurrentTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		tags, err := s.FetchCurrentTags(t.Context(), "my-secret")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to describe secret")
@@ -900,7 +900,7 @@ func TestSecretStrategy_FetchCurrentTags(t *testing.T) {
 			},
 		}
 
-		s := staging.NewSecretStrategy(mock)
+		s := staging.NewAWSSecretStrategy(mock)
 		tags, err := s.FetchCurrentTags(t.Context(), "my-secret")
 		require.NoError(t, err)
 		assert.Nil(t, tags)

--- a/internal/staging/cli/export_test.go
+++ b/internal/staging/cli/export_test.go
@@ -49,7 +49,7 @@ func paramExportImportConfig(resolver staging.ScopeResolver) stgcli.CommandConfi
 	return stgcli.CommandConfig{
 		CommandName:   "param",
 		ItemName:      "parameter",
-		ParserFactory: staging.ParamParserFactory,
+		ParserFactory: staging.AWSParamParserFactory,
 		ScopeResolver: resolver,
 	}
 }
@@ -60,7 +60,7 @@ func secretExportImportConfig(resolver staging.ScopeResolver) stgcli.CommandConf
 	return stgcli.CommandConfig{
 		CommandName:   "secret",
 		ItemName:      "secret",
-		ParserFactory: staging.SecretParserFactory,
+		ParserFactory: staging.AWSSecretParserFactory,
 		ScopeResolver: resolver,
 	}
 }

--- a/internal/staging/cli/global_test.go
+++ b/internal/staging/cli/global_test.go
@@ -14,8 +14,8 @@ import (
 func TestAWSGlobalConfig(t *testing.T) {
 	t.Parallel()
 
-	param := stgcli.CommandConfig{Factory: nil, ParserFactory: staging.ParamParserFactory}
-	secret := stgcli.CommandConfig{Factory: nil, ParserFactory: staging.SecretParserFactory}
+	param := stgcli.CommandConfig{Factory: nil, ParserFactory: staging.AWSParamParserFactory}
+	secret := stgcli.CommandConfig{Factory: nil, ParserFactory: staging.AWSSecretParserFactory}
 
 	cfg := stgcli.AWSGlobalConfig(param, secret)
 

--- a/internal/staging/gcloud_secret.go
+++ b/internal/staging/gcloud_secret.go
@@ -17,7 +17,7 @@ import (
 
 // GoogleCloudSecretStrategy implements the staging strategies for Google Cloud Secret
 // Manager. Like the AWS strategies it is backed by a provider.Store and carries
-// no cloud SDK dependency. It differs from the AWS SecretStrategy in three
+// no cloud SDK dependency. It differs from the AWSSecretStrategy in three
 // provider-specific ways:
 //
 //   - Versions are immutable integers, parsed with gcloudversion (#N, ~SHIFT); a


### PR DESCRIPTION
## Summary

Part of Epic #620 (Step 5 of 11). Provider-marks the AWS staging strategies and factories so they match their already-marked peers (`GoogleCloudSecretStrategy`, `AzureKeyVaultSecretStrategy`, `AzureAppConfigParamStrategy` and factories). Removes the historical "unmarked = AWS" naming privilege on the staging strategy axis.

> Stacked on `epic620/step04-cli-moves` (#637). Will retarget to `main` once #624/#637 squash-merges.

## Related

- Closes #625
- Part of #620

## Changes

- `git mv internal/staging/param.go internal/staging/aws_param.go`, `secret.go` → `aws_secret.go`, and the corresponding `*_test.go` files.
- Renamed exported symbols:
  - `ParamStrategy` → `AWSParamStrategy`, `NewParamStrategy` → `NewAWSParamStrategy`, `ParamParserFactory` → `AWSParamParserFactory`
  - `SecretStrategy` → `AWSSecretStrategy`, `NewSecretStrategy` → `NewAWSSecretStrategy`, `SecretParserFactory` → `AWSSecretParserFactory`
- `internal/cli/commands/internal/client.go`: `ParamStrategyFactory` → `AWSParamStrategyFactory`, `SecretStrategyFactory` → `AWSSecretStrategyFactory` (matching the `GoogleCloudSecretStrategyFactory` / `AzureKeyVaultSecretStrategyFactory` / `AzureAppConfigParamStrategyFactory` convention).
- Updated all references across `internal/gui/app.go`, staging CLI tests, aws stage command/tests, and the `gcloud_secret.go` doc comment.
- Reflowed four test struct literals that gofmt/lll flagged after the (longer) `AWSParamParserFactory` rename.

**Guardrails honored (unchanged):** `staging.Service` constants `"param"`/`"secret"`, store file names, everything in `internal/staging/store/`, and `internal/staging/cli` symbols `AWSGlobalConfig`/`AWSScopeResolver`/`awsTarget`.

## Verification

Grep proof — no bare `Param`/`Secret` `Strategy`/`ParserFactory`/`StrategyFactory` symbols remain (only AWS-prefixed + gcloud/azure peers):

```
$ grep -rnE '\b(Param|Secret)Strategy\b|\b(Param|Secret)ParserFactory\b|\b(Param|Secret)StrategyFactory\b' --include='*.go' . | grep -vE 'AWS|GoogleCloud|Azure'
(no output)
```

All Strategy/Factory symbols present in the tree:
```
AWSParamStrategy / NewAWSParamStrategy / AWSParamParserFactory / AWSParamStrategyFactory
AWSSecretStrategy / NewAWSSecretStrategy / AWSSecretParserFactory / AWSSecretStrategyFactory
GoogleCloudSecretStrategy(Factory) / AzureKeyVaultSecretStrategy(Factory) / AzureAppConfigParamStrategy(Factory)
```

Gates (all green):
- `mise test` — all packages `ok`
- `golangci-lint run --allow-parallel-runners ./internal/staging/... ./internal/cli/commands/internal/... ./internal/cli/commands/aws/stage/... ./internal/gui/...` — `0 issues`
- `mise build-cli` — success
- `go build -tags e2e ./e2e/...` — success

🤖 Generated with [Claude Code](https://claude.com/claude-code)
