### PR TITLE
refactor(version): rename paramversion/secretversion to awsparamversion/awssecretversion (#626)

### DIFF
--- a/internal/cli/commands/aws/param/diff.go
+++ b/internal/cli/commands/aws/param/diff.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/usecase/param"
-	"github.com/mpyw/suve/internal/version/paramversion"
+	"github.com/mpyw/suve/internal/version/awsparamversion"
 )
 
 // diffJSONOutput represents the JSON output structure for the diff command.
@@ -30,14 +30,14 @@ type diffJSONOutput struct {
 // diffPresenter renders SSM Parameter Store diff output byte-for-byte as before.
 type diffPresenter struct {
 	uc     *param.DiffUseCase
-	spec1  *paramversion.Spec
-	spec2  *paramversion.Spec
+	spec1  *awsparamversion.Spec
+	spec2  *awsparamversion.Spec
 	result *param.DiffOutput
 }
 
 // NewDiffPresenter builds a param diff presenter over the given reader and specs.
 // It is exported for the shared golden-output test harness.
-func NewDiffPresenter(reader provider.Reader, spec1, spec2 *paramversion.Spec) genericdiff.Presenter {
+func NewDiffPresenter(reader provider.Reader, spec1, spec2 *awsparamversion.Spec) genericdiff.Presenter {
 	return &diffPresenter{uc: &param.DiffUseCase{Reader: reader}, spec1: spec1, spec2: spec2}
 }
 
@@ -81,7 +81,7 @@ func (p *diffPresenter) Hints(stderr io.Writer) {
 
 // DiffCommand returns the SSM Parameter Store diff command.
 func DiffCommand() *cli.Command {
-	return genericdiff.Command(genericdiff.Config[*paramversion.Spec]{
+	return genericdiff.Command(genericdiff.Config[*awsparamversion.Spec]{
 		Usage:     "Show diff between two versions",
 		ArgsUsage: "<spec1> [spec2] | <name> #<version1> [#<version2>]",
 		Description: `Compare two versions of a parameter in unified diff format.
@@ -102,8 +102,8 @@ EXAMPLES:
   suve param diff --output=json /app/config~      Output comparison as JSON
 
 For comparing staged values, use: suve stage param diff`,
-		ParseDiffArgs: paramversion.ParseDiffArgs,
-		NewPresenter: func(ctx context.Context, spec1, spec2 *paramversion.Spec) (genericdiff.Presenter, error) {
+		ParseDiffArgs: awsparamversion.ParseDiffArgs,
+		NewPresenter: func(ctx context.Context, spec1, spec2 *awsparamversion.Spec) (genericdiff.Presenter, error) {
 			store, err := cliinternal.ParamStore(ctx)
 			if err != nil {
 				return nil, err

--- a/internal/cli/commands/aws/param/show.go
+++ b/internal/cli/commands/aws/param/show.go
@@ -18,7 +18,7 @@ import (
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/usecase/param"
-	"github.com/mpyw/suve/internal/version/paramversion"
+	"github.com/mpyw/suve/internal/version/awsparamversion"
 )
 
 // showJSONOutput represents the JSON output structure for the show command.
@@ -35,14 +35,14 @@ type showJSONOutput struct {
 // showPresenter renders SSM Parameter Store show output byte-for-byte as before.
 type showPresenter struct {
 	uc         *param.ShowUseCase
-	spec       *paramversion.Spec
+	spec       *awsparamversion.Spec
 	result     *param.ShowOutput
 	jsonParsed bool
 }
 
 // NewShowPresenter builds a param show presenter over the given reader and spec.
 // It is exported for the shared golden-output test harness.
-func NewShowPresenter(reader provider.Reader, spec *paramversion.Spec) genericshow.Presenter {
+func NewShowPresenter(reader provider.Reader, spec *awsparamversion.Spec) genericshow.Presenter {
 	return &showPresenter{uc: &param.ShowUseCase{Reader: reader}, spec: spec}
 }
 
@@ -133,7 +133,7 @@ func (p *showPresenter) RenderJSON(stdout io.Writer, value string) error {
 
 // ShowCommand returns the SSM Parameter Store show command.
 func ShowCommand() *cli.Command {
-	return genericshow.Command(genericshow.Config[*paramversion.Spec]{
+	return genericshow.Command(genericshow.Config[*awsparamversion.Spec]{
 		Usage:     "Show parameter value with metadata",
 		ArgsUsage: "<name[#VERSION][~SHIFT]*>",
 		Description: `Display a parameter's value along with its metadata (name, version, type, modification date).
@@ -154,8 +154,8 @@ EXAMPLES:
   suve param show --output=json /app/config                 Output as JSON
   DB_URL=$(suve param show --raw /app/config)               Use in shell variable`,
 		UsageError: "usage: suve param show <name>",
-		ParseSpec:  paramversion.Parse,
-		NewPresenter: func(ctx context.Context, spec *paramversion.Spec) (genericshow.Presenter, error) {
+		ParseSpec:  awsparamversion.Parse,
+		NewPresenter: func(ctx context.Context, spec *awsparamversion.Spec) (genericshow.Presenter, error) {
 			store, err := cliinternal.ParamStore(ctx)
 			if err != nil {
 				return nil, err

--- a/internal/cli/commands/aws/secret/diff.go
+++ b/internal/cli/commands/aws/secret/diff.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/usecase/secret"
-	"github.com/mpyw/suve/internal/version/secretversion"
+	"github.com/mpyw/suve/internal/version/awssecretversion"
 )
 
 // diffJSONOutput represents the JSON output structure for the diff command.
@@ -30,14 +30,14 @@ type diffJSONOutput struct {
 // diffPresenter renders Secrets Manager diff output byte-for-byte as before.
 type diffPresenter struct {
 	uc     *secret.DiffUseCase
-	spec1  *secretversion.Spec
-	spec2  *secretversion.Spec
+	spec1  *awssecretversion.Spec
+	spec2  *awssecretversion.Spec
 	result *secret.DiffOutput
 }
 
 // NewDiffPresenter builds a secret diff presenter over the given reader and specs.
 // It is exported for the shared golden-output test harness.
-func NewDiffPresenter(reader provider.Reader, spec1, spec2 *secretversion.Spec) genericdiff.Presenter {
+func NewDiffPresenter(reader provider.Reader, spec1, spec2 *awssecretversion.Spec) genericdiff.Presenter {
 	return &diffPresenter{uc: &secret.DiffUseCase{Reader: reader}, spec1: spec1, spec2: spec2}
 }
 
@@ -56,8 +56,8 @@ func (p *diffPresenter) OldValue() string { return p.result.OldValue }
 func (p *diffPresenter) NewValue() string { return p.result.NewValue }
 
 func (p *diffPresenter) Labels() (string, string) {
-	return fmt.Sprintf("%s#%s", p.result.OldName, secretversion.TruncateVersionID(p.result.OldVersionID)),
-		fmt.Sprintf("%s#%s", p.result.NewName, secretversion.TruncateVersionID(p.result.NewVersionID))
+	return fmt.Sprintf("%s#%s", p.result.OldName, awssecretversion.TruncateVersionID(p.result.OldVersionID)),
+		fmt.Sprintf("%s#%s", p.result.NewName, awssecretversion.TruncateVersionID(p.result.NewVersionID))
 }
 
 func (p *diffPresenter) RenderJSON(stdout io.Writer, oldValue, newValue string, identical bool, diff string) error {
@@ -82,7 +82,7 @@ func (p *diffPresenter) Hints(stderr io.Writer) {
 
 // DiffCommand returns the Secrets Manager diff command.
 func DiffCommand() *cli.Command {
-	return genericdiff.Command(genericdiff.Config[*secretversion.Spec]{
+	return genericdiff.Command(genericdiff.Config[*awssecretversion.Spec]{
 		Usage:     "Show diff between two versions",
 		ArgsUsage: "<spec1> [spec2] | <name> #<version1> [#<version2>]",
 		Description: `Compare two versions of a secret in unified diff format.
@@ -104,8 +104,8 @@ EXAMPLES:
   suve secret diff --output=json my-secret~          Output comparison as JSON
 
 For comparing staged values, use: suve stage secret diff`,
-		ParseDiffArgs: secretversion.ParseDiffArgs,
-		NewPresenter: func(ctx context.Context, spec1, spec2 *secretversion.Spec) (genericdiff.Presenter, error) {
+		ParseDiffArgs: awssecretversion.ParseDiffArgs,
+		NewPresenter: func(ctx context.Context, spec1, spec2 *awssecretversion.Spec) (genericdiff.Presenter, error) {
 			store, err := cliinternal.SecretStore(ctx)
 			if err != nil {
 				return nil, err

--- a/internal/cli/commands/aws/secret/log.go
+++ b/internal/cli/commands/aws/secret/log.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/usecase/secret"
-	"github.com/mpyw/suve/internal/version/secretversion"
+	"github.com/mpyw/suve/internal/version/awssecretversion"
 )
 
 // logJSONItem represents a single version entry in JSON output.
@@ -112,7 +112,7 @@ func (p *logPresenter) RenderOneline(stdout io.Writer, i, _ int) {
 	}
 
 	output.Printf(stdout, "%s%s  %s%s\n",
-		colors.For(stdout).Version(secretversion.TruncateVersionID(entry.VersionID)),
+		colors.For(stdout).Version(awssecretversion.TruncateVersionID(entry.VersionID)),
 		labelsStr,
 		colors.For(stdout).FieldLabel(dateStr),
 		"",
@@ -122,7 +122,7 @@ func (p *logPresenter) RenderOneline(stdout io.Writer, i, _ int) {
 func (p *logPresenter) RenderHeader(stdout io.Writer, i int) {
 	entry := p.result.Entries[i]
 
-	versionLabel := fmt.Sprintf("Version %s", secretversion.TruncateVersionID(entry.VersionID))
+	versionLabel := fmt.Sprintf("Version %s", awssecretversion.TruncateVersionID(entry.VersionID))
 	if len(entry.VersionStage) > 0 {
 		versionLabel += " " + colors.For(stdout).Current(fmt.Sprintf("%v", entry.VersionStage))
 	}
@@ -175,14 +175,14 @@ func (p *logPresenter) RenderPatch(stdout, stderr io.Writer, i int, parseJSON, r
 			return
 		}
 
-		oldName = fmt.Sprintf("%s#%s", p.result.Name, secretversion.TruncateVersionID(oldEntry.VersionID))
+		oldName = fmt.Sprintf("%s#%s", p.result.Name, awssecretversion.TruncateVersionID(oldEntry.VersionID))
 
 		if parseJSON {
 			oldValue, newValue = jsonutil.TryFormatOrWarn2(oldValue, newValue, stderr, "")
 		}
 	}
 
-	newName := fmt.Sprintf("%s#%s", p.result.Name, secretversion.TruncateVersionID(newEntry.VersionID))
+	newName := fmt.Sprintf("%s#%s", p.result.Name, awssecretversion.TruncateVersionID(newEntry.VersionID))
 
 	diff := output.Diff(stdout, oldName, newName, oldValue, newValue)
 	if diff != "" {

--- a/internal/cli/commands/aws/secret/show.go
+++ b/internal/cli/commands/aws/secret/show.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/usecase/secret"
-	"github.com/mpyw/suve/internal/version/secretversion"
+	"github.com/mpyw/suve/internal/version/awssecretversion"
 )
 
 // showJSONOutput represents the JSON output structure for the show command.
@@ -31,13 +31,13 @@ type showJSONOutput struct {
 // showPresenter renders Secrets Manager show output byte-for-byte as before.
 type showPresenter struct {
 	uc     *secret.ShowUseCase
-	spec   *secretversion.Spec
+	spec   *awssecretversion.Spec
 	result *secret.ShowOutput
 }
 
 // NewShowPresenter builds a secret show presenter over the given reader and spec.
 // It is exported for the shared golden-output test harness.
-func NewShowPresenter(reader provider.Reader, spec *secretversion.Spec) genericshow.Presenter {
+func NewShowPresenter(reader provider.Reader, spec *awssecretversion.Spec) genericshow.Presenter {
 	return &showPresenter{uc: &secret.ShowUseCase{Reader: reader}, spec: spec}
 }
 
@@ -124,7 +124,7 @@ func (p *showPresenter) RenderJSON(stdout io.Writer, value string) error {
 
 // ShowCommand returns the Secrets Manager show command.
 func ShowCommand() *cli.Command {
-	return genericshow.Command(genericshow.Config[*secretversion.Spec]{
+	return genericshow.Command(genericshow.Config[*awssecretversion.Spec]{
 		Usage:     "Show secret value with metadata",
 		ArgsUsage: "<name[#VERSION | :LABEL][~SHIFT]*>",
 		Description: `Display a secret's value along with its metadata.
@@ -146,8 +146,8 @@ EXAMPLES:
   suve secret show --output=json my-secret                Output as JSON
   API_KEY=$(suve secret show --raw my-secret)             Use in shell variable`,
 		UsageError: "usage: suve secret show <name>",
-		ParseSpec:  secretversion.Parse,
-		NewPresenter: func(ctx context.Context, spec *secretversion.Spec) (genericshow.Presenter, error) {
+		ParseSpec:  awssecretversion.Parse,
+		NewPresenter: func(ctx context.Context, spec *awssecretversion.Spec) (genericshow.Presenter, error) {
 			store, err := cliinternal.SecretStore(ctx)
 			if err != nil {
 				return nil, err

--- a/internal/cli/commands/generic/diff/diff_test.go
+++ b/internal/cli/commands/generic/diff/diff_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/providermock"
-	"github.com/mpyw/suve/internal/version/paramversion"
-	"github.com/mpyw/suve/internal/version/secretversion"
+	"github.com/mpyw/suve/internal/version/awsparamversion"
+	"github.com/mpyw/suve/internal/version/awssecretversion"
 )
 
 func TestCommand_Validation(t *testing.T) {
@@ -65,7 +65,7 @@ type paramWantSpec struct {
 	shift   int
 }
 
-func assertParamSpec(t *testing.T, label string, got *paramversion.Spec, want *paramWantSpec) {
+func assertParamSpec(t *testing.T, label string, got *awsparamversion.Spec, want *paramWantSpec) {
 	t.Helper()
 	assert.Equal(t, want.name, got.Name, "%s.Name", label)
 	assert.Equal(t, want.version, got.Absolute.Version, "%s.Absolute.Version", label)
@@ -198,8 +198,8 @@ func TestParseArgsParam(t *testing.T) {
 
 			spec1, spec2, err := diffargs.ParseArgs(
 				tt.args,
-				paramversion.Parse,
-				func(abs paramversion.AbsoluteSpec) bool { return abs.Version != nil },
+				awsparamversion.Parse,
+				func(abs awsparamversion.AbsoluteSpec) bool { return abs.Version != nil },
 				"#~",
 				"usage: suve param diff <spec1> [spec2] | <name> <version1> [version2]",
 			)
@@ -227,7 +227,7 @@ type secretWantSpec struct {
 	shift      int
 }
 
-func assertSecretSpec(t *testing.T, label string, got *secretversion.Spec, want *secretWantSpec) {
+func assertSecretSpec(t *testing.T, label string, got *awssecretversion.Spec, want *secretWantSpec) {
 	t.Helper()
 	assert.Equal(t, want.secretName, got.Name, "%s.Name", label)
 	assert.Equal(t, want.id, got.Absolute.ID, "%s.Absolute.ID", label)
@@ -357,8 +357,8 @@ func TestParseArgsSecret(t *testing.T) {
 
 			spec1, spec2, err := diffargs.ParseArgs(
 				tt.args,
-				secretversion.Parse,
-				func(abs secretversion.AbsoluteSpec) bool { return abs.ID != nil || abs.Label != nil },
+				awssecretversion.Parse,
+				func(abs awssecretversion.AbsoluteSpec) bool { return abs.ID != nil || abs.Label != nil },
 				"#:~",
 				"usage: suve secret diff <spec1> [spec2] | <name> <version1> [version2]",
 			)
@@ -410,8 +410,8 @@ func paramDiffStore(byRef map[string]*domain.Entry) *providermock.Store {
 	}
 }
 
-func paramVersionSpec(v int64) *paramversion.Spec {
-	return &paramversion.Spec{Name: "/app/param", Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(v)}}
+func paramVersionSpec(v int64) *awsparamversion.Spec {
+	return &awsparamversion.Spec{Name: "/app/param", Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(v)}}
 }
 
 func TestRunParam(t *testing.T) {
@@ -419,8 +419,8 @@ func TestRunParam(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		spec1   *paramversion.Spec
-		spec2   *paramversion.Spec
+		spec1   *awsparamversion.Spec
+		spec2   *awsparamversion.Spec
 		opts    genericdiff.Options
 		store   *providermock.Store
 		wantErr bool
@@ -526,7 +526,7 @@ func TestParamIdenticalWarning(t *testing.T) {
 		"": {Name: "/app/param", Value: "same-value", Version: domain.Version{ID: "1"}},
 	})
 
-	spec := &paramversion.Spec{Name: "/app/param", Absolute: paramversion.AbsoluteSpec{}}
+	spec := &awsparamversion.Spec{Name: "/app/param", Absolute: awsparamversion.AbsoluteSpec{}}
 	presenter := cmdparam.NewDiffPresenter(store, spec, spec)
 	stdout, stderr, err := run(t, presenter, genericdiff.Options{})
 	require.NoError(t, err)
@@ -552,8 +552,8 @@ func TestDiff_DistinctVersionsSameContent(t *testing.T) {
 		"3": {Name: "/app/param", Value: "same-value", Version: domain.Version{ID: "3"}},
 	})
 
-	spec1 := &paramversion.Spec{Name: "/app/param", Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))}}
-	spec3 := &paramversion.Spec{Name: "/app/param", Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))}}
+	spec1 := &awsparamversion.Spec{Name: "/app/param", Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))}}
+	spec3 := &awsparamversion.Spec{Name: "/app/param", Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))}}
 
 	stdout, stderr, err := run(t, cmdparam.NewDiffPresenter(store, spec1, spec3), genericdiff.Options{})
 	require.NoError(t, err)
@@ -576,8 +576,8 @@ func TestDiff_FormattingOnlyDifference(t *testing.T) {
 		"3": {Name: "/app/param", Value: `{"b":2,"a":1}`, Version: domain.Version{ID: "3"}},
 	})
 
-	spec1 := &paramversion.Spec{Name: "/app/param", Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))}}
-	spec3 := &paramversion.Spec{Name: "/app/param", Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))}}
+	spec1 := &awsparamversion.Spec{Name: "/app/param", Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))}}
+	spec3 := &awsparamversion.Spec{Name: "/app/param", Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))}}
 
 	stdout, stderr, err := run(t, cmdparam.NewDiffPresenter(store, spec1, spec3), genericdiff.Options{ParseJSON: true})
 	require.NoError(t, err)
@@ -598,8 +598,8 @@ func TestDiff_JSONOutputIdenticalOnRawValues(t *testing.T) {
 		"3": {Name: "/app/param", Value: `{"b":2,"a":1}`, Version: domain.Version{ID: "3"}},
 	})
 
-	spec1 := &paramversion.Spec{Name: "/app/param", Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))}}
-	spec3 := &paramversion.Spec{Name: "/app/param", Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))}}
+	spec1 := &awsparamversion.Spec{Name: "/app/param", Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))}}
+	spec3 := &awsparamversion.Spec{Name: "/app/param", Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))}}
 
 	stdout, _, err := run(t, cmdparam.NewDiffPresenter(store, spec1, spec3),
 		genericdiff.Options{ParseJSON: true, Output: output.FormatJSON})
@@ -628,9 +628,9 @@ func secretDiffStore(entries map[string]*domain.Entry, errs map[string]error) *p
 	}
 }
 
-func prevCurrSpecs() (*secretversion.Spec, *secretversion.Spec) {
-	return &secretversion.Spec{Name: "my-secret", Absolute: secretversion.AbsoluteSpec{Label: lo.ToPtr("AWSPREVIOUS")}},
-		&secretversion.Spec{Name: "my-secret", Absolute: secretversion.AbsoluteSpec{Label: lo.ToPtr("AWSCURRENT")}}
+func prevCurrSpecs() (*awssecretversion.Spec, *awssecretversion.Spec) {
+	return &awssecretversion.Spec{Name: "my-secret", Absolute: awssecretversion.AbsoluteSpec{Label: lo.ToPtr("AWSPREVIOUS")}},
+		&awssecretversion.Spec{Name: "my-secret", Absolute: awssecretversion.AbsoluteSpec{Label: lo.ToPtr("AWSCURRENT")}}
 }
 
 func TestRunSecret(t *testing.T) {
@@ -738,7 +738,7 @@ func TestSecretIdenticalWarning(t *testing.T) {
 		"": {Name: "my-secret", Value: "same-content", Version: domain.Version{ID: "version-id"}},
 	}, nil)
 
-	spec := &secretversion.Spec{Name: "my-secret", Absolute: secretversion.AbsoluteSpec{}}
+	spec := &awssecretversion.Spec{Name: "my-secret", Absolute: awssecretversion.AbsoluteSpec{}}
 	presenter := cmdsecret.NewDiffPresenter(store, spec, spec)
 	stdout, stderr, err := run(t, presenter, genericdiff.Options{})
 	require.NoError(t, err)

--- a/internal/cli/commands/generic/show/show_test.go
+++ b/internal/cli/commands/generic/show/show_test.go
@@ -18,8 +18,8 @@ import (
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/providermock"
-	"github.com/mpyw/suve/internal/version/paramversion"
-	"github.com/mpyw/suve/internal/version/secretversion"
+	"github.com/mpyw/suve/internal/version/awsparamversion"
+	"github.com/mpyw/suve/internal/version/awssecretversion"
 )
 
 func TestCommand_Validation(t *testing.T) {
@@ -73,10 +73,10 @@ func run(
 	return buf.String(), err
 }
 
-func mustParseParam(t *testing.T, s string) *paramversion.Spec {
+func mustParseParam(t *testing.T, s string) *awsparamversion.Spec {
 	t.Helper()
 
-	spec, err := paramversion.Parse(s)
+	spec, err := awsparamversion.Parse(s)
 	require.NoError(t, err)
 
 	return spec
@@ -373,7 +373,7 @@ func TestRunSecret(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		spec    *secretversion.Spec
+		spec    *awssecretversion.Spec
 		opts    genericshow.Options
 		store   *providermock.Store
 		wantErr bool
@@ -381,7 +381,7 @@ func TestRunSecret(t *testing.T) {
 	}{
 		{
 			name: "show latest version",
-			spec: &secretversion.Spec{Name: "my-secret"},
+			spec: &awssecretversion.Spec{Name: "my-secret"},
 			store: showStore(&domain.Entry{
 				Name:    "my-secret",
 				Value:   "secret-value",
@@ -396,7 +396,7 @@ func TestRunSecret(t *testing.T) {
 		},
 		{
 			name: "show with shift",
-			spec: &secretversion.Spec{Name: "my-secret", Shift: 1},
+			spec: &awssecretversion.Spec{Name: "my-secret", Shift: 1},
 			store: showStore(&domain.Entry{
 				Name:    "my-secret",
 				Value:   "previous-value",
@@ -409,7 +409,7 @@ func TestRunSecret(t *testing.T) {
 		},
 		{
 			name: "show JSON formatted with sorted keys",
-			spec: &secretversion.Spec{Name: "my-secret"},
+			spec: &awssecretversion.Spec{Name: "my-secret"},
 			opts: genericshow.Options{ParseJSON: true},
 			store: showStore(&domain.Entry{
 				Name:    "my-secret",
@@ -430,7 +430,7 @@ func TestRunSecret(t *testing.T) {
 		},
 		{
 			name: "error from AWS",
-			spec: &secretversion.Spec{Name: "my-secret"},
+			spec: &awssecretversion.Spec{Name: "my-secret"},
 			store: &providermock.Store{
 				ResolveFunc: func(_ context.Context, _, _ string) (provider.VersionRef, error) {
 					return provider.VersionRef{}, nil
@@ -443,7 +443,7 @@ func TestRunSecret(t *testing.T) {
 		},
 		{
 			name: "show without optional fields",
-			spec: &secretversion.Spec{Name: "my-secret"},
+			spec: &awssecretversion.Spec{Name: "my-secret"},
 			store: showStore(&domain.Entry{
 				Name:  "my-secret",
 				Value: "secret-value",
@@ -459,7 +459,7 @@ func TestRunSecret(t *testing.T) {
 		},
 		{
 			name: "json flag with non-JSON value warns",
-			spec: &secretversion.Spec{Name: "my-secret"},
+			spec: &awssecretversion.Spec{Name: "my-secret"},
 			opts: genericshow.Options{ParseJSON: true},
 			store: showStore(&domain.Entry{
 				Name:  "my-secret",
@@ -473,7 +473,7 @@ func TestRunSecret(t *testing.T) {
 		},
 		{
 			name: "raw mode outputs only value",
-			spec: &secretversion.Spec{Name: "my-secret"},
+			spec: &awssecretversion.Spec{Name: "my-secret"},
 			opts: genericshow.Options{Raw: true},
 			store: showStore(&domain.Entry{
 				Name:  "my-secret",
@@ -486,7 +486,7 @@ func TestRunSecret(t *testing.T) {
 		},
 		{
 			name: "raw mode with shift",
-			spec: &secretversion.Spec{Name: "my-secret", Shift: 1},
+			spec: &awssecretversion.Spec{Name: "my-secret", Shift: 1},
 			opts: genericshow.Options{Raw: true},
 			store: showStore(&domain.Entry{
 				Name:  "my-secret",
@@ -499,7 +499,7 @@ func TestRunSecret(t *testing.T) {
 		},
 		{
 			name: "raw mode with JSON formatting",
-			spec: &secretversion.Spec{Name: "my-secret"},
+			spec: &awssecretversion.Spec{Name: "my-secret"},
 			opts: genericshow.Options{ParseJSON: true, Raw: true},
 			store: showStore(&domain.Entry{
 				Name:  "my-secret",
@@ -518,7 +518,7 @@ func TestRunSecret(t *testing.T) {
 		},
 		{
 			name: "show with tags",
-			spec: &secretversion.Spec{Name: "my-secret"},
+			spec: &awssecretversion.Spec{Name: "my-secret"},
 			store: showStore(&domain.Entry{
 				Name:    "my-secret",
 				Value:   "secret-value",
@@ -541,7 +541,7 @@ func TestRunSecret(t *testing.T) {
 		},
 		{
 			name: "show with tags in JSON output",
-			spec: &secretversion.Spec{Name: "my-secret"},
+			spec: &awssecretversion.Spec{Name: "my-secret"},
 			opts: genericshow.Options{Output: output.FormatJSON},
 			store: showStore(&domain.Entry{
 				Name:    "my-secret",
@@ -564,7 +564,7 @@ func TestRunSecret(t *testing.T) {
 		},
 		{
 			name: "JSON output with empty tags shows empty object",
-			spec: &secretversion.Spec{Name: "my-secret"},
+			spec: &awssecretversion.Spec{Name: "my-secret"},
 			opts: genericshow.Options{Output: output.FormatJSON},
 			store: showStore(&domain.Entry{
 				Name:  "my-secret",

--- a/internal/cli/diffargs/args.go
+++ b/internal/cli/diffargs/args.go
@@ -69,7 +69,7 @@ import (
 // # Parameters
 //
 //   - args: Command line arguments (1-3 arguments supported)
-//   - parse: Service-specific parser function (e.g., paramversion.Parse, secretversion.Parse)
+//   - parse: Service-specific parser function (e.g., awsparamversion.Parse, awssecretversion.Parse)
 //   - hasAbsolute: Returns true if the absolute specifier is set (non-zero).
 //     Used to distinguish "mixed" pattern from "partial spec" pattern in 2-arg case.
 //     For SSM Parameter Store: func(abs) bool { return abs.Version != nil }
@@ -92,8 +92,8 @@ import (
 //
 //	spec1, spec2, err := ParseArgs(
 //	    args,
-//	    paramversion.Parse,
-//	    func(abs paramversion.AbsoluteSpec) bool { return abs.Version != nil },
+//	    awsparamversion.Parse,
+//	    func(abs awsparamversion.AbsoluteSpec) bool { return abs.Version != nil },
 //	    "#~",
 //	    "usage: suve param diff <spec1> [spec2] | <name> #<version1> [#<version2>]",
 //	)
@@ -102,8 +102,8 @@ import (
 //
 //	spec1, spec2, err := ParseArgs(
 //	    args,
-//	    secretversion.Parse,
-//	    func(abs secretversion.AbsoluteSpec) bool { return abs.ID != nil || abs.Label != nil },
+//	    awssecretversion.Parse,
+//	    func(abs awssecretversion.AbsoluteSpec) bool { return abs.ID != nil || abs.Label != nil },
 //	    "#:~",
 //	    "usage: suve secret diff <spec1> [spec2] | <name> #<version1> [#<version2>]",
 //	)

--- a/internal/cli/diffargs/args_test.go
+++ b/internal/cli/diffargs/args_test.go
@@ -8,23 +8,23 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/mpyw/suve/internal/cli/diffargs"
-	"github.com/mpyw/suve/internal/version/paramversion"
-	"github.com/mpyw/suve/internal/version/secretversion"
+	"github.com/mpyw/suve/internal/version/awsparamversion"
+	"github.com/mpyw/suve/internal/version/awssecretversion"
 )
 
 func TestParseArgs_Param(t *testing.T) {
 	t.Parallel()
 
-	parse := paramversion.Parse
-	hasAbsolute := func(abs paramversion.AbsoluteSpec) bool { return abs.Version != nil }
+	parse := awsparamversion.Parse
+	hasAbsolute := func(abs awsparamversion.AbsoluteSpec) bool { return abs.Version != nil }
 	prefixes := "#~"
 	usage := "usage: suve param diff"
 
 	tests := []struct {
 		name       string
 		args       []string
-		wantSpec1  *paramversion.Spec
-		wantSpec2  *paramversion.Spec
+		wantSpec1  *awsparamversion.Spec
+		wantSpec2  *awsparamversion.Spec
 		wantErrMsg string
 	}{
 		// Error cases
@@ -43,22 +43,22 @@ func TestParseArgs_Param(t *testing.T) {
 		{
 			name: "one arg with version",
 			args: []string{"/app/param#3"},
-			wantSpec1: &paramversion.Spec{
+			wantSpec1: &awsparamversion.Spec{
 				Name:     "/app/param",
-				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))},
+				Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))},
 			},
-			wantSpec2: &paramversion.Spec{
+			wantSpec2: &awsparamversion.Spec{
 				Name: "/app/param",
 			},
 		},
 		{
 			name: "one arg with shift",
 			args: []string{"/app/param~1"},
-			wantSpec1: &paramversion.Spec{
+			wantSpec1: &awsparamversion.Spec{
 				Name:  "/app/param",
 				Shift: 1,
 			},
-			wantSpec2: &paramversion.Spec{
+			wantSpec2: &awsparamversion.Spec{
 				Name: "/app/param",
 			},
 		},
@@ -72,25 +72,25 @@ func TestParseArgs_Param(t *testing.T) {
 		{
 			name: "two args both full spec",
 			args: []string{"/app/param#1", "/app/param#2"},
-			wantSpec1: &paramversion.Spec{
+			wantSpec1: &awsparamversion.Spec{
 				Name:     "/app/param",
-				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))},
+				Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))},
 			},
-			wantSpec2: &paramversion.Spec{
+			wantSpec2: &awsparamversion.Spec{
 				Name:     "/app/param",
-				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(2))},
+				Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(2))},
 			},
 		},
 		{
 			name: "two args different names",
 			args: []string{"/app/config#1", "/app/secrets#2"},
-			wantSpec1: &paramversion.Spec{
+			wantSpec1: &awsparamversion.Spec{
 				Name:     "/app/config",
-				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))},
+				Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))},
 			},
-			wantSpec2: &paramversion.Spec{
+			wantSpec2: &awsparamversion.Spec{
 				Name:     "/app/secrets",
-				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(2))},
+				Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(2))},
 			},
 		},
 
@@ -98,23 +98,23 @@ func TestParseArgs_Param(t *testing.T) {
 		{
 			name: "two args mixed format",
 			args: []string{"/app/param#1", "#2"},
-			wantSpec1: &paramversion.Spec{
+			wantSpec1: &awsparamversion.Spec{
 				Name:     "/app/param",
-				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))},
+				Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))},
 			},
-			wantSpec2: &paramversion.Spec{
+			wantSpec2: &awsparamversion.Spec{
 				Name:     "/app/param",
-				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(2))},
+				Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(2))},
 			},
 		},
 		{
 			name: "two args mixed format with shift",
 			args: []string{"/app/param~1", "~2"},
-			wantSpec1: &paramversion.Spec{
+			wantSpec1: &awsparamversion.Spec{
 				Name:  "/app/param",
 				Shift: 1,
 			},
-			wantSpec2: &paramversion.Spec{
+			wantSpec2: &awsparamversion.Spec{
 				Name:  "/app/param",
 				Shift: 2,
 			},
@@ -124,22 +124,22 @@ func TestParseArgs_Param(t *testing.T) {
 		{
 			name: "two args partial spec format",
 			args: []string{"/app/param", "#3"},
-			wantSpec1: &paramversion.Spec{
+			wantSpec1: &awsparamversion.Spec{
 				Name:     "/app/param",
-				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))},
+				Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))},
 			},
-			wantSpec2: &paramversion.Spec{
+			wantSpec2: &awsparamversion.Spec{
 				Name: "/app/param",
 			},
 		},
 		{
 			name: "two args partial spec with shift",
 			args: []string{"/app/param", "~2"},
-			wantSpec1: &paramversion.Spec{
+			wantSpec1: &awsparamversion.Spec{
 				Name:  "/app/param",
 				Shift: 2,
 			},
-			wantSpec2: &paramversion.Spec{
+			wantSpec2: &awsparamversion.Spec{
 				Name: "/app/param",
 			},
 		},
@@ -163,23 +163,23 @@ func TestParseArgs_Param(t *testing.T) {
 		{
 			name: "three args",
 			args: []string{"/app/param", "#1", "#2"},
-			wantSpec1: &paramversion.Spec{
+			wantSpec1: &awsparamversion.Spec{
 				Name:     "/app/param",
-				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))},
+				Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))},
 			},
-			wantSpec2: &paramversion.Spec{
+			wantSpec2: &awsparamversion.Spec{
 				Name:     "/app/param",
-				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(2))},
+				Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(2))},
 			},
 		},
 		{
 			name: "three args with shifts",
 			args: []string{"/app/param", "~2", "~1"},
-			wantSpec1: &paramversion.Spec{
+			wantSpec1: &awsparamversion.Spec{
 				Name:  "/app/param",
 				Shift: 2,
 			},
-			wantSpec2: &paramversion.Spec{
+			wantSpec2: &awsparamversion.Spec{
 				Name:  "/app/param",
 				Shift: 1,
 			},
@@ -222,16 +222,16 @@ func TestParseArgs_Param(t *testing.T) {
 func TestParseArgs_ThreeArgRequiresSpecifier(t *testing.T) {
 	t.Parallel()
 
-	parse := paramversion.Parse
-	hasAbsolute := func(abs paramversion.AbsoluteSpec) bool { return abs.Version != nil }
+	parse := awsparamversion.Parse
+	hasAbsolute := func(abs awsparamversion.AbsoluteSpec) bool { return abs.Version != nil }
 	prefixes := "#~"
 	usage := "usage: suve param diff"
 
 	tests := []struct {
 		name       string
 		args       []string
-		wantSpec1  *paramversion.Spec
-		wantSpec2  *paramversion.Spec
+		wantSpec1  *awsparamversion.Spec
+		wantSpec2  *awsparamversion.Spec
 		wantErrMsg string
 	}{
 		{
@@ -247,13 +247,13 @@ func TestParseArgs_ThreeArgRequiresSpecifier(t *testing.T) {
 		{
 			name: "hash specifiers keep name",
 			args: []string{"/p", "#3", "#1"},
-			wantSpec1: &paramversion.Spec{
+			wantSpec1: &awsparamversion.Spec{
 				Name:     "/p",
-				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))},
+				Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))},
 			},
-			wantSpec2: &paramversion.Spec{
+			wantSpec2: &awsparamversion.Spec{
 				Name:     "/p",
-				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))},
+				Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))},
 			},
 		},
 	}
@@ -281,27 +281,27 @@ func TestParseArgs_ThreeArgRequiresSpecifier(t *testing.T) {
 func TestParseArgs_Secret(t *testing.T) {
 	t.Parallel()
 
-	parse := secretversion.Parse
-	hasAbsolute := func(abs secretversion.AbsoluteSpec) bool { return abs.ID != nil || abs.Label != nil }
+	parse := awssecretversion.Parse
+	hasAbsolute := func(abs awssecretversion.AbsoluteSpec) bool { return abs.ID != nil || abs.Label != nil }
 	prefixes := "#:~"
 	usage := "usage: suve secret diff"
 
 	tests := []struct {
 		name       string
 		args       []string
-		wantSpec1  *secretversion.Spec
-		wantSpec2  *secretversion.Spec
+		wantSpec1  *awssecretversion.Spec
+		wantSpec2  *awssecretversion.Spec
 		wantErrMsg string
 	}{
 		// 1 arg with label
 		{
 			name: "one arg with label",
 			args: []string{"my-secret:AWSPREVIOUS"},
-			wantSpec1: &secretversion.Spec{
+			wantSpec1: &awssecretversion.Spec{
 				Name:     "my-secret",
-				Absolute: secretversion.AbsoluteSpec{Label: lo.ToPtr("AWSPREVIOUS")},
+				Absolute: awssecretversion.AbsoluteSpec{Label: lo.ToPtr("AWSPREVIOUS")},
 			},
-			wantSpec2: &secretversion.Spec{
+			wantSpec2: &awssecretversion.Spec{
 				Name: "my-secret",
 			},
 		},
@@ -310,13 +310,13 @@ func TestParseArgs_Secret(t *testing.T) {
 		{
 			name: "two args mixed with labels",
 			args: []string{"my-secret:AWSPREVIOUS", ":AWSCURRENT"},
-			wantSpec1: &secretversion.Spec{
+			wantSpec1: &awssecretversion.Spec{
 				Name:     "my-secret",
-				Absolute: secretversion.AbsoluteSpec{Label: lo.ToPtr("AWSPREVIOUS")},
+				Absolute: awssecretversion.AbsoluteSpec{Label: lo.ToPtr("AWSPREVIOUS")},
 			},
-			wantSpec2: &secretversion.Spec{
+			wantSpec2: &awssecretversion.Spec{
 				Name:     "my-secret",
-				Absolute: secretversion.AbsoluteSpec{Label: lo.ToPtr("AWSCURRENT")},
+				Absolute: awssecretversion.AbsoluteSpec{Label: lo.ToPtr("AWSCURRENT")},
 			},
 		},
 
@@ -324,13 +324,13 @@ func TestParseArgs_Secret(t *testing.T) {
 		{
 			name: "two args with version ID",
 			args: []string{"my-secret#abc123", "#def456"},
-			wantSpec1: &secretversion.Spec{
+			wantSpec1: &awssecretversion.Spec{
 				Name:     "my-secret",
-				Absolute: secretversion.AbsoluteSpec{ID: lo.ToPtr("abc123")},
+				Absolute: awssecretversion.AbsoluteSpec{ID: lo.ToPtr("abc123")},
 			},
-			wantSpec2: &secretversion.Spec{
+			wantSpec2: &awssecretversion.Spec{
 				Name:     "my-secret",
-				Absolute: secretversion.AbsoluteSpec{ID: lo.ToPtr("def456")},
+				Absolute: awssecretversion.AbsoluteSpec{ID: lo.ToPtr("def456")},
 			},
 		},
 
@@ -338,13 +338,13 @@ func TestParseArgs_Secret(t *testing.T) {
 		{
 			name: "three args with labels",
 			args: []string{"my-secret", ":AWSPREVIOUS", ":AWSCURRENT"},
-			wantSpec1: &secretversion.Spec{
+			wantSpec1: &awssecretversion.Spec{
 				Name:     "my-secret",
-				Absolute: secretversion.AbsoluteSpec{Label: lo.ToPtr("AWSPREVIOUS")},
+				Absolute: awssecretversion.AbsoluteSpec{Label: lo.ToPtr("AWSPREVIOUS")},
 			},
-			wantSpec2: &secretversion.Spec{
+			wantSpec2: &awssecretversion.Spec{
 				Name:     "my-secret",
-				Absolute: secretversion.AbsoluteSpec{Label: lo.ToPtr("AWSCURRENT")},
+				Absolute: awssecretversion.AbsoluteSpec{Label: lo.ToPtr("AWSCURRENT")},
 			},
 		},
 	}

--- a/internal/gui/specparse.go
+++ b/internal/gui/specparse.go
@@ -11,14 +11,14 @@ import (
 	"github.com/mpyw/suve/internal/version/azureappconfigversion"
 	"github.com/mpyw/suve/internal/version/azurekvversion"
 	"github.com/mpyw/suve/internal/version/gcloudversion"
-	"github.com/mpyw/suve/internal/version/paramversion"
-	"github.com/mpyw/suve/internal/version/secretversion"
+	"github.com/mpyw/suve/internal/version/awsparamversion"
+	"github.com/mpyw/suve/internal/version/awssecretversion"
 )
 
 // Per-provider version-spec parsing.
 //
-// The param/secret usecases the GUI drives are typed to *paramversion.Spec /
-// *secretversion.Spec, but the grammar that is legal depends on the active
+// The param/secret usecases the GUI drives are typed to *awsparamversion.Spec /
+// *awssecretversion.Spec, but the grammar that is legal depends on the active
 // provider. Parsing every input with the AWS grammar mis-handles other
 // providers — most visibly it splits an Azure App Configuration key that
 // legally contains '#' or '~' into a bogus name+version. These helpers select
@@ -29,17 +29,17 @@ import (
 // usecase reconstructs a suffix string from the returned spec and hands
 // name+suffix to provider.Reader.Resolve, which re-parses it with the
 // provider's OWN grammar (see each adapter's Resolve). So carrying the parsed
-// name and an equivalent absolute/shift in a paramversion/secretversion spec is
+// name and an equivalent absolute/shift in a awsparamversion/awssecretversion spec is
 // sufficient — the suffix bytes are grammar-agnostic (#id / :label / ~N).
 
 // parseParamSpec parses a parameter version spec with the grammar of the active
-// provider and adapts it to the *paramversion.Spec the param usecase expects.
+// provider and adapts it to the *awsparamversion.Spec the param usecase expects.
 //
-//   - AWS   -> paramversion (name#N~shift).
+//   - AWS   -> awsparamversion (name#N~shift).
 //   - Azure -> App Configuration is unversioned; azureappconfigversion accepts a
 //     bare name only and rejects any specifier, so a key containing '#'/'~' gets
 //     a clean error instead of a mis-split.
-func (a *App) parseParamSpec(specStr string) (*paramversion.Spec, error) {
+func (a *App) parseParamSpec(specStr string) (*awsparamversion.Spec, error) {
 	switch a.currentScope().Provider {
 	case provider.ProviderAzure:
 		spec, err := azureappconfigversion.Parse(specStr)
@@ -48,20 +48,20 @@ func (a *App) parseParamSpec(specStr string) (*paramversion.Spec, error) {
 		}
 
 		// App Configuration has no absolute/shift specifier, so the equivalent
-		// paramversion spec is a bare name (empty suffix).
-		return &paramversion.Spec{Name: spec.Name}, nil
+		// awsparamversion spec is a bare name (empty suffix).
+		return &awsparamversion.Spec{Name: spec.Name}, nil
 	default:
-		return paramversion.Parse(specStr)
+		return awsparamversion.Parse(specStr)
 	}
 }
 
 // parseSecretSpec parses a secret version spec with the grammar of the active
-// provider and adapts it to the *secretversion.Spec the secret usecase expects.
+// provider and adapts it to the *awssecretversion.Spec the secret usecase expects.
 //
-//   - AWS          -> secretversion (name#id | :label, plus ~shift).
+//   - AWS          -> awssecretversion (name#id | :label, plus ~shift).
 //   - Google Cloud -> gcloudversion (integer #N, ~shift; ':' labels rejected).
 //   - Azure        -> azurekvversion (opaque #id, ~shift; ':' labels rejected).
-func (a *App) parseSecretSpec(specStr string) (*secretversion.Spec, error) {
+func (a *App) parseSecretSpec(specStr string) (*awssecretversion.Spec, error) {
 	switch a.currentScope().Provider {
 	case provider.ProviderGoogleCloud:
 		spec, err := gcloudversion.Parse(specStr)
@@ -69,7 +69,7 @@ func (a *App) parseSecretSpec(specStr string) (*secretversion.Spec, error) {
 			return nil, err
 		}
 
-		out := &secretversion.Spec{Name: spec.Name, Shift: spec.Shift}
+		out := &awssecretversion.Spec{Name: spec.Name, Shift: spec.Shift}
 		if spec.Absolute.Version != nil {
 			out.Absolute.ID = lo.ToPtr(strconv.FormatInt(*spec.Absolute.Version, 10))
 		}
@@ -81,12 +81,12 @@ func (a *App) parseSecretSpec(specStr string) (*secretversion.Spec, error) {
 			return nil, err
 		}
 
-		return &secretversion.Spec{
+		return &awssecretversion.Spec{
 			Name:     spec.Name,
-			Absolute: secretversion.AbsoluteSpec{ID: spec.Absolute.ID},
+			Absolute: awssecretversion.AbsoluteSpec{ID: spec.Absolute.ID},
 			Shift:    spec.Shift,
 		}, nil
 	default:
-		return secretversion.Parse(specStr)
+		return awssecretversion.Parse(specStr)
 	}
 }

--- a/internal/gui/specparse.go
+++ b/internal/gui/specparse.go
@@ -8,11 +8,11 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/version/awsparamversion"
+	"github.com/mpyw/suve/internal/version/awssecretversion"
 	"github.com/mpyw/suve/internal/version/azureappconfigversion"
 	"github.com/mpyw/suve/internal/version/azurekvversion"
 	"github.com/mpyw/suve/internal/version/gcloudversion"
-	"github.com/mpyw/suve/internal/version/awsparamversion"
-	"github.com/mpyw/suve/internal/version/awssecretversion"
 )
 
 // Per-provider version-spec parsing.

--- a/internal/gui/specparse_internal_test.go
+++ b/internal/gui/specparse_internal_test.go
@@ -108,7 +108,7 @@ func TestApp_parseSecretSpec(t *testing.T) {
 			input: "sec:AWSCURRENT", wantName: "sec", wantLabel: ptrStr("AWSCURRENT"),
 		},
 		{
-			// Google Cloud integer version adapts to a secretversion ID whose
+			// Google Cloud integer version adapts to a awssecretversion ID whose
 			// suffix ("#3") the Secret Manager adapter re-parses as integer 3.
 			name: "google cloud integer version", provider: provider.ProviderGoogleCloud,
 			input: "sec#3", wantName: "sec", wantID: ptrStr("3"),

--- a/internal/provider/aws/param/param.go
+++ b/internal/provider/aws/param/param.go
@@ -1,7 +1,7 @@
 // Package param implements the provider.Store contract for AWS Systems Manager
 // Parameter Store. It confines all SSM SDK types to this package: version
 // resolution (absolute #version and ~shift against history) lives here, while
-// spec PARSING stays generic via paramversion.Parse.
+// spec PARSING stays generic via awsparamversion.Parse.
 package param
 
 import (
@@ -19,7 +19,7 @@ import (
 	"github.com/mpyw/suve/internal/debug"
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
-	"github.com/mpyw/suve/internal/version/paramversion"
+	"github.com/mpyw/suve/internal/version/awsparamversion"
 )
 
 // Client is the narrow SSM Parameter Store surface this adapter needs. The
@@ -60,7 +60,7 @@ func New(client Client) *Store {
 // an opaque VersionRef holding the concrete version number. An empty/latest
 // spec resolves to the latest ref (empty id).
 func (s *Store) Resolve(ctx context.Context, name, spec string) (provider.VersionRef, error) {
-	parsed, err := paramversion.Parse(name + spec)
+	parsed, err := awsparamversion.Parse(name + spec)
 	if err != nil {
 		return provider.VersionRef{}, err
 	}

--- a/internal/provider/aws/secret/secret.go
+++ b/internal/provider/aws/secret/secret.go
@@ -2,7 +2,7 @@
 // provider.Describer contracts for AWS Secrets Manager. It confines all
 // Secrets Manager SDK types to this package: version/label/shift resolution
 // lives here, so AWS staging labels (AWSCURRENT etc.) never leak past this
-// boundary. Spec PARSING stays generic via secretversion.Parse.
+// boundary. Spec PARSING stays generic via awssecretversion.Parse.
 package secret
 
 import (
@@ -20,7 +20,7 @@ import (
 	"github.com/mpyw/suve/internal/debug"
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
-	"github.com/mpyw/suve/internal/version/secretversion"
+	"github.com/mpyw/suve/internal/version/awssecretversion"
 )
 
 // Client is the narrow Secrets Manager surface this adapter needs. The concrete
@@ -86,7 +86,7 @@ func New(client Client) *Store {
 // so no AWS label escapes this package. An empty/latest spec resolves to the
 // latest ref (empty id).
 func (s *Store) Resolve(ctx context.Context, name, spec string) (provider.VersionRef, error) {
-	parsed, err := secretversion.Parse(name + spec)
+	parsed, err := awssecretversion.Parse(name + spec)
 	if err != nil {
 		return provider.VersionRef{}, err
 	}
@@ -177,7 +177,7 @@ func (s *Store) listAllVersions(ctx context.Context, name string) ([]types.Secre
 // the newest-created version, so anchoring at index 0 would make `~1` skip past
 // AWSCURRENT (and leave AWSPREVIOUS unreachable). Anchor at AWSCURRENT instead,
 // falling back to index 0 only if no version carries that label.
-func baseIndex(list []types.SecretVersionsListEntry, abs secretversion.AbsoluteSpec) (int, error) {
+func baseIndex(list []types.SecretVersionsListEntry, abs awssecretversion.AbsoluteSpec) (int, error) {
 	switch {
 	case abs.ID != nil:
 		_, idx, found := lo.FindIndexOf(list, func(v types.SecretVersionsListEntry) bool {

--- a/internal/staging/aws_param.go
+++ b/internal/staging/aws_param.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
-	"github.com/mpyw/suve/internal/version/paramversion"
+	"github.com/mpyw/suve/internal/version/awsparamversion"
 )
 
 // AWSParamStrategy implements ServiceStrategy for SSM Parameter Store. It is backed
@@ -189,7 +189,7 @@ func (s *AWSParamStrategy) FetchCurrentTags(ctx context.Context, name string) (m
 
 // ParseName parses and validates a name for editing.
 func (s *AWSParamStrategy) ParseName(input string) (string, error) {
-	spec, err := paramversion.Parse(input)
+	spec, err := awsparamversion.Parse(input)
 	if err != nil {
 		return "", err
 	}
@@ -226,7 +226,7 @@ func (s *AWSParamStrategy) FetchCurrentValue(ctx context.Context, name string) (
 
 // ParseSpec parses a version spec string for reset.
 func (s *AWSParamStrategy) ParseSpec(input string) (name string, hasVersion bool, err error) {
-	spec, err := paramversion.Parse(input)
+	spec, err := awsparamversion.Parse(input)
 	if err != nil {
 		return "", false, err
 	}
@@ -238,7 +238,7 @@ func (s *AWSParamStrategy) ParseSpec(input string) (name string, hasVersion bool
 
 // FetchVersion fetches the value for a specific version.
 func (s *AWSParamStrategy) FetchVersion(ctx context.Context, input string) (value string, versionLabel string, err error) {
-	spec, err := paramversion.Parse(input)
+	spec, err := awsparamversion.Parse(input)
 	if err != nil {
 		return "", "", err
 	}
@@ -258,7 +258,7 @@ func (s *AWSParamStrategy) FetchVersion(ctx context.Context, input string) (valu
 
 // paramSpecSuffix reconstructs the version-spec suffix (the part after the name)
 // so that name+suffix re-parses to an equivalent spec, as provider.Reader.Resolve expects.
-func paramSpecSuffix(spec *paramversion.Spec) string {
+func paramSpecSuffix(spec *awsparamversion.Spec) string {
 	var b strings.Builder
 
 	if spec.Absolute.Version != nil {

--- a/internal/staging/aws_secret.go
+++ b/internal/staging/aws_secret.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
 	awssecret "github.com/mpyw/suve/internal/provider/aws/secret"
-	"github.com/mpyw/suve/internal/version/secretversion"
+	"github.com/mpyw/suve/internal/version/awssecretversion"
 )
 
 // AWSSecretStrategy implements ServiceStrategy for Secrets Manager. It is backed by
@@ -172,7 +172,7 @@ func (s *AWSSecretStrategy) FetchCurrent(ctx context.Context, name string) (*Fet
 
 	return &FetchResult{
 		Value:      entry.Value,
-		Identifier: "#" + secretversion.TruncateVersionID(entry.Version.ID),
+		Identifier: "#" + awssecretversion.TruncateVersionID(entry.Version.ID),
 	}, nil
 }
 
@@ -202,7 +202,7 @@ func (s *AWSSecretStrategy) FetchCurrentTags(ctx context.Context, name string) (
 
 // ParseName parses and validates a name for editing.
 func (s *AWSSecretStrategy) ParseName(input string) (string, error) {
-	spec, err := secretversion.Parse(input)
+	spec, err := awssecretversion.Parse(input)
 	if err != nil {
 		return "", err
 	}
@@ -239,7 +239,7 @@ func (s *AWSSecretStrategy) FetchCurrentValue(ctx context.Context, name string) 
 
 // ParseSpec parses a version spec string for reset.
 func (s *AWSSecretStrategy) ParseSpec(input string) (name string, hasVersion bool, err error) {
-	spec, err := secretversion.Parse(input)
+	spec, err := awssecretversion.Parse(input)
 	if err != nil {
 		return "", false, err
 	}
@@ -251,7 +251,7 @@ func (s *AWSSecretStrategy) ParseSpec(input string) (name string, hasVersion boo
 
 // FetchVersion fetches the value for a specific version.
 func (s *AWSSecretStrategy) FetchVersion(ctx context.Context, input string) (value string, versionLabel string, err error) {
-	spec, err := secretversion.Parse(input)
+	spec, err := awssecretversion.Parse(input)
 	if err != nil {
 		return "", "", err
 	}
@@ -266,12 +266,12 @@ func (s *AWSSecretStrategy) FetchVersion(ctx context.Context, input string) (val
 		return "", "", err
 	}
 
-	return entry.Value, "#" + secretversion.TruncateVersionID(entry.Version.ID), nil
+	return entry.Value, "#" + awssecretversion.TruncateVersionID(entry.Version.ID), nil
 }
 
 // secretSpecSuffix reconstructs the version-spec suffix (the part after the name)
 // so that name+suffix re-parses to an equivalent spec, as provider.Reader.Resolve expects.
-func secretSpecSuffix(spec *secretversion.Spec) string {
+func secretSpecSuffix(spec *awssecretversion.Spec) string {
 	var b strings.Builder
 
 	switch {

--- a/internal/usecase/param/diff.go
+++ b/internal/usecase/param/diff.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
-	"github.com/mpyw/suve/internal/version/paramversion"
+	"github.com/mpyw/suve/internal/version/awsparamversion"
 )
 
 // DiffInput holds input for the diff use case.
 type DiffInput struct {
-	Spec1 *paramversion.Spec
-	Spec2 *paramversion.Spec
+	Spec1 *awsparamversion.Spec
+	Spec2 *awsparamversion.Spec
 }
 
 // DiffOutput holds the result of the diff use case.
@@ -52,7 +52,7 @@ func (u *DiffUseCase) Execute(ctx context.Context, input DiffInput) (*DiffOutput
 }
 
 // resolveAndGet resolves a spec to a version ref and fetches the entry.
-func (u *DiffUseCase) resolveAndGet(ctx context.Context, spec *paramversion.Spec) (*domain.Entry, error) {
+func (u *DiffUseCase) resolveAndGet(ctx context.Context, spec *awsparamversion.Spec) (*domain.Entry, error) {
 	ref, err := u.Reader.Resolve(ctx, spec.Name, specSuffix(spec))
 	if err != nil {
 		return nil, err

--- a/internal/usecase/param/diff_test.go
+++ b/internal/usecase/param/diff_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/providermock"
 	"github.com/mpyw/suve/internal/usecase/param"
-	"github.com/mpyw/suve/internal/version/paramversion"
+	"github.com/mpyw/suve/internal/version/awsparamversion"
 )
 
 // resolveBySuffix returns a ResolveFunc mapping a version-spec suffix to a ref.
@@ -45,8 +45,8 @@ func TestDiffUseCase_Execute(t *testing.T) {
 
 	uc := &param.DiffUseCase{Reader: store}
 
-	spec1, _ := paramversion.Parse("/app/config#1")
-	spec2, _ := paramversion.Parse("/app/config#2")
+	spec1, _ := awsparamversion.Parse("/app/config#1")
+	spec2, _ := awsparamversion.Parse("/app/config#2")
 
 	output, err := uc.Execute(t.Context(), param.DiffInput{Spec1: spec1, Spec2: spec2})
 	require.NoError(t, err)
@@ -72,8 +72,8 @@ func TestDiffUseCase_Execute_Spec1Error(t *testing.T) {
 
 	uc := &param.DiffUseCase{Reader: store}
 
-	spec1, _ := paramversion.Parse("/app/config#1")
-	spec2, _ := paramversion.Parse("/app/config#2")
+	spec1, _ := awsparamversion.Parse("/app/config#1")
+	spec2, _ := awsparamversion.Parse("/app/config#2")
 
 	_, err := uc.Execute(t.Context(), param.DiffInput{Spec1: spec1, Spec2: spec2})
 	assert.Error(t, err)
@@ -95,8 +95,8 @@ func TestDiffUseCase_Execute_Spec2Error(t *testing.T) {
 
 	uc := &param.DiffUseCase{Reader: store}
 
-	spec1, _ := paramversion.Parse("/app/config#1")
-	spec2, _ := paramversion.Parse("/app/config#2")
+	spec1, _ := awsparamversion.Parse("/app/config#1")
+	spec2, _ := awsparamversion.Parse("/app/config#2")
 
 	_, err := uc.Execute(t.Context(), param.DiffInput{Spec1: spec1, Spec2: spec2})
 	assert.Error(t, err)
@@ -112,8 +112,8 @@ func TestDiffUseCase_Execute_WithLatest(t *testing.T) {
 
 	uc := &param.DiffUseCase{Reader: store}
 
-	spec1, _ := paramversion.Parse("/app/config#3")
-	spec2, _ := paramversion.Parse("/app/config")
+	spec1, _ := awsparamversion.Parse("/app/config#3")
+	spec2, _ := awsparamversion.Parse("/app/config")
 
 	output, err := uc.Execute(t.Context(), param.DiffInput{Spec1: spec1, Spec2: spec2})
 	require.NoError(t, err)
@@ -132,8 +132,8 @@ func TestDiffUseCase_Execute_WithShift(t *testing.T) {
 
 	uc := &param.DiffUseCase{Reader: store}
 
-	spec1, _ := paramversion.Parse("/app/config~2") // 2 versions back from latest (v3 -> v1)
-	spec2, _ := paramversion.Parse("/app/config~1") // 1 version back from latest (v3 -> v2)
+	spec1, _ := awsparamversion.Parse("/app/config~2") // 2 versions back from latest (v3 -> v1)
+	spec2, _ := awsparamversion.Parse("/app/config~1") // 1 version back from latest (v3 -> v2)
 
 	output, err := uc.Execute(t.Context(), param.DiffInput{Spec1: spec1, Spec2: spec2})
 	require.NoError(t, err)
@@ -154,8 +154,8 @@ func TestDiffUseCase_Execute_WithShift_Error(t *testing.T) {
 
 	uc := &param.DiffUseCase{Reader: store}
 
-	spec1, _ := paramversion.Parse("/app/config~1")
-	spec2, _ := paramversion.Parse("/app/config")
+	spec1, _ := awsparamversion.Parse("/app/config~1")
+	spec2, _ := awsparamversion.Parse("/app/config")
 
 	_, err := uc.Execute(t.Context(), param.DiffInput{Spec1: spec1, Spec2: spec2})
 	assert.Error(t, err)

--- a/internal/usecase/param/show.go
+++ b/internal/usecase/param/show.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
-	"github.com/mpyw/suve/internal/version/paramversion"
+	"github.com/mpyw/suve/internal/version/awsparamversion"
 )
 
 // ShowInput holds input for the show use case.
 type ShowInput struct {
-	Spec *paramversion.Spec
+	Spec *awsparamversion.Spec
 }
 
 // ShowTag represents a tag key-value pair.

--- a/internal/usecase/param/show_test.go
+++ b/internal/usecase/param/show_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/providermock"
 	"github.com/mpyw/suve/internal/usecase/param"
-	"github.com/mpyw/suve/internal/version/paramversion"
+	"github.com/mpyw/suve/internal/version/awsparamversion"
 )
 
 func TestShowUseCase_Execute(t *testing.T) {
@@ -39,7 +39,7 @@ func TestShowUseCase_Execute(t *testing.T) {
 
 	uc := &param.ShowUseCase{Reader: store}
 
-	spec, err := paramversion.Parse("/app/config")
+	spec, err := awsparamversion.Parse("/app/config")
 	require.NoError(t, err)
 
 	output, err := uc.Execute(t.Context(), param.ShowInput{Spec: spec})
@@ -72,7 +72,7 @@ func TestShowUseCase_Execute_WithVersion(t *testing.T) {
 
 	uc := &param.ShowUseCase{Reader: store}
 
-	spec, err := paramversion.Parse("/app/config#3")
+	spec, err := awsparamversion.Parse("/app/config#3")
 	require.NoError(t, err)
 
 	output, err := uc.Execute(t.Context(), param.ShowInput{Spec: spec})
@@ -103,7 +103,7 @@ func TestShowUseCase_Execute_WithShift(t *testing.T) {
 
 	uc := &param.ShowUseCase{Reader: store}
 
-	spec, err := paramversion.Parse("/app/config~1")
+	spec, err := awsparamversion.Parse("/app/config~1")
 	require.NoError(t, err)
 
 	output, err := uc.Execute(t.Context(), param.ShowInput{Spec: spec})
@@ -127,7 +127,7 @@ func TestShowUseCase_Execute_Error(t *testing.T) {
 
 	uc := &param.ShowUseCase{Reader: store}
 
-	spec, err := paramversion.Parse("/app/config")
+	spec, err := awsparamversion.Parse("/app/config")
 	require.NoError(t, err)
 
 	_, err = uc.Execute(t.Context(), param.ShowInput{Spec: spec})
@@ -145,7 +145,7 @@ func TestShowUseCase_Execute_ResolveError(t *testing.T) {
 
 	uc := &param.ShowUseCase{Reader: store}
 
-	spec, err := paramversion.Parse("/app/config")
+	spec, err := awsparamversion.Parse("/app/config")
 	require.NoError(t, err)
 
 	_, err = uc.Execute(t.Context(), param.ShowInput{Spec: spec})
@@ -171,7 +171,7 @@ func TestShowUseCase_Execute_NoLastModified(t *testing.T) {
 
 	uc := &param.ShowUseCase{Reader: store}
 
-	spec, err := paramversion.Parse("/app/config")
+	spec, err := awsparamversion.Parse("/app/config")
 	require.NoError(t, err)
 
 	output, err := uc.Execute(t.Context(), param.ShowInput{Spec: spec})
@@ -202,7 +202,7 @@ func TestShowUseCase_Execute_WithTags(t *testing.T) {
 
 	uc := &param.ShowUseCase{Reader: store}
 
-	spec, err := paramversion.Parse("/app/config")
+	spec, err := awsparamversion.Parse("/app/config")
 	require.NoError(t, err)
 
 	output, err := uc.Execute(t.Context(), param.ShowInput{Spec: spec})

--- a/internal/usecase/param/version.go
+++ b/internal/usecase/param/version.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mpyw/suve/internal/version/paramversion"
+	"github.com/mpyw/suve/internal/version/awsparamversion"
 )
 
 // specSuffix reconstructs the version-spec suffix (the part after the name)
@@ -16,7 +16,7 @@ import (
 //	{Shift:2}            -> "~2"
 //	{Version:5, Shift:2} -> "#5~2"
 //	{}                   -> ""  (latest)
-func specSuffix(spec *paramversion.Spec) string {
+func specSuffix(spec *awsparamversion.Spec) string {
 	var b strings.Builder
 
 	if spec.Absolute.Version != nil {

--- a/internal/usecase/secret/diff.go
+++ b/internal/usecase/secret/diff.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
-	"github.com/mpyw/suve/internal/version/secretversion"
+	"github.com/mpyw/suve/internal/version/awssecretversion"
 )
 
 // DiffInput holds input for the diff use case.
 type DiffInput struct {
-	Spec1 *secretversion.Spec
-	Spec2 *secretversion.Spec
+	Spec1 *awssecretversion.Spec
+	Spec2 *awssecretversion.Spec
 }
 
 // DiffOutput holds the result of the diff use case.
@@ -52,7 +52,7 @@ func (u *DiffUseCase) Execute(ctx context.Context, input DiffInput) (*DiffOutput
 }
 
 // resolveAndGet resolves a spec to a version ref and fetches the entry.
-func (u *DiffUseCase) resolveAndGet(ctx context.Context, spec *secretversion.Spec) (*domain.Entry, error) {
+func (u *DiffUseCase) resolveAndGet(ctx context.Context, spec *awssecretversion.Spec) (*domain.Entry, error) {
 	ref, err := u.Reader.Resolve(ctx, spec.Name, specSuffix(spec))
 	if err != nil {
 		return nil, err

--- a/internal/usecase/secret/show.go
+++ b/internal/usecase/secret/show.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
-	"github.com/mpyw/suve/internal/version/secretversion"
+	"github.com/mpyw/suve/internal/version/awssecretversion"
 )
 
 // ShowInput holds input for the show use case.
 type ShowInput struct {
-	Spec *secretversion.Spec
+	Spec *awssecretversion.Spec
 }
 
 // ShowTag represents a tag key-value pair.

--- a/internal/usecase/secret/show_test.go
+++ b/internal/usecase/secret/show_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/providermock"
 	"github.com/mpyw/suve/internal/usecase/secret"
-	"github.com/mpyw/suve/internal/version/secretversion"
+	"github.com/mpyw/suve/internal/version/awssecretversion"
 )
 
 // showStore builds a mock reader that resolves to the latest ref and returns the
@@ -28,10 +28,10 @@ func showStore(entry *domain.Entry) *providermock.Store {
 	}
 }
 
-func mustParseSpec(t *testing.T, s string) *secretversion.Spec {
+func mustParseSpec(t *testing.T, s string) *awssecretversion.Spec {
 	t.Helper()
 
-	spec, err := secretversion.Parse(s)
+	spec, err := awssecretversion.Parse(s)
 	require.NoError(t, err)
 
 	return spec

--- a/internal/usecase/secret/version.go
+++ b/internal/usecase/secret/version.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/mpyw/suve/internal/domain"
-	"github.com/mpyw/suve/internal/version/secretversion"
+	"github.com/mpyw/suve/internal/version/awssecretversion"
 )
 
 // specSuffix reconstructs the version-spec suffix (the part after the name)
@@ -19,7 +19,7 @@ import (
 //	{Shift:2}                    -> "~2"
 //	{Label:"AWSCURRENT", Shift:1}-> ":AWSCURRENT~1"
 //	{}                           -> ""  (current/latest)
-func specSuffix(spec *secretversion.Spec) string {
+func specSuffix(spec *awssecretversion.Spec) string {
 	var b strings.Builder
 
 	switch {

--- a/internal/version/awsparamversion/spec.go
+++ b/internal/version/awsparamversion/spec.go
@@ -1,6 +1,6 @@
-// Package paramversion provides version spec parsing for AWS Systems Manager
+// Package awsparamversion provides version spec parsing for AWS Systems Manager
 // Parameter Store (name#VERSION~SHIFT).
-package paramversion
+package awsparamversion
 
 import (
 	"errors"

--- a/internal/version/awsparamversion/spec_test.go
+++ b/internal/version/awsparamversion/spec_test.go
@@ -1,4 +1,4 @@
-package paramversion_test
+package awsparamversion_test
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/mpyw/suve/internal/version/paramversion"
+	"github.com/mpyw/suve/internal/version/awsparamversion"
 )
 
 //nolint:funlen // Table-driven test with many cases
@@ -272,7 +272,7 @@ func TestParse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			spec, err := paramversion.Parse(tt.input)
+			spec, err := awsparamversion.Parse(tt.input)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -293,22 +293,22 @@ func TestSpec_HasShift(t *testing.T) {
 
 	tests := []struct {
 		name string
-		spec *paramversion.Spec
+		spec *awsparamversion.Spec
 		want bool
 	}{
 		{
 			name: "no shift",
-			spec: &paramversion.Spec{Name: "/my/param", Shift: 0},
+			spec: &awsparamversion.Spec{Name: "/my/param", Shift: 0},
 			want: false,
 		},
 		{
 			name: "with shift 1",
-			spec: &paramversion.Spec{Name: "/my/param", Shift: 1},
+			spec: &awsparamversion.Spec{Name: "/my/param", Shift: 1},
 			want: true,
 		},
 		{
 			name: "with shift 5",
-			spec: &paramversion.Spec{Name: "/my/param", Shift: 5},
+			spec: &awsparamversion.Spec{Name: "/my/param", Shift: 5},
 			want: true,
 		},
 	}
@@ -327,43 +327,43 @@ func TestParseDiffArgs(t *testing.T) {
 	tests := []struct {
 		name       string
 		args       []string
-		wantSpec1  *paramversion.Spec
-		wantSpec2  *paramversion.Spec
+		wantSpec1  *awsparamversion.Spec
+		wantSpec2  *awsparamversion.Spec
 		wantErrMsg string
 	}{
 		{
 			name: "one arg with version",
 			args: []string{"/app/param#3"},
-			wantSpec1: &paramversion.Spec{
+			wantSpec1: &awsparamversion.Spec{
 				Name:     "/app/param",
-				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))},
+				Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(3))},
 			},
-			wantSpec2: &paramversion.Spec{
+			wantSpec2: &awsparamversion.Spec{
 				Name: "/app/param",
 			},
 		},
 		{
 			name: "two args",
 			args: []string{"/app/param#1", "#2"},
-			wantSpec1: &paramversion.Spec{
+			wantSpec1: &awsparamversion.Spec{
 				Name:     "/app/param",
-				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))},
+				Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))},
 			},
-			wantSpec2: &paramversion.Spec{
+			wantSpec2: &awsparamversion.Spec{
 				Name:     "/app/param",
-				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(2))},
+				Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(2))},
 			},
 		},
 		{
 			name: "three args",
 			args: []string{"/app/param", "#1", "#2"},
-			wantSpec1: &paramversion.Spec{
+			wantSpec1: &awsparamversion.Spec{
 				Name:     "/app/param",
-				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))},
+				Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(1))},
 			},
-			wantSpec2: &paramversion.Spec{
+			wantSpec2: &awsparamversion.Spec{
 				Name:     "/app/param",
-				Absolute: paramversion.AbsoluteSpec{Version: lo.ToPtr(int64(2))},
+				Absolute: awsparamversion.AbsoluteSpec{Version: lo.ToPtr(int64(2))},
 			},
 		},
 		{
@@ -382,7 +382,7 @@ func TestParseDiffArgs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			spec1, spec2, err := paramversion.ParseDiffArgs(tt.args)
+			spec1, spec2, err := awsparamversion.ParseDiffArgs(tt.args)
 
 			if tt.wantErrMsg != "" {
 				require.Error(t, err)

--- a/internal/version/awssecretversion/spec.go
+++ b/internal/version/awssecretversion/spec.go
@@ -1,4 +1,4 @@
-package secretversion
+package awssecretversion
 
 import (
 	"errors"

--- a/internal/version/awssecretversion/spec_test.go
+++ b/internal/version/awssecretversion/spec_test.go
@@ -1,4 +1,4 @@
-package secretversion_test
+package awssecretversion_test
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/mpyw/suve/internal/version/secretversion"
+	"github.com/mpyw/suve/internal/version/awssecretversion"
 )
 
 //nolint:funlen // Table-driven test with many cases
@@ -399,7 +399,7 @@ func TestParse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			spec, err := secretversion.Parse(tt.input)
+			spec, err := awssecretversion.Parse(tt.input)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -421,22 +421,22 @@ func TestSpec_HasShift(t *testing.T) {
 
 	tests := []struct {
 		name string
-		spec *secretversion.Spec
+		spec *awssecretversion.Spec
 		want bool
 	}{
 		{
 			name: "no shift",
-			spec: &secretversion.Spec{Name: "my-secret", Shift: 0},
+			spec: &awssecretversion.Spec{Name: "my-secret", Shift: 0},
 			want: false,
 		},
 		{
 			name: "with shift 1",
-			spec: &secretversion.Spec{Name: "my-secret", Shift: 1},
+			spec: &awssecretversion.Spec{Name: "my-secret", Shift: 1},
 			want: true,
 		},
 		{
 			name: "with shift 5",
-			spec: &secretversion.Spec{Name: "my-secret", Shift: 5},
+			spec: &awssecretversion.Spec{Name: "my-secret", Shift: 5},
 			want: true,
 		},
 	}
@@ -455,43 +455,43 @@ func TestParseDiffArgs(t *testing.T) {
 	tests := []struct {
 		name       string
 		args       []string
-		wantSpec1  *secretversion.Spec
-		wantSpec2  *secretversion.Spec
+		wantSpec1  *awssecretversion.Spec
+		wantSpec2  *awssecretversion.Spec
 		wantErrMsg string
 	}{
 		{
 			name: "one arg with label",
 			args: []string{"my-secret:AWSPREVIOUS"},
-			wantSpec1: &secretversion.Spec{
+			wantSpec1: &awssecretversion.Spec{
 				Name:     "my-secret",
-				Absolute: secretversion.AbsoluteSpec{Label: lo.ToPtr("AWSPREVIOUS")},
+				Absolute: awssecretversion.AbsoluteSpec{Label: lo.ToPtr("AWSPREVIOUS")},
 			},
-			wantSpec2: &secretversion.Spec{
+			wantSpec2: &awssecretversion.Spec{
 				Name: "my-secret",
 			},
 		},
 		{
 			name: "two args with version ID",
 			args: []string{"my-secret#abc123", "#def456"},
-			wantSpec1: &secretversion.Spec{
+			wantSpec1: &awssecretversion.Spec{
 				Name:     "my-secret",
-				Absolute: secretversion.AbsoluteSpec{ID: lo.ToPtr("abc123")},
+				Absolute: awssecretversion.AbsoluteSpec{ID: lo.ToPtr("abc123")},
 			},
-			wantSpec2: &secretversion.Spec{
+			wantSpec2: &awssecretversion.Spec{
 				Name:     "my-secret",
-				Absolute: secretversion.AbsoluteSpec{ID: lo.ToPtr("def456")},
+				Absolute: awssecretversion.AbsoluteSpec{ID: lo.ToPtr("def456")},
 			},
 		},
 		{
 			name: "three args with labels",
 			args: []string{"my-secret", ":AWSPREVIOUS", ":AWSCURRENT"},
-			wantSpec1: &secretversion.Spec{
+			wantSpec1: &awssecretversion.Spec{
 				Name:     "my-secret",
-				Absolute: secretversion.AbsoluteSpec{Label: lo.ToPtr("AWSPREVIOUS")},
+				Absolute: awssecretversion.AbsoluteSpec{Label: lo.ToPtr("AWSPREVIOUS")},
 			},
-			wantSpec2: &secretversion.Spec{
+			wantSpec2: &awssecretversion.Spec{
 				Name:     "my-secret",
-				Absolute: secretversion.AbsoluteSpec{Label: lo.ToPtr("AWSCURRENT")},
+				Absolute: awssecretversion.AbsoluteSpec{Label: lo.ToPtr("AWSCURRENT")},
 			},
 		},
 		{
@@ -510,7 +510,7 @@ func TestParseDiffArgs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			spec1, spec2, err := secretversion.ParseDiffArgs(tt.args)
+			spec1, spec2, err := awssecretversion.ParseDiffArgs(tt.args)
 
 			if tt.wantErrMsg != "" {
 				require.Error(t, err)

--- a/internal/version/awssecretversion/version.go
+++ b/internal/version/awssecretversion/version.go
@@ -1,6 +1,6 @@
-// Package secretversion provides version spec parsing and display helpers for
+// Package awssecretversion provides version spec parsing and display helpers for
 // AWS Secrets Manager.
-package secretversion
+package awssecretversion
 
 // TruncateVersionID truncates a version ID to 8 characters for display.
 // Secrets Manager version IDs are UUIDs which are long; this provides

--- a/internal/version/awssecretversion/version_test.go
+++ b/internal/version/awssecretversion/version_test.go
@@ -1,11 +1,11 @@
-package secretversion_test
+package awssecretversion_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/mpyw/suve/internal/version/secretversion"
+	"github.com/mpyw/suve/internal/version/awssecretversion"
 )
 
 func TestTruncateVersionID(t *testing.T) {
@@ -14,28 +14,28 @@ func TestTruncateVersionID(t *testing.T) {
 	t.Run("long ID - truncate to 8", func(t *testing.T) {
 		t.Parallel()
 
-		result := secretversion.TruncateVersionID("abcdefgh-1234-5678-9abc-def012345678")
+		result := awssecretversion.TruncateVersionID("abcdefgh-1234-5678-9abc-def012345678")
 		assert.Equal(t, "abcdefgh", result)
 	})
 
 	t.Run("exactly 8 chars", func(t *testing.T) {
 		t.Parallel()
 
-		result := secretversion.TruncateVersionID("12345678")
+		result := awssecretversion.TruncateVersionID("12345678")
 		assert.Equal(t, "12345678", result)
 	})
 
 	t.Run("short ID - no truncation", func(t *testing.T) {
 		t.Parallel()
 
-		result := secretversion.TruncateVersionID("abc")
+		result := awssecretversion.TruncateVersionID("abc")
 		assert.Equal(t, "abc", result)
 	})
 
 	t.Run("empty string", func(t *testing.T) {
 		t.Parallel()
 
-		result := secretversion.TruncateVersionID("")
+		result := awssecretversion.TruncateVersionID("")
 		assert.Empty(t, result)
 	})
 }


### PR DESCRIPTION
## Summary

Renames the AWS version-spec parser packages to the provider+service naming pattern already used by every other cloud (`gcloudversion`, `azurekvversion`, `azureappconfigversion`). This removes the historical "unmarked = AWS" naming privilege (Epic #620 ruling D2).

- `internal/version/paramversion` → `internal/version/awsparamversion`
- `internal/version/secretversion` → `internal/version/awssecretversion`

Mechanical rename only: directories, `package` clauses (including `_test` external-test clauses), and all import sites + qualified references across the repo. The provider-neutral shared helpers (`internal/version/parse.go`, `shift.go`, `internal/version/internal/`) are untouched. The `gcloudversion` doc comment references the "SSM Parameter Store grammar" conceptually (not the package/path), so it needs no change.

## Related

- Closes #626
- Part of #620 (Step 6 of 11)
- Stacked on #625 (#638) — base branch is `epic620/step05-staging-symbols`.

## Changes

- `git mv` of both package directories (rename-detected in the diff).
- Updated `package` clauses in `spec.go` / `version.go` and `_test.go` files.
- Updated all importer files (~29): `internal/cli/commands/aws/{param,secret}/*.go`, `internal/cli/diffargs/args{,_test}.go`, `internal/cli/commands/generic/{show,diff}/*_test.go`, `internal/usecase/{param,secret}/*.go`, `internal/staging/aws_{param,secret}.go`, `internal/provider/aws/{param,secret}/*.go`, `internal/gui/specparse{,_internal_test}.go`.

## Verification

Grep proof — zero bare old names remain (only new aws-prefixed names):

```
$ grep -rn 'paramversion\|secretversion' --include='*.go' . | grep -v 'awsparamversion\|awssecretversion'
(no output)
$ grep -rn 'awsaws' --include='*.go' .
(no output)
```

Gates:

- `mise test` — all packages pass (incl. `internal/version/awsparamversion`, `internal/version/awssecretversion`).
- `golangci-lint run --allow-parallel-runners ./...` — no issues in this worktree.
- `mise build-cli` — OK.
- `go build -tags e2e ./e2e/...` — OK.

`go test ./internal/version/... -v` summary:

```
ok  github.com/mpyw/suve/internal/version/awsparamversion
ok  github.com/mpyw/suve/internal/version/awssecretversion
ok  github.com/mpyw/suve/internal/version/azureappconfigversion
ok  github.com/mpyw/suve/internal/version/azurekvversion
ok  github.com/mpyw/suve/internal/version/gcloudversion
ok  github.com/mpyw/suve/internal/version/internal
ok  github.com/mpyw/suve/internal/version
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
