### PR TITLE
fix(staging): carry ValueType so staged SecureString is not silently applied as plaintext (#664)

### DIFF
--- a/internal/cli/commands/aws/stage/param/command.go
+++ b/internal/cli/commands/aws/stage/param/command.go
@@ -2,19 +2,68 @@
 package param
 
 import (
+	"errors"
+
 	"github.com/urfave/cli/v3"
 
+	"github.com/mpyw/suve/internal/cli/commands/aws/param/paramtype"
 	cliinternal "github.com/mpyw/suve/internal/cli/commands/internal"
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/staging"
 	stgcli "github.com/mpyw/suve/internal/staging/cli"
 )
 
 //nolint:gochecknoglobals // package-level config for command factory
 var config = stgcli.CommandConfig{
-	CommandName:   "param",
-	ItemName:      "parameter",
-	Factory:       cliinternal.AWSParamStrategyFactory,
-	ParserFactory: staging.AWSParamParserFactory,
+	CommandName:      "param",
+	ItemName:         "parameter",
+	Factory:          cliinternal.AWSParamStrategyFactory,
+	ParserFactory:    staging.AWSParamParserFactory,
+	ValueTypeFlags:   valueTypeFlags(),
+	ValueTypeFromCmd: resolveValueType,
+}
+
+// valueTypeFlags returns the SSM Parameter Store type flags for stage add/edit,
+// matching the immediate `param create`/`param update` commands. --type carries
+// no default so an unset flag stays "not specified" (create then applies String,
+// edit preserves the existing type).
+func valueTypeFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:  "type",
+			Usage: "Parameter type (String, StringList, SecureString)",
+		},
+		&cli.BoolFlag{
+			Name:  "secure",
+			Usage: "Shorthand for --type SecureString",
+		},
+	}
+}
+
+// resolveValueType maps the --type/--secure flags to a domain.ValueType, using
+// the same mutual-exclusion and validation as immediate `param create`. It
+// returns an empty value type when neither flag is set, meaning "not specified".
+func resolveValueType(cmd *cli.Command) (domain.ValueType, error) {
+	secure := cmd.Bool("secure")
+	typeSet := cmd.IsSet("type")
+
+	if secure && typeSet {
+		return "", errors.New("cannot use --secure with --type; use one or the other")
+	}
+
+	switch {
+	case secure:
+		return domain.ValueTypeSecret, nil
+	case typeSet:
+		paramType := cmd.String("type")
+		if err := paramtype.Validate(paramType); err != nil {
+			return "", err
+		}
+
+		return paramtype.Parse(paramType), nil
+	default:
+		return "", nil
+	}
 }
 
 // Config returns the AWS SSM Parameter Store staging command config. It is used

--- a/internal/cli/commands/aws/stage/param/command_test.go
+++ b/internal/cli/commands/aws/stage/param/command_test.go
@@ -92,6 +92,26 @@ func TestCommand_EditSubcommand(t *testing.T) {
 	assert.NotNil(t, editCmd.Action)
 }
 
+func TestCommand_AddEditHaveTypeFlags(t *testing.T) {
+	t.Parallel()
+
+	cmd := param.Command()
+	require.NotNil(t, cmd)
+
+	for _, name := range []string{"add", "edit"} {
+		leaf, found := lo.Find(cmd.Commands, func(c *cli.Command) bool {
+			return c.Name == name
+		})
+		require.True(t, found, "should have %s subcommand", name)
+
+		flagNames := lo.FlatMap(leaf.Flags, func(f cli.Flag, _ int) []string {
+			return f.Names()
+		})
+		assert.Contains(t, flagNames, "type", "%s should accept --type", name)
+		assert.Contains(t, flagNames, "secure", "%s should accept --secure", name)
+	}
+}
+
 func TestCommand_DeleteSubcommand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/commands/aws/stage/param/resolve_internal_test.go
