### PR TITLE
Step 4 follow-up: QA fixes — $EDITOR tokenization, editor no-op normalize, staged Type containment, Description gating

### DIFF
--- a/internal/capability/capability.go
+++ b/internal/capability/capability.go
@@ -56,6 +56,11 @@ type ServiceCapability struct {
 	// delete immediately or govern retention by policy, so no "recoverable until"
 	// date is shown.
 	HasRecoveryWindow bool `json:"hasRecoveryWindow"`
+	// HasDescription is true when a write carries a free-text description (AWS
+	// Parameter Store + Secrets Manager only). The gcloud, Azure Key Vault, and
+	// Azure App Configuration writers ignore a description, so the frontend hides
+	// the description field for them (GUI parity: only AWS forms offer it).
+	HasDescription bool `json:"hasDescription"`
 }
 
 // ProviderCapability describes a provider and the services it offers.
@@ -88,12 +93,12 @@ func All() []ProviderCapability {
 				{
 					Service: serviceParam, DisplayName: "Param",
 					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: false,
-					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false,
+					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false, HasDescription: true,
 				},
 				{
 					Service: serviceSecret, DisplayName: displayNameSecret,
 					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: true,
-					HasStaging: true, HasForceDelete: true, HasRecoveryWindow: true,
+					HasStaging: true, HasForceDelete: true, HasRecoveryWindow: true, HasDescription: true,
 				},
 			},
 		},

