### PR TITLE
Step 1: Lift provider capability matrix into internal/capability

### DIFF
--- a/.github/deadcode-allow.txt
+++ b/.github/deadcode-allow.txt
@@ -77,3 +77,11 @@ internal/timeutil/timeutil.go: unreachable func: ResetLocationCache
 # step, so they are waived here rather than deleted.
 internal/usecase/param/tag.go: unreachable func: TagUseCase.Execute
 internal/usecase/secret/tag.go: unreachable func: TagUseCase.Execute
+
+# capability.All: the provider×service capability matrix. In this first TUI-epic
+# step its only non-test caller is internal/gui (providers.go, production-gated),
+# so under the default build tags it looks dead — the same GUI-only situation as
+# the two entries above. TEMPORARY: Step 2 adds internal/tui (untagged), which
+# consumes capability.All() in the default build and makes this reachable; this
+# waiver must be removed then (and must be gone by Step 6 per the epic guardrail).
+internal/capability/capability.go: unreachable func: All

--- a/internal/capability/capability.go
+++ b/internal/capability/capability.go
@@ -1,0 +1,136 @@
+// Package capability holds the provider×service capability matrix — the static,
+// provider-neutral descriptor that drives conditional UI in every frontend. It
+// carries no build tag and no SDK or Wails dependency, so the GUI (build-tagged)
+// and the TUI (default build) consume one source of truth instead of duplicating
+// the matrix.
+package capability
+
+import (
+	"github.com/mpyw/suve/internal/provider"
+)
+
+// Service keys and display labels reused across the capability descriptors.
+const (
+	serviceParam      = "param"
+	serviceSecret     = "secret"
+	displayNameSecret = "Secret"
+)
+
+// ServiceCapability describes one provider service (param or secret) so a
+// frontend can render the right label and hide unsupported controls.
+type ServiceCapability struct {
+	// Service is the internal key ("param" or "secret").
+	Service string `json:"service"`
+	// DisplayName is the label shown in the UI (e.g. "Key Vault").
+	DisplayName string `json:"displayName"`
+	// HasVersionHistory is true when `log`/history is supported (false for the
+	// unversioned Azure App Configuration).
+	HasVersionHistory bool `json:"hasVersionHistory"`
+	// HasVersionSpecifiers is true when #VERSION/~SHIFT specifiers apply.
+	HasVersionSpecifiers bool `json:"hasVersionSpecifiers"`
+	// HasTags is true when tag/label read+write is supported (false for Azure
+	// App Configuration).
+	HasTags bool `json:"hasTags"`
+	// TagsPerVersion is true when tags are scoped to a specific version rather
+	// than the resource (Azure Key Vault only): each version has its own tags,
+	// so the GUI shows them per version in the history and writes target the
+	// latest version. Every other provider keeps tags at the resource level.
+	TagsPerVersion bool `json:"tagsPerVersion"`
+	// HasRestore is true when a soft-deleted item can be restored (AWS Secrets
+	// Manager only).
+	HasRestore bool `json:"hasRestore"`
+	// HasStaging is true when the GUI's staging workflow applies to this
+	// service (every provider service today); the frontend hides the staging
+	// tab/banner/checkbox when false.
+	HasStaging bool `json:"hasStaging"`
+	// HasNamespaces is true when the service partitions keys by a namespace (the
+	// Azure App Configuration label axis, #431). The frontend shows the namespace
+	// column/badge and the create-form namespace field only when true.
+	HasNamespaces bool `json:"hasNamespaces"`
+	// HasForceDelete is true when an immediate (no-recovery-window) delete is
+	// offered (AWS Secrets Manager only). The frontend hides the force-delete
+	// checkbox otherwise.
+	HasForceDelete bool `json:"hasForceDelete"`
+	// HasRecoveryWindow is true when a soft delete schedules a recovery window
+	// whose end date can be surfaced (AWS Secrets Manager only). Other providers
+	// delete immediately or govern retention by policy, so no "recoverable until"
+	// date is shown.
+	HasRecoveryWindow bool `json:"hasRecoveryWindow"`
+}
+
+// ProviderCapability describes a provider and the services it offers.
+type ProviderCapability struct {
+	// Provider is the internal key ("aws" | "googlecloud" | "azure").
+	Provider string `json:"provider"`
+	// DisplayName is the provider label (e.g. "Google Cloud").
+	DisplayName string `json:"displayName"`
+	// ScopeFields lists the provider-level scope inputs the frontend must collect
+	// (e.g. ["project"] for Google Cloud). Empty for AWS (ambient config) and for
+	// Azure, whose per-service vault/store names are collected by the service's
+	// own view.
+	ScopeFields []string `json:"scopeFields"`
+	// Services are the param/secret services this provider offers, in stable
+	// display order.
+	Services []ServiceCapability `json:"services"`
+}
+
+// All returns the static capability descriptor for every provider, driving
+// provider-selection and control-visibility in the frontends. Display names:
+// AWS {Param, Secret}, Google Cloud {Secret}, Azure {App Configuration,
+// Key Vault}.
+func All() []ProviderCapability {
+	return []ProviderCapability{
+		{
+			Provider:    string(provider.ProviderAWS),
+			DisplayName: "AWS",
+			ScopeFields: []string{},
+			Services: []ServiceCapability{
+				{
+					Service: serviceParam, DisplayName: "Param",
+					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: false,
+					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false,
+				},
+				{
+					Service: serviceSecret, DisplayName: displayNameSecret,
+					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: true,
+					HasStaging: true, HasForceDelete: true, HasRecoveryWindow: true,
+				},
+			},
+		},
+		{
+			Provider:    string(provider.ProviderGoogleCloud),
+			DisplayName: "Google Cloud",
+			ScopeFields: []string{"project"},
+			Services: []ServiceCapability{
+				{
+					Service: serviceSecret, DisplayName: displayNameSecret,
+					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: false,
+					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false,
+				},
+			},
+		},
+		{
+			Provider:    string(provider.ProviderAzure),
+			DisplayName: "Azure",
+			ScopeFields: []string{},
+			Services: []ServiceCapability{
+				// App Configuration is unversioned; tags are writable via
+				// GET-merge-PUT (azappconfig/v2).
+				{
+					Service: serviceParam, DisplayName: "App Configuration",
+					HasVersionHistory: false, HasVersionSpecifiers: false, HasTags: true, HasRestore: false,
+					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false, HasNamespaces: true,
+				},
+				{
+					Service: serviceSecret, DisplayName: "Key Vault",
+					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, TagsPerVersion: true, HasRestore: true,
+					// Force-delete (purge) is unsupported: Key Vault retention is a vault
+					// property (softDeleteRetentionInDays), not a per-delete choice, and
+					// staged deletes can't carry it — so deletes are always soft (Restore
+					// recovers them). HasForceDelete/HasRecoveryWindow both stay false.
+					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false,
+				},
+			},
+		},
+	}
+}