+++ b/internal/cli/commands/aws/stage/param/resolve_internal_test.go
@@ -1,0 +1,98 @@
+package param
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
+
+	"github.com/mpyw/suve/internal/domain"
+)
+
+// runResolve builds a throwaway command carrying the value-type flags, runs it
+// with the given args so the flags are populated, and returns what
+// resolveValueType produced.
+func runResolve(t *testing.T, args []string) (domain.ValueType, error) {
+	t.Helper()
+
+	var (
+		got    domain.ValueType
+		gotErr error
+	)
+
+	cmd := &cli.Command{
+		Name:  "add",
+		Flags: valueTypeFlags(),
+		Action: func(_ context.Context, c *cli.Command) error {
+			got, gotErr = resolveValueType(c)
+
+			return nil
+		},
+	}
+
+	require.NoError(t, cmd.Run(context.Background(), append([]string{"add"}, args...)))
+
+	return got, gotErr
+}
+
+func TestResolveValueType(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no flags is unset", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := runResolve(t, nil)
+		require.NoError(t, err)
+		assert.Empty(t, string(got))
+	})
+
+	t.Run("--secure is SecureString", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := runResolve(t, []string{"--secure"})
+		require.NoError(t, err)
+		assert.Equal(t, domain.ValueTypeSecret, got)
+	})
+
+	t.Run("--type SecureString is secret", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := runResolve(t, []string{"--type", "SecureString"})
+		require.NoError(t, err)
+		assert.Equal(t, domain.ValueTypeSecret, got)
+	})
+
+	t.Run("--type StringList is list", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := runResolve(t, []string{"--type", "StringList"})
+		require.NoError(t, err)
+		assert.Equal(t, domain.ValueTypeList, got)
+	})
+
+	t.Run("--type String is plaintext", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := runResolve(t, []string{"--type", "String"})
+		require.NoError(t, err)
+		assert.Equal(t, domain.ValueTypePlaintext, got)
+	})
+
+	t.Run("--type with an invalid value errors", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := runResolve(t, []string{"--type", "Sekret"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid --type")
+	})
+
+	t.Run("--secure with --type conflicts", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := runResolve(t, []string{"--secure", "--type", "String"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "cannot use --secure with --type")
+	})
+}

--- a/internal/staging/aws_param.go
+++ b/internal/staging/aws_param.go
@@ -67,9 +67,16 @@ func (s *AWSParamStrategy) applyCreate(ctx context.Context, name string, entry E
 		return nil
 	}
 
