### PR TITLE
refactor: sweep hand-rolled transform loops to it.Map/lo.Map (follow-up to #643)

### DIFF
--- a/internal/maputil/maputil.go
+++ b/internal/maputil/maputil.go
@@ -19,9 +19,7 @@ func SortedKeys[M ~map[K]V, K cmp.Ordered, V any](m M) iter.Seq[K] {
 // SortedNames returns an iterator over the unique names extracted from items
 // via getName, in ascending order.
 func SortedNames[T any](items []T, getName func(T) string) iter.Seq[string] {
-	names := lo.Map(items, func(item T, _ int) string {
+	return SortedKeys(NewSet(lo.Map(items, func(item T, _ int) string {
 		return getName(item)
-	})
-
-	return SortedKeys(NewSet(names...))
+	})...))
 }

--- a/internal/provider/azure/appconfig/appconfig.go
+++ b/internal/provider/azure/appconfig/appconfig.go
@@ -36,11 +36,13 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
+	"slices"
 	"sort"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/data/azappconfig/v2"
 	"github.com/samber/lo"
+	"github.com/samber/lo/it"
 
 	"github.com/mpyw/suve/internal/debug"
 	"github.com/mpyw/suve/internal/domain"
@@ -413,12 +415,9 @@ func mapTags(tags map[string]*string) []domain.Tag {
 		return nil
 	}
 
-	out := make([]domain.Tag, 0, len(tags))
-	for k := range maputil.SortedKeys(tags) {
-		out = append(out, domain.Tag{Key: k, Value: lo.FromPtr(tags[k])})
-	}
-
-	return out
+	return slices.Collect(it.Map(maputil.SortedKeys(tags), func(k string) domain.Tag {
+		return domain.Tag{Key: k, Value: lo.FromPtr(tags[k])}
+	}))
 }
 
 // isNotFound reports whether err is an Azure 404 response error.

--- a/internal/provider/azure/keyvault/keyvault.go
+++ b/internal/provider/azure/keyvault/keyvault.go
@@ -24,12 +24,14 @@ import (
 	"fmt"
 	"maps"
 	"net/http"
+	"slices"
 	"sort"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets"
 	"github.com/samber/lo"
+	"github.com/samber/lo/it"
 
 	"github.com/mpyw/suve/internal/debug"
 	"github.com/mpyw/suve/internal/domain"
@@ -433,12 +435,9 @@ func mapTags(tags map[string]*string) []domain.Tag {
 		return nil
 	}
 
-	out := make([]domain.Tag, 0, len(tags))
-	for k := range maputil.SortedKeys(tags) {
-		out = append(out, domain.Tag{Key: k, Value: lo.FromPtr(tags[k])})
-	}
-
-	return out
+	return slices.Collect(it.Map(maputil.SortedKeys(tags), func(k string) domain.Tag {
+		return domain.Tag{Key: k, Value: lo.FromPtr(tags[k])}
+	}))
 }
 
 // isNotFound reports whether err is an Azure 404 response error.

--- a/internal/provider/gcloud/secret/secret.go
+++ b/internal/provider/gcloud/secret/secret.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -25,6 +26,7 @@ import (
 
 	secretmanagerpb "cloud.google.com/go/secretmanager/apiv1/secretmanagerpb"
 	"github.com/samber/lo"
+	"github.com/samber/lo/it"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
@@ -505,10 +507,7 @@ func mapLabels(labels map[string]string) []domain.Tag {
 		return nil
 	}
 
-	tags := make([]domain.Tag, 0, len(labels))
-	for k := range maputil.SortedKeys(labels) {
-		tags = append(tags, domain.Tag{Key: k, Value: labels[k]})
-	}
-
-	return tags
+	return slices.Collect(it.Map(maputil.SortedKeys(labels), func(k string) domain.Tag {
+		return domain.Tag{Key: k, Value: labels[k]}
+	}))
 }


### PR DESCRIPTION
## Summary

Follow-up to #643. That PR merged the `maputil` iterator groundwork (`SortedKeys`/`SortedNames` → `iter.Seq`, `Set` via `slices`/`maps`) but landed before the call-site polish was committed. This PR carries that polish and extends it into a small sweep of hand-rolled collection-building loops → declarative iterator/functional utilities.

## Changes (so far)

- **`slices.Collect(it.Map(maputil.SortedKeys(m), …))`** for the sorted tag builders that were still manual `make(+append)` range loops:
  - `internal/provider/gcloud/secret/secret.go` (`mapLabels`)
  - `internal/provider/azure/keyvault/keyvault.go` (`mapTags`)
  - `internal/provider/azure/appconfig/appconfig.go` (`mapTags`)
- **Inlined `maputil.SortedNames`** body (single expression).

`it` is `github.com/samber/lo/it` (range-over-func iterators); source is `maputil.SortedKeys(...)` which returns `iter.Seq`.

## In progress

A codebase-wide audit is cataloguing the remaining manual transform loops and classifying each as `lo.Map` (slice→slice), `slices.Collect(it.Map)` (iter→slice), `lo.FilterMap` (conditional), or leave-as-is (side-effecting / early-return / shared accumulator). Confirmed clean conversions (e.g. the App Configuration `KeyNamespace` builder over a `settings` slice → `lo.Map`) will be added as further commits before this PR is marked ready to merge. `lo.FromPtr`/`lo.ToPtr` are out of scope.

## Verification

- `go build ./internal/...` OK; `mise test` for the affected packages passes; `golangci-lint run --allow-parallel-runners` reports 0 issues on the touched packages.
- `codecov/project` may be red (best-effort / non-blocking per repo policy); all other required checks must be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
