### PR TITLE
refactor(gui): build DTO slices with lo.Map/lo.FilterMap

### DIFF
--- a/internal/gui/param.go
+++ b/internal/gui/param.go
@@ -141,15 +141,14 @@ func (a *App) ParamList(prefix string, recursive bool, withValue bool, filter st
 		return nil, err
 	}
 
-	entries := make([]ParamListEntry, len(result.Entries))
-	for i, e := range result.Entries {
-		entries[i] = ParamListEntry{
+	entries := lo.Map(result.Entries, func(e param.ListEntry, _ int) ParamListEntry {
+		return ParamListEntry{
 			Name:   e.Name,
 			Type:   paramtype.Display(e.Type),
 			Secret: e.Type == domain.ValueTypeSecret,
 			Value:  e.Value,
 		}
-	}
+	})
 
 	return &ParamListResult{Entries: entries}, nil
 }
@@ -177,15 +176,13 @@ func (a *App) paramListWithNamespaces(
 		return nil, err
 	}
 
-	entries := make([]ParamListEntry, 0, len(items))
-
-	for _, item := range items {
+	entries := lo.FilterMap(items, func(item appconfig.KeyNamespace, _ int) (ParamListEntry, bool) {
 		if !param.MatchPrefix(item.Key, prefix, recursive) {
-			continue
+			return ParamListEntry{}, false
 		}
 
 		if filterRegex != nil && !filterRegex.MatchString(item.Key) {
-			continue
+			return ParamListEntry{}, false
 		}
 
 		// App Configuration values are always plaintext (never a secret), so the
@@ -200,8 +197,8 @@ func (a *App) paramListWithNamespaces(
 			entry.Value = lo.ToPtr(item.Value)
 		}
 
-		entries = append(entries, entry)
-	}
+		return entry, true
+	})
 
 	return &ParamListResult{Entries: entries}, nil
 }
@@ -236,17 +233,12 @@ func (a *App) ParamShow(specStr, namespace string) (*ParamShowResult, error) {
 		Type:        paramtype.Display(result.Type),
 		Secret:      result.Type == domain.ValueTypeSecret,
 		Description: result.Description,
-		Tags:        make([]ParamShowTag, 0, len(result.Tags)),
+		Tags: lo.Map(result.Tags, func(tag param.ShowTag, _ int) ParamShowTag {
+			return ParamShowTag{Key: tag.Key, Value: tag.Value}
+		}),
 	}
 	if result.LastModified != nil {
 		r.LastModified = timeutil.FormatRFC3339(*result.LastModified)
-	}
-
-	for _, tag := range result.Tags {
-		r.Tags = append(r.Tags, ParamShowTag{
-			Key:   tag.Key,
-			Value: tag.Value,
-		})
 	}
 
 	return r, nil
@@ -271,8 +263,7 @@ func (a *App) ParamLog(name string, maxResults int32, namespace string) (*ParamL
 		return nil, err
 	}
 
-	entries := make([]ParamLogEntry, len(result.Entries))
-	for i, e := range result.Entries {
+	entries := lo.Map(result.Entries, func(e param.LogEntry, _ int) ParamLogEntry {
 		entry := ParamLogEntry{
 			Version:   e.Version,
 			Value:     e.Value,
@@ -284,8 +275,8 @@ func (a *App) ParamLog(name string, maxResults int32, namespace string) (*ParamL
 			entry.LastModified = timeutil.FormatRFC3339(*e.LastModified)
 		}
 
-		entries[i] = entry
-	}
+		return entry
+	})
 
 	return &ParamLogResult{Name: result.Name, Entries: entries}, nil
 }

--- a/internal/gui/providers.go
+++ b/internal/gui/providers.go
@@ -3,6 +3,8 @@
 package gui
 
 import (
+	"github.com/samber/lo"
+
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/detect"
 )
@@ -82,12 +84,7 @@ func uniqueActiveProvider(r detect.Result) provider.Provider {
 }
 
 func providerStrings(ps []provider.Provider) []string {
-	out := make([]string, 0, len(ps))
-	for _, p := range ps {
-		out = append(out, string(p))
-	}
-
-	return out
+	return lo.Map(ps, func(p provider.Provider, _ int) string { return string(p) })
 }
 
 // =============================================================================

--- a/internal/gui/secret.go
+++ b/internal/gui/secret.go
@@ -5,6 +5,9 @@ package gui
 import (
 	"time"
 
+	"github.com/samber/lo"
+
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/usecase/secret"
@@ -138,13 +141,12 @@ func (a *App) SecretList(prefix string, withValue bool, filter string, _ int, _ 
 		return nil, err
 	}
 
-	entries := make([]SecretListEntry, len(result.Entries))
-	for i, e := range result.Entries {
-		entries[i] = SecretListEntry{
+	entries := lo.Map(result.Entries, func(e secret.ListEntry, _ int) SecretListEntry {
+		return SecretListEntry{
 			Name:  e.Name,
 			Value: e.Value,
 		}
-	}
+	})
 
 	return &SecretListResult{Entries: entries, NextToken: result.NextToken}, nil
 }
@@ -176,17 +178,12 @@ func (a *App) SecretShow(specStr string) (*SecretShowResult, error) {
 		State:         result.State,
 		Value:         result.Value,
 		Description:   result.Description,
-		Tags:          make([]SecretShowTag, 0, len(result.Tags)),
+		Tags: lo.Map(result.Tags, func(tag secret.ShowTag, _ int) SecretShowTag {
+			return SecretShowTag{Key: tag.Key, Value: tag.Value}
+		}),
 	}
 	if result.CreatedDate != nil {
 		r.CreatedDate = timeutil.FormatRFC3339(*result.CreatedDate)
-	}
-
-	for _, tag := range result.Tags {
-		r.Tags = append(r.Tags, SecretShowTag{
-			Key:   tag.Key,
-			Value: tag.Value,
-		})
 	}
 
 	return r, nil
@@ -209,26 +206,23 @@ func (a *App) SecretLog(name string, maxResults int32) (*SecretLogResult, error)
 		return nil, err
 	}
 
-	entries := make([]SecretLogEntry, len(result.Entries))
-	for i, e := range result.Entries {
+	entries := lo.Map(result.Entries, func(e secret.LogEntry, _ int) SecretLogEntry {
 		entry := SecretLogEntry{
 			VersionID:     e.VersionID,
 			StagingLabels: e.VersionStage,
 			State:         e.State,
 			Value:         e.Value,
 			IsCurrent:     e.IsCurrent,
-			Tags:          make([]SecretShowTag, 0, len(e.Tags)),
+			Tags: lo.Map(e.Tags, func(tag domain.Tag, _ int) SecretShowTag {
+				return SecretShowTag{Key: tag.Key, Value: tag.Value}
+			}),
 		}
 		if e.CreatedDate != nil {
 			entry.Created = timeutil.FormatRFC3339(*e.CreatedDate)
 		}
 
-		for _, tag := range e.Tags {
-			entry.Tags = append(entry.Tags, SecretShowTag{Key: tag.Key, Value: tag.Value})
-		}
-
-		entries[i] = entry
-	}
+		return entry
+	})
 
 	return &SecretLogResult{Name: result.Name, Entries: entries}, nil
 }

--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -281,35 +281,29 @@ func statusTagEntries(o *stagingusecase.StatusOutput) []stagingusecase.StatusTag
 // toStagingEntries converts use-case status entries into the frontend DTO,
 // formatting timestamps as RFC3339.
 func toStagingEntries(entries []stagingusecase.StatusEntry) []StagingEntry {
-	out := make([]StagingEntry, len(entries))
-	for i, e := range entries {
-		out[i] = StagingEntry{
+	return lo.Map(entries, func(e stagingusecase.StatusEntry, _ int) StagingEntry {
+		return StagingEntry{
 			Name:      e.Name,
 			Namespace: e.Namespace,
 			Operation: string(e.Operation),
 			Value:     e.Value,
 			StagedAt:  timeutil.FormatRFC3339(e.StagedAt),
 		}
-	}
-
-	return out
+	})
 }
 
 // toStagingTagEntries converts use-case status tag entries into the frontend
 // DTO, formatting timestamps as RFC3339.
 func toStagingTagEntries(tags []stagingusecase.StatusTagEntry) []StagingTagEntry {
-	out := make([]StagingTagEntry, len(tags))
-	for i, t := range tags {
-		out[i] = StagingTagEntry{
+	return lo.Map(tags, func(t stagingusecase.StatusTagEntry, _ int) StagingTagEntry {
+		return StagingTagEntry{
 			Name:       t.Name,
 			Namespace:  t.Namespace,
 			AddTags:    t.Add,
 			RemoveTags: t.Remove.Values(),
 			StagedAt:   timeutil.FormatRFC3339(t.StagedAt),
 		}
-	}
-
-	return out
+	})
 }
 
 // StagingApply applies staged changes for a service.
@@ -374,7 +368,7 @@ func newStagingApplyResult(result *stagingusecase.ApplyOutput) *StagingApplyResu
 		TagFailed:      result.TagFailed,
 	}
 
-	for _, r := range result.EntryResults {
+	output.EntryResults = lo.Map(result.EntryResults, func(r stagingusecase.ApplyEntryResult, _ int) StagingApplyEntryResult {
 		entry := StagingApplyEntryResult{
 			Name:      r.Name,
 			Namespace: r.Namespace,
@@ -388,10 +382,10 @@ func newStagingApplyResult(result *stagingusecase.ApplyOutput) *StagingApplyResu
 			entry.UnstageError = r.UnstageError.Error()
 		}
 
-		output.EntryResults = append(output.EntryResults, entry)
-	}
+		return entry
+	})
 
-	for _, r := range result.TagResults {
+	output.TagResults = lo.Map(result.TagResults, func(r stagingusecase.ApplyTagResult, _ int) StagingApplyTagResult {
 		tagResult := StagingApplyTagResult{
 			Name:       r.Name,
 			Namespace:  r.Namespace,
@@ -406,8 +400,8 @@ func newStagingApplyResult(result *stagingusecase.ApplyOutput) *StagingApplyResu
 			tagResult.UnstageError = r.UnstageError.Error()
 		}
 
-		output.TagResults = append(output.TagResults, tagResult)
-	}
+		return tagResult
+	})
 
 	return output
 }
@@ -824,9 +818,8 @@ func (a *App) StagingDiff(service string, name string) (*StagingDiffResult, erro
 		return nil, err
 	}
 
-	entries := make([]StagingDiffEntry, len(result.Entries))
-	for i, e := range result.Entries {
-		entries[i] = StagingDiffEntry{
+	entries := lo.Map(result.Entries, func(e stagingusecase.DiffEntry, _ int) StagingDiffEntry {
+		return StagingDiffEntry{
 			Name:             e.Name,
 			Namespace:        e.Namespace,
 			Type:             diffEntryTypeNames[e.Type],
@@ -837,17 +830,16 @@ func (a *App) StagingDiff(service string, name string) (*StagingDiffResult, erro
 			Description:      e.Description,
 			Warning:          e.Warning,
 		}
-	}
+	})
 
-	tagEntries := make([]StagingDiffTagEntry, len(result.TagEntries))
-	for i, t := range result.TagEntries {
-		tagEntries[i] = StagingDiffTagEntry{
+	tagEntries := lo.Map(result.TagEntries, func(t stagingusecase.DiffTagEntry, _ int) StagingDiffTagEntry {
+		return StagingDiffTagEntry{
 			Name:       t.Name,
 			Namespace:  t.Namespace,
 			AddTags:    t.Add,
 			RemoveTags: t.Remove,
 		}
-	}
+	})
 
 	return &StagingDiffResult{
 		ItemName:   result.ItemName,


### PR DESCRIPTION
## Summary

Part of the declarative-transform sweep (follows #643/#644). Converts the hand-rolled DTO-building loops in the GUI Go layer to `lo.Map` / `lo.FilterMap`.

## Changes (11 sites)
- `providers.go` providerStrings → `lo.Map`
- `param.go`: ParamList, ParamLog, ParamShow.Tags (inlined) → `lo.Map`; paramListWithNamespaces (prefix+regex gates) → `lo.FilterMap`
- `secret.go`: SecretList, SecretShow.Tags, SecretLog (+ nested Tags) → `lo.Map`
- `staging.go`: toStagingEntries/toStagingTagEntries, StagingApply Entry/Tag results (conditional fields kept in closure), StagingDiff entries/tagEntries → `lo.Map`

## Notes
- `lo.FromPtr`/`lo.ToPtr` untouched (separate future scope).
- **Behavior nuance (reviewed safe):** `newStagingApplyResult` EntryResults/TagResults shift from append-from-nil (`null`) to `lo.Map` (`[]`) when empty. The Svelte frontend tolerates both (`?? []` / length guards) and no Go/Playwright test asserts the distinction.

## Verification
`go build`/`go test` (-tags dev) pass; `golangci-lint` 0 issues (production & dev tags); context-isolated review clean. `codecov/project` best-effort (non-blocking); other required checks must be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