-	// Create is create-only (never overwrites an existing parameter). New
-	// parameters are created as plain String, matching the prior behavior.
-	if _, err := s.store.Create(ctx, name, *entry.Value, domain.ValueTypePlaintext, lo.FromPtr(entry.Description)); err != nil {
+	// Create is create-only (never overwrites an existing parameter). Use the
+	// staged value type (String / SecureString / StringList); an unset type
+	// defaults to plaintext String, matching entries staged before the staging
+	// model carried a type.
+	valueType := entry.ValueType
+	if valueType == "" {
+		valueType = domain.ValueTypePlaintext
+	}
+
+	if _, err := s.store.Create(ctx, name, *entry.Value, valueType, lo.FromPtr(entry.Description)); err != nil {
 		return fmt.Errorf("failed to create parameter: %w", err)
 	}
 
@@ -81,7 +88,7 @@ func (s *AWSParamStrategy) applyUpdate(ctx context.Context, name string, entry E
 		return nil
 	}
 
-	// Preserve the existing parameter type; a missing parameter is a hard error.
+	// A missing parameter is a hard error.
 	existing, err := s.store.Get(ctx, name, provider.VersionRef{})
 	if err != nil {
 		if errors.Is(err, provider.ErrNotFound) {
@@ -91,8 +98,16 @@ func (s *AWSParamStrategy) applyUpdate(ctx context.Context, name string, entry E
 		return fmt.Errorf("failed to get existing parameter: %w", err)
 	}
 
+	// Use the staged value type when the edit specified one; otherwise preserve
+	// the existing parameter type (an unset staged type must never downgrade a
+	// SecureString to plain String).
+	valueType := existing.Type
+	if entry.ValueType != "" {
+		valueType = entry.ValueType
+	}
+
 	// Put overwrites the existing parameter.
-	if _, err := s.store.Put(ctx, name, *entry.Value, existing.Type, lo.FromPtr(entry.Description)); err != nil {
+	if _, err := s.store.Put(ctx, name, *entry.Value, valueType, lo.FromPtr(entry.Description)); err != nil {
 		return fmt.Errorf("failed to update parameter: %w", err)
 	}
 

--- a/internal/staging/aws_param_test.go
+++ b/internal/staging/aws_param_test.go
@@ -226,6 +226,120 @@ func TestParamStrategy_Apply(t *testing.T) {
 	})
 }
 
+// TestParamStrategy_Apply_ValueType covers #664: a staged param create/update
+// must apply with the staged value type instead of a hardcoded plaintext String.
+func TestParamStrategy_Apply_ValueType(t *testing.T) {
+	t.Parallel()
+
+	t.Run("create operation - SecureString applies as SecureString", func(t *testing.T) {
+		t.Parallel()
+
+		var gotType domain.ValueType
+
+		mock := &providermock.Store{
+			CreateFunc: func(
+				_ context.Context, name, value string, valueType domain.ValueType, _ string, _ ...provider.WriteOption,
+			) (domain.Version, error) {
+				gotType = valueType
+
+				assert.Equal(t, "/app/secure", name)
+				assert.Equal(t, "secret-value", value)
+
+				return domain.Version{ID: "1"}, nil
+			},
+		}
+
+		s := staging.NewAWSParamStrategy(mock)
+		err := s.Apply(t.Context(), "/app/secure", staging.Entry{
+			Operation: staging.OperationCreate,
+			Value:     lo.ToPtr("secret-value"),
+			ValueType: domain.ValueTypeSecret,
+		})
+		require.NoError(t, err)
+		// The staged SecureString must NOT be silently downgraded to plaintext (#664).
+		assert.Equal(t, domain.ValueTypeSecret, gotType)
+	})
+
+	t.Run("create operation - StringList applies as StringList", func(t *testing.T) {
+		t.Parallel()
+
+		var gotType domain.ValueType
+
+		mock := &providermock.Store{
+			CreateFunc: func(
+				_ context.Context, _, _ string, valueType domain.ValueType, _ string, _ ...provider.WriteOption,
+			) (domain.Version, error) {
+				gotType = valueType
+
+				return domain.Version{ID: "1"}, nil
+			},
+		}
+
+		s := staging.NewAWSParamStrategy(mock)
+		err := s.Apply(t.Context(), "/app/list", staging.Entry{
+			Operation: staging.OperationCreate,
+			Value:     lo.ToPtr("a,b,c"),
+			ValueType: domain.ValueTypeList,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, domain.ValueTypeList, gotType)
+	})
+
+	t.Run("create operation - unset type defaults to plaintext", func(t *testing.T) {
+		t.Parallel()
+
+		var gotType domain.ValueType
+
+		mock := &providermock.Store{
+			CreateFunc: func(
+				_ context.Context, _, _ string, valueType domain.ValueType, _ string, _ ...provider.WriteOption,
+			) (domain.Version, error) {
+				gotType = valueType
+
+				return domain.Version{ID: "1"}, nil
+			},
+		}
+
+		s := staging.NewAWSParamStrategy(mock)
+		err := s.Apply(t.Context(), "/app/plain", staging.Entry{
+			Operation: staging.OperationCreate,
+			Value:     lo.ToPtr("plain"),
+			// ValueType intentionally unset (mirrors an entry staged before #664).
+		})
+		require.NoError(t, err)
+		assert.Equal(t, domain.ValueTypePlaintext, gotType)
+	})
+
+	t.Run("update operation - staged type overrides existing", func(t *testing.T) {
+		t.Parallel()
+
+		var gotType domain.ValueType
+
+		mock := &providermock.Store{
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) {
+				return &domain.Entry{Value: "old-value", Type: domain.ValueTypePlaintext}, nil
+			},
+			PutFunc: func(
+				_ context.Context, _, _ string, valueType domain.ValueType, _ string, _ ...provider.WriteOption,
+			) (domain.Version, error) {
+				gotType = valueType
+
+				return domain.Version{ID: "2"}, nil
+			},
+		}
+
+		s := staging.NewAWSParamStrategy(mock)
+		err := s.Apply(t.Context(), "/app/param", staging.Entry{
+			Operation: staging.OperationUpdate,
+			Value:     lo.ToPtr("updated"),
+			ValueType: domain.ValueTypeSecret,
+		})
+		require.NoError(t, err)
+		// An explicit staged type upgrades the existing String to SecureString.
+		assert.Equal(t, domain.ValueTypeSecret, gotType)
+	})
+}
+
 func TestParamStrategy_FetchCurrent(t *testing.T) {
 	t.Parallel()
 

--- a/internal/staging/cli/add.go
+++ b/internal/staging/cli/add.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mpyw/suve/internal/cli/editor"
 	"github.com/mpyw/suve/internal/cli/output"
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/staging"
 	stagingusecase "github.com/mpyw/suve/internal/usecase/staging"
 )
@@ -27,6 +28,9 @@ type AddOptions struct {
 	// Namespace is the App Configuration namespace to stage under (empty for the
 	// null/default namespace and every other provider).
 	Namespace string
+	// ValueType is the provider-neutral value type to record on the staged entry
+	// (AWS SSM Parameter Store axis). Empty for providers without a type axis.
+	ValueType domain.ValueType
 }
 
 // Run executes the add command.
@@ -73,6 +77,7 @@ func (r *AddRunner) Run(ctx context.Context, opts AddOptions) error {
 		Key:         staging.EntryKey{Name: opts.Name, Namespace: opts.Namespace},
 		Value:       newValue,
 		Description: opts.Description,
+		ValueType:   opts.ValueType,
 	})
 	if err != nil {
 		return err

--- a/internal/staging/cli/command.go
+++ b/internal/staging/cli/command.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mpyw/suve/internal/cli/confirm"
 	"github.com/mpyw/suve/internal/cli/pager"
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/staging"
 	stagingusecase "github.com/mpyw/suve/internal/usecase/staging"
 )
@@ -58,6 +59,28 @@ type CommandConfig struct {
 	// its own namespace (App Configuration keeps all namespaces in one staging
 	// store). Nil for providers without a namespace axis.
 	StrategyForNamespace func(ctx context.Context, namespace string) (staging.FullStrategy, error)
+
+	// ValueTypeFlags are provider-specific flags appended to the add and edit
+	// commands so the staged entry can carry a value type (the AWS SSM Parameter
+	// Store --type/--secure axis). Nil for providers without a value-type axis.
+	ValueTypeFlags []cli.Flag
+
+	// ValueTypeFromCmd validates and resolves the staged value type from the
+	// add/edit command flags (ValueTypeFlags). Nil for providers without a
+	// value-type axis, in which case the staged value type is left unset. An
+	// empty return means "not specified": create applies plaintext and update
+	// preserves the existing type.
+	ValueTypeFromCmd func(cmd *cli.Command) (domain.ValueType, error)
+}
+
+// valueTypeFor resolves the staged value type from the command flags, or ""
+// when the provider has no value-type axis.
+func (c CommandConfig) valueTypeFor(cmd *cli.Command) (domain.ValueType, error) {
+	if c.ValueTypeFromCmd == nil {
+		return "", nil
+	}
+
+	return c.ValueTypeFromCmd(cmd)
 }
 
 // namespaceFor returns the single-item namespace for this command context, or ""
@@ -211,12 +234,12 @@ func NewAddCommand(cfg CommandConfig) *cli.Command {
 		Usage:       fmt.Sprintf("Create new %s and stage it", cfg.ItemName),
 		ArgsUsage:   "<name> [value]",
 		Description: addDescription(cfg),
-		Flags: []cli.Flag{
+		Flags: append([]cli.Flag{
 			&cli.StringFlag{
 				Name:  "description",
 				Usage: fmt.Sprintf("Description for the %s", cfg.ItemName),
 			},
-		},
+		}, cfg.ValueTypeFlags...),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.Args().Len() < 1 {
 				return fmt.Errorf("usage: suve stage %s add <name> [value]", cfg.CommandName)
@@ -227,6 +250,11 @@ func NewAddCommand(cfg CommandConfig) *cli.Command {
 			var value string
 			if cmd.Args().Len() >= 2 { //nolint:mnd // check for optional value argument
 				value = cmd.Args().Get(1)
+			}
+
+			valueType, err := cfg.valueTypeFor(cmd)
+			if err != nil {
+				return err
 			}
 
 			store, _, err := workingStore(ctx, cfg.ScopeResolver)
@@ -253,6 +281,7 @@ func NewAddCommand(cfg CommandConfig) *cli.Command {
 				Value:       value,
 				Description: cmd.String("description"),
 				Namespace:   cfg.namespaceFor(ctx),
+				ValueType:   valueType,
 			})
 		},
 	}
@@ -265,12 +294,12 @@ func NewEditCommand(cfg CommandConfig) *cli.Command {
 		Usage:       fmt.Sprintf("Edit %s value and stage changes", cfg.ItemName),
 		ArgsUsage:   "<name> [value]",
 		Description: editDescription(cfg),
-		Flags: []cli.Flag{
+		Flags: append([]cli.Flag{
 			&cli.StringFlag{
 				Name:  "description",
 				Usage: fmt.Sprintf("Description for the %s", cfg.ItemName),
 			},
-		},
+		}, cfg.ValueTypeFlags...),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.Args().Len() < 1 {
 				return fmt.Errorf("usage: suve stage %s edit <name> [value]", cfg.CommandName)
@@ -281,6 +310,11 @@ func NewEditCommand(cfg CommandConfig) *cli.Command {
 			var value string
 			if cmd.Args().Len() >= 2 { //nolint:mnd // check for optional value argument
 				value = cmd.Args().Get(1)
+			}
+
+			valueType, err := cfg.valueTypeFor(cmd)
+			if err != nil {
+				return err
 			}
 
 			store, _, err := workingStore(ctx, cfg.ScopeResolver)
@@ -307,6 +341,7 @@ func NewEditCommand(cfg CommandConfig) *cli.Command {
 				Value:       value,
 				Description: cmd.String("description"),
 				Namespace:   cfg.namespaceFor(ctx),
+				ValueType:   valueType,
 			})
 		},
 	}

--- a/internal/staging/cli/edit.go
+++ b/internal/staging/cli/edit.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mpyw/suve/internal/cli/editor"
 	"github.com/mpyw/suve/internal/cli/output"
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/staging"
 	stagingusecase "github.com/mpyw/suve/internal/usecase/staging"
 )
@@ -27,6 +28,9 @@ type EditOptions struct {
 	// Namespace is the App Configuration namespace of the setting (empty for the
 	// null/default namespace and every other provider).
 	Namespace string
+	// ValueType is the provider-neutral value type to record on the staged entry
+	// (AWS SSM Parameter Store axis). Empty preserves the existing type.
+	ValueType domain.ValueType
 }
 
 // Run executes the edit command.
@@ -66,6 +70,7 @@ func (r *EditRunner) Run(ctx context.Context, opts EditOptions) error {
 		Key:         staging.EntryKey{Name: opts.Name, Namespace: opts.Namespace},
 		Value:       newValue,
 		Description: opts.Description,
+		ValueType:   opts.ValueType,
 	})
 	if err != nil {
 		return err

--- a/internal/staging/stage.go
+++ b/internal/staging/stage.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/maputil"
 )
 
@@ -83,6 +84,16 @@ type Entry struct {
 	Operation   Operation `json:"operation"`
 	Value       *string   `json:"value,omitempty"` // nil for delete, pointer to distinguish from empty string
 	Description *string   `json:"description,omitempty"`
+	// ValueType classifies the staged value in the provider-neutral domain model.
+	// It only matters on the AWS SSM Parameter Store axis (String / SecureString /
+	// StringList); every other provider's staging path ignores it. An empty value
+	// means "unset": the apply path treats it as ValueTypePlaintext for create, and
+	// as "preserve the existing type" for update. Older on-disk entries written
+	// before this field existed decode as empty, preserving the prior plaintext
+	// behavior. Optional and additive so the working-store schema stays backward
+	// compatible (no version bump).
+	//nolint:tagliatelle // JSON uses snake_case for consistency with file storage format
+	ValueType domain.ValueType `json:"value_type,omitempty"`
 	//nolint:tagliatelle // JSON uses snake_case for consistency with file storage format
 	StagedAt time.Time `json:"staged_at"`
 	// BaseModifiedAt records the AWS LastModified time when the value was fetched.

--- a/internal/staging/stage_test.go
+++ b/internal/staging/stage_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/maputil"
 	"github.com/mpyw/suve/internal/staging"
 )
@@ -318,6 +319,78 @@ func TestState_UnmarshalJSON_Duplicate(t *testing.T) {
 		err := json.Unmarshal([]byte(data), &state)
 		require.NoError(t, err)
 		assert.Equal(t, 2, state.EntryCount())
+	})
+}
+
+func TestState_UnmarshalJSON_ValueType(t *testing.T) {
+	t.Parallel()
+
+	key := staging.EntryKey{Name: "/app/x"}
+
+	t.Run("entry written before value_type existed decodes as unset", func(t *testing.T) {
+		t.Parallel()
+
+		// A v3 working-store file written before #664 has no "value_type" field.
+		// It must load without error and default to the empty (plaintext) type.
+		data := `{"version":3,"entries":{"param":[` +
+			`{"name":"/app/x","operation":"create","value":"v","staged_at":"2024-01-01T00:00:00Z"}]}}`
+
+		var state staging.State
+
+		require.NoError(t, json.Unmarshal([]byte(data), &state))
+
+		entry := state.Entries[staging.ServiceParam][key]
+		assert.Equal(t, staging.OperationCreate, entry.Operation)
+		assert.Empty(t, string(entry.ValueType))
+	})
+
+	t.Run("entry with value_type decodes it", func(t *testing.T) {
+		t.Parallel()
+
+		data := `{"version":3,"entries":{"param":[` +
+			`{"name":"/app/x","operation":"create","value":"v","value_type":"secret","staged_at":"2024-01-01T00:00:00Z"}]}}`
+
+		var state staging.State
+
+		require.NoError(t, json.Unmarshal([]byte(data), &state))
+
+		entry := state.Entries[staging.ServiceParam][key]
+		assert.Equal(t, domain.ValueTypeSecret, entry.ValueType)
+	})
+
+	t.Run("round-trips through marshal", func(t *testing.T) {
+		t.Parallel()
+
+		state := staging.NewEmptyState()
+		state.Entries[staging.ServiceParam][key] = staging.Entry{
+			Operation: staging.OperationCreate,
+			Value:     lo.ToPtr("v"),
+			ValueType: domain.ValueTypeSecret,
+			StagedAt:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
+
+		data, err := json.Marshal(state)
+		require.NoError(t, err)
+
+		var got staging.State
+
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, domain.ValueTypeSecret, got.Entries[staging.ServiceParam][key].ValueType)
+	})
+
+	t.Run("unset type is omitted from the marshaled form", func(t *testing.T) {
+		t.Parallel()
+
+		state := staging.NewEmptyState()
+		state.Entries[staging.ServiceParam][key] = staging.Entry{
+			Operation: staging.OperationCreate,
+			Value:     lo.ToPtr("v"),
+			StagedAt:  time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
+
+		data, err := json.Marshal(state)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "value_type")
 	})
 }
 