--- a/internal/cli/editor/editor.go
+++ b/internal/cli/editor/editor.go
@@ -15,16 +15,33 @@ import (
 // OpenFunc is the type for editor functions.
 type OpenFunc func(ctx context.Context, content string) (string, error)
 
-// Open opens the content in an external editor and returns the edited result.
-// It uses the VISUAL or EDITOR environment variable to determine the editor.
-// Falls back to notepad on Windows or vi on other platforms.
-func Open(ctx context.Context, content string) (string, error) {
+// Command builds the *exec.Cmd that opens tmpFile in the user's editor. It
+// resolves VISUAL then EDITOR, falling back to notepad on Windows or vi on other
+// platforms, and invokes through the shell (`sh -c 'editor "$1"' sh tmpFile`) so
+// that quoting and arguments behave exactly like Git does: the temp-file path is
+// passed as $1 so an $EDITOR that itself carries flags or a space-containing path
+// is expanded by the shell (e.g. "code --wait" or
+// "/Applications/Visual Studio Code.app/.../code").
+//
+// It does NOT wire Stdin/Stdout/Stderr, so the caller (the CLI, or the TUI via
+// tea.ExecProcess) owns the terminal handoff. This is the single command builder
+// both the CLI editor and the TUI's $EDITOR handoff share, so they cannot
+// diverge on VISUAL→EDITOR precedence, shell quoting, or the OS fallback.
+func Command(ctx context.Context, tmpFile string) *exec.Cmd {
 	editor := lo.CoalesceOrEmpty(
 		os.Getenv("VISUAL"),
 		os.Getenv("EDITOR"),
 		lo.Ternary(runtime.GOOS == "windows", "notepad", "vi"),
 	)
 
+	//nolint:gosec // $VISUAL/$EDITOR are user-controlled by design
+	return exec.CommandContext(ctx, "sh", "-c", editor+` "$1"`, "sh", tmpFile)
+}
+
+// Open opens the content in an external editor and returns the edited result.
+// It uses the VISUAL or EDITOR environment variable to determine the editor.
+// Falls back to notepad on Windows or vi on other platforms.
+func Open(ctx context.Context, content string) (string, error) {
 	tmpFile, err := os.CreateTemp("", "suve-edit-*.txt")
 	if err != nil {
 		return "", err
@@ -40,11 +57,7 @@ func Open(ctx context.Context, content string) (string, error) {
 		return "", err
 	}
 
-	// Invoke the editor through the shell so that quoting and arguments behave
-	// exactly like Git does. The temp-file path is passed as $1 so that $EDITOR,
-	// which may itself contain flags and a space-containing path, is expanded by
-	// the shell (e.g. "code --wait" or "/Applications/Visual Studio Code.app/.../code").
-	cmd := exec.CommandContext(ctx, "sh", "-c", editor+` "$1"`, "sh", tmpFile.Name()) //nolint:gosec // $EDITOR is user-controlled by design
+	cmd := Command(ctx, tmpFile.Name())
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -58,10 +71,10 @@ func Open(ctx context.Context, content string) (string, error) {
 		return "", err
 	}
 
-	return normalize(content, string(data)), nil
+	return Normalize(content, string(data)), nil
 }
 
-// normalize applies the round-trip-lossless rule to the editor's read-back
+// Normalize applies the round-trip-lossless rule to the editor's read-back
 // (result) given the exact content that was written into the tmpfile.
 //
 // Editors typically auto-append a single trailing newline to a buffer that did
@@ -71,7 +84,7 @@ func Open(ctx context.Context, content string) (string, error) {
 // value carried in (PEM keys, JSON, ...) is preserved, so opening a value and
 // saving it untouched is byte-identical — which the callers then detect and
 // report as a no-op change.
-func normalize(content, result string) string {
+func Normalize(content, result string) string {
 	// The value already carried a trailing newline: the editor did not add one,
 	// so keep the read-back verbatim to stay lossless.
 	if strings.HasSuffix(content, "\n") {

--- a/internal/gui/frontend/wailsjs/go/models.ts
+++ b/internal/gui/frontend/wailsjs/go/models.ts
@@ -283,7 +283,8 @@ export namespace gui {
 	    hasNamespaces: boolean;
 	    hasForceDelete: boolean;
 	    hasRecoveryWindow: boolean;
-	
+	    hasDescription: boolean;
+
 	    static createFrom(source: any = {}) {
 	        return new ServiceCapability(source);
 	    }
@@ -301,6 +302,7 @@ export namespace gui {
 	        this.hasNamespaces = source["hasNamespaces"];
 	        this.hasForceDelete = source["hasForceDelete"];
 	        this.hasRecoveryWindow = source["hasRecoveryWindow"];
+	        this.hasDescription = source["hasDescription"];
 	    }
 	}
 	export class ProviderCapability {

--- a/internal/tui/dialog_golden_test.go
+++ b/internal/tui/dialog_golden_test.go
@@ -174,9 +174,12 @@ func goldenCap(prov, service string) capability.ServiceCapability {
 	return sc
 }
 
-// TestDialog_EntryFormAWSParamGolden renders the create form for AWS SSM param
-// (name, Type select, empty value textarea, mode toggle). No value is seeded, so
-// no secret is rendered.
+// TestDialog_EntryFormAWSParamGolden renders the create form for AWS SSM param in
+// its default (staged) mode: name, value textarea, Description, and the mode
+// toggle. The Type select is NOT drawn — it is offered only in immediate mode
+// (#664 containment: a staged write drops the value type, so a staged
+// SecureString would silently downgrade to plaintext). No value is seeded, so no
+// secret is rendered.
 func TestDialog_EntryFormAWSParamGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
 	goldenEnv(t)
 
@@ -185,7 +188,7 @@ func TestDialog_EntryFormAWSParamGolden(t *testing.T) { //nolint:paralleltest //
 		Service: "param", Styles: styles.New(),
 	})
 
-	dialogGolden(t, newDialogHost(m, cmd), "Type")
+	dialogGolden(t, newDialogHost(m, cmd), "Value")
 }
 
 // TestDialog_EntryFormAppConfigGolden renders the create form for Azure App
@@ -280,6 +283,17 @@ func TestDialog_TagAWSParamGolden(t *testing.T) { //nolint:paralleltest // golde
 	})
 
 	dialogGolden(t, newDialogHost(m, cmd), "Action")
+}
+
+// TestDialog_ErrorGolden renders the plain error dialog (a blocked operation the
+// app surfaces modally). It never mutates and carries no secret.
+func TestDialog_ErrorGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
+	goldenEnv(t)
+
+	m := dialogs.NewError(styles.New(), "Cannot create here",
+		"Creating is blocked while viewing all namespaces. Pick one namespace first.")
+
+	dialogGolden(t, newDialogHost(m, nil), "Cannot create here")
 }
 
 // TestDialog_RestoreGolden renders the restore form (name input, no mode toggle).

--- a/internal/tui/dialogs/dialogs_test.go
+++ b/internal/tui/dialogs/dialogs_test.go
@@ -3,6 +3,8 @@ package dialogs
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -83,7 +85,7 @@ func (m *fakeMutator) Restore(context.Context, string) (data.WriteOutcome, error
 
 // Capability fixtures.
 func awsParamCap() capability.ServiceCapability {
-	return capability.ServiceCapability{Service: "param", HasTags: true, HasStaging: true}
+	return capability.ServiceCapability{Service: "param", HasTags: true, HasStaging: true, HasDescription: true}
 }
 
 func appConfigCap() capability.ServiceCapability {
@@ -93,7 +95,7 @@ func appConfigCap() capability.ServiceCapability {
 func awsSecretCap() capability.ServiceCapability {
 	return capability.ServiceCapability{
 		Service: "secret", HasTags: true, HasStaging: true, HasRestore: true,
-		HasForceDelete: true, HasRecoveryWindow: true,
+		HasForceDelete: true, HasRecoveryWindow: true, HasDescription: true,
 	}
 }
 
@@ -181,18 +183,52 @@ func TestEntryForm_NamespaceReadOnlyOnEdit(t *testing.T) {
 }
 
 // TestEntryForm_TypeSelectGating pins the Type select is offered only for the
-// typed AWS SSM param service (App Configuration is untyped; secret has none).
+// typed AWS SSM param service (App Configuration is untyped; secret has none)
+// AND only in immediate mode: containment for #664, since the staged path drops
+// the value type (staging apply hardcodes a plaintext String), so a staged
+// SecureString would silently downgrade to plaintext. Staged mode must not
+// present a Type control that can't take effect.
 func TestEntryForm_TypeSelectGating(t *testing.T) {
 	t.Parallel()
 
 	awsParam, _ := newEntry(t, awsParamCap(), false)
-	assert.True(t, awsParam.showType())
+	require.True(t, awsParam.staged, "AWS param defaults to staged")
+	assert.False(t, awsParam.showType(), "staged mode hides the Type select (#664 containment)")
+	assert.NotContains(t, awsParam.View(), "Type", "staged form draws no Type row")
+
+	awsParam.staged = false
+	require.NotNil(t, awsParam.rebuildForm())
+	assert.True(t, awsParam.showType(), "immediate mode offers the Type select")
+	assert.Contains(t, awsParam.View(), "Type", "immediate form draws the Type row")
 
 	appConfig, _ := newEntry(t, appConfigCap(), false)
-	assert.False(t, appConfig.showType())
+	appConfig.staged = false
+	require.NotNil(t, appConfig.rebuildForm())
+	assert.False(t, appConfig.showType(), "App Configuration is untyped even in immediate mode")
 
 	secret, _ := newEntry(t, awsSecretCap(), false)
-	assert.False(t, secret.showType())
+	secret.staged = false
+	require.NotNil(t, secret.rebuildForm())
+	assert.False(t, secret.showType(), "secret has no value type even in immediate mode")
+}
+
+// TestEntryForm_DescriptionGating pins that the Description field is drawn only
+// for a service that honors it (AWS param/secret). The gcloud, Azure Key Vault,
+// and App Configuration writers ignore a description, so their forms omit it.
+func TestEntryForm_DescriptionGating(t *testing.T) {
+	t.Parallel()
+
+	awsParam, _ := newEntry(t, awsParamCap(), false)
+	assert.Contains(t, awsParam.View(), "Description", "AWS param offers a description")
+
+	awsSecret, _ := newEntry(t, awsSecretCap(), false)
+	assert.Contains(t, awsSecret.View(), "Description", "AWS secret offers a description")
+
+	appConfig := newAppConfigEntry(t, false, "prod")
+	assert.NotContains(t, appConfig.View(), "Description", "App Configuration ignores a description")
+
+	gcloudSecret, _ := newEntry(t, gcloudSecretCap(), false)
+	assert.NotContains(t, gcloudSecret.View(), "Description", "gcloud secret ignores a description")
 }
 
 // TestEntryForm_SubmitRoutesStaged pins that a staged submit routes through the
@@ -232,20 +268,37 @@ func TestEntryForm_EditSubmitImmediate(t *testing.T) {
 	assert.Equal(t, "SecureString", mut.typeLabel, "edit preserves the current type")
 }
 
-// TestEntryForm_EditorNoOp pins the $EDITOR no-op: an unchanged buffer keeps the
-// value and shows "No changes made."; a changed buffer replaces it.
+// TestEntryForm_EditorNoOp pins the editor no-op as a REAL round-trip: the value
+// is written to a temp file, a simulated editor appends a trailing newline (as
+// most editors do), and the file is read back through the actual read path
+// (onEditorFinished). The newline-normalization must treat this as untouched
+// ("No changes made.", value unchanged) rather than silently mutating the value
+// with a stray newline; a genuine edit still replaces it.
 func TestEntryForm_EditorNoOp(t *testing.T) {
 	t.Parallel()
 
 	d, _ := newEntry(t, awsParamCap(), true)
 	d.value = "same"
 
-	_, _ = d.onEditorFinished(editorFinishedMsg{content: "same"})
-	assert.Equal(t, "same", d.value)
+	tmp := filepath.Join(t.TempDir(), "edit.txt")
+
+	// Simulate an editor that saved the buffer untouched but appended a newline.
+	require.NoError(t, os.WriteFile(tmp, []byte(d.value+"\n"), 0o600))
+	raw, err := os.ReadFile(tmp) //nolint:gosec // tmp is this test's own temp file
+	require.NoError(t, err)
+
+	_, _ = d.onEditorFinished(editorFinishedMsg{content: string(raw)})
+	assert.Equal(t, "same", d.value, "an editor-appended newline is a no-op round-trip")
 	assert.Equal(t, "No changes made.", d.notice)
 
-	_, _ = d.onEditorFinished(editorFinishedMsg{content: "edited"})
-	assert.Equal(t, "edited", d.value, "a changed buffer replaces the value")
+	// A genuine edit still replaces the value (with the editor newline normalized).
+	require.NoError(t, os.WriteFile(tmp, []byte("edited\n"), 0o600))
+	raw, err = os.ReadFile(tmp) //nolint:gosec // tmp is this test's own temp file
+	require.NoError(t, err)
+
+	_, _ = d.onEditorFinished(editorFinishedMsg{content: string(raw)})
+	assert.Equal(t, "edited", d.value, "a changed buffer replaces the value (newline normalized)")
+	assert.Equal(t, "Loaded from editor.", d.notice)
 }
 
 // TestEntryForm_EditorNoTTY pins the TTY gate: without a TTY the editor is not
@@ -418,6 +471,53 @@ func TestTagForm_Routing(t *testing.T) {
 	d.remove = true
 	execCmd(t, d.submit())
 	assert.Equal(t, "owner", mut.tagKey, "remove action routes to RemoveTag with the key")
+}
+
+// TestDeleteConfirm_ResultVoicing pins the delete status voicing, including the
+// auto-unstage case: deleting a staged create removes it (nothing left to
+// delete). The pure voicing is asserted, then routed through onResult to confirm
+// it reaches the MutationDoneMsg status line.
+func TestDeleteConfirm_ResultVoicing(t *testing.T) {
+	t.Parallel()
+
+	assert.Contains(t, deleteStatus(true, data.WriteOutcome{Unstaged: true}), "nothing left to delete")
+	assert.Equal(t, "Staged delete.", deleteStatus(true, data.WriteOutcome{}))
+	assert.Equal(t, "Deleted.", deleteStatus(false, data.WriteOutcome{}))
+
+	d := newDelete(t, awsSecretCap())
+	d.staged = true
+
+	_, cmd := d.onResult(mutationResultMsg{outcome: data.WriteOutcome{Unstaged: true}})
+	done, ok := cmd().(MutationDoneMsg)
+	require.True(t, ok, "a successful delete emits MutationDoneMsg")
+	assert.Contains(t, done.Status, "nothing left to delete", "auto-unstage surfaces in the status line")
+}
+
+// TestTagForm_ResultVoicing pins the tag status voicing (staged/applied,
+// add/removal) and that it reaches the MutationDoneMsg status line. Tags carry no
+// auto-unstage/skip outcome today (TagOutput/UntagOutput hold only the name), so
+// the tag equivalent that surfaces is the staged/applied voicing.
+func TestTagForm_ResultVoicing(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "Staged tag add.", tagStatus(false, true))
+	assert.Equal(t, "Staged tag removal.", tagStatus(true, true))
+	assert.Equal(t, "Applied tag add.", tagStatus(false, false))
+	assert.Equal(t, "Applied tag removal.", tagStatus(true, false))
+
+	mut := &fakeMutator{svcCap: awsParamCap()}
+	m, _ := NewTagForm(TagInput{
+		Ctx: context.Background(), Mutator: mut, Service: "param", Styles: styles.New(), Name: "/app/X",
+	})
+	d, ok := m.(*tagForm)
+	require.True(t, ok)
+
+	d.remove, d.staged = true, true
+
+	_, cmd := d.onResult(mutationResultMsg{outcome: data.WriteOutcome{}})
+	done, ok := cmd().(MutationDoneMsg)
+	require.True(t, ok, "a successful tag write emits MutationDoneMsg")
+	assert.Equal(t, "Staged tag removal.", done.Status, "tag voicing surfaces in the status line")
 }
 
 // TestRestoreForm_Routing pins that the restore form routes to Restore.

--- a/internal/tui/dialogs/entryform.go
+++ b/internal/tui/dialogs/entryform.go
@@ -3,7 +3,6 @@ package dialogs
 import (
 	"context"
 	"os"
-	"os/exec"
 	"strings"
 
 	"charm.land/bubbles/v2/key"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/mpyw/suve/internal/capability"
 	"github.com/mpyw/suve/internal/cli/commands/aws/param/paramtype"
+	"github.com/mpyw/suve/internal/cli/editor"
 	"github.com/mpyw/suve/internal/tui/data"
 	"github.com/mpyw/suve/internal/tui/styles"
 )
@@ -21,10 +21,6 @@ import (
 // to, so the modal size (and its goldens) stay deterministic regardless of
 // terminal width.
 const dialogContentWidth = 54
-
-// editorFallback is the editor used when $EDITOR is unset (the CLI $EDITOR gate
-// parity).
-const editorFallback = "vi"
 
 // isTTY reports whether the process is attached to a terminal, gating the
 // $EDITOR handoff (which suspends the program to run an editor). It is a package
@@ -66,8 +62,7 @@ type entryForm struct {
 	description string
 	staged      bool
 
-	form       *huh.Form
-	valueField *huh.Text
+	form *huh.Form
 
 	busy   bool
 	err    string
@@ -120,9 +115,15 @@ func NewEntryForm(in EntryFormInput) (Model, tea.Cmd) {
 
 // showType reports whether the typed-param Type select is offered: only the AWS
 // SSM param service has a value type (App Configuration is untyped; secret has
-// none) — parity with the GUI's ParamTypeOptions.
+// none) — parity with the GUI's ParamTypeOptions — AND only in immediate mode.
+//
+// Containment for #664: the staged write path drops the value type (staging
+// apply hardcodes a plaintext String), so a staged SecureString create would
+// silently apply as plaintext String. Until the systemic staged-type fix lands
+// (#664), the Type select is offered only in immediate mode, where it takes
+// effect; staged mode never presents a Type control that can't be honored.
 func (d *entryForm) showType() bool {
-	return d.svcCap.Service == serviceParam && !d.svcCap.HasNamespaces
+	return d.svcCap.Service == serviceParam && !d.svcCap.HasNamespaces && !d.staged
 }
 
 // defaultTypeLabel picks the Type select's initial value: the seeded label when
@@ -158,12 +159,16 @@ func (d *entryForm) rebuildForm() tea.Cmd {
 			Options(huh.NewOptions(paramtype.Options()...)...).Value(&d.valueType))
 	}
 
-	d.valueField = huh.NewText().Key("value").Title("Value").Lines(4). //nolint:mnd // value textarea height
-										ExternalEditor(false).Value(&d.value)
-	fields = append(fields, d.valueField)
+	fields = append(fields, huh.NewText().Key("value").Title("Value").Lines(4). //nolint:mnd // value textarea height
+											ExternalEditor(false).Value(&d.value))
 
-	fields = append(fields, huh.NewInput().Key("description").Title("Description").
-		Placeholder("(optional)").Value(&d.description))
+	// Description is AWS-only: the gcloud, Azure Key Vault, and App Configuration
+	// writers ignore it (and the GUI never offers it), so it is shown only for a
+	// service that honors it.
+	if d.svcCap.HasDescription {
+		fields = append(fields, huh.NewInput().Key("description").Title("Description").
+			Placeholder("(optional)").Value(&d.description))
+	}
 
 	if d.svcCap.HasStaging {
 		fields = append(fields, newModeField(&d.staged))
@@ -279,17 +284,16 @@ func (d *entryForm) onResult(msg mutationResultMsg) (Model, tea.Cmd) {
 	return d, doneCmd(d.service, status, d.staged)
 }
 
-// openEditor writes the current value to a temp file and hands off to $EDITOR.
+// openEditor writes the current value to a temp file and hands off to the user's
+// editor. The editor command is built by the shared internal/cli/editor helper,
+// so the TUI and the CLI resolve VISUAL→EDITOR, honor a flag-bearing or
+// space-containing editor path, and pick the same OS fallback — they cannot
+// diverge.
 func (d *entryForm) openEditor() tea.Cmd {
 	if !isTTY() {
 		d.notice = "editor needs a TTY."
 
 		return nil
-	}
-
-	editor := os.Getenv("EDITOR")
-	if editor == "" {
-		editor = editorFallback
 	}
 
 	buffer := d.value
@@ -313,8 +317,7 @@ func (d *entryForm) openEditor() tea.Cmd {
 
 	_ = tmp.Close()
 
-	//nolint:gosec // editor comes from $EDITOR (fallback vi); the CLI uses the same handoff
-	cmd := exec.CommandContext(d.ctx, editor, name)
+	cmd := editor.Command(d.ctx, name)
 
 	return tea.ExecProcess(cmd, func(runErr error) tea.Msg {
 		//nolint:gosec // name is the temp file this handler just created, not user input
@@ -329,9 +332,10 @@ func (d *entryForm) openEditor() tea.Cmd {
 	})
 }
 
-// onEditorFinished folds the $EDITOR buffer back into the value field: an
+// onEditorFinished folds the editor buffer back into the value field: an
 // unchanged buffer is a no-op ("No changes made."), otherwise the new content
-// replaces the textarea's value.
+// replaces the textarea's value and the form is rebuilt so the huh textarea
+// buffer re-syncs (mirroring every other path).
 func (d *entryForm) onEditorFinished(msg editorFinishedMsg) (Model, tea.Cmd) {
 	if msg.err != nil {
 		d.notice = "editor error: " + msg.err.Error()
@@ -339,20 +343,25 @@ func (d *entryForm) onEditorFinished(msg editorFinishedMsg) (Model, tea.Cmd) {
 		return d, nil
 	}
 
-	if msg.content == d.value {
+	// Most editors auto-append a trailing newline; normalize it away with the same
+	// round-trip-lossless rule the CLI uses, so an untouched round-trip is
+	// byte-identical to the seed value and correctly reported as a no-op (instead
+	// of silently mutating the value with a stray newline). d.value still holds the
+	// pre-edit buffer that was written to the tmpfile.
+	content := editor.Normalize(d.value, msg.content)
+
+	if content == d.value {
 		d.notice = "No changes made."
 
 		return d, nil
 	}
 
-	d.value = msg.content
-	if d.valueField != nil {
-		d.valueField.Value(&d.value) // re-sync the textarea to the edited buffer
-	}
-
+	d.value = content
 	d.notice = "Loaded from editor."
 
-	return d, nil
+	// Rebuild so the huh textarea re-binds to the edited value (consistent with
+	// every other value-changing path; avoids a stale textarea buffer).
+	return d, d.rebuildForm()
 }
 
 func (d *entryForm) View() string {

--- a/internal/tui/testdata/TestDialog_EntryFormAWSParamGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormAWSParamGolden.golden
@@ -4,11 +4,6 @@
 │┃ Name                                                │
 │┃ >                                                   │
 │                                                      │
-│  Type                                                │
-│  > String                                            │
-│    SecureString                                      │
-│    StringList                                        │
-│                                                      │
 │  Value                                               │
 │                                                      │
 │                                                      │

--- a/internal/tui/testdata/TestDialog_EntryFormAppConfigGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormAppConfigGolden.golden
@@ -13,9 +13,6 @@
 │                                                      │
 │                                                      │
 │                                                      │
-│  Description                                         │
-│  > (optional)                                        │
-│                                                      │
 │  Mode                                                │
 │  (•) Stage    ( ) Apply immediately                  │
 │tab/↑↓: fields · enter: submit · esc: cancel          │

--- a/internal/tui/testdata/TestDialog_ErrorGolden.golden
+++ b/internal/tui/testdata/TestDialog_ErrorGolden.golden
@@ -1,0 +1,7 @@
+╭───────────────────────────────────────────────────────────────────────────╮
+│Cannot create here                                                         │
+│                                                                           │
+│Creating is blocked while viewing all namespaces. Pick one namespace first.│
+│                                                                           │
+│enter/esc: close                                                           │
+╰───────────────────────────────────────────────────────────────────────────╯


### PR DESCRIPTION
Follow-up to #654 (post-merge QA of #662). Targets **`epic/tui`**. Addresses the actionable QA findings; dialog-mouse is folded into #663 and the systemic staged-type downgrade is tracked in **#664** (this PR only *contains* it in the TUI).

## Fixes
1. **[HIGH] `$EDITOR` tokenization + VISUAL + Windows fallback** — extracted a shared `editor.Command(ctx, tmpFile) *exec.Cmd` + exported `editor.Normalize` in `internal/cli/editor`; both the CLI (`Open`) and the TUI (`tea.ExecProcess`) now use it (`sh -c 'editor "$1"'`, VISUAL→EDITOR, notepad/vi fallback). Removed the false `//nolint` parity comment.
2. **[MED-HIGH] Editor read-back newline normalization** — `Normalize` applied before the no-op compare; `TestEntryForm_EditorNoOp` is now a real round-trip (editor appends `\n` → "No changes made.").
3. **[MED, security containment] Staged Type** — `showType()` gated to immediate mode so staged mode never shows a Type control that can't take effect (silent SecureString→plaintext). Real fix tracked in **#664**.
4. **[MED] Description field** — new `capability.ServiceCapability.HasDescription` (AWS param/secret only) gates the Description input; `models.ts` kept in sync with the DTO contract.
5. **[LOW-MED]** editor read-back now `rebuildForm()` (consistency).
6. **[LOW]** added `errordialog` golden + delete/tag result-voicing tests.

## Gates
`go test -race ./internal/tui/... ./internal/cli/editor/...` clean (twice); `mise test`/`lint`/deadcode/naming/`build-cli` green. Goldens regenerated (Type/Description rows removed as intended); no secret value in any golden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)