### PR TITLE
refactor(staging,cli): adopt lo.Map/it.Map for key/tag transforms

### DIFF
--- a/internal/cli/commands/aws/stage/diff/diff.go
+++ b/internal/cli/commands/aws/stage/diff/diff.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/samber/lo"
+	"github.com/samber/lo/it"
 	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/cli/colors"
@@ -441,10 +443,9 @@ func (r *Runner) outputTagDiff(ctx context.Context, svc ServiceStrategy, key sta
 	output.Printf(r.Stdout, "%s %s (staged tag changes)\n", colors.For(r.Stdout).Info("Tags:"), diffDisplayName(key))
 
 	if len(tagEntry.Add) > 0 {
-		tagPairs := make([]string, 0, len(tagEntry.Add))
-		for k := range maputil.SortedKeys(tagEntry.Add) {
-			tagPairs = append(tagPairs, fmt.Sprintf("%s=%s", k, tagEntry.Add[k]))
-		}
+		tagPairs := slices.Collect(it.Map(maputil.SortedKeys(tagEntry.Add), func(k string) string {
+			return fmt.Sprintf("%s=%s", k, tagEntry.Add[k])
+		}))
 
 		output.Printf(r.Stdout, "  %s %s\n", colors.For(r.Stdout).OpAdd("+"), strings.Join(tagPairs, ", "))
 	}
@@ -462,18 +463,15 @@ func (r *Runner) outputTagDiff(ctx context.Context, svc ServiceStrategy, key sta
 }
 
 func (r *Runner) outputRemovedTags(remove maputil.Set[string], currentTags map[string]string) {
-	tagPairs := make([]string, 0, remove.Len())
-	for k := range maputil.SortedKeys(remove) {
+	tagPairs := slices.Collect(it.Map(maputil.SortedKeys(remove), func(k string) string {
 		if currentTags != nil {
 			if v := currentTags[k]; v != "" {
-				tagPairs = append(tagPairs, fmt.Sprintf("%s=%s", k, v))
-			} else {
-				tagPairs = append(tagPairs, k)
+				return fmt.Sprintf("%s=%s", k, v)
 			}
-		} else {
-			tagPairs = append(tagPairs, k)
 		}
-	}
+
+		return k
+	}))
 
 	output.Printf(r.Stdout, "  %s %s\n", colors.For(r.Stdout).OpDelete("-"), strings.Join(tagPairs, ", "))
 }

--- a/internal/cli/diffargs/args.go
+++ b/internal/cli/diffargs/args.go
@@ -57,6 +57,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/samber/lo"
+
 	"github.com/mpyw/suve/internal/version"
 )
 
@@ -309,10 +311,9 @@ func requireSpecifier(label, arg, prefixes string) error {
 // formatPrefixes renders the specifier prefix characters as a human-readable
 // comma-separated list, e.g. "#~" → "#, ~".
 func formatPrefixes(prefixes string) string {
-	parts := make([]string, 0, len(prefixes))
-	for _, r := range prefixes {
-		parts = append(parts, string(r))
-	}
+	parts := lo.Map([]rune(prefixes), func(r rune, _ int) string {
+		return string(r)
+	})
 
 	return strings.Join(parts, ", ")
 }

--- a/internal/provider/azure/appconfig/appconfig.go
+++ b/internal/provider/azure/appconfig/appconfig.go
@@ -221,14 +221,13 @@ func (s *Store) listWithNamespaces(ctx context.Context, filter, what string) ([]
 		return nil, fmt.Errorf("failed to list settings %s: %w", what, err)
 	}
 
-	out := make([]KeyNamespace, 0, len(settings))
-	for _, setting := range settings {
-		out = append(out, KeyNamespace{
+	out := lo.Map(settings, func(setting azappconfig.Setting, _ int) KeyNamespace {
+		return KeyNamespace{
 			Key:       lo.FromPtr(setting.Key),
 			Namespace: lo.FromPtr(setting.Label),
 			Value:     lo.FromPtr(setting.Value),
-		})
-	}
+		}
+	})
 
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].Key != out[j].Key {

--- a/internal/staging/cli/diff.go
+++ b/internal/staging/cli/diff.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
+	"github.com/samber/lo/it"
 
 	"github.com/mpyw/suve/internal/cli/colors"
 	"github.com/mpyw/suve/internal/cli/output"
@@ -190,23 +191,21 @@ func (r *DiffRunner) OutputTagEntry(tagEntry stagingusecase.DiffTagEntry) {
 	output.Printf(r.Stdout, "%s %s (staged tag changes)\n", colors.For(r.Stdout).Info("Tags:"), tagEntry.Name)
 
 	if len(tagEntry.Add) > 0 {
-		tagPairs := make([]string, 0, len(tagEntry.Add))
-		for k := range maputil.SortedKeys(tagEntry.Add) {
-			tagPairs = append(tagPairs, fmt.Sprintf("%s=%s", k, tagEntry.Add[k]))
-		}
+		tagPairs := slices.Collect(it.Map(maputil.SortedKeys(tagEntry.Add), func(k string) string {
+			return fmt.Sprintf("%s=%s", k, tagEntry.Add[k])
+		}))
 
 		output.Printf(r.Stdout, "  %s %s\n", colors.For(r.Stdout).OpAdd("+"), strings.Join(tagPairs, ", "))
 	}
 
 	if len(tagEntry.Remove) > 0 {
-		tagPairs := make([]string, 0, len(tagEntry.Remove))
-		for k := range maputil.SortedKeys(tagEntry.Remove) {
+		tagPairs := slices.Collect(it.Map(maputil.SortedKeys(tagEntry.Remove), func(k string) string {
 			if v := tagEntry.Remove[k]; v != "" {
-				tagPairs = append(tagPairs, fmt.Sprintf("%s=%s", k, v))
-			} else {
-				tagPairs = append(tagPairs, k)
+				return fmt.Sprintf("%s=%s", k, v)
 			}
-		}
+
+			return k
+		}))
 
 		output.Printf(r.Stdout, "  %s %s\n", colors.For(r.Stdout).OpDelete("-"), strings.Join(tagPairs, ", "))
 	}

--- a/internal/staging/cli/export.go
+++ b/internal/staging/cli/export.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/samber/lo"
 	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/cli/confirm"
@@ -217,10 +218,9 @@ func exportAction(service staging.Service, resolver staging.ScopeResolver) func(
 			return filepath.Join(dest, string(svc)+".json")
 		}
 
-		targetPaths := make([]string, 0, len(services))
-		for _, svc := range services {
-			targetPaths = append(targetPaths, pathFor(svc))
-		}
+		targetPaths := lo.Map(services, func(svc staging.Service, _ int) string {
+			return pathFor(svc)
+		})
 
 		// Share one buffered stdin reader across the overwrite confirmation and the
 		// passphrase prompt so consecutive reads over piped stdin don't

--- a/internal/staging/scope.go
+++ b/internal/staging/scope.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/samber/lo"
+
 	"github.com/mpyw/suve/internal/provider"
 )
 
@@ -50,10 +52,9 @@ func KindToService(k provider.Kind) Service {
 func SupportedServices(scope provider.Scope) []Service {
 	kinds := scope.SupportedKinds()
 
-	services := make([]Service, 0, len(kinds))
-	for _, k := range kinds {
-		services = append(services, KindToService(k))
-	}
+	services := lo.Map(kinds, func(k provider.Kind, _ int) Service {
+		return KindToService(k)
+	})
 
 	return services
 }

--- a/internal/staging/stage.go
+++ b/internal/staging/stage.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/samber/lo"
+
 	"github.com/mpyw/suve/internal/maputil"
 )
 
@@ -167,10 +169,9 @@ func (s *State) MarshalJSON() ([]byte, error) {
 			out.Entries = make(map[Service][]entryRecord)
 		}
 
-		recs := make([]entryRecord, 0, len(m))
-		for _, k := range SortedEntryKeys(m) {
-			recs = append(recs, entryRecord{Name: k.Name, Namespace: k.Namespace, Entry: m[k]})
-		}
+		recs := lo.Map(SortedEntryKeys(m), func(k EntryKey, _ int) entryRecord {
+			return entryRecord{Name: k.Name, Namespace: k.Namespace, Entry: m[k]}
+		})
 
 		out.Entries[svc] = recs
 	}
@@ -184,10 +185,9 @@ func (s *State) MarshalJSON() ([]byte, error) {
 			out.Tags = make(map[Service][]tagRecord)
 		}
 
-		recs := make([]tagRecord, 0, len(m))
-		for _, k := range SortedEntryKeys(m) {
-			recs = append(recs, tagRecord{Name: k.Name, Namespace: k.Namespace, TagEntry: m[k]})
-		}
+		recs := lo.Map(SortedEntryKeys(m), func(k EntryKey, _ int) tagRecord {
+			return tagRecord{Name: k.Name, Namespace: k.Namespace, TagEntry: m[k]}
+		})
 
 		out.Tags[svc] = recs
 	}


### PR DESCRIPTION
## Summary

Part of the declarative-transform sweep (follows #643/#644). Adopts `lo.Map` (slice sources) and `slices.Collect(it.Map(...))` (iter.Seq sources = `maputil.SortedKeys`) across staging + a few CLI helpers.

## Changes (7 files)
- `lo.Map`: appconfig `KeyNamespace` builder (trailing `sort.Slice` preserved), staging `scope.go` KindToService, `stage.go` entry/tagRecord over SortedEntryKeys, `cli/export.go` targetPaths, `diffargs/args.go` (`[]rune` conversion)
- `slices.Collect(it.Map(...))`: `staging/cli/diff.go` tag Add/Remove, `aws/stage/diff/diff.go` tag Add/Remove (nested currentTags guard preserved)

## Notes (SKIPs respected)
- `SortedEntryKeys` itself (struct key → `slices.SortFunc`), paginated accumulators, `parseTags` (slice→map+err), `Untag` `delete(map,...)`, io.Writer loops — all left as-is. `it.Map` used only where the source is a genuine `iter.Seq`. `lo.FromPtr`/`lo.ToPtr` untouched.

## Verification
`go build ./...`/`go test` pass; `golangci-lint` 0 issues (isolated cache); context-isolated review clean. `codecov/project` best-effort (non-blocking); other required checks must be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