--- a/internal/staging/transition/executor.go
+++ b/internal/staging/transition/executor.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store"
 )
@@ -23,8 +24,9 @@ func NewExecutor(store store.ReadWriteOperator) *Executor {
 
 // EntryExecuteOptions holds optional metadata for entry execution.
 type EntryExecuteOptions struct {
-	BaseModifiedAt *time.Time // Base modification time for conflict detection
-	Description    *string    // Optional description for the staged entry
+	BaseModifiedAt *time.Time       // Base modification time for conflict detection
+	Description    *string          // Optional description for the staged entry
+	ValueType      domain.ValueType // Provider-neutral value type (AWS param axis); empty means unset
 }
 
 // ExecuteEntry executes an entry action and persists the result.
@@ -106,8 +108,11 @@ func (e *Executor) persistEntryState(
 			Value:     lo.ToPtr(s.DraftValue),
 			StagedAt:  time.Now(),
 		}
-		if opts != nil && opts.Description != nil {
-			entry.Description = opts.Description
+		if opts != nil {
+			entry.ValueType = opts.ValueType
+			if opts.Description != nil {
+				entry.Description = opts.Description
+			}
 		}
 
 		err = e.Store.StageEntry(ctx, service, key, entry)
@@ -120,6 +125,8 @@ func (e *Executor) persistEntryState(
 		}
 		if opts != nil {
 			entry.BaseModifiedAt = opts.BaseModifiedAt
+			entry.ValueType = opts.ValueType
+
 			if opts.Description != nil {
 				entry.Description = opts.Description
 			}

--- a/internal/usecase/staging/add.go
+++ b/internal/usecase/staging/add.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store"
 	"github.com/mpyw/suve/internal/staging/transition"
@@ -26,6 +27,11 @@ type AddInput struct {
 	Key         staging.EntryKey
 	Value       string
 	Description string
+	// ValueType is the provider-neutral value type for the staged create. It is
+	// only meaningful on the AWS SSM Parameter Store axis (String / SecureString /
+	// StringList); other providers leave it empty. An empty value applies as
+	// plaintext, so callers that do not set it keep the prior behavior.
+	ValueType domain.ValueType
 }
 
 // AddOutput holds the result of the add use case.
@@ -71,6 +77,21 @@ func (u *AddUseCase) Execute(ctx context.Context, input AddInput) (*AddOutput, e
 
 	key := staging.EntryKey{Name: name, Namespace: input.Key.Namespace}
 
+	// Resolve the staged value type. When the caller specifies none, preserve a
+	// previously staged type so re-staging the create (e.g. re-editing the draft
+	// without --secure) never silently downgrades a SecureString to plain String.
+	valueType := input.ValueType
+	if valueType == "" {
+		existing, gerr := u.Store.GetEntry(ctx, service, key)
+
+		switch {
+		case gerr == nil:
+			valueType = existing.ValueType
+		case !errors.Is(gerr, staging.ErrNotStaged):
+			return nil, gerr
+		}
+	}
+
 	// Load current state with AWS existence check
 	entryState, err := transition.LoadEntryState(ctx, u.Store, service, key, currentValue)
 	if err != nil {
@@ -80,7 +101,7 @@ func (u *AddUseCase) Execute(ctx context.Context, input AddInput) (*AddOutput, e
 	// Execute the transition
 	executor := transition.NewExecutor(u.Store)
 
-	opts := &transition.EntryExecuteOptions{}
+	opts := &transition.EntryExecuteOptions{ValueType: valueType}
 	if input.Description != "" {
 		opts.Description = &input.Description
 	}

--- a/internal/usecase/staging/add_test.go
+++ b/internal/usecase/staging/add_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store/testutil"
 	"github.com/mpyw/suve/internal/staging/transition"
@@ -67,6 +68,57 @@ func TestAddUseCase_Execute(t *testing.T) {
 	assert.Equal(t, staging.OperationCreate, entry.Operation)
 	assert.Equal(t, "new-value", lo.FromPtr(entry.Value))
 	assert.Equal(t, "test description", lo.FromPtr(entry.Description))
+}
+
+func TestAddUseCase_Execute_RecordsValueType(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	uc := &usecasestaging.AddUseCase{
+		Strategy: newMockEditStrategyNotFound(),
+		Store:    store,
+	}
+
+	_, err := uc.Execute(t.Context(), usecasestaging.AddInput{
+		Key:       staging.EntryKey{Name: "/app/secure"},
+		Value:     "secret",
+		ValueType: domain.ValueTypeSecret,
+	})
+	require.NoError(t, err)
+
+	entry, err := store.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/secure"})
+	require.NoError(t, err)
+	assert.Equal(t, domain.ValueTypeSecret, entry.ValueType)
+}
+
+func TestAddUseCase_Execute_PreservesStagedTypeOnReAddWithoutType(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	// A create was previously staged as SecureString.
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/secure"}, staging.Entry{
+		Operation: staging.OperationCreate,
+		Value:     lo.ToPtr("v1"),
+		ValueType: domain.ValueTypeSecret,
+		StagedAt:  time.Now(),
+	}))
+
+	uc := &usecasestaging.AddUseCase{
+		Strategy: newMockEditStrategyNotFound(),
+		Store:    store,
+	}
+
+	// Re-staging without a type must NOT downgrade the prior SecureString (#664).
+	_, err := uc.Execute(t.Context(), usecasestaging.AddInput{
+		Key:   staging.EntryKey{Name: "/app/secure"},
+		Value: "v2",
+	})
+	require.NoError(t, err)
+
+	entry, err := store.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/secure"})
+	require.NoError(t, err)
+	assert.Equal(t, "v2", lo.FromPtr(entry.Value))
+	assert.Equal(t, domain.ValueTypeSecret, entry.ValueType)
 }
 
 func TestAddUseCase_Execute_RejectsWhenResourceExists(t *testing.T) {

--- a/internal/usecase/staging/edit.go
+++ b/internal/usecase/staging/edit.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store"
 	"github.com/mpyw/suve/internal/staging/transition"
@@ -20,6 +21,12 @@ type EditInput struct {
 	Key         staging.EntryKey
 	Value       string
 	Description string
+	// ValueType is the provider-neutral value type for the staged update. It is
+	// only meaningful on the AWS SSM Parameter Store axis (String / SecureString /
+	// StringList); other providers leave it empty. An empty value preserves the
+	// existing (staged or cloud) type, so callers that do not set it keep the
+	// prior type-preserving behavior.
+	ValueType domain.ValueType
 }
 
 // EditOutput holds the result of the edit use case.
@@ -92,9 +99,18 @@ func (u *EditUseCase) Execute(ctx context.Context, input EditInput) (*EditOutput
 		baseModifiedAt = awsBaseModifiedAt
 	}
 
+	// Resolve the staged value type. When the caller specifies none, preserve a
+	// previously staged type so a follow-up edit never silently downgrades it;
+	// aws_param then falls back to the existing cloud type when this stays empty.
+	valueType := input.ValueType
+	if valueType == "" && stagedEntry != nil {
+		valueType = stagedEntry.ValueType
+	}
+
 	// Build options with metadata
 	opts := &transition.EntryExecuteOptions{
 		BaseModifiedAt: baseModifiedAt,
+		ValueType:      valueType,
 	}
 	if input.Description != "" {
 		opts.Description = &input.Description

--- a/internal/usecase/staging/edit_test.go
+++ b/internal/usecase/staging/edit_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store/testutil"
 	usecasestaging "github.com/mpyw/suve/internal/usecase/staging"
@@ -71,6 +72,59 @@ func TestEditUseCase_Execute(t *testing.T) {
 	assert.Equal(t, staging.OperationUpdate, entry.Operation)
 	assert.Equal(t, "updated-value", lo.FromPtr(entry.Value))
 	assert.NotNil(t, entry.BaseModifiedAt)
+}
+
+func TestEditUseCase_Execute_RecordsValueType(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	uc := &usecasestaging.EditUseCase{
+		Strategy: newMockEditStrategy(),
+		Store:    store,
+	}
+
+	_, err := uc.Execute(t.Context(), usecasestaging.EditInput{
+		Key:       staging.EntryKey{Name: "/app/config"},
+		Value:     "updated-value",
+		ValueType: domain.ValueTypeSecret,
+	})
+	require.NoError(t, err)
+
+	entry, err := store.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/config"})
+	require.NoError(t, err)
+	assert.Equal(t, domain.ValueTypeSecret, entry.ValueType)
+}
+
+func TestEditUseCase_Execute_PreservesStagedTypeWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	// A create was previously staged as SecureString.
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/secure"}, staging.Entry{
+		Operation: staging.OperationCreate,
+		Value:     lo.ToPtr("v1"),
+		ValueType: domain.ValueTypeSecret,
+		StagedAt:  time.Now(),
+	}))
+
+	uc := &usecasestaging.EditUseCase{
+		Strategy: newMockEditStrategyNotFound(),
+		Store:    store,
+	}
+
+	// Editing the staged draft value without a type must preserve SecureString.
+	_, err := uc.Execute(t.Context(), usecasestaging.EditInput{
+		Key:   staging.EntryKey{Name: "/app/secure"},
+		Value: "v2",
+	})
+	require.NoError(t, err)
+
+	entry, err := store.GetEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/secure"})
+	require.NoError(t, err)
+	assert.Equal(t, "v2", lo.FromPtr(entry.Value))
+	assert.Equal(t, domain.ValueTypeSecret, entry.ValueType)
+	// Operation stays create (editing a staged create keeps it a create).
+	assert.Equal(t, staging.OperationCreate, entry.Operation)
 }
 
 func TestEditUseCase_Execute_RejectsNonUTF8Value(t *testing.T) {


### PR DESCRIPTION
Refs **#664** (Priority:Critical). Backend + CLI (PR1). **Does not fully close #664** — the GUI still drops the staged param type (follow-up PR2) and the TUI staged-Type re-enable comes after `main` merges into `epic/tui`; #664 stays open until all frontends are fixed.

Previously a staged AWS SSM param create/edit was **always** applied as plaintext `String` (`internal/staging/aws_param.go` hardcoded `domain.ValueTypePlaintext`), silently downgrading an intended `SecureString` to cleartext.

## Fix (backend + CLI)
- **Schema (back-compat)**: optional `ValueType` on `staging.Entry` (`value_type,omitempty`); no version bump; old files decode as empty → plaintext. Real old-JSON fixture + round-trip tested.
- **Threading**: `EntryExecuteOptions.ValueType`; `AddInput`/`EditInput` gained `ValueType`; a re-add/edit **without** a type **preserves** the previously staged type (never re-downgrades).
- **Apply**: `applyCreate` uses the staged type (default plaintext); `applyUpdate` overrides only when a type is given.
- **CLI**: `stage param add`/`edit` accept `--type`/`--secure` (mutually exclusive), **AWS-param-only**.
- GUI compiles unchanged (still drops type — fixed in PR2); other providers untouched.

## Tests
SecureString→SecureString / unset→plaintext / update-override asserted at the provider-mock write boundary; old-JSON back-compat; re-add/edit type preservation; CLI flag/conflict cases. `go test -race ./internal/staging/... ./internal/usecase/staging/... ./internal/cli/...` clean; other gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)