### PR TITLE
refactor(cli): build list/log presenter slices with lo.Map

### DIFF
--- a/internal/cli/commands/aws/param/list.go
+++ b/internal/cli/commands/aws/param/list.go
@@ -3,6 +3,7 @@ package param
 import (
 	"context"
 
+	"github.com/samber/lo"
 	"github.com/urfave/cli/v3"
 
 	genericlist "github.com/mpyw/suve/internal/cli/commands/generic/list"
@@ -83,10 +84,9 @@ EXAMPLES:
 					return nil, err
 				}
 
-				entries := make([]genericlist.Entry, len(result.Entries))
-				for i, e := range result.Entries {
-					entries[i] = genericlist.Entry{Name: e.Name, Value: e.Value, Error: e.Error}
-				}
+				entries := lo.Map(result.Entries, func(e param.ListEntry, _ int) genericlist.Entry {
+					return genericlist.Entry{Name: e.Name, Value: e.Value, Error: e.Error}
+				})
 
 				return entries, nil
 			}, nil

--- a/internal/cli/commands/aws/secret/list.go
+++ b/internal/cli/commands/aws/secret/list.go
@@ -3,6 +3,7 @@ package secret
 import (
 	"context"
 
+	"github.com/samber/lo"
 	"github.com/urfave/cli/v3"
 
 	genericlist "github.com/mpyw/suve/internal/cli/commands/generic/list"
@@ -76,10 +77,9 @@ EXAMPLES:
 					return nil, err
 				}
 
-				entries := make([]genericlist.Entry, len(result.Entries))
-				for i, e := range result.Entries {
-					entries[i] = genericlist.Entry{Name: e.Name, Value: e.Value, Error: e.Error}
-				}
+				entries := lo.Map(result.Entries, func(e secret.ListEntry, _ int) genericlist.Entry {
+					return genericlist.Entry{Name: e.Name, Value: e.Value, Error: e.Error}
+				})
 
 				return entries, nil
 			}, nil

--- a/internal/cli/commands/aws/secret/log.go
+++ b/internal/cli/commands/aws/secret/log.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/samber/lo"
 	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/cli/colors"
@@ -70,10 +71,7 @@ func (p *logPresenter) Fetch(ctx context.Context) error {
 func (p *logPresenter) Len() int { return len(p.result.Entries) }
 
 func (p *logPresenter) RenderJSON(stdout io.Writer) error {
-	entries := p.result.Entries
-	items := make([]logJSONItem, 0, len(entries))
-
-	for _, entry := range entries {
+	items := lo.Map(p.result.Entries, func(entry secret.LogEntry, _ int) logJSONItem {
 		item := logJSONItem{
 			VersionID: entry.VersionID,
 		}
@@ -91,8 +89,8 @@ func (p *logPresenter) RenderJSON(stdout io.Writer) error {
 			item.Value = &entry.Value
 		}
 
-		items = append(items, item)
-	}
+		return item
+	})
 
 	return output.WriteJSON(stdout, items)
 }

--- a/internal/cli/commands/azure/param/list.go
+++ b/internal/cli/commands/azure/param/list.go
@@ -102,10 +102,9 @@ func (r *ListRunner) keyOnlyEntriesFromReader(opts ListOptions) func(context.Con
 			return nil, err
 		}
 
-		entries := make([]genericlist.Entry, len(result.Entries))
-		for i, e := range result.Entries {
-			entries[i] = genericlist.Entry{Name: e.Name, Value: e.Value, Error: e.Error}
-		}
+		entries := lo.Map(result.Entries, func(e azure.ListEntry, _ int) genericlist.Entry {
+			return genericlist.Entry{Name: e.Name, Value: e.Value, Error: e.Error}
+		})
 
 		return entries, nil
 	}
@@ -158,17 +157,14 @@ func collapseToKeyOnly(rows []azure.ListNamespacesEntry) []genericlist.Entry {
 
 	slices.Sort(names)
 
-	entries := make([]genericlist.Entry, 0, len(names))
-
-	for _, name := range names {
-		if c := byName[name]; c.ambiguous {
-			entries = append(entries, genericlist.Entry{Name: name, Error: errAmbiguousValue})
-		} else {
-			entries = append(entries, genericlist.Entry{Name: name, Value: lo.ToPtr(c.value)})
+	return lo.Map(names, func(name string, _ int) genericlist.Entry {
+		c := byName[name]
+		if c.ambiguous {
+			return genericlist.Entry{Name: name, Error: errAmbiguousValue}
 		}
-	}
 
-	return entries
+		return genericlist.Entry{Name: name, Value: lo.ToPtr(c.value)}
+	})
 }
 
 // errAmbiguousValue marks a key whose value differs across the namespaces a
@@ -187,10 +183,9 @@ func (r *ListRunner) runNamespaced(ctx context.Context, opts ListOptions) error 
 	}
 
 	if opts.Output == output.FormatJSON {
-		items := make([]namespaceJSONItem, len(result.Entries))
-		for i, e := range result.Entries {
-			items[i] = namespaceJSONItem{Namespace: e.Namespace, Name: e.Name, Value: e.Value}
-		}
+		items := lo.Map(result.Entries, func(e azure.ListNamespacesEntry, _ int) namespaceJSONItem {
+			return namespaceJSONItem{Namespace: e.Namespace, Name: e.Name, Value: e.Value}
+		})
 
 		return output.WriteJSON(r.Stdout, items)
 	}

--- a/internal/cli/commands/azure/secret/list.go
+++ b/internal/cli/commands/azure/secret/list.go
@@ -3,6 +3,7 @@ package secret
 import (
 	"context"
 
+	"github.com/samber/lo"
 	"github.com/urfave/cli/v3"
 
 	genericlist "github.com/mpyw/suve/internal/cli/commands/generic/list"
@@ -67,10 +68,9 @@ EXAMPLES:
 					return nil, err
 				}
 
-				entries := make([]genericlist.Entry, len(result.Entries))
-				for i, e := range result.Entries {
-					entries[i] = genericlist.Entry{Name: e.Name, Value: e.Value, Error: e.Error}
-				}
+				entries := lo.Map(result.Entries, func(e azure.ListEntry, _ int) genericlist.Entry {
+					return genericlist.Entry{Name: e.Name, Value: e.Value, Error: e.Error}
+				})
 
 				return entries, nil
 			}, nil

--- a/internal/cli/commands/azure/secret/log.go
+++ b/internal/cli/commands/azure/secret/log.go
@@ -6,12 +6,14 @@ import (
 	"io"
 	"strings"
 
+	"github.com/samber/lo"
 	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/cli/colors"
 	genericlog "github.com/mpyw/suve/internal/cli/commands/generic/log"
 	cliinternal "github.com/mpyw/suve/internal/cli/commands/internal"
 	"github.com/mpyw/suve/internal/cli/output"
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/jsonutil"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/timeutil"
@@ -68,10 +70,7 @@ func (p *logPresenter) Fetch(ctx context.Context) error {
 func (p *logPresenter) Len() int { return len(p.result.Entries) }
 
 func (p *logPresenter) RenderJSON(stdout io.Writer) error {
-	entries := p.result.Entries
-	items := make([]logJSONItem, 0, len(entries))
-
-	for _, entry := range entries {
+	items := lo.Map(p.result.Entries, func(entry azure.LogEntry, _ int) logJSONItem {
 		item := logJSONItem{Version: entry.Version, State: entry.State}
 
 		if entry.CreatedDate != nil {
@@ -91,8 +90,8 @@ func (p *logPresenter) RenderJSON(stdout io.Writer) error {
 			}
 		}
 
-		items = append(items, item)
-	}
+		return item
+	})
 
 	return output.WriteJSON(stdout, items)
 }
@@ -133,10 +132,9 @@ func (p *logPresenter) RenderHeader(stdout io.Writer, i int) {
 
 	// Key Vault tags are per version, so show this version's own tags.
 	if len(entry.Tags) > 0 {
-		pairs := make([]string, 0, len(entry.Tags))
-		for _, tag := range entry.Tags {
-			pairs = append(pairs, fmt.Sprintf("%s=%s", tag.Key, tag.Value))
-		}
+		pairs := lo.Map(entry.Tags, func(tag domain.Tag, _ int) string {
+			return fmt.Sprintf("%s=%s", tag.Key, tag.Value)
+		})
 
 		output.Printf(stdout, "%s %s\n", colors.For(stdout).FieldLabel("Tags:"), strings.Join(pairs, ", "))
 	}

--- a/internal/cli/commands/gcloud/list.go
+++ b/internal/cli/commands/gcloud/list.go
@@ -3,6 +3,7 @@ package gcloud
 import (
 	"context"
 
+	"github.com/samber/lo"
 	"github.com/urfave/cli/v3"
 
 	genericlist "github.com/mpyw/suve/internal/cli/commands/generic/list"
@@ -67,10 +68,9 @@ EXAMPLES:
 					return nil, err
 				}
 
-				entries := make([]genericlist.Entry, len(result.Entries))
-				for i, e := range result.Entries {
-					entries[i] = genericlist.Entry{Name: e.Name, Value: e.Value, Error: e.Error}
-				}
+				entries := lo.Map(result.Entries, func(e gcloud.ListEntry, _ int) genericlist.Entry {
+					return genericlist.Entry{Name: e.Name, Value: e.Value, Error: e.Error}
+				})
 
 				return entries, nil
 			}, nil

--- a/internal/cli/commands/gcloud/log.go
+++ b/internal/cli/commands/gcloud/log.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/samber/lo"
 	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/cli/colors"
@@ -66,10 +67,7 @@ func (p *logPresenter) Fetch(ctx context.Context) error {
 func (p *logPresenter) Len() int { return len(p.result.Entries) }
 
 func (p *logPresenter) RenderJSON(stdout io.Writer) error {
-	entries := p.result.Entries
-	items := make([]logJSONItem, 0, len(entries))
-
-	for _, entry := range entries {
+	items := lo.Map(p.result.Entries, func(entry gcloud.LogEntry, _ int) logJSONItem {
 		item := logJSONItem{Version: entry.Version, State: entry.State}
 
 		if entry.CreatedDate != nil {
@@ -82,8 +80,8 @@ func (p *logPresenter) RenderJSON(stdout io.Writer) error {
 			item.Value = &entry.Value
 		}
 
-		items = append(items, item)
-	}
+		return item
+	})
 
 	return output.WriteJSON(stdout, items)
 }

--- a/internal/cli/commands/generic/list/list.go
+++ b/internal/cli/commands/generic/list/list.go
@@ -77,24 +77,22 @@ func (r *Runner) Run(ctx context.Context) error {
 
 	// For JSON output without --show, output names only
 	if r.Options.Output == output.FormatJSON && !r.Options.Show {
-		items := make([]JSONOutputItem, len(entries))
-		for i, entry := range entries {
-			items[i] = JSONOutputItem{Name: entry.Name}
-		}
+		items := lo.Map(entries, func(entry Entry, _ int) JSONOutputItem {
+			return JSONOutputItem{Name: entry.Name}
+		})
 
 		return output.WriteJSON(r.Stdout, items)
 	}
 
 	// JSON output with values
 	if r.Options.Output == output.FormatJSON {
-		items := make([]JSONOutputItem, 0, len(entries))
-		for _, entry := range entries {
+		items := lo.Map(entries, func(entry Entry, _ int) JSONOutputItem {
 			if entry.Error != nil {
-				items = append(items, JSONOutputItem{Name: entry.Name, Error: entry.Error.Error()})
-			} else {
-				items = append(items, JSONOutputItem{Name: entry.Name, Value: entry.Value})
+				return JSONOutputItem{Name: entry.Name, Error: entry.Error.Error()}
 			}
-		}
+
+			return JSONOutputItem{Name: entry.Name, Value: entry.Value}
+		})
 
 		return output.WriteJSON(r.Stdout, items)
 	}


### PR DESCRIPTION
## Summary

Part of the declarative-transform sweep (follows #643/#644). Converts the CLI list/log **presenter** slice builders to `lo.Map`.

## Changes (12 sites)
- 5 byte-identical `genericlist.Entry` builders (gcloud/aws-param/aws-secret/azure-secret/azure-param list) → `lo.Map`
- azure/param `collapseToKeyOnly` second loop (ambiguous→error branch preserved) + `runNamespaced` JSON builder
- generic/list JSON builders (names-only + values/error branch)
- 3 log `RenderJSON` outer loops (gcloud/aws-secret/azure-secret) + azure-secret `RenderHeader` tag pairs

## Notes (SKIPs respected)
- azure/param `collapseToKeyOnly` **first** loop (dedup map w/ cross-iteration state) left as a loop.
- Nested tags-map build inside azure-secret RenderJSON left inside the closure. No io.Writer/text loops touched. `lo.FromPtr`/`lo.ToPtr` untouched.

## Verification
`go build`/`go test ./internal/cli/...` pass; `golangci-lint` 0 issues on the touched files; context-isolated review clean. `codecov/project` best-effort (non-blocking); other required checks must be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