--- a/internal/capability/capability.go
+++ b/internal/capability/capability.go
@@ -33,13 +33,13 @@ type ServiceCapability struct {
 	HasTags bool `json:"hasTags"`
 	// TagsPerVersion is true when tags are scoped to a specific version rather
 	// than the resource (Azure Key Vault only): each version has its own tags,
-	// so the GUI shows them per version in the history and writes target the
+	// so the frontend shows them per version in the history and writes target the
 	// latest version. Every other provider keeps tags at the resource level.
 	TagsPerVersion bool `json:"tagsPerVersion"`
 	// HasRestore is true when a soft-deleted item can be restored (AWS Secrets
 	// Manager only).
 	HasRestore bool `json:"hasRestore"`
-	// HasStaging is true when the GUI's staging workflow applies to this
+	// HasStaging is true when the frontend's staging workflow applies to this
 	// service (every provider service today); the frontend hides the staging
 	// tab/banner/checkbox when false.
 	HasStaging bool `json:"hasStaging"`

--- a/internal/capability/capability_test.go
+++ b/internal/capability/capability_test.go
@@ -1,0 +1,190 @@
+package capability_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mpyw/suve/internal/capability"
+	"github.com/mpyw/suve/internal/provider"
+)
+
+// findService returns the ServiceCapability for (provider, service) from the
+// capability matrix, failing the test when absent.
+func findService(t *testing.T, caps []capability.ProviderCapability, prov, service string) capability.ServiceCapability {
+	t.Helper()
+
+	for _, p := range caps {
+		if p.Provider != prov {
+			continue
+		}
+
+		for _, s := range p.Services {
+			if s.Service == service {
+				return s
+			}
+		}
+	}
+
+	t.Fatalf("no capability for provider %q service %q", prov, service)
+
+	return capability.ServiceCapability{}
+}
+
+// TestAll_StagingAndDeleteFlags pins the staging/delete capability values that
+// drive control visibility, so a stray edit to the matrix is caught. Staging is
+// available for every provider service; force-delete/recovery-window are AWS
+// Secrets Manager only.
+func TestAll_StagingAndDeleteFlags(t *testing.T) {
+	t.Parallel()
+
+	caps := capability.All()
+
+	tests := []struct {
+		provider          string
+		service           string
+		hasStaging        bool
+		hasForceDelete    bool
+		hasRecoveryWindow bool
+		hasRestore        bool
+	}{
+		// Staging is available for every provider service. Restore belongs to the
+		// soft-delete providers — AWS Secrets Manager AND Azure Key Vault — but
+		// force-delete and the per-delete recovery window are AWS SM only: Key Vault
+		// retention is a vault property and force-delete/purge is unsupported there.
+		{string(provider.ProviderAWS), "param", true, false, false, false},
+		{string(provider.ProviderAWS), "secret", true, true, true, true},
+		{string(provider.ProviderGoogleCloud), "secret", true, false, false, false},
+		{string(provider.ProviderAzure), "param", true, false, false, false},
+		{string(provider.ProviderAzure), "secret", true, false, false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider+"/"+tt.service, func(t *testing.T) {
+			t.Parallel()
+
+			svc := findService(t, caps, tt.provider, tt.service)
+			assert.Equal(t, tt.hasStaging, svc.HasStaging, "HasStaging")
+			assert.Equal(t, tt.hasForceDelete, svc.HasForceDelete, "HasForceDelete")
+			assert.Equal(t, tt.hasRecoveryWindow, svc.HasRecoveryWindow, "HasRecoveryWindow")
+			assert.Equal(t, tt.hasRestore, svc.HasRestore, "HasRestore")
+		})
+	}
+}
+
+// TestAll_EveryServiceHasStaging pins the invariant that the staging workflow
+// applies to every provider service today.
+func TestAll_EveryServiceHasStaging(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range capability.All() {
+		for _, s := range p.Services {
+			assert.True(t, s.HasStaging, "%s/%s must have staging", p.Provider, s.Service)
+		}
+	}
+}
+
+// TestAll_ForceDeleteAndRecoveryWindowAWSSecretOnly pins the AWS-only invariant:
+// both force-delete and the per-delete recovery window are Secrets Manager
+// features. Azure Key Vault soft-deletes (Restore recovers) but neither purges
+// on force nor exposes a per-delete recovery window (retention is a vault
+// property), so no other provider/service may report these.
+func TestAll_ForceDeleteAndRecoveryWindowAWSSecretOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range capability.All() {
+		for _, s := range p.Services {
+			isAWSSecret := p.Provider == string(provider.ProviderAWS) && s.Service == "secret"
+			if !isAWSSecret {
+				assert.False(t, s.HasForceDelete, "%s/%s must not offer force-delete", p.Provider, s.Service)
+				assert.False(t, s.HasRecoveryWindow, "%s/%s must not have a recovery window", p.Provider, s.Service)
+			}
+		}
+	}
+}
+
+// TestAll_AzureAppConfigUnversionedWithNamespaces pins Azure App Configuration's
+// two distinguishing traits: it is unversioned (no history or specifiers) and it
+// partitions keys by a namespace (the label axis).
+func TestAll_AzureAppConfigUnversionedWithNamespaces(t *testing.T) {
+	t.Parallel()
+
+	svc := findService(t, capability.All(), string(provider.ProviderAzure), "param")
+
+	assert.False(t, svc.HasVersionHistory, "App Config is unversioned")
+	assert.False(t, svc.HasVersionSpecifiers, "App Config has no version specifiers")
+	assert.True(t, svc.HasNamespaces, "App Config partitions keys by namespace")
+	assert.True(t, svc.HasTags, "App Config tags are writable via GET-merge-PUT")
+}
+
+// TestAll_TagsPerVersionAzureKeyVaultOnly pins that per-version tags are unique
+// to Azure Key Vault; every other service keeps tags at the resource level.
+func TestAll_TagsPerVersionAzureKeyVaultOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range capability.All() {
+		for _, s := range p.Services {
+			isAzureKeyVault := p.Provider == string(provider.ProviderAzure) && s.Service == "secret"
+			assert.Equal(t, isAzureKeyVault, s.TagsPerVersion, "%s/%s TagsPerVersion", p.Provider, s.Service)
+		}
+	}
+}
+
+// TestAll_RestoreSoftDeleteProvidersOnly pins that Restore is offered exactly by
+// the soft-delete services: AWS Secrets Manager and Azure Key Vault.
+func TestAll_RestoreSoftDeleteProvidersOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range capability.All() {
+		for _, s := range p.Services {
+			isAWSSecret := p.Provider == string(provider.ProviderAWS) && s.Service == "secret"
+			isAzureKeyVault := p.Provider == string(provider.ProviderAzure) && s.Service == "secret"
+			assert.Equal(t, isAWSSecret || isAzureKeyVault, s.HasRestore, "%s/%s HasRestore", p.Provider, s.Service)
+		}
+	}
+}
+
+// TestAll_HasNamespacesAzureAppConfigOnly pins that the namespace axis is unique
+// to Azure App Configuration among all services.
+func TestAll_HasNamespacesAzureAppConfigOnly(t *testing.T) {
+	t.Parallel()
+
+	for _, p := range capability.All() {
+		for _, s := range p.Services {
+			isAzureAppConfig := p.Provider == string(provider.ProviderAzure) && s.Service == "param"
+			assert.Equal(t, isAzureAppConfig, s.HasNamespaces, "%s/%s HasNamespaces", p.Provider, s.Service)
+		}
+	}
+}
+
+// TestAll_ProviderShape pins the provider axis: which providers exist, in order,
+// with the services and scope fields they offer.
+func TestAll_ProviderShape(t *testing.T) {
+	t.Parallel()
+
+	caps := capability.All()
+
+	type shape struct {
+		provider    string
+		scopeFields []string
+		services    []string
+	}
+
+	got := make([]shape, len(caps))
+	for i, p := range caps {
+		svcs := make([]string, len(p.Services))
+		for j, s := range p.Services {
+			svcs[j] = s.Service
+		}
+
+		got[i] = shape{provider: p.Provider, scopeFields: p.ScopeFields, services: svcs}
+	}
+
+	want := []shape{
+		{provider: string(provider.ProviderAWS), scopeFields: []string{}, services: []string{"param", "secret"}},
+		{provider: string(provider.ProviderGoogleCloud), scopeFields: []string{"project"}, services: []string{"secret"}},
+		{provider: string(provider.ProviderAzure), scopeFields: []string{}, services: []string{"param", "secret"}},
+	}
+
+	assert.Equal(t, want, got)
+}

--- a/internal/gui/capabilities_internal_test.go
+++ b/internal/gui/capabilities_internal_test.go
@@ -8,89 +8,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mpyw/suve/internal/capability"
 	"github.com/mpyw/suve/internal/provider"
 )
 
-// findService returns the ServiceCapability for (provider, service) from the
-// capability descriptor, failing the test when absent.
-func findService(t *testing.T, caps []ProviderCapability, prov, service string) ServiceCapability {
-	t.Helper()
-
-	for _, p := range caps {
-		if p.Provider != prov {
-			continue
-		}
-
-		for _, s := range p.Services {
-			if s.Service == service {
-				return s
-			}
-		}
-	}
-
-	t.Fatalf("no capability for provider %q service %q", prov, service)
-
-	return ServiceCapability{}
-}
-
-// TestApp_Capabilities_StagingAndDeleteFlags pins the staging/delete capability
-// values that drive control visibility, so a stray edit to providers.go is
-// caught. Staging is available for every provider service;
-// force-delete/recovery-window are AWS Secrets Manager only.
-func TestApp_Capabilities_StagingAndDeleteFlags(t *testing.T) {
+// TestApp_Capabilities_DelegatesToCapabilityPackage pins the Wails binding
+// contract: the (*App).Capabilities binding returns the neutral matrix from
+// internal/capability unchanged. The matrix-content invariants themselves are
+// asserted in internal/capability's own tests.
+func TestApp_Capabilities_DelegatesToCapabilityPackage(t *testing.T) {
 	t.Parallel()
 
-	caps := (&App{}).Capabilities()
-
-	tests := []struct {
-		provider          string
-		service           string
-		hasStaging        bool
-		hasForceDelete    bool
-		hasRecoveryWindow bool
-		hasRestore        bool
-	}{
-		// Staging is available for every provider service. Restore belongs to the
-		// soft-delete providers — AWS Secrets Manager AND Azure Key Vault — but
-		// force-delete and the per-delete recovery window are AWS SM only: Key Vault
-		// retention is a vault property and force-delete/purge is unsupported there.
-		{string(provider.ProviderAWS), "param", true, false, false, false},
-		{string(provider.ProviderAWS), "secret", true, true, true, true},
-		{string(provider.ProviderGoogleCloud), "secret", true, false, false, false},
-		{string(provider.ProviderAzure), "param", true, false, false, false},
-		{string(provider.ProviderAzure), "secret", true, false, false, true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.provider+"/"+tt.service, func(t *testing.T) {
-			t.Parallel()
-
-			svc := findService(t, caps, tt.provider, tt.service)
-			assert.Equal(t, tt.hasStaging, svc.HasStaging, "HasStaging")
-			assert.Equal(t, tt.hasForceDelete, svc.HasForceDelete, "HasForceDelete")
-			assert.Equal(t, tt.hasRecoveryWindow, svc.HasRecoveryWindow, "HasRecoveryWindow")
-			assert.Equal(t, tt.hasRestore, svc.HasRestore, "HasRestore")
-		})
-	}
-}
-
-// TestApp_Capabilities_ForceDeleteAndRecoveryWindowAWSOnly pins the AWS-only
-// invariant: both force-delete and the per-delete recovery window are Secrets
-// Manager features. Azure Key Vault soft-deletes (Restore recovers) but neither
-// purges on force nor exposes a per-delete recovery window (retention is a vault
-// property), so no other provider/service may report these.
-func TestApp_Capabilities_ForceDeleteAndRecoveryWindowAWSOnly(t *testing.T) {
-	t.Parallel()
-
-	for _, p := range (&App{}).Capabilities() {
-		for _, s := range p.Services {
-			isAWSSecret := p.Provider == string(provider.ProviderAWS) && s.Service == "secret"
-			if !isAWSSecret {
-				assert.False(t, s.HasForceDelete, "%s/%s must not offer force-delete", p.Provider, s.Service)
-				assert.False(t, s.HasRecoveryWindow, "%s/%s must not have a recovery window", p.Provider, s.Service)
-			}
-		}
-	}
+	assert.Equal(t, capability.All(), (&App{}).Capabilities())
 }
 
 func TestApp_ParamTypeOptions_ScopeAware(t *testing.T) {

--- a/internal/gui/providers.go
+++ b/internal/gui/providers.go
@@ -5,15 +5,9 @@ package gui
 import (
 	"github.com/samber/lo"
 
+	"github.com/mpyw/suve/internal/capability"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/detect"
-)
-
-// Service keys and display labels reused across the capability descriptors.
-const (
-	serviceParam      = "param"
-	serviceSecret     = "secret"
-	displayNameSecret = "Secret"
 )
 
 // =============================================================================
@@ -91,121 +85,22 @@ func providerStrings(ps []provider.Provider) []string {
 // Capabilities
 // =============================================================================
 
-// ServiceCapability describes one provider service (param or secret) so the
-// frontend can render the right label and hide unsupported controls.
-type ServiceCapability struct {
-	// Service is the internal key ("param" or "secret").
-	Service string `json:"service"`
-	// DisplayName is the label shown in the UI (e.g. "Key Vault").
-	DisplayName string `json:"displayName"`
-	// HasVersionHistory is true when `log`/history is supported (false for the
-	// unversioned Azure App Configuration).
-	HasVersionHistory bool `json:"hasVersionHistory"`
-	// HasVersionSpecifiers is true when #VERSION/~SHIFT specifiers apply.
-	HasVersionSpecifiers bool `json:"hasVersionSpecifiers"`
-	// HasTags is true when tag/label read+write is supported (false for Azure
-	// App Configuration).
-	HasTags bool `json:"hasTags"`
-	// TagsPerVersion is true when tags are scoped to a specific version rather
-	// than the resource (Azure Key Vault only): each version has its own tags,
-	// so the GUI shows them per version in the history and writes target the
-	// latest version. Every other provider keeps tags at the resource level.
-	TagsPerVersion bool `json:"tagsPerVersion"`
-	// HasRestore is true when a soft-deleted item can be restored (AWS Secrets
-	// Manager only).
-	HasRestore bool `json:"hasRestore"`
-	// HasStaging is true when the GUI's staging workflow applies to this
-	// service (every provider service today); the frontend hides the staging
-	// tab/banner/checkbox when false.
-	HasStaging bool `json:"hasStaging"`
-	// HasNamespaces is true when the service partitions keys by a namespace (the
-	// Azure App Configuration label axis, #431). The frontend shows the namespace
-	// column/badge and the create-form namespace field only when true.
-	HasNamespaces bool `json:"hasNamespaces"`
-	// HasForceDelete is true when an immediate (no-recovery-window) delete is
-	// offered (AWS Secrets Manager only). The frontend hides the force-delete
-	// checkbox otherwise.
-	HasForceDelete bool `json:"hasForceDelete"`
-	// HasRecoveryWindow is true when a soft delete schedules a recovery window
-	// whose end date can be surfaced (AWS Secrets Manager only). Other providers
-	// delete immediately or govern retention by policy, so no "recoverable until"
-	// date is shown.
-	HasRecoveryWindow bool `json:"hasRecoveryWindow"`
-}
+// ServiceCapability is re-exported from the neutral internal/capability package
+// so the Wails binding surface (and the generated TypeScript models) stay stable
+// while the matrix itself lives untagged and is shared with the TUI. The alias
+// resolves to the same JSON shape, so the generated bindings need no
+// regeneration.
+type ServiceCapability = capability.ServiceCapability
 
-// ProviderCapability describes a provider and the services it offers.
-type ProviderCapability struct {
-	// Provider is the internal key ("aws" | "googlecloud" | "azure").
-	Provider string `json:"provider"`
-	// DisplayName is the provider label (e.g. "Google Cloud").
-	DisplayName string `json:"displayName"`
-	// ScopeFields lists the provider-level scope inputs the frontend must collect
-	// (e.g. ["project"] for Google Cloud). Empty for AWS (ambient config) and for
-	// Azure, whose per-service vault/store names are collected by the service's
-	// own view.
-	ScopeFields []string `json:"scopeFields"`
-	// Services are the param/secret services this provider offers, in stable
-	// display order.
-	Services []ServiceCapability `json:"services"`
-}
+// ProviderCapability is re-exported from the neutral internal/capability package
+// so the Wails binding surface stays stable while the matrix lives untagged and
+// is shared with the TUI. The alias resolves to the same JSON shape.
+type ProviderCapability = capability.ProviderCapability
 
 // Capabilities returns the static capability descriptor for every provider,
 // driving provider-selection and control-visibility in the frontend. Display
 // names: AWS {Param, Secret}, Google Cloud {Secret}, Azure {App Configuration,
-// Key Vault}.
+// Key Vault}. The data lives in internal/capability so the TUI shares it.
 func (a *App) Capabilities() []ProviderCapability {
-	return []ProviderCapability{
-		{
-			Provider:    string(provider.ProviderAWS),
-			DisplayName: "AWS",
-			ScopeFields: []string{},
-			Services: []ServiceCapability{
-				{
-					Service: serviceParam, DisplayName: "Param",
-					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: false,
-					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false,
-				},
-				{
-					Service: serviceSecret, DisplayName: displayNameSecret,
-					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: true,
-					HasStaging: true, HasForceDelete: true, HasRecoveryWindow: true,
-				},
-			},
-		},
-		{
-			Provider:    string(provider.ProviderGoogleCloud),
-			DisplayName: "Google Cloud",
-			ScopeFields: []string{"project"},
-			Services: []ServiceCapability{
-				{
-					Service: serviceSecret, DisplayName: displayNameSecret,
-					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: false,
-					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false,
-				},
-			},
-		},
-		{
-			Provider:    string(provider.ProviderAzure),
-			DisplayName: "Azure",
-			ScopeFields: []string{},
-			Services: []ServiceCapability{
-				// App Configuration is unversioned; tags are writable via
-				// GET-merge-PUT (azappconfig/v2).
-				{
-					Service: serviceParam, DisplayName: "App Configuration",
-					HasVersionHistory: false, HasVersionSpecifiers: false, HasTags: true, HasRestore: false,
-					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false, HasNamespaces: true,
-				},
-				{
-					Service: serviceSecret, DisplayName: "Key Vault",
-					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, TagsPerVersion: true, HasRestore: true,
-					// Force-delete (purge) is unsupported: Key Vault retention is a vault
-					// property (softDeleteRetentionInDays), not a per-delete choice, and
-					// staged deletes can't carry it — so deletes are always soft (Restore
-					// recovers them). HasForceDelete/HasRecoveryWindow both stay false.
-					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false,
-				},
-			},
-		},
-	}
+	return capability.All()
 }

--- a/internal/gui/providers.go
+++ b/internal/gui/providers.go
@@ -85,16 +85,18 @@ func providerStrings(ps []provider.Provider) []string {
 // Capabilities
 // =============================================================================
 
-// ServiceCapability is re-exported from the neutral internal/capability package
-// so the Wails binding surface (and the generated TypeScript models) stay stable
-// while the matrix itself lives untagged and is shared with the TUI. The alias
-// resolves to the same JSON shape, so the generated bindings need no
-// regeneration.
+// ServiceCapability and ProviderCapability are re-exported from the neutral
+// internal/capability package so the matrix lives untagged and is shared with the
+// TUI. The aliases keep the marshaled JSON byte-identical, so the committed
+// wailsjs bindings under the gui namespace stay runtime-correct. Regenerating
+// would resolve each alias to its underlying type and relocate both into a
+// capability namespace in the generated TypeScript, forcing an update of every
+// frontend ref (gui.ProviderCapability / gui.ServiceCapability) for no runtime
+// gain — so the bindings are intentionally kept under gui and not regenerated for
+// this refactor.
 type ServiceCapability = capability.ServiceCapability
 
-// ProviderCapability is re-exported from the neutral internal/capability package
-// so the Wails binding surface stays stable while the matrix lives untagged and
-// is shared with the TUI. The alias resolves to the same JSON shape.
+// ProviderCapability — see ServiceCapability above.
 type ProviderCapability = capability.ProviderCapability
 
 // Capabilities returns the static capability descriptor for every provider,


### PR DESCRIPTION
Part of Epic #650. Closes #651. Targets **`epic/tui`**.

Lifts `ServiceCapability` / `ProviderCapability` / the static capability matrix out of the build-tagged `internal/gui` into a new neutral, untagged package `internal/capability` (`func All()`), so the upcoming pure-Go TUI and the GUI share one source of truth. The GUI keeps a stable Wails binding surface via type aliases + a delegating `Capabilities()` method — JSON shape byte-identical, no bindings regeneration needed.

## Gates
- `mise test` — green (new `internal/capability` covered).
- `mise lint` + deadcode gate — green.
- `go vet`/`go test -tags production ./internal/gui/...` (DTO contract) — green; GUI compiles with the aliases.

## Note
A **temporary** `.github/deadcode-allow.txt` waiver for `capability.All` is included (its only non-test caller in this step is the build-tagged GUI). Step 2's untagged `internal/tui` consumes it in the default build; **this waiver is removed in Step 2** and must be gone by Step 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)