### PR TITLE
refactor(usecase): build list/log outputs with lo.Map/Filter/FilterMap

### DIFF
--- a/internal/usecase/azure/list.go
+++ b/internal/usecase/azure/list.go
@@ -86,16 +86,16 @@ func (u *ListUseCase) buildOutput(ctx context.Context, withValue bool, names []s
 	output := &ListOutput{}
 
 	if !withValue {
-		for _, name := range names {
-			output.Entries = append(output.Entries, ListEntry{Name: name})
-		}
+		output.Entries = lo.Map(names, func(name string, _ int) ListEntry {
+			return ListEntry{Name: name}
+		})
 
 		return output
 	}
 
 	values, errs := u.fetchValues(ctx, names)
 
-	for _, name := range names {
+	output.Entries = lo.Map(names, func(name string, _ int) ListEntry {
 		entry := ListEntry{Name: name}
 
 		if err, hasErr := errs[name]; hasErr {
@@ -104,8 +104,8 @@ func (u *ListUseCase) buildOutput(ctx context.Context, withValue bool, names []s
 			entry.Value = lo.ToPtr(val)
 		}
 
-		output.Entries = append(output.Entries, entry)
-	}
+		return entry
+	})
 
 	return output
 }

--- a/internal/usecase/azure/list_namespaces.go
+++ b/internal/usecase/azure/list_namespaces.go
@@ -71,13 +71,13 @@ func (u *ListNamespacesUseCase) Execute(ctx context.Context, input ListNamespace
 
 	out := &ListNamespacesOutput{}
 
-	for _, row := range rows {
+	out.Entries = lo.FilterMap(rows, func(row appconfig.KeyNamespace, _ int) (ListNamespacesEntry, bool) {
 		if input.Prefix != "" && !strings.HasPrefix(row.Key, input.Prefix) {
-			continue
+			return ListNamespacesEntry{}, false
 		}
 
 		if filterRegex != nil && !filterRegex.MatchString(row.Key) {
-			continue
+			return ListNamespacesEntry{}, false
 		}
 
 		entry := ListNamespacesEntry{Namespace: row.Namespace, Name: row.Key}
@@ -85,8 +85,8 @@ func (u *ListNamespacesUseCase) Execute(ctx context.Context, input ListNamespace
 			entry.Value = lo.ToPtr(row.Value)
 		}
 
-		out.Entries = append(out.Entries, entry)
-	}
+		return entry, true
+	})
 
 	debug.From(ctx).Logf("azure list (namespaces): provider returned %d rows, %d after filters (prefix=%q, filter=%q)\n",
 		len(rows), len(out.Entries), input.Prefix, input.Filter)

--- a/internal/usecase/azure/log.go
+++ b/internal/usecase/azure/log.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"time"
 
+	"github.com/samber/lo"
+
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
 )
@@ -70,27 +72,26 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 
 	// Apply date filters BEFORE the count limit: -n must return up to N versions
 	// that match --since/--until, not N newest-then-filtered to fewer (#351).
-	if input.Since != nil || input.Until != nil {
-		kept := versions[:0]
-
-		for _, v := range versions {
-			if v.Created == nil {
-				continue
-			}
-
-			if input.Since != nil && v.Created.Before(*input.Since) {
-				continue
-			}
-
-			if input.Until != nil && v.Created.After(*input.Until) {
-				continue
-			}
-
-			kept = append(kept, v)
+	versions = lo.Filter(versions, func(v domain.Version, _ int) bool {
+		if input.Since == nil && input.Until == nil {
+			return true
 		}
 
-		versions = kept
-	}
+		// Skip versions without a timestamp when date filters are applied.
+		if v.Created == nil {
+			return false
+		}
+
+		if input.Since != nil && v.Created.Before(*input.Since) {
+			return false
+		}
+
+		if input.Until != nil && v.Created.After(*input.Until) {
+			return false
+		}
+
+		return true
+	})
 
 	if input.MaxResults > 0 && len(versions) > int(input.MaxResults) {
 		versions = versions[:input.MaxResults]
@@ -100,20 +101,18 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 		slices.Reverse(versions)
 	}
 
-	entries := make([]LogEntry, 0, len(versions))
-
-	for _, v := range versions {
+	entries := lo.Map(versions, func(v domain.Version, _ int) LogEntry {
 		value, fetchErr := u.getValue(ctx, input.Name, v.ID)
 
-		entries = append(entries, LogEntry{
+		return LogEntry{
 			Version:     v.ID,
 			State:       v.State,
 			Value:       value,
 			CreatedDate: v.Created,
 			Tags:        v.Tags,
 			Error:       fetchErr,
-		})
-	}
+		}
+	})
 
 	return &LogOutput{
 		Name:    input.Name,

--- a/internal/usecase/gcloud/list.go
+++ b/internal/usecase/gcloud/list.go
@@ -86,16 +86,16 @@ func (u *ListUseCase) buildOutput(ctx context.Context, withValue bool, names []s
 	output := &ListOutput{}
 
 	if !withValue {
-		for _, name := range names {
-			output.Entries = append(output.Entries, ListEntry{Name: name})
-		}
+		output.Entries = lo.Map(names, func(name string, _ int) ListEntry {
+			return ListEntry{Name: name}
+		})
 
 		return output
 	}
 
 	values, errs := u.fetchValues(ctx, names)
 
-	for _, name := range names {
+	output.Entries = lo.Map(names, func(name string, _ int) ListEntry {
 		entry := ListEntry{Name: name}
 
 		if err, hasErr := errs[name]; hasErr {
@@ -104,8 +104,8 @@ func (u *ListUseCase) buildOutput(ctx context.Context, withValue bool, names []s
 			entry.Value = lo.ToPtr(val)
 		}
 
-		output.Entries = append(output.Entries, entry)
-	}
+		return entry
+	})
 
 	return output
 }

--- a/internal/usecase/gcloud/log.go
+++ b/internal/usecase/gcloud/log.go
@@ -6,6 +6,9 @@ import (
 	"slices"
 	"time"
 
+	"github.com/samber/lo"
+
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
 )
 
@@ -64,27 +67,26 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 
 	// Apply date filters BEFORE the count limit: -n must return up to N versions
 	// that match --since/--until, not N newest-then-filtered to fewer (#351).
-	if input.Since != nil || input.Until != nil {
-		kept := versions[:0]
-
-		for _, v := range versions {
-			if v.Created == nil {
-				continue
-			}
-
-			if input.Since != nil && v.Created.Before(*input.Since) {
-				continue
-			}
-
-			if input.Until != nil && v.Created.After(*input.Until) {
-				continue
-			}
-
-			kept = append(kept, v)
+	versions = lo.Filter(versions, func(v domain.Version, _ int) bool {
+		if input.Since == nil && input.Until == nil {
+			return true
 		}
 
-		versions = kept
-	}
+		// Skip versions without a timestamp when date filters are applied.
+		if v.Created == nil {
+			return false
+		}
+
+		if input.Since != nil && v.Created.Before(*input.Since) {
+			return false
+		}
+
+		if input.Until != nil && v.Created.After(*input.Until) {
+			return false
+		}
+
+		return true
+	})
 
 	if input.MaxResults > 0 && len(versions) > int(input.MaxResults) {
 		versions = versions[:input.MaxResults]
@@ -94,19 +96,17 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 		slices.Reverse(versions)
 	}
 
-	entries := make([]LogEntry, 0, len(versions))
-
-	for _, v := range versions {
+	entries := lo.Map(versions, func(v domain.Version, _ int) LogEntry {
 		value, fetchErr := u.getValue(ctx, input.Name, v.ID)
 
-		entries = append(entries, LogEntry{
+		return LogEntry{
 			Version:     v.ID,
 			State:       v.State,
 			Value:       value,
 			CreatedDate: v.Created,
 			Error:       fetchErr,
-		})
-	}
+		}
+	})
 
 	return &LogOutput{
 		Name:    input.Name,

--- a/internal/usecase/param/list.go
+++ b/internal/usecase/param/list.go
@@ -132,16 +132,16 @@ func (u *ListUseCase) buildOutput(ctx context.Context, withValue bool, names []s
 	output := &ListOutput{}
 
 	if !withValue {
-		for _, name := range names {
-			output.Entries = append(output.Entries, ListEntry{Name: name})
-		}
+		output.Entries = lo.Map(names, func(name string, _ int) ListEntry {
+			return ListEntry{Name: name}
+		})
 
 		return output
 	}
 
 	entries, errs := u.fetchEntries(ctx, names)
 
-	for _, name := range names {
+	output.Entries = lo.Map(names, func(name string, _ int) ListEntry {
 		entry := ListEntry{Name: name}
 
 		if err, hasErr := errs[name]; hasErr {
@@ -151,8 +151,8 @@ func (u *ListUseCase) buildOutput(ctx context.Context, withValue bool, names []s
 			entry.Type = e.Type
 		}
 
-		output.Entries = append(output.Entries, entry)
-	}
+		return entry
+	})
 
 	return output
 }

--- a/internal/usecase/param/log.go
+++ b/internal/usecase/param/log.go
@@ -101,9 +101,7 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 		filtered = filtered[:input.MaxResults]
 	}
 
-	entries := make([]LogEntry, 0, len(filtered))
-
-	for _, v := range filtered {
+	entries := lo.Map(filtered, func(v domain.Version, _ int) LogEntry {
 		entry, fetchErr := u.getVersion(ctx, input.Name, v)
 
 		logEntry := LogEntry{
@@ -119,8 +117,8 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 			logEntry.Value = entry.Value
 		}
 
-		entries = append(entries, logEntry)
-	}
+		return logEntry
+	})
 
 	// History yields newest first (default). Reverse to oldest first on request.
 	if input.Reverse {

--- a/internal/usecase/secret/list.go
+++ b/internal/usecase/secret/list.go
@@ -91,16 +91,16 @@ func (u *ListUseCase) buildOutput(ctx context.Context, withValue bool, names []s
 	output := &ListOutput{}
 
 	if !withValue {
-		for _, name := range names {
-			output.Entries = append(output.Entries, ListEntry{Name: name})
-		}
+		output.Entries = lo.Map(names, func(name string, _ int) ListEntry {
+			return ListEntry{Name: name}
+		})
 
 		return output
 	}
 
 	values, errs := u.fetchValues(ctx, names)
 
-	for _, name := range names {
+	output.Entries = lo.Map(names, func(name string, _ int) ListEntry {
 		entry := ListEntry{Name: name}
 
 		if err, hasErr := errs[name]; hasErr {
@@ -109,8 +109,8 @@ func (u *ListUseCase) buildOutput(ctx context.Context, withValue bool, names []s
 			entry.Value = lo.ToPtr(val)
 		}
 
-		output.Entries = append(output.Entries, entry)
-	}
+		return entry
+	})
 
 	return output
 }

--- a/internal/usecase/secret/log.go
+++ b/internal/usecase/secret/log.go
@@ -6,6 +6,8 @@ import (
 	"slices"
 	"time"
 
+	"github.com/samber/lo"
+
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
 )
@@ -83,27 +85,26 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 
 	// Apply date filters BEFORE the count limit: -n must return up to N versions
 	// that match --since/--until, not N newest-then-filtered to fewer (#351).
-	if input.Since != nil || input.Until != nil {
-		kept := versions[:0]
-
-		for _, v := range versions {
-			if v.Created == nil {
-				continue
-			}
-
-			if input.Since != nil && v.Created.Before(*input.Since) {
-				continue
-			}
-
-			if input.Until != nil && v.Created.After(*input.Until) {
-				continue
-			}
-
-			kept = append(kept, v)
+	versions = lo.Filter(versions, func(v domain.Version, _ int) bool {
+		if input.Since == nil && input.Until == nil {
+			return true
 		}
 
-		versions = kept
-	}
+		// Skip versions without a timestamp when date filters are applied.
+		if v.Created == nil {
+			return false
+		}
+
+		if input.Since != nil && v.Created.Before(*input.Since) {
+			return false
+		}
+
+		if input.Until != nil && v.Created.After(*input.Until) {
+			return false
+		}
+
+		return true
+	})
 
 	// History is newest first; MaxResults caps the number of versions shown.
 	if input.MaxResults > 0 && len(versions) > int(input.MaxResults) {
@@ -115,12 +116,10 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 		slices.Reverse(versions)
 	}
 
-	entries := make([]LogEntry, 0, len(versions))
-
-	for _, v := range versions {
+	entries := lo.Map(versions, func(v domain.Version, _ int) LogEntry {
 		value, fetchErr := u.getValue(ctx, input.Name, v.ID)
 
-		entries = append(entries, LogEntry{
+		return LogEntry{
 			VersionID:    v.ID,
 			VersionStage: stages(v.StagingLabels),
 			State:        v.State,
@@ -129,8 +128,8 @@ func (u *LogUseCase) Execute(ctx context.Context, input LogInput) (*LogOutput, e
 			IsCurrent:    v.ID == currentVersion,
 			Tags:         v.Tags,
 			Error:        fetchErr,
-		})
-	}
+		}
+	})
 
 	return &LogOutput{
 		Name:    input.Name,


### PR DESCRIPTION
## Summary

Part of the declarative-transform sweep (follows #643/#644). Converts the service-neutral usecase list/log builders to `lo.Map` / `lo.Filter` / `lo.FilterMap`.

## Changes
- **buildOutput** (param/secret/gcloud/azure `list.go`) — both name-only and with-value branches → `lo.Map`
- **LogEntry builders** (4× `log.go`) → `lo.Map` (per-element getValue/getVersion kept in closure; eager & ordered, identical to the loop)
- **`--since/--until` filter** (gcloud/azure/secret `log.go`) → `lo.Filter`, matching the existing `param/log.go` idiom exactly
- **azure/list_namespaces.go** → `lo.FilterMap`

## Notes
- `fetchValues`/`fetchEntries` two-map loops left as-is (SKIP). `lo.FromPtr`/`lo.ToPtr` untouched.
- Empty-input `lo.Map` yields `[]` vs the old nil; confirmed unobservable to all CLI/GUI/test consumers.

## Verification
`go build`/`go test ./internal/usecase/...` pass; `golangci-lint` 0 issues; context-isolated review clean. `codecov/project` best-effort (non-blocking); other required checks must be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
