### PR TITLE
Step 5: TUI staging page — sections, diff/value, apply with conflicts/results, reset

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -25,7 +25,6 @@ import (
 	"github.com/mpyw/suve/internal/tui/dialogs"
 	"github.com/mpyw/suve/internal/tui/keys"
 	"github.com/mpyw/suve/internal/tui/nav"
-	"github.com/mpyw/suve/internal/tui/pages/browser"
 	"github.com/mpyw/suve/internal/tui/styles"
 )
 
@@ -73,6 +72,11 @@ type config struct {
 	// dialogs' seam). Production wires it to the registry-backed sourceFactory,
 	// tests to a providermock-backed one; nil disables the write dialogs.
 	mutatorFor func(service string) data.Mutator
+	// stagingFor builds the review/apply/reset seam for a service, backing the
+	// staging page's sections and the apply/reset dialogs. Production wires it to
+	// the registry-backed sourceFactory, tests to a providermock-backed one; nil
+	// leaves the Staging tab a placeholder.
+	stagingFor func(service string) data.StagingService
 	// runCtx is the Run context threaded into pages so their fetch commands are
 	// cancelled when the program exits. Tests may leave it nil (newApp defaults it
 	// to context.Background()).
@@ -135,6 +139,7 @@ type App struct {
 	// threaded into pages.
 	sourceFor  func(service string) (data.Source, data.StagingProbe)
 	mutatorFor func(service string) data.Mutator
+	stagingFor func(service string) data.StagingService
 	runCtx     context.Context //nolint:containedctx // threaded into page fetch commands; mirrors the GUI
 
 	// status is a transient one-line outcome (staged/applied/skipped/unstaged)
@@ -165,6 +170,7 @@ func newApp(cfg config) *App {
 		identity:      cfg.identity,
 		sourceFor:     cfg.sourceFor,
 		mutatorFor:    cfg.mutatorFor,
+		stagingFor:    cfg.stagingFor,
 		runCtx:        cmp.Or(cfg.runCtx, context.Background()),
 		stagedCounts:  map[string]int{},
 	}
@@ -262,6 +268,12 @@ func (m *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.openTag(msg)
 	case nav.OpenRestore:
 		return m, m.openRestore(msg)
+	case nav.OpenApply:
+		return m, m.openApply(msg)
+	case nav.OpenReset:
+		return m, m.openReset(msg)
+	case nav.OpenStagingDetail:
+		return m, m.pushStagingDetail(msg)
 	case nav.OpenError:
 		m.pushDialog(dialogs.NewError(m.styles, msg.Title, msg.Message), nil)
 
@@ -303,7 +315,7 @@ func (m *App) reloadActivePage() tea.Cmd {
 	}
 
 	top := len(m.pages) - 1
-	p, cmd := m.pages[top].Update(browser.ReloadMsg{})
+	p, cmd := m.pages[top].Update(nav.Reload{})
 	m.pages[top] = p
 
 	return cmd
@@ -426,8 +438,8 @@ func (m *App) refreshStagingTab() {
 	}
 }
 
-// openStaging switches to the Staging tab (the browser's `S` jump). The staging
-// page is a placeholder until Step 5; landing on the tab is enough.
+// openStaging switches to the Staging tab (the browser's `S` jump); setTab
+// builds and loads the real staging page.
 func (m *App) openStaging() {
 	for i, t := range m.tabs {
 		if t.Service == stagingService {
@@ -688,12 +700,23 @@ func (m *App) setTab(i int) tea.Cmd {
 	return cmd
 }
 
-// pageForTab builds the page for a tab index: a real browser page for a
-// param/secret service when a data source is wired, else the placeholder.
+// pageForTab builds the page for a tab index: the staging page for the Staging
+// tab (when its seam is wired), a browser page for a param/secret service (when
+// a data source is wired), else the placeholder.
 func (m *App) pageForTab(i int) (page, tea.Cmd) {
 	tab := m.tabs[i]
 
-	if tab.Service != stagingService && m.sourceFor != nil {
+	if tab.Service == stagingService {
+		if services := m.stagingServicesFor(m.offeredServices()); len(services) > 0 {
+			p := newStagingPage(m.runCtx, services, m.styles, m.keys)
+
+			return p, p.Init()
+		}
+
+		return newPlaceholderPage(m.styles, tab.Title, placeholderNotice(tab)), nil
+	}
+
+	if m.sourceFor != nil {
 		if source, staging := m.sourceFor(tab.Service); source != nil {
 			p := newBrowserPage(m.runCtx, source, staging, m.styles, m.keys)
 
@@ -702,6 +725,136 @@ func (m *App) pageForTab(i int) (page, tea.Cmd) {
 	}
 
 	return newPlaceholderPage(m.styles, tab.Title, placeholderNotice(tab)), nil
+}
+
+// offeredServices returns the service-axis keys the scope offers (the non-staging
+// tabs, in tab order), so the staging page and the apply/reset fan-out iterate
+// exactly the services that have a browser tab.
+func (m *App) offeredServices() []string {
+	var services []string
+
+	for _, t := range m.tabs {
+		if t.Service != stagingService {
+			services = append(services, t.Service)
+		}
+	}
+
+	return services
+}
+
+// stagingServicesFor resolves the staging seams for a set of service keys,
+// dropping any the factory does not offer (nil seam), preserving order.
+func (m *App) stagingServicesFor(services []string) []data.StagingService {
+	if m.stagingFor == nil {
+		return nil
+	}
+
+	out := make([]data.StagingService, 0, len(services))
+
+	for _, s := range services {
+		if svc := m.stagingFor(s); svc != nil {
+			out = append(out, svc)
+		}
+	}
+
+	return out
+}
+
+// openApply builds and pushes the apply confirmation for the requested services.
+func (m *App) openApply(req nav.OpenApply) tea.Cmd {
+	targets := m.stagingServicesFor(req.Services)
+	if len(targets) == 0 {
+		return nil
+	}
+
+	d := dialogs.NewApply(dialogs.ApplyInput{
+		Ctx: m.runCtx, Targets: targets, TargetLine: m.applyTargetLine(),
+		Title: applyTitle(req.Global, targets), EntryCount: req.EntryCount, TagCount: req.TagCount,
+		Styles: m.styles,
+	})
+
+	return m.pushDialog(d, nil)
+}
+
+// openReset builds and pushes the reset confirmation for the requested services.
+func (m *App) openReset(req nav.OpenReset) tea.Cmd {
+	targets := m.stagingServicesFor(req.Services)
+	if len(targets) == 0 {
+		return nil
+	}
+
+	d := dialogs.NewReset(dialogs.ResetInput{
+		Ctx: m.runCtx, Targets: targets, Title: resetTitle(req.Global, targets), Styles: m.styles,
+	})
+
+	return m.pushDialog(d, nil)
+}
+
+// pushStagingDetail pushes a full remote-vs-staged diff page for the staging
+// page's `enter` detail, reusing the diff viewer over static content.
+func (m *App) pushStagingDetail(req nav.OpenStagingDetail) tea.Cmd {
+	p := newStaticDiffPage(data.DiffContent{
+		OldLabel: req.OldLabel, NewLabel: req.NewLabel,
+		OldValue: req.OldValue, NewValue: req.NewValue, Secret: req.Secret,
+	}, m.styles, m.keys)
+	m.pages = append(m.pages, p)
+	m.forwardResizeToTop()
+
+	return p.Init()
+}
+
+// applyTargetLine renders the apply target identity (account/region, project, or
+// vault/store) shown on the apply confirmation — parity with the CLI's prompt.
+func (m *App) applyTargetLine() string {
+	switch m.scope.Provider {
+	case provider.ProviderAWS:
+		parts := []string{"aws"}
+		if m.identity != nil {
+			parts = appendKV(parts, "account", m.identity.Account)
+			parts = appendKV(parts, "region", m.identity.Region)
+		}
+
+		return strings.Join(parts, " · ")
+	case provider.ProviderGoogleCloud:
+		return strings.Join(appendKV([]string{"googlecloud"}, "project", m.scope.ProjectID), " · ")
+	case provider.ProviderAzure:
+		parts := []string{"azure"}
+		parts = appendKV(parts, "vault", m.scope.VaultName)
+		parts = appendKV(parts, "store", m.scope.StoreName)
+
+		return strings.Join(parts, " · ")
+	default:
+		return string(m.scope.Provider)
+	}
+}
+
+// appendKV appends a "key value" segment when value is non-empty.
+func appendKV(parts []string, key, value string) []string {
+	if value == "" {
+		return parts
+	}
+
+	return append(parts, key+" "+value)
+}
+
+// applyTitle names the apply confirmation: "— all" for the fan-out, else the
+// single service's label.
+func applyTitle(global bool, targets []data.StagingService) string {
+	return "Apply staged changes — " + targetTitle(global, targets)
+}
+
+// resetTitle names the reset confirmation.
+func resetTitle(global bool, targets []data.StagingService) string {
+	return "Reset staged changes — " + targetTitle(global, targets)
+}
+
+// targetTitle is "all" for a global fan-out, else the single target's label.
+func targetTitle(global bool, targets []data.StagingService) string {
+	if global || len(targets) != 1 {
+		return "all"
+	}
+
+	return targets[0].Label()
 }
 
 // copyFocusedValue copies the focused value through the OSC52 clipboard seam, or
@@ -889,8 +1042,8 @@ func (m *App) overlayDialogs(base string) string {
 // the step its real page arrives in.
 func placeholderNotice(t components.Tab) string {
 	if t.Service == stagingService {
-		return "(staging page lands in Step 5)"
+		return "(no staging services available for this scope)"
 	}
 
-	return "(browser page lands in Step 3)"
+	return "(no data source available for this service)"
 }

--- a/internal/tui/data/stagingservice.go
+++ b/internal/tui/data/stagingservice.go
@@ -1,0 +1,482 @@
+package data
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+
+	"github.com/samber/lo"
+
+	"github.com/mpyw/suve/internal/capability"
+	"github.com/mpyw/suve/internal/staging"
+	"github.com/mpyw/suve/internal/staging/store"
+	stagingusecase "github.com/mpyw/suve/internal/usecase/staging"
+)
+
+// =============================================================================
+// Neutral staging-review output types
+// =============================================================================
+
+// StagedDiffType classifies a staged entry's diff row (mirrors the staging
+// DiffUseCase's DiffEntryType), so the page can color/label auto-unstaged and
+// warning rows distinctly.
+type StagedDiffType int
+
+// StagedDiffType values.
+const (
+	StagedDiffNormal StagedDiffType = iota
+	StagedDiffCreate
+	StagedDiffAutoUnstaged
+	StagedDiffWarning
+)
+
+// StagedDiffRow is one staged entry rendered as a Remote-vs-Staged diff. The
+// page shows RemoteValue/StagedValue in diff view and StagedValue in value view;
+// a delete carries an empty StagedValue.
+type StagedDiffRow struct {
+	Name        string
+	Namespace   string
+	Type        StagedDiffType
+	Operation   string // "create" / "update" / "delete"
+	RemoteValue string
+	StagedValue string
+	Warning     string
+}
+
+// StagedTagRow is one item's staged tag changes: independent +add and −remove
+// deltas the page renders as separate cancellable rows.
+type StagedTagRow struct {
+	Name      string
+	Namespace string
+	// Adds are the staged tag adds/updates (key=value).
+	Adds []Tag
+	// Removes are the staged tag removals: the tag key plus the current remote
+	// value (empty when unknown), so the row reads "−key (was value)".
+	Removes []TagRemoval
+}
+
+// TagRemoval is a staged tag removal: the key and its current remote value.
+type TagRemoval struct {
+	Key   string
+	Value string
+}
+
+// StagingReview is the full staged picture for one service — entries (as diffs)
+// plus independent tag changes.
+type StagingReview struct {
+	Entries []StagedDiffRow
+	Tags    []StagedTagRow
+}
+
+// EntryCount is the number of still-staged entry rows (auto-unstaged rows are
+// excluded — they were removed from the store during the review).
+func (r StagingReview) EntryCount() int {
+	return lo.CountBy(r.Entries, func(e StagedDiffRow) bool {
+		return e.Type != StagedDiffAutoUnstaged
+	})
+}
+
+// TagCount is the number of staged tag-change rows.
+func (r StagingReview) TagCount() int { return len(r.Tags) }
+
+// AutoUnstaged returns the keys of entries auto-unstaged during the review
+// (staged value equalled remote, or the target vanished), for the dismissible
+// notice.
+func (r StagingReview) AutoUnstaged() []StagedKey {
+	return lo.FilterMap(r.Entries, func(e StagedDiffRow, _ int) (StagedKey, bool) {
+		return StagedKey{Name: e.Name, Namespace: e.Namespace}, e.Type == StagedDiffAutoUnstaged
+	})
+}
+
+// ApplyEntryResult is one entry's apply outcome.
+type ApplyEntryResult struct {
+	Name      string
+	Namespace string
+	// Status is "created" / "updated" / "deleted" / "failed".
+	Status string
+	// Error is the cloud-write failure (empty on success).
+	Error string
+	// UnstageError is set when the cloud write succeeded but the entry could not
+	// be cleared from staging afterwards — the page must always surface it.
+	UnstageError string
+}
+
+// ApplyTagResult is one item's tag-apply outcome.
+type ApplyTagResult struct {
+	Name         string
+	Namespace    string
+	Adds         []Tag
+	Removes      []string
+	Error        string
+	UnstageError string
+}
+
+// StagingApplyResult is the aggregated result of applying a service's staged
+// changes.
+type StagingApplyResult struct {
+	// ServiceLabel is the service's display name for the results header.
+	ServiceLabel string
+	Entries      []ApplyEntryResult
+	Tags         []ApplyTagResult
+	// Conflicts are the labels of entries rejected because remote changed after
+	// staging (empty unless conflict detection tripped).
+	Conflicts []string
+}
+
+// StagingResetType mirrors the staging ResetUseCase's ResetResultType so the
+// page can voice the exact outcome.
+type StagingResetType int
+
+// StagingResetType values (mirror stagingusecase.ResetResultType).
+const (
+	StagingResetUnstaged StagingResetType = iota
+	StagingResetUnstagedAll
+	StagingResetRestored
+	StagingResetNotStaged
+	StagingResetNothingStaged
+	StagingResetSkipped
+	StagingResetUnstagedTag
+)
+
+// StagingResetResult is the outcome of resetting a service.
+type StagingResetResult struct {
+	Type         StagingResetType
+	Count        int
+	ServiceLabel string
+}
+
+// StagingService is the review/apply/reset seam the staging page depends on for
+// one service. It wraps the internal/usecase/staging use cases over a
+// per-scope-cached staging store paired with a scope-matched strategy, mirroring
+// the GUI's staging methods. Keeping the page behind this interface lets a test
+// drive it over providermock + an in-memory staging store without a keychain.
+type StagingService interface {
+	// Service is the internal key ("param" / "secret").
+	Service() string
+	// Label is the display name for the section/results header (e.g. "Key Vault").
+	Label() string
+	// Capability gates the section's controls.
+	Capability() capability.ServiceCapability
+	// Review returns the staged entries (as diffs) and tag changes; it may
+	// auto-unstage entries whose staged value now equals remote.
+	Review(ctx context.Context) (StagingReview, error)
+	// Apply applies the service's staged changes. A conflict rejection or a
+	// per-entry failure returns a POPULATED result (the detail is in its fields),
+	// not an error; only a hard store failure returns a non-nil error.
+	Apply(ctx context.Context, ignoreConflicts bool) (StagingApplyResult, error)
+	// Reset unstages every staged change for the service.
+	Reset(ctx context.Context) (StagingResetResult, error)
+	// Unstage removes one item's staged entry and its staged tags.
+	Unstage(ctx context.Context, key StagedKey) error
+	// CancelAddTag drops one staged tag add.
+	CancelAddTag(ctx context.Context, key StagedKey, tagKey string) error
+	// CancelRemoveTag drops one staged tag removal.
+	CancelRemoveTag(ctx context.Context, key StagedKey, tagKey string) error
+}
+
+// StagingResources bundle the resolved staging store and strategy for one
+// service. Store and Strategy MUST be paired to the same scope (the
+// serviceStrategyScoped discipline).
+type StagingResources struct {
+	Store    store.ReadWriteOperator
+	Strategy staging.FullStrategy
+	// StrategyFor resolves a per-namespace strategy for Azure App Configuration,
+	// whose settings share one staging store across namespaces; nil for every
+	// other provider/service (the single Strategy handles all).
+	StrategyFor func(namespace string) (staging.FullStrategy, error)
+}
+
+// StagingResolver lazily builds a service's staging resources. It is invoked
+// inside the async Review/Apply/Reset commands (never at page construction), so
+// touching the keychain/registry never blocks the update loop; a key-loss
+// hard-fail surfaces as the returned error.
+type StagingResolver func(ctx context.Context) (StagingResources, error)
+
+// stagingService is the concrete StagingService over the staging use cases.
+type stagingService struct {
+	service staging.Service
+	key     string // "param" / "secret"
+	label   string
+	svcCap  capability.ServiceCapability
+	resolve StagingResolver
+}
+
+// NewStagingService builds a StagingService for one service. resolve lazily
+// yields the scope-paired store and strategy.
+func NewStagingService(svcCap capability.ServiceCapability, label string, resolve StagingResolver) StagingService {
+	return &stagingService{
+		service: staging.Service(svcCap.Service),
+		key:     svcCap.Service,
+		label:   label,
+		svcCap:  svcCap,
+		resolve: resolve,
+	}
+}
+
+func (s *stagingService) Service() string                          { return s.key }
+func (s *stagingService) Label() string                            { return s.label }
+func (s *stagingService) Capability() capability.ServiceCapability { return s.svcCap }
+
+func (s *stagingService) Review(ctx context.Context) (StagingReview, error) {
+	res, err := s.resolve(ctx)
+	if err != nil {
+		return StagingReview{}, err
+	}
+
+	uc := &stagingusecase.DiffUseCase{Strategy: res.Strategy, Store: res.Store}
+	if res.StrategyFor != nil {
+		uc.StrategyFor = func(ns string) (staging.DiffStrategy, error) {
+			return res.StrategyFor(ns)
+		}
+	}
+
+	out, err := uc.Execute(ctx, stagingusecase.DiffInput{})
+	if err != nil {
+		return StagingReview{}, err
+	}
+
+	// DiffUseCase appends entries/tags in map-iteration (nondeterministic) order;
+	// sort by (name, namespace) so the page — and its goldens — render stably.
+	review := StagingReview{
+		Entries: lo.Map(out.Entries, func(e stagingusecase.DiffEntry, _ int) StagedDiffRow {
+			return StagedDiffRow{
+				Name:        e.Name,
+				Namespace:   e.Namespace,
+				Type:        stagedDiffType(e.Type),
+				Operation:   string(e.Operation),
+				RemoteValue: e.AWSValue,
+				StagedValue: e.StagedValue,
+				Warning:     e.Warning,
+			}
+		}),
+		Tags: lo.Map(out.TagEntries, func(t stagingusecase.DiffTagEntry, _ int) StagedTagRow {
+			return StagedTagRow{
+				Name:      t.Name,
+				Namespace: t.Namespace,
+				Adds:      mapToTags(t.Add),
+				Removes: sortedRemovals(lo.MapToSlice(t.Remove, func(k, v string) TagRemoval {
+					return TagRemoval{Key: k, Value: v}
+				})),
+			}
+		}),
+	}
+
+	slices.SortFunc(review.Entries, func(a, b StagedDiffRow) int { return compareKey(a.Name, a.Namespace, b.Name, b.Namespace) })
+	slices.SortFunc(review.Tags, func(a, b StagedTagRow) int { return compareKey(a.Name, a.Namespace, b.Name, b.Namespace) })
+
+	return review, nil
+}
+
+// compareKey orders two (name, namespace) pairs deterministically.
+func compareKey(aName, aNS, bName, bNS string) int {
+	if c := strings.Compare(aName, bName); c != 0 {
+		return c
+	}
+
+	return strings.Compare(aNS, bNS)
+}
+
+func (s *stagingService) Apply(ctx context.Context, ignoreConflicts bool) (StagingApplyResult, error) {
+	res, err := s.resolve(ctx)
+	if err != nil {
+		return StagingApplyResult{}, err
+	}
+
+	uc := &stagingusecase.ApplyUseCase{Strategy: res.Strategy, Store: res.Store}
+	if res.StrategyFor != nil {
+		uc.StrategyFor = func(ns string) (staging.ApplyStrategy, error) {
+			return res.StrategyFor(ns)
+		}
+	}
+
+	// A conflict/partial-failure returns a populated output with an error; only a
+	// nil output (a store read failure) is a hard error with nothing to show.
+	out, err := uc.Execute(ctx, stagingusecase.ApplyInput{IgnoreConflicts: ignoreConflicts})
+	if out == nil {
+		return StagingApplyResult{}, err
+	}
+
+	return s.newApplyResult(out), nil
+}
+
+func (s *stagingService) newApplyResult(out *stagingusecase.ApplyOutput) StagingApplyResult {
+	return StagingApplyResult{
+		ServiceLabel: s.label,
+		Conflicts: lo.Map(out.Conflicts, func(k staging.EntryKey, _ int) string {
+			return k.Label()
+		}),
+		Entries: lo.Map(out.EntryResults, func(r stagingusecase.ApplyEntryResult, _ int) ApplyEntryResult {
+			entry := ApplyEntryResult{
+				Name:      r.Name,
+				Namespace: r.Namespace,
+				Status:    applyStatusLabel(r.Status),
+			}
+			if r.Status == stagingusecase.ApplyResultFailed && r.Error != nil {
+				entry.Error = r.Error.Error()
+			}
+
+			if r.UnstageError != nil {
+				entry.UnstageError = r.UnstageError.Error()
+			}
+
+			return entry
+		}),
+		Tags: lo.Map(out.TagResults, func(r stagingusecase.ApplyTagResult, _ int) ApplyTagResult {
+			tag := ApplyTagResult{
+				Name:      r.Name,
+				Namespace: r.Namespace,
+				Adds:      mapToTags(r.AddTags),
+				Removes:   r.RemoveTag.Values(),
+			}
+			if r.Error != nil {
+				tag.Error = r.Error.Error()
+			}
+
+			if r.UnstageError != nil {
+				tag.UnstageError = r.UnstageError.Error()
+			}
+
+			return tag
+		}),
+	}
+}
+
+func (s *stagingService) Reset(ctx context.Context) (StagingResetResult, error) {
+	res, err := s.resolve(ctx)
+	if err != nil {
+		return StagingResetResult{}, err
+	}
+
+	uc := &stagingusecase.ResetUseCase{Parser: res.Strategy, Store: res.Store}
+
+	out, err := uc.Execute(ctx, stagingusecase.ResetInput{All: true})
+	if err != nil {
+		return StagingResetResult{}, err
+	}
+
+	return StagingResetResult{
+		Type:         stagingResetType(out.Type),
+		Count:        out.Count,
+		ServiceLabel: s.label,
+	}, nil
+}
+
+func (s *stagingService) Unstage(ctx context.Context, key StagedKey) error {
+	res, err := s.resolve(ctx)
+	if err != nil {
+		return err
+	}
+
+	entryKey := staging.EntryKey{Name: key.Name, Namespace: key.Namespace}
+
+	if err := res.Store.UnstageEntry(ctx, s.service, entryKey); err != nil && !errors.Is(err, staging.ErrNotStaged) {
+		return err
+	}
+
+	if err := res.Store.UnstageTag(ctx, s.service, entryKey); err != nil && !errors.Is(err, staging.ErrNotStaged) {
+		return err
+	}
+
+	return nil
+}
+
+func (s *stagingService) CancelAddTag(ctx context.Context, key StagedKey, tagKey string) error {
+	return s.editStagedTag(ctx, key, func(tag *staging.TagEntry) {
+		delete(tag.Add, tagKey)
+	})
+}
+
+func (s *stagingService) CancelRemoveTag(ctx context.Context, key StagedKey, tagKey string) error {
+	return s.editStagedTag(ctx, key, func(tag *staging.TagEntry) {
+		tag.Remove.Remove(tagKey)
+	})
+}
+
+// editStagedTag loads a staged tag entry, applies edit, then re-stages it (or
+// unstages it when nothing is left) — mirroring the GUI's cancel handlers.
+func (s *stagingService) editStagedTag(ctx context.Context, key StagedKey, edit func(*staging.TagEntry)) error {
+	res, err := s.resolve(ctx)
+	if err != nil {
+		return err
+	}
+
+	entryKey := staging.EntryKey{Name: key.Name, Namespace: key.Namespace}
+
+	tag, err := res.Store.GetTag(ctx, s.service, entryKey)
+	if err != nil {
+		return err
+	}
+
+	edit(tag)
+
+	if len(tag.Add) == 0 && tag.Remove.Len() == 0 {
+		return res.Store.UnstageTag(ctx, s.service, entryKey)
+	}
+
+	return res.Store.StageTag(ctx, s.service, entryKey, *tag)
+}
+
+// mapToTags renders a tag map as a slice of neutral Tags sorted by key, so the
+// page (and its goldens) render staged tags in a stable order.
+func mapToTags(m map[string]string) []Tag {
+	tags := lo.MapToSlice(m, func(k, v string) Tag { return Tag{Key: k, Value: v} })
+	slices.SortFunc(tags, func(a, b Tag) int { return strings.Compare(a.Key, b.Key) })
+
+	return tags
+}
+
+// sortedRemovals sorts tag removals by key for a stable render order.
+func sortedRemovals(rs []TagRemoval) []TagRemoval {
+	slices.SortFunc(rs, func(a, b TagRemoval) int { return strings.Compare(a.Key, b.Key) })
+
+	return rs
+}
+
+// stagedDiffType maps the use-case diff type onto the neutral one.
+func stagedDiffType(t stagingusecase.DiffEntryType) StagedDiffType {
+	switch t {
+	case stagingusecase.DiffEntryCreate:
+		return StagedDiffCreate
+	case stagingusecase.DiffEntryAutoUnstaged:
+		return StagedDiffAutoUnstaged
+	case stagingusecase.DiffEntryWarning:
+		return StagedDiffWarning
+	default:
+		return StagedDiffNormal
+	}
+}
+
+// stagingResetType maps the use-case reset type onto the neutral one.
+func stagingResetType(t stagingusecase.ResetResultType) StagingResetType {
+	switch t {
+	case stagingusecase.ResetResultUnstagedAll:
+		return StagingResetUnstagedAll
+	case stagingusecase.ResetResultRestored:
+		return StagingResetRestored
+	case stagingusecase.ResetResultNotStaged:
+		return StagingResetNotStaged
+	case stagingusecase.ResetResultNothingStaged:
+		return StagingResetNothingStaged
+	case stagingusecase.ResetResultSkipped:
+		return StagingResetSkipped
+	case stagingusecase.ResetResultUnstagedTag:
+		return StagingResetUnstagedTag
+	default:
+		return StagingResetUnstaged
+	}
+}
+
+// applyStatusLabel maps an apply status enum onto its display verb.
+func applyStatusLabel(s stagingusecase.ApplyResultStatus) string {
+	switch s {
+	case stagingusecase.ApplyResultCreated:
+		return "created"
+	case stagingusecase.ApplyResultUpdated:
+		return "updated"
+	case stagingusecase.ApplyResultDeleted:
+		return "deleted"
+	default:
+		return "failed"
+	}
+}

--- a/internal/tui/dialogs/apply.go
+++ b/internal/tui/dialogs/apply.go
@@ -1,0 +1,358 @@
+package dialogs
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/mpyw/suve/internal/tui/data"
+	"github.com/mpyw/suve/internal/tui/styles"
+)
+
+// applyControl identifies a focusable row in the apply confirmation.
+type applyControl int
+
+const (
+	ctrlIgnore applyControl = iota
+	ctrlApply
+	ctrlApplyCancel
+)
+
+// applyPhase is the dialog's stage: confirm → busy → results.
+type applyPhase int
+
+const (
+	phaseConfirm applyPhase = iota
+	phaseBusy
+	phaseResults
+)
+
+// applyResultsMsg carries the aggregated fan-out results back into the dialog.
+type applyResultsMsg struct {
+	results []data.StagingApplyResult
+	err     error
+}
+
+// applyDialog confirms, runs, and reports a staged-apply. It drives one
+// ApplyUseCase per target service and aggregates the results client-side, so a
+// global apply-all (Azure's param and secret have independent scopes) is one
+// coherent results view. While busy it swallows input (the #568 double-fire
+// guard) and reports Busy() so the shell suppresses dismissal.
+type applyDialog struct {
+	ctx        context.Context //nolint:containedctx // the apply command needs the Run context; mirrors the browser
+	targets    []data.StagingService
+	targetLine string
+	entryCount int
+	tagCount   int
+	styles     styles.Styles
+
+	ignoreConflicts bool
+	focus           int
+	phase           applyPhase
+	results         []data.StagingApplyResult
+	err             string
+	title           string
+}
+
+// ApplyInput configures an apply dialog.
+type ApplyInput struct {
+	Ctx context.Context //nolint:containedctx // Run context threaded into the apply command; mirrors the browser
+	// Targets are the services to apply (one for per-service, all for apply-all).
+	Targets []data.StagingService
+	// TargetLine is the resolved target identity string (account/region, project,
+	// or vault/store) shown on the confirmation — parity with the CLI prompt.
+	TargetLine string
+	// Title is the dialog title (e.g. "Apply staged changes — Param" / "— all").
+	Title string
+	// EntryCount / TagCount are the staged totals across the targets.
+	EntryCount int
+	TagCount   int
+	Styles     styles.Styles
+}
+
+// NewApply builds an apply dialog.
+func NewApply(in ApplyInput) Model {
+	return &applyDialog{
+		ctx:        in.Ctx,
+		targets:    in.Targets,
+		targetLine: in.TargetLine,
+		entryCount: in.EntryCount,
+		tagCount:   in.TagCount,
+		styles:     in.Styles,
+		title:      in.Title,
+	}
+}
+
+func (d *applyDialog) Busy() bool { return d.phase == phaseBusy }
+
+func (d *applyDialog) Update(msg tea.Msg) (Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case applyResultsMsg:
+		d.phase = phaseResults
+		d.results = msg.results
+
+		if msg.err != nil {
+			d.err = msg.err.Error()
+		}
+
+		return d, nil
+	case tea.KeyPressMsg:
+		return d.handleKey(msg)
+	}
+
+	return d, nil
+}
+
+func (d *applyDialog) handleKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
+	if d.phase == phaseBusy {
+		return d, nil // double-submit guard: swallow input while applying
+	}
+
+	if d.phase == phaseResults {
+		if key.Matches(msg, navSelect) {
+			return d, doneCmd("", d.summary(), true)
+		}
+
+		return d, nil
+	}
+
+	return d.handleConfirmKey(msg)
+}
+
+func (d *applyDialog) handleConfirmKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, navUp):
+		d.move(-1)
+	case key.Matches(msg, navDown):
+		d.move(1)
+	case key.Matches(msg, navSelect):
+		return d.activate()
+	}
+
+	return d, nil
+}
+
+func (d *applyDialog) move(delta int) {
+	const n = 3 // ignore, apply, cancel
+
+	d.focus = ((d.focus+delta)%n + n) % n
+}
+
+func (d *applyDialog) activate() (Model, tea.Cmd) {
+	switch applyControl(d.focus) {
+	case ctrlIgnore:
+		d.ignoreConflicts = !d.ignoreConflicts
+	case ctrlApply:
+		d.phase = phaseBusy
+
+		return d, d.applyCmd()
+	case ctrlApplyCancel:
+		return d, canceledCmd
+	}
+
+	return d, nil
+}
+
+// applyCmd fans the apply out across every target sequentially (one goroutine,
+// so no shared state races) and aggregates the per-service results.
+func (d *applyDialog) applyCmd() tea.Cmd {
+	ctx := d.ctx
+	targets := d.targets
+	ignore := d.ignoreConflicts
+
+	return func() tea.Msg {
+		results := make([]data.StagingApplyResult, 0, len(targets))
+
+		for _, svc := range targets {
+			res, err := svc.Apply(ctx, ignore)
+			if err != nil {
+				return applyResultsMsg{results: results, err: err}
+			}
+
+			results = append(results, res)
+		}
+
+		return applyResultsMsg{results: results}
+	}
+}
+
+func (d *applyDialog) View() string {
+	if d.phase == phaseResults {
+		return d.resultsView()
+	}
+
+	return d.confirmView()
+}
+
+func (d *applyDialog) confirmView() string {
+	var b strings.Builder
+
+	b.WriteString(d.styles.PaneTitle.Render(d.title))
+	b.WriteString("\n\n")
+	b.WriteString(d.styles.FieldLabel.Render("Target  ") + " " + d.targetLine + "\n")
+	b.WriteString(d.styles.FieldLabel.Render("Changes ") + " " + d.changesLine() + "\n\n")
+
+	if d.phase == phaseBusy {
+		b.WriteString(d.styles.PageHint.Render("applying…"))
+
+		return b.String()
+	}
+
+	b.WriteString(d.confirmRow(ctrlIgnore, checkbox(d.ignoreConflicts)+" Ignore conflicts"))
+	b.WriteString("\n\n")
+	b.WriteString(d.confirmRow(ctrlApply, "[ Apply ]") + "    " + d.confirmRow(ctrlApplyCancel, "[ Cancel ]"))
+	b.WriteString("\n\n")
+	b.WriteString(d.styles.PageHint.Render("↑↓: move · space/enter: toggle/confirm · esc: cancel"))
+
+	return b.String()
+}
+
+// confirmRow renders a focusable confirm control, marking the focused one.
+func (d *applyDialog) confirmRow(c applyControl, label string) string {
+	if applyControl(d.focus) == c {
+		return d.styles.StatusValue.Render("▸ " + label)
+	}
+
+	return "  " + label
+}
+
+// changesLine renders the "N entries · M tag change(s)" summary.
+func (d *applyDialog) changesLine() string {
+	return pluralize(d.entryCount, "entry", "entries") + " · " + pluralize(d.tagCount, "tag change", "tag changes")
+}
+
+func (d *applyDialog) resultsView() string {
+	var b strings.Builder
+
+	b.WriteString(d.styles.PaneTitle.Render("Apply results"))
+	b.WriteString("\n\n")
+
+	if d.err != "" {
+		b.WriteString(d.styles.ErrorText.Render(d.err) + "\n\n")
+	}
+
+	for _, res := range d.results {
+		d.writeServiceResults(&b, res)
+	}
+
+	b.WriteString(d.styles.PageHint.Render("enter/esc: close"))
+
+	return b.String()
+}
+
+// writeServiceResults appends one service's entry/tag statuses, conflicts, and
+// post-apply unstage warnings.
+func (d *applyDialog) writeServiceResults(b *strings.Builder, res data.StagingApplyResult) {
+	if len(d.results) > 1 {
+		b.WriteString(d.styles.PaneTitle.Render(res.ServiceLabel) + "\n")
+	}
+
+	for _, e := range res.Entries {
+		b.WriteString(d.entryResultLine(e) + "\n")
+	}
+
+	for _, t := range res.Tags {
+		b.WriteString(d.tagResultLine(t) + "\n")
+	}
+
+	for _, c := range res.Conflicts {
+		b.WriteString(d.styles.Banner.Render("⚠ conflict: "+c+
+			" was modified remotely after staging — re-apply with \"Ignore conflicts\" to overwrite.") + "\n")
+	}
+
+	for _, e := range res.Entries {
+		if e.UnstageError != "" {
+			b.WriteString(d.unstageWarn(entryLabel(e.Name, e.Namespace), e.UnstageError) + "\n")
+		}
+	}
+
+	for _, t := range res.Tags {
+		if t.UnstageError != "" {
+			b.WriteString(d.unstageWarn(entryLabel(t.Name, t.Namespace), t.UnstageError) + "\n")
+		}
+	}
+
+	b.WriteString("\n")
+}
+
+// entryResultLine renders one entry apply status.
+func (d *applyDialog) entryResultLine(e data.ApplyEntryResult) string {
+	if e.Error != "" {
+		return d.styles.ErrorText.Render("✗ "+e.Status) + "  " + entryLabel(e.Name, e.Namespace) +
+			"   " + d.styles.ErrorText.Render(e.Error)
+	}
+
+	return d.styles.DiffAdded.Render("✓ "+e.Status) + "  " + entryLabel(e.Name, e.Namespace)
+}
+
+// tagResultLine renders one tag apply status.
+func (d *applyDialog) tagResultLine(t data.ApplyTagResult) string {
+	if t.Error != "" {
+		return d.styles.ErrorText.Render("✗ tags") + "  " + entryLabel(t.Name, t.Namespace) +
+			"   " + d.styles.ErrorText.Render(t.Error)
+	}
+
+	return d.styles.DiffAdded.Render("✓ tags") + "  " + entryLabel(t.Name, t.Namespace)
+}
+
+// unstageWarn renders the "applied but could not be unstaged" warning.
+func (d *applyDialog) unstageWarn(label, err string) string {
+	return d.styles.Banner.Render("⚠ " + label + " applied but could not be unstaged: " + err + " — clear it manually.")
+}
+
+// summary voices the aggregated apply outcome for the status line.
+func (d *applyDialog) summary() string {
+	applied, failed, conflicts := 0, 0, 0
+
+	for _, res := range d.results {
+		conflicts += len(res.Conflicts)
+
+		for _, e := range res.Entries {
+			countOutcome(e.Error, &applied, &failed)
+		}
+
+		for _, t := range res.Tags {
+			countOutcome(t.Error, &applied, &failed)
+		}
+	}
+
+	switch {
+	case conflicts > 0 && applied == 0 && failed == 0:
+		return fmt.Sprintf("Apply rejected: %d conflict(s). Re-apply with Ignore conflicts to overwrite.", conflicts)
+	case failed > 0:
+		return fmt.Sprintf("Applied %d, failed %d.", applied, failed)
+	default:
+		return "Applied " + strconv.Itoa(applied) + " staged change(s)."
+	}
+}
+
+// countOutcome tallies a result as applied or failed.
+func countOutcome(errMsg string, applied, failed *int) {
+	if errMsg != "" {
+		*failed++
+	} else {
+		*applied++
+	}
+}
+
+// entryLabel renders a name with its namespace badge (bare name when empty).
+func entryLabel(name, namespace string) string {
+	if namespace == "" {
+		return name
+	}
+
+	return name + " [" + namespace + "]"
+}
+
+// pluralize renders "n singular"/"n plural".
+func pluralize(n int, singular, plural string) string {
+	if n == 1 {
+		return "1 " + singular
+	}
+
+	return strconv.Itoa(n) + " " + plural
+}

--- a/internal/tui/dialogs/apply.go
+++ b/internal/tui/dialogs/apply.go
@@ -8,10 +8,22 @@ import (
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 
 	"github.com/mpyw/suve/internal/tui/data"
 	"github.com/mpyw/suve/internal/tui/styles"
 )
+
+// dialogChrome is the column overhead the shell's dialog frame adds around the
+// content (a 1-cell rounded border plus 1 cell of horizontal padding on each
+// side); the results view caps its lines at width−dialogChrome so a long
+// conflict / unstage-error line wraps inside the box instead of clipping its
+// border.
+const dialogChrome = 4
+
+// minDialogContent floors the wrap width so a very narrow terminal still wraps
+// to something legible rather than one column.
+const minDialogContent = 24
 
 // applyControl identifies a focusable row in the apply confirmation.
 type applyControl int
@@ -56,6 +68,9 @@ type applyDialog struct {
 	results         []data.StagingApplyResult
 	err             string
 	title           string
+	// width is the terminal width (from the last WindowSizeMsg); the results view
+	// wraps its lines to width−dialogChrome so the box never overflows the screen.
+	width int
 }
 
 // ApplyInput configures an apply dialog.
@@ -91,6 +106,10 @@ func (d *applyDialog) Busy() bool { return d.phase == phaseBusy }
 
 func (d *applyDialog) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		d.width = msg.Width
+
+		return d, nil
 	case applyResultsMsg:
 		d.phase = phaseResults
 		d.results = msg.results
@@ -105,6 +124,29 @@ func (d *applyDialog) Update(msg tea.Msg) (Model, tea.Cmd) {
 	}
 
 	return d, nil
+}
+
+// contentWidth is the inner width the results box may fill: the terminal width
+// less the shell's dialog frame, floored so a narrow terminal still wraps. Zero
+// (before the first WindowSizeMsg) means "don't wrap".
+func (d *applyDialog) contentWidth() int {
+	if d.width <= 0 {
+		return 0
+	}
+
+	return max(d.width-dialogChrome, minDialogContent)
+}
+
+// fit wraps one already-styled result line to the content width when it would
+// overflow, so a long conflict / unstage-error / error line stays inside the box
+// instead of pushing the border off-screen. Short lines pass through untouched
+// so the box keeps its natural width when nothing wraps.
+func (d *applyDialog) fit(line string) string {
+	if w := d.contentWidth(); w > 0 && lipgloss.Width(line) > w {
+		return lipgloss.NewStyle().Width(w).Render(line)
+	}
+
+	return line
 }
 
 func (d *applyDialog) handleKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
@@ -232,7 +274,7 @@ func (d *applyDialog) resultsView() string {
 	b.WriteString("\n\n")
 
 	if d.err != "" {
-		b.WriteString(d.styles.ErrorText.Render(d.err) + "\n\n")
+		b.WriteString(d.fit(d.styles.ErrorText.Render(d.err)) + "\n\n")
 	}
 
 	for _, res := range d.results {
@@ -252,27 +294,27 @@ func (d *applyDialog) writeServiceResults(b *strings.Builder, res data.StagingAp
 	}
 
 	for _, e := range res.Entries {
-		b.WriteString(d.entryResultLine(e) + "\n")
+		b.WriteString(d.fit(d.entryResultLine(e)) + "\n")
 	}
 
 	for _, t := range res.Tags {
-		b.WriteString(d.tagResultLine(t) + "\n")
+		b.WriteString(d.fit(d.tagResultLine(t)) + "\n")
 	}
 
 	for _, c := range res.Conflicts {
-		b.WriteString(d.styles.Banner.Render("⚠ conflict: "+c+
-			" was modified remotely after staging — re-apply with \"Ignore conflicts\" to overwrite.") + "\n")
+		b.WriteString(d.fit(d.styles.Banner.Render("⚠ conflict: "+c+
+			" was modified remotely after staging — re-apply with \"Ignore conflicts\" to overwrite.")) + "\n")
 	}
 
 	for _, e := range res.Entries {
 		if e.UnstageError != "" {
-			b.WriteString(d.unstageWarn(entryLabel(e.Name, e.Namespace), e.UnstageError) + "\n")
+			b.WriteString(d.fit(d.unstageWarn(entryLabel(e.Name, e.Namespace), e.UnstageError)) + "\n")
 		}
 	}
 
 	for _, t := range res.Tags {
 		if t.UnstageError != "" {
-			b.WriteString(d.unstageWarn(entryLabel(t.Name, t.Namespace), t.UnstageError) + "\n")
+			b.WriteString(d.fit(d.unstageWarn(entryLabel(t.Name, t.Namespace), t.UnstageError)) + "\n")
 		}
 	}
 

--- a/internal/tui/dialogs/apply_test.go
+++ b/internal/tui/dialogs/apply_test.go
@@ -1,0 +1,189 @@
+//nolint:testpackage // white-box: drives the apply dialog's Update/fan-out and inspects its state
+package dialogs
+
+import (
+	"context"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/capability"
+	"github.com/mpyw/suve/internal/tui/data"
+	"github.com/mpyw/suve/internal/tui/styles"
+)
+
+// stubStaging is a controllable data.StagingService for the apply/reset dialog
+// tests: Apply returns a preset result (or a conflict result until conflicts are
+// ignored) and records the ignoreConflicts flag each call was made with.
+type stubStaging struct {
+	service string
+	label   string
+
+	// result is returned by Apply when ignoreConflicts is honored (or always,
+	// when conflict is empty).
+	result data.StagingApplyResult
+	// conflict, when non-empty, is returned by Apply while ignoreConflicts is
+	// false — modelling a conflict rejection that clears once conflicts are
+	// ignored.
+	conflict data.StagingApplyResult
+
+	applied []bool
+}
+
+func (s *stubStaging) Service() string { return s.service }
+func (s *stubStaging) Label() string   { return s.label }
+func (s *stubStaging) Capability() capability.ServiceCapability {
+	return capability.ServiceCapability{}
+}
+
+func (s *stubStaging) Apply(_ context.Context, ignoreConflicts bool) (data.StagingApplyResult, error) {
+	s.applied = append(s.applied, ignoreConflicts)
+
+	if !ignoreConflicts && len(s.conflict.Conflicts) > 0 {
+		return s.conflict, nil
+	}
+
+	return s.result, nil
+}
+
+func (s *stubStaging) Review(context.Context) (data.StagingReview, error) {
+	return data.StagingReview{}, nil
+}
+func (s *stubStaging) Reset(context.Context) (data.StagingResetResult, error) {
+	return data.StagingResetResult{}, nil
+}
+func (s *stubStaging) Unstage(context.Context, data.StagedKey) error              { return nil }
+func (s *stubStaging) CancelAddTag(context.Context, data.StagedKey, string) error { return nil }
+func (s *stubStaging) CancelRemoveTag(context.Context, data.StagedKey, string) error {
+	return nil
+}
+
+// drive runs the dialog's returned command (if any) and feeds its message back,
+// returning the updated dialog.
+func drive(t *testing.T, d Model, cmd tea.Cmd) Model {
+	t.Helper()
+
+	if cmd == nil {
+		return d
+	}
+
+	next, _ := d.Update(cmd())
+
+	return next
+}
+
+// pressEnter sends an enter key press.
+func pressEnter() tea.KeyPressMsg { return tea.KeyPressMsg{Code: tea.KeyEnter} }
+
+// pressDown sends a down key press.
+func pressDown() tea.KeyPressMsg { return tea.KeyPressMsg{Code: tea.KeyDown} }
+
+// TestApply_FanOutAggregation pins the global apply-all fan-out: one ApplyUseCase
+// per target service, aggregated client-side into a single results view (Azure's
+// param and secret have independent scopes, so this must combine per service).
+func TestApply_FanOutAggregation(t *testing.T) {
+	t.Parallel()
+
+	param := &stubStaging{service: "param", label: "Param", result: data.StagingApplyResult{
+		ServiceLabel: "Param",
+		Entries:      []data.ApplyEntryResult{{Name: "/a", Status: "updated"}},
+	}}
+	secret := &stubStaging{service: "secret", label: "Secret", result: data.StagingApplyResult{
+		ServiceLabel: "Secret",
+		Entries:      []data.ApplyEntryResult{{Name: "s1", Status: "created"}},
+	}}
+
+	d := NewApply(ApplyInput{
+		Ctx: context.Background(), Targets: []data.StagingService{param, secret},
+		TargetLine: "aws", Title: "Apply staged changes — all", EntryCount: 2, Styles: styles.New(),
+	})
+
+	// Focus the Apply button (row 1) and confirm.
+	d, _ = d.Update(pressDown())
+	d, cmd := d.Update(pressEnter())
+	require.True(t, d.Busy(), "the dialog is busy while applying")
+
+	d = drive(t, d, cmd) // run the fan-out command and fold in the results
+
+	assert.Equal(t, []bool{false}, param.applied, "param applied once")
+	assert.Equal(t, []bool{false}, secret.applied, "secret applied once")
+
+	view := d.View()
+	assert.Contains(t, view, "/a", "the param result is shown")
+	assert.Contains(t, view, "s1", "the secret result is shown")
+	assert.Contains(t, view, "Param", "results are grouped by service")
+	assert.Contains(t, view, "Secret")
+}
+
+// TestApply_ConflictThenIgnoreReapply pins the conflict → re-apply path: the
+// first apply is rejected with a conflict, and re-applying with "Ignore
+// conflicts" enabled overwrites and succeeds.
+func TestApply_ConflictThenIgnoreReapply(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubStaging{
+		service: "param", label: "Param",
+		conflict: data.StagingApplyResult{ServiceLabel: "Param", Conflicts: []string{"/app/api/REDIS_URL"}},
+		result:   data.StagingApplyResult{ServiceLabel: "Param", Entries: []data.ApplyEntryResult{{Name: "/app/api/REDIS_URL", Status: "updated"}}},
+	}
+
+	d := NewApply(ApplyInput{
+		Ctx: context.Background(), Targets: []data.StagingService{svc},
+		TargetLine: "aws", Title: "Apply staged changes — Param", EntryCount: 1, Styles: styles.New(),
+	})
+
+	// First apply (ignore-conflicts off) → conflict result.
+	d, _ = d.Update(pressDown()) // focus Apply
+	d, cmd := d.Update(pressEnter())
+	d = drive(t, d, cmd)
+
+	assert.Contains(t, d.View(), "conflict", "the first apply reports a conflict")
+	assert.Contains(t, d.View(), "Ignore conflicts", "and points to the ignore-conflicts re-apply")
+
+	// Close the results, re-open with ignore-conflicts, and re-apply.
+	svc2 := &stubStaging{
+		service: "param", label: "Param",
+		result: data.StagingApplyResult{ServiceLabel: "Param", Entries: []data.ApplyEntryResult{{Name: "/app/api/REDIS_URL", Status: "updated"}}},
+	}
+	d2 := NewApply(ApplyInput{
+		Ctx: context.Background(), Targets: []data.StagingService{svc2},
+		TargetLine: "aws", Title: "Apply staged changes — Param", EntryCount: 1, Styles: styles.New(),
+	})
+
+	// Toggle Ignore conflicts (focus is on the checkbox by default), then Apply.
+	d2, _ = d2.Update(pressEnter())   // toggle ignore-conflicts on
+	d2, _ = d2.Update(pressDown())    // move to Apply
+	d2, cmd = d2.Update(pressEnter()) // confirm
+	d2 = drive(t, d2, cmd)
+
+	assert.Equal(t, []bool{true}, svc2.applied, "the re-apply passed ignoreConflicts=true")
+	assert.Contains(t, d2.View(), "updated", "the re-apply succeeded")
+	assert.NotContains(t, d2.View(), "conflict", "no conflict on the ignore-conflicts re-apply")
+}
+
+// TestReset_FanOutAggregation pins that reset-all fans out one reset per service
+// and voices the combined unstaged count.
+func TestReset_FanOutAggregation(t *testing.T) {
+	t.Parallel()
+
+	param := &stubStaging{service: "param", label: "Param"}
+	secret := &stubStaging{service: "secret", label: "Secret"}
+
+	d := NewReset(ResetInput{
+		Ctx: context.Background(), Targets: []data.StagingService{param, secret},
+		Title: "Reset staged changes — all", Styles: styles.New(),
+	})
+
+	d, cmd := d.Update(pressEnter()) // focus is on Reset by default
+	require.True(t, d.Busy())
+
+	next, doneCmd := d.Update(cmd())
+	require.NotNil(t, doneCmd)
+
+	done, ok := doneCmd().(MutationDoneMsg)
+	require.True(t, ok, "reset emits a done message")
+	assert.NotEmpty(t, done.Status, "the reset outcome is voiced")
+	assert.False(t, next.Busy(), "the dialog clears busy once the reset finishes")
+}

--- a/internal/tui/dialogs/reset.go
+++ b/internal/tui/dialogs/reset.go
@@ -37,7 +37,6 @@ type resetDialog struct {
 
 	focus int
 	busy  bool
-	err   string
 }
 
 // ResetInput configures a reset dialog.
@@ -67,9 +66,11 @@ func (d *resetDialog) Update(msg tea.Msg) (Model, tea.Cmd) {
 		d.busy = false
 
 		if msg.err != nil {
-			d.err = msg.err.Error()
-
-			return d, nil
+			// A hard failure may still have reset earlier fan-out targets. Close and
+			// reload like a success (the app's onMutationDone), so those succeeded
+			// resets refresh their badges immediately, and voice the failure on the
+			// status line rather than leaving the dialog stuck open.
+			return d, doneCmd("", "Reset failed: "+msg.err.Error(), true)
 		}
 
 		return d, doneCmd("", resetSummary(msg.results), true)
@@ -142,11 +143,6 @@ func (d *resetDialog) View() string {
 	b.WriteString(d.resetRow(ctrlReset, d.styles.ErrorText.Render("[ Reset ]")) + "    " +
 		d.resetRow(ctrlResetCancel, "[ Cancel ]"))
 	b.WriteString("\n\n")
-
-	if d.err != "" {
-		b.WriteString(d.styles.ErrorText.Render(d.err) + "\n")
-	}
-
 	b.WriteString(d.styles.PageHint.Render("↑↓: move · enter: confirm · esc: cancel"))
 
 	return b.String()

--- a/internal/tui/dialogs/reset.go
+++ b/internal/tui/dialogs/reset.go
@@ -1,0 +1,202 @@
+package dialogs
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/mpyw/suve/internal/tui/data"
+	"github.com/mpyw/suve/internal/tui/styles"
+)
+
+// resetControl identifies a focusable row in the reset confirmation.
+type resetControl int
+
+const (
+	ctrlReset resetControl = iota
+	ctrlResetCancel
+)
+
+// resetResultsMsg carries the aggregated fan-out reset results back.
+type resetResultsMsg struct {
+	results []data.StagingResetResult
+	err     error
+}
+
+// resetDialog confirms and runs a staged reset (per-service or reset-all). It
+// fans out one ResetUseCase per target and voices the aggregated outcome. While
+// busy it swallows input and reports Busy() so the shell suppresses dismissal.
+type resetDialog struct {
+	ctx     context.Context //nolint:containedctx // the reset command needs the Run context; mirrors the browser
+	targets []data.StagingService
+	title   string
+	styles  styles.Styles
+
+	focus int
+	busy  bool
+	err   string
+}
+
+// ResetInput configures a reset dialog.
+type ResetInput struct {
+	Ctx     context.Context //nolint:containedctx // Run context threaded into the reset command; mirrors the browser
+	Targets []data.StagingService
+	// Title is the dialog title (e.g. "Reset staged changes — Secret" / "— all").
+	Title  string
+	Styles styles.Styles
+}
+
+// NewReset builds a reset dialog.
+func NewReset(in ResetInput) Model {
+	return &resetDialog{
+		ctx:     in.Ctx,
+		targets: in.Targets,
+		title:   in.Title,
+		styles:  in.Styles,
+	}
+}
+
+func (d *resetDialog) Busy() bool { return d.busy }
+
+func (d *resetDialog) Update(msg tea.Msg) (Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case resetResultsMsg:
+		d.busy = false
+
+		if msg.err != nil {
+			d.err = msg.err.Error()
+
+			return d, nil
+		}
+
+		return d, doneCmd("", resetSummary(msg.results), true)
+	case tea.KeyPressMsg:
+		if d.busy {
+			return d, nil // double-submit guard
+		}
+
+		return d.handleKey(msg)
+	}
+
+	return d, nil
+}
+
+func (d *resetDialog) handleKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, navUp), key.Matches(msg, navDown):
+		d.focus = 1 - d.focus
+	case key.Matches(msg, navSelect):
+		return d.activate()
+	}
+
+	return d, nil
+}
+
+func (d *resetDialog) activate() (Model, tea.Cmd) {
+	if resetControl(d.focus) == ctrlResetCancel {
+		return d, canceledCmd
+	}
+
+	d.busy = true
+
+	return d, d.resetCmd()
+}
+
+// resetCmd fans the reset out across every target sequentially.
+func (d *resetDialog) resetCmd() tea.Cmd {
+	ctx := d.ctx
+	targets := d.targets
+
+	return func() tea.Msg {
+		results := make([]data.StagingResetResult, 0, len(targets))
+
+		for _, svc := range targets {
+			res, err := svc.Reset(ctx)
+			if err != nil {
+				return resetResultsMsg{results: results, err: err}
+			}
+
+			results = append(results, res)
+		}
+
+		return resetResultsMsg{results: results}
+	}
+}
+
+func (d *resetDialog) View() string {
+	var b strings.Builder
+
+	b.WriteString(d.styles.PaneTitle.Render(d.title))
+	b.WriteString("\n\n")
+
+	if d.busy {
+		b.WriteString(d.styles.PageHint.Render("resetting…"))
+
+		return b.String()
+	}
+
+	b.WriteString("Unstage every staged change for the target(s)?\n\n")
+	b.WriteString(d.resetRow(ctrlReset, d.styles.ErrorText.Render("[ Reset ]")) + "    " +
+		d.resetRow(ctrlResetCancel, "[ Cancel ]"))
+	b.WriteString("\n\n")
+
+	if d.err != "" {
+		b.WriteString(d.styles.ErrorText.Render(d.err) + "\n")
+	}
+
+	b.WriteString(d.styles.PageHint.Render("↑↓: move · enter: confirm · esc: cancel"))
+
+	return b.String()
+}
+
+func (d *resetDialog) resetRow(c resetControl, label string) string {
+	if resetControl(d.focus) == c {
+		return d.styles.StatusValue.Render("▸ " + label)
+	}
+
+	return "  " + label
+}
+
+// resetSummary voices the aggregated reset outcome. A single target voices its
+// exact ResetResultType; a fan-out sums the unstaged counts.
+func resetSummary(results []data.StagingResetResult) string {
+	if len(results) == 1 {
+		return resetTypeStatus(results[0])
+	}
+
+	total := 0
+	for _, r := range results {
+		total += r.Count
+	}
+
+	if total == 0 {
+		return "Nothing staged."
+	}
+
+	return "Unstaged " + strconv.Itoa(total) + " staged change(s)."
+}
+
+// resetTypeStatus maps a single reset result's type onto its voiced phrase.
+func resetTypeStatus(r data.StagingResetResult) string {
+	switch r.Type {
+	case data.StagingResetUnstagedAll:
+		return "Unstaged " + strconv.Itoa(r.Count) + " staged change(s)."
+	case data.StagingResetNothingStaged:
+		return "Nothing staged."
+	case data.StagingResetUnstaged:
+		return "Unstaged the staged change."
+	case data.StagingResetUnstagedTag:
+		return "Unstaged the staged tag change."
+	case data.StagingResetRestored:
+		return "Restored the staged value."
+	case data.StagingResetSkipped:
+		return "Skipped — value matches the current value."
+	case data.StagingResetNotStaged:
+		return "Not staged."
+	default:
+		return "Reset."
+	}
+}

--- a/internal/tui/nav/nav.go
+++ b/internal/tui/nav/nav.go
@@ -13,9 +13,44 @@ import (
 // diff page returns to the browser).
 type PopPage struct{}
 
-// OpenStaging asks the app to switch to the Staging tab (the `S` jump; the
-// staging page itself is a placeholder until Step 5).
+// OpenStaging asks the app to switch to the Staging tab (the browser's `S` jump).
 type OpenStaging struct{}
+
+// Reload asks the app to reload the active page after a mutation or staging
+// action applied through a dialog (both the browser and the staging page react
+// to it, refreshing their data and staged-count badges).
+type Reload struct{}
+
+// OpenApply asks the app to open the apply confirmation dialog for a set of
+// services. Global marks the fan-out (apply-all) variant; EntryCount/TagCount are
+// the staged totals across the targets, shown on the confirmation.
+type OpenApply struct {
+	Services   []string
+	Global     bool
+	EntryCount int
+	TagCount   int
+}
+
+// OpenReset asks the app to open the reset confirmation dialog for a set of
+// services. Global marks the reset-all variant.
+type OpenReset struct {
+	Services []string
+	Global   bool
+}
+
+// OpenStagingDetail asks the app to push a full-diff page comparing an entry's
+// remote value against its staged value (the staging page's `enter` detail),
+// reusing the diff viewer for long values.
+type OpenStagingDetail struct {
+	Title    string
+	OldLabel string
+	NewLabel string
+	OldValue string
+	NewValue string
+	// Secret masks both sides before diffing, so a secret detail never renders a
+	// revealed value.
+	Secret bool
+}
 
 // OpenEntryForm asks the app to open the create/edit dialog. Edit fixes the name
 // and seeds the value/type/description from the selected entry; create seeds only

--- a/internal/tui/pages/browser/cmds.go
+++ b/internal/tui/pages/browser/cmds.go
@@ -40,10 +40,6 @@ type (
 	debounceMsg struct{ seq int }
 )
 
-// ReloadMsg asks the browser to re-fetch its list and staged flags after a
-// mutation applied through a dialog. The app forwards it to the active page.
-type ReloadMsg struct{}
-
 // listParams snapshots the header state into a data.ListParams.
 func (m *Model) listParams() data.ListParams {
 	return data.ListParams{

--- a/internal/tui/pages/browser/update.go
+++ b/internal/tui/pages/browser/update.go
@@ -33,7 +33,7 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 		return m, nil
 	case stagedLoadedMsg:
 		return m, m.onStagedLoaded(msg)
-	case ReloadMsg:
+	case nav.Reload:
 		return m, m.reload()
 	case namespacesLoadedMsg:
 		m.onNamespacesLoaded(msg)
@@ -156,7 +156,7 @@ func (m *Model) onStagedLoaded(msg stagedLoadedMsg) tea.Cmd {
 }
 
 // reload re-fetches the list and staged flags after a mutation (the app forwards
-// ReloadMsg). The list load re-issues the selection's detail/history on landing,
+// nav.Reload). The list load re-issues the selection's detail/history on landing,
 // so the value and badges reflect the write.
 func (m *Model) reload() tea.Cmd {
 	cmds := []tea.Cmd{m.loadListCmd(false)}

--- a/internal/tui/pages/diff/diff.go
+++ b/internal/tui/pages/diff/diff.go
@@ -74,8 +74,28 @@ func New(ctx context.Context, req nav.OpenDiff, st styles.Styles, km keys.Map) *
 	}
 }
 
-// Init dispatches the one-shot version-contents fetch.
+// NewStatic builds a diff page over already-known content (no fetch). It backs
+// the staging page's remote-vs-staged detail, where the two sides are the staged
+// review's values rather than two provider versions. Secret masking is honored
+// exactly as in the fetched path.
+func NewStatic(content data.DiffContent, st styles.Styles, km keys.Map) *Model {
+	return &Model{
+		name:    content.NewLabel,
+		content: content,
+		loaded:  true,
+		styles:  st,
+		keys:    km,
+		vp:      viewport.New(),
+	}
+}
+
+// Init dispatches the one-shot version-contents fetch, or nothing for a static
+// page whose content is already known.
 func (m *Model) Init() tea.Cmd {
+	if m.source == nil {
+		return nil
+	}
+
 	return m.loadCmd()
 }
 

--- a/internal/tui/pages/staging/cmds.go
+++ b/internal/tui/pages/staging/cmds.go
@@ -1,0 +1,54 @@
+package staging
+
+import (
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/mpyw/suve/internal/tui/data"
+)
+
+// Async result messages. Each staged read carries the section index and the
+// sequence its fetch was issued with, so the reducer drops a stale response.
+type (
+	reviewLoadedMsg struct {
+		section int
+		seq     int
+		review  data.StagingReview
+		err     error
+	}
+	// actionDoneMsg reports an inline row action (unstage / cancel-tag) finished;
+	// the page reloads on success or surfaces the error.
+	actionDoneMsg struct {
+		section int
+		err     error
+	}
+)
+
+// unstageCmd runs an unstage (entry + tags) for a row's item off the update loop.
+func (m *Model) unstageCmd(sectionIdx int, key data.StagedKey) tea.Cmd {
+	ctx := m.ctx
+	svc := m.sections[sectionIdx].svc
+
+	return func() tea.Msg {
+		return actionDoneMsg{section: sectionIdx, err: svc.Unstage(ctx, key)}
+	}
+}
+
+// cancelAddTagCmd cancels one staged tag add.
+func (m *Model) cancelAddTagCmd(sectionIdx int, key data.StagedKey, tagKey string) tea.Cmd {
+	ctx := m.ctx
+	svc := m.sections[sectionIdx].svc
+
+	return func() tea.Msg {
+		return actionDoneMsg{section: sectionIdx, err: svc.CancelAddTag(ctx, key, tagKey)}
+	}
+}
+
+// cancelRemoveTagCmd cancels one staged tag removal.
+func (m *Model) cancelRemoveTagCmd(sectionIdx int, key data.StagedKey, tagKey string) tea.Cmd {
+	ctx := m.ctx
+	svc := m.sections[sectionIdx].svc
+
+	return func() tea.Msg {
+		return actionDoneMsg{section: sectionIdx, err: svc.CancelRemoveTag(ctx, key, tagKey)}
+	}
+}

--- a/internal/tui/pages/staging/mouse.go
+++ b/internal/tui/pages/staging/mouse.go
@@ -1,0 +1,101 @@
+package staging
+
+import (
+	tea "charm.land/bubbletea/v2"
+)
+
+// handleMouseClick maps a left click onto the last-rendered geometry, reducing
+// each click to the SAME internal action its keyboard equivalent performs: a
+// section's apply/reset button to apply/reset that section, an entry row to the
+// full-diff detail (like enter), a tag row to its cancel (like enter/x), and the
+// auto-unstaged notice to dismiss. It follows the browser's hand-rolled geom
+// hit-testing so #663 can migrate both pages to the compositor uniformly.
+func (m *Model) handleMouseClick(msg tea.MouseClickMsg) (*Model, tea.Cmd) {
+	if msg.Button != tea.MouseLeft {
+		return m, nil
+	}
+
+	if m.geom.noticeRow >= 0 && msg.Y == m.geom.noticeRow {
+		m.noticeDismissed = true
+
+		return m, nil
+	}
+
+	line := msg.Y - m.geom.bodyTop
+	if line < 0 || line >= len(m.geom.lines) {
+		return m, nil
+	}
+
+	desc := m.geom.lines[line]
+
+	if desc.section >= 0 {
+		return m.clickSection(desc, msg.X)
+	}
+
+	if desc.row >= 0 {
+		return m.clickRow(desc.row)
+	}
+
+	return m, nil
+}
+
+// clickSection handles a click on a section header: apply/reset when the click
+// falls on the corresponding button columns.
+func (m *Model) clickSection(desc lineDesc, x int) (*Model, tea.Cmd) {
+	if desc.section >= len(m.sections) {
+		return m, nil
+	}
+
+	service := m.sections[desc.section].service
+
+	switch {
+	case inRange(x, desc.apply):
+		return m, m.applyServices([]string{service}, false)
+	case inRange(x, desc.reset):
+		return m, m.resetServices([]string{service}, false)
+	default:
+		return m, nil
+	}
+}
+
+// clickRow selects a row and performs its enter action (detail for an entry,
+// cancel for a tag change), so a click reduces to the key path.
+func (m *Model) clickRow(row int) (*Model, tea.Cmd) {
+	if row >= len(m.rows) {
+		return m, nil
+	}
+
+	m.selected = row
+
+	return m, m.onEnter()
+}
+
+// handleMouseWheel scrolls the section body.
+func (m *Model) handleMouseWheel(msg tea.MouseWheelMsg) (*Model, tea.Cmd) {
+	delta := wheelDelta(msg.Button)
+	if delta == 0 {
+		return m, nil
+	}
+
+	m.scroll += delta
+	m.scrollToSelection = false // an explicit scroll is not overridden by the selection
+
+	return m, nil
+}
+
+// wheelDelta maps a wheel button to a row delta (down positive, up negative).
+func wheelDelta(button tea.MouseButton) int {
+	switch button {
+	case tea.MouseWheelDown:
+		return 1
+	case tea.MouseWheelUp:
+		return -1
+	default:
+		return 0
+	}
+}
+
+// inRange reports whether x is within the [start,end) column range.
+func inRange(x int, r [2]int) bool {
+	return x >= r[0] && x < r[1]
+}

--- a/internal/tui/pages/staging/rows.go
+++ b/internal/tui/pages/staging/rows.go
@@ -1,0 +1,126 @@
+package staging
+
+import (
+	"github.com/mpyw/suve/internal/tui/data"
+)
+
+// rowKind is the type of a selectable staging row.
+type rowKind int
+
+const (
+	// rowEntry is a staged entry (create/update/delete).
+	rowEntry rowKind = iota
+	// rowTagAdd is one staged tag add (cancellable with `x`).
+	rowTagAdd
+	// rowTagRemove is one staged tag removal (cancellable with `↩`/enter).
+	rowTagRemove
+)
+
+// rowRef locates a selectable row within a section and carries what an action
+// needs to act on it. Every action addresses its item by (section, key) — never
+// by a screen coordinate.
+type rowRef struct {
+	section int
+	kind    rowKind
+
+	// entry is the staged entry (rowEntry only).
+	entry data.StagedDiffRow
+
+	// key identifies the item (all kinds); tagKey/tagValue name the tag change
+	// (rowTagAdd/rowTagRemove).
+	key      data.StagedKey
+	tagKey   string
+	tagValue string
+}
+
+// rebuildRows flattens every section's entries and tag changes into the
+// selectable-row list, clamping the selection into range.
+func (m *Model) rebuildRows() {
+	var rows []rowRef
+
+	for i, sec := range m.sections {
+		for _, e := range sec.entryRows() {
+			rows = append(rows, rowRef{
+				section: i,
+				kind:    rowEntry,
+				entry:   e,
+				key:     data.StagedKey{Name: e.Name, Namespace: e.Namespace},
+			})
+		}
+
+		for _, t := range sec.review.Tags {
+			key := data.StagedKey{Name: t.Name, Namespace: t.Namespace}
+
+			for _, add := range t.Adds {
+				rows = append(rows, rowRef{
+					section: i, kind: rowTagAdd, key: key, tagKey: add.Key, tagValue: add.Value,
+				})
+			}
+
+			for _, rem := range t.Removes {
+				rows = append(rows, rowRef{
+					section: i, kind: rowTagRemove, key: key, tagKey: rem.Key, tagValue: rem.Value,
+				})
+			}
+		}
+	}
+
+	m.rows = rows
+
+	if m.selected >= len(rows) {
+		m.selected = max(len(rows)-1, 0)
+	}
+
+	if m.selected < 0 {
+		m.selected = 0
+	}
+}
+
+// selectedRow returns the currently-selected row and true, or false when there
+// are no rows.
+func (m *Model) selectedRow() (rowRef, bool) {
+	if m.selected < 0 || m.selected >= len(m.rows) {
+		return rowRef{}, false
+	}
+
+	return m.rows[m.selected], true
+}
+
+// selectedSection returns the index of the section the selection sits in, or 0
+// when there is no selection (so a section-scoped action still has a target when
+// exactly one section exists).
+func (m *Model) selectedSection() int {
+	if row, ok := m.selectedRow(); ok {
+		return row.section
+	}
+
+	return 0
+}
+
+// autoUnstaged collects the auto-unstaged keys across all sections for the
+// dismissible notice.
+func (m *Model) autoUnstaged() []data.StagedKey {
+	var keys []data.StagedKey
+	for _, sec := range m.sections {
+		keys = append(keys, sec.review.AutoUnstaged()...)
+	}
+
+	return keys
+}
+
+// totalCounts returns the staged entry and tag counts across the given service
+// keys (all services when services is nil), for the apply confirmation.
+func (m *Model) totalCounts(services map[string]bool) (int, int) {
+	entries, tags := 0, 0
+
+	for _, sec := range m.sections {
+		if services != nil && !services[sec.service] {
+			continue
+		}
+
+		entries += sec.review.EntryCount()
+		tags += sec.review.TagCount()
+	}
+
+	return entries, tags
+}

--- a/internal/tui/pages/staging/rows.go
+++ b/internal/tui/pages/staging/rows.go
@@ -26,11 +26,10 @@ type rowRef struct {
 	// entry is the staged entry (rowEntry only).
 	entry data.StagedDiffRow
 
-	// key identifies the item (all kinds); tagKey/tagValue name the tag change
-	// (rowTagAdd/rowTagRemove).
-	key      data.StagedKey
-	tagKey   string
-	tagValue string
+	// key identifies the item (all kinds); tagKey names the tag change the row's
+	// cancel action targets (rowTagAdd/rowTagRemove).
+	key    data.StagedKey
+	tagKey string
 }
 
 // rebuildRows flattens every section's entries and tag changes into the
@@ -53,13 +52,13 @@ func (m *Model) rebuildRows() {
 
 			for _, add := range t.Adds {
 				rows = append(rows, rowRef{
-					section: i, kind: rowTagAdd, key: key, tagKey: add.Key, tagValue: add.Value,
+					section: i, kind: rowTagAdd, key: key, tagKey: add.Key,
 				})
 			}
 
 			for _, rem := range t.Removes {
 				rows = append(rows, rowRef{
-					section: i, kind: rowTagRemove, key: key, tagKey: rem.Key, tagValue: rem.Value,
+					section: i, kind: rowTagRemove, key: key, tagKey: rem.Key,
 				})
 			}
 		}

--- a/internal/tui/pages/staging/staging.go
+++ b/internal/tui/pages/staging/staging.go
@@ -1,0 +1,170 @@
+// Package staging implements the TUI's staging review page: per-service sections
+// listing staged entries (as Remote-vs-Staged diffs or raw staged values) and
+// independent staged tag changes, with unstage / edit-staged / cancel-tag row
+// actions and the apply and reset flows. It completes the TUI's stage → review →
+// apply loop. Only the services the launched scope offers get a section; every
+// staged read is a tea.Cmd guarded by a monotonic sequence (the browser's
+// loadSeq pattern), and a staging read failure degrades to a per-section error
+// line rather than blocking the rest of the app.
+package staging
+
+import (
+	"context"
+
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/mpyw/suve/internal/tui/data"
+	"github.com/mpyw/suve/internal/tui/keys"
+	"github.com/mpyw/suve/internal/tui/styles"
+)
+
+// serviceSecret is the secret service key (the sections' masking axis).
+const serviceSecret = "secret"
+
+// Page-local key bindings not present in the global map.
+//
+//nolint:gochecknoglobals // immutable page-local bindings
+var (
+	viewKey     = key.NewBinding(key.WithKeys("v"), key.WithHelp("v", "view"))
+	revealKey   = key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "reveal/cancel-tag"))
+	resetKey    = key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "reset"))
+	unstageKey  = key.NewBinding(key.WithKeys("u"), key.WithHelp("u", "unstage"))
+	editKey     = key.NewBinding(key.WithKeys("e"), key.WithHelp("e", "edit"))
+	tagKey      = key.NewBinding(key.WithKeys("t"), key.WithHelp("t", "tags"))
+	applyKey    = key.NewBinding(key.WithKeys("a"), key.WithHelp("a", "apply"))
+	applyAllKey = key.NewBinding(key.WithKeys("A"), key.WithHelp("A", "apply-all"))
+	resetAllKey = key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "reset-all"))
+	refreshKey  = key.NewBinding(key.WithKeys("ctrl+r"), key.WithHelp("ctrl+r", "refresh"))
+)
+
+// section is one service's staged review plus its load/error state.
+type section struct {
+	svc     data.StagingService
+	service string // "param" / "secret"
+	label   string
+	secret  bool
+
+	review  data.StagingReview
+	loaded  bool
+	err     string
+	loadSeq int
+}
+
+// entryRows returns the section's still-staged entry rows (auto-unstaged rows are
+// excluded — they moved to the dismissible notice).
+func (s *section) entryRows() []data.StagedDiffRow {
+	rows := make([]data.StagedDiffRow, 0, len(s.review.Entries))
+
+	for _, e := range s.review.Entries {
+		if e.Type != data.StagedDiffAutoUnstaged {
+			rows = append(rows, e)
+		}
+	}
+
+	return rows
+}
+
+// Model is the staging page.
+type Model struct {
+	// ctx is the Run context threaded through every staged read/write command, so
+	// a fetch is cancelled when the program exits.
+	ctx context.Context //nolint:containedctx // fetch commands need the Run context; mirrors the browser
+
+	sections []*section
+
+	styles styles.Styles
+	keys   keys.Map
+
+	width  int
+	height int
+
+	// diffView selects diff (Remote vs Staged) vs value (raw staged) rendering.
+	diffView bool
+	// reveal unmasks secret staged values in value view (never persisted, reset
+	// on load).
+	reveal bool
+	// noticeDismissed hides the auto-unstaged notice until the next load.
+	noticeDismissed bool
+
+	// rows is the flattened list of selectable rows (entries + tag changes across
+	// all sections), rebuilt on every load; selected indexes into it.
+	rows     []rowRef
+	selected int
+
+	// actionBusy guards the inline row actions (unstage / cancel-tag) so a
+	// double-press never fires two writes at once (#568).
+	actionBusy bool
+
+	// scroll is the section-body scroll offset (wheel/overflow).
+	scroll int
+	// scrollToSelection, set when the selection moves, tells the next View to
+	// scroll the body so the selected row is visible.
+	scrollToSelection bool
+
+	// geom records the last-rendered line hit-map so mouse handlers hit-test what
+	// is actually on screen (never a hard-coded coordinate) — the browser geom
+	// pattern, kept consistent for the #663 compositor migration.
+	geom stagingGeom
+}
+
+// New builds the staging page over the offered services' staging seams (param
+// and/or secret, in tab order). ctx is the Run context threaded through reads.
+func New(ctx context.Context, services []data.StagingService, st styles.Styles, km keys.Map) *Model {
+	sections := make([]*section, 0, len(services))
+	for _, svc := range services {
+		sections = append(sections, &section{
+			svc:     svc,
+			service: svc.Service(),
+			label:   svc.Label(),
+			secret:  svc.Service() == serviceSecret,
+		})
+	}
+
+	return &Model{
+		ctx:      ctx,
+		sections: sections,
+		styles:   st,
+		keys:     km,
+		diffView: true, // diff is the default view (the mock's [diff] value)
+	}
+}
+
+// Init dispatches the initial staged reads for every section.
+func (m *Model) Init() tea.Cmd {
+	return m.reload()
+}
+
+// CapturesInput is always false: the staging page has no focused text input, so
+// the app's global key map stays active.
+func (m *Model) CapturesInput() bool { return false }
+
+// reload re-reads every section's staged review, each guarded by a fresh
+// sequence, and clears the dismissible notice so a fresh auto-unstage shows.
+func (m *Model) reload() tea.Cmd {
+	m.noticeDismissed = false
+	m.reveal = false
+
+	cmds := make([]tea.Cmd, 0, len(m.sections))
+	for i := range m.sections {
+		cmds = append(cmds, m.reviewCmd(i))
+	}
+
+	return tea.Batch(cmds...)
+}
+
+// reviewCmd issues a staged-review read for section i, tagged with a fresh
+// sequence so a stale response is dropped.
+func (m *Model) reviewCmd(i int) tea.Cmd {
+	sec := m.sections[i]
+	sec.loadSeq++
+	seq := sec.loadSeq
+	ctx := m.ctx
+	svc := sec.svc
+
+	return func() tea.Msg {
+		review, err := svc.Review(ctx)
+
+		return reviewLoadedMsg{section: i, seq: seq, review: review, err: err}
+	}
+}

--- a/internal/tui/pages/staging/staging_test.go
+++ b/internal/tui/pages/staging/staging_test.go
@@ -1,0 +1,339 @@
+//nolint:testpackage // white-box: exercises the unexported reducer, rows, and geometry
+package staging
+
+import (
+	"context"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/capability"
+	"github.com/mpyw/suve/internal/tui/data"
+	"github.com/mpyw/suve/internal/tui/keys"
+	"github.com/mpyw/suve/internal/tui/nav"
+	"github.com/mpyw/suve/internal/tui/styles"
+)
+
+// canceledTag records a cancel-tag call for assertions.
+type canceledTag struct {
+	key    data.StagedKey
+	tagKey string
+}
+
+// stubService is a controllable data.StagingService for Update-layer tests: it
+// returns preset review/apply/reset results and records the mutating calls.
+type stubService struct {
+	service string
+	label   string
+	svcCap  capability.ServiceCapability
+
+	review      data.StagingReview
+	applyResult data.StagingApplyResult
+	applyErr    error
+	resetResult data.StagingResetResult
+
+	unstaged      []data.StagedKey
+	cancelAdds    []canceledTag
+	cancelRemoves []canceledTag
+	applied       []bool
+	resetCalls    int
+}
+
+func (s *stubService) Service() string                          { return s.service }
+func (s *stubService) Label() string                            { return s.label }
+func (s *stubService) Capability() capability.ServiceCapability { return s.svcCap }
+
+func (s *stubService) Review(context.Context) (data.StagingReview, error) {
+	return s.review, nil
+}
+
+func (s *stubService) Apply(_ context.Context, ignoreConflicts bool) (data.StagingApplyResult, error) {
+	s.applied = append(s.applied, ignoreConflicts)
+
+	return s.applyResult, s.applyErr
+}
+
+func (s *stubService) Reset(context.Context) (data.StagingResetResult, error) {
+	s.resetCalls++
+
+	return s.resetResult, nil
+}
+
+func (s *stubService) Unstage(_ context.Context, key data.StagedKey) error {
+	s.unstaged = append(s.unstaged, key)
+
+	return nil
+}
+
+func (s *stubService) CancelAddTag(_ context.Context, key data.StagedKey, tagKey string) error {
+	s.cancelAdds = append(s.cancelAdds, canceledTag{key: key, tagKey: tagKey})
+
+	return nil
+}
+
+func (s *stubService) CancelRemoveTag(_ context.Context, key data.StagedKey, tagKey string) error {
+	s.cancelRemoves = append(s.cancelRemoves, canceledTag{key: key, tagKey: tagKey})
+
+	return nil
+}
+
+// capFor looks up a neutral capability for the fixtures.
+//
+//nolint:unparam // prov is "aws" for every current fixture but reads clearer explicit
+func capFor(prov, service string) capability.ServiceCapability {
+	for _, pc := range capability.All() {
+		if pc.Provider != prov {
+			continue
+		}
+
+		for _, sc := range pc.Services {
+			if sc.Service == service {
+				return sc
+			}
+		}
+	}
+
+	return capability.ServiceCapability{}
+}
+
+func keyPress(r rune) tea.KeyPressMsg { return tea.KeyPressMsg{Code: r, Text: string(r)} }
+
+// newModel builds a staging page over stub services, loads their reviews, and
+// sizes it so View populates the geometry.
+func newModel(t *testing.T, secs ...*stubService) *Model {
+	t.Helper()
+
+	services := make([]data.StagingService, len(secs))
+	for i, s := range secs {
+		services[i] = s
+	}
+
+	m := New(context.Background(), services, styles.New(), keys.Default())
+
+	for i, s := range secs {
+		m, _ = m.Update(reviewLoadedMsg{section: i, seq: m.sections[i].loadSeq, review: s.review})
+	}
+
+	m.width, m.height = 100, 30
+	_ = m.View(m.width, m.height)
+
+	return m
+}
+
+// updateEntryReview is a param section with an update entry.
+func updateReview() data.StagingReview {
+	return data.StagingReview{
+		Entries: []data.StagedDiffRow{{
+			Name: "/app/web/CDN_URL", Type: data.StagedDiffNormal, Operation: "update",
+			RemoteValue: "https://old.example.com", StagedValue: "https://new.example.com",
+		}},
+	}
+}
+
+// TestUpdate_ViewToggle pins that `v` flips the diff/value view.
+func TestUpdate_ViewToggle(t *testing.T) {
+	t.Parallel()
+
+	sec := &stubService{service: "param", label: "Param", svcCap: capFor("aws", "param"), review: updateReview()}
+	m := newModel(t, sec)
+
+	require.True(t, m.diffView, "diff is the default view")
+
+	m, _ = m.Update(keyPress('v'))
+	assert.False(t, m.diffView, "v switches to value view")
+
+	m, _ = m.Update(keyPress('v'))
+	assert.True(t, m.diffView, "v switches back to diff view")
+}
+
+// TestUpdate_CancelTagOps pins that `x` cancels a staged tag add and enter
+// cancels a staged tag removal, each addressing the correct (item, tagKey).
+func TestUpdate_CancelTagOps(t *testing.T) {
+	t.Parallel()
+
+	sec := &stubService{
+		service: "param", label: "Param", svcCap: capFor("aws", "param"),
+		review: data.StagingReview{
+			Tags: []data.StagedTagRow{{
+				Name:    "/app/api/DATABASE_URL",
+				Adds:    []data.Tag{{Key: "owner", Value: "platform"}},
+				Removes: []data.TagRemoval{{Key: "env", Value: "prod"}},
+			}},
+		},
+	}
+	m := newModel(t, sec)
+
+	require.Len(t, m.rows, 2, "one add row and one remove row")
+
+	// Row 0 is the add; `x` cancels it.
+	m.selected = 0
+	m, cmd := m.Update(keyPress('x'))
+	require.NotNil(t, cmd)
+
+	m, _ = m.Update(cmd()) // feed the actionDoneMsg back, clearing the busy guard
+
+	require.Len(t, sec.cancelAdds, 1)
+	assert.Equal(t, "owner", sec.cancelAdds[0].tagKey)
+	assert.Equal(t, "/app/api/DATABASE_URL", sec.cancelAdds[0].key.Name)
+
+	// Row 1 is the removal; enter (↩) cancels it.
+	m.selected = 1
+	_, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.NotNil(t, cmd)
+	_ = cmd()
+
+	require.Len(t, sec.cancelRemoves, 1)
+	assert.Equal(t, "env", sec.cancelRemoves[0].tagKey)
+}
+
+// TestUpdate_UnstageAndApplyKeys pins the `u` unstage action (entry + its tags)
+// and the `A` apply-all fan-out request across every section.
+func TestUpdate_UnstageAndApplyKeys(t *testing.T) {
+	t.Parallel()
+
+	param := &stubService{
+		service: "param", label: "Param", svcCap: capFor("aws", "param"),
+		review: data.StagingReview{Entries: []data.StagedDiffRow{{Name: "/p", Operation: "update", StagedValue: "v"}}},
+	}
+	secret := &stubService{
+		service: "secret", label: "Secret", svcCap: capFor("aws", "secret"),
+		review: data.StagingReview{Entries: []data.StagedDiffRow{{Name: "s", Operation: "create", StagedValue: "v"}}},
+	}
+	m := newModel(t, param, secret)
+
+	// `u` unstages the selected row's item.
+	m.selected = 0
+	_, cmd := m.Update(keyPress('u'))
+	require.NotNil(t, cmd)
+	_ = cmd()
+
+	require.Len(t, param.unstaged, 1)
+	assert.Equal(t, "/p", param.unstaged[0].Name)
+
+	// `A` requests apply-all across every service.
+	_, cmd = m.Update(keyPress('A'))
+	require.NotNil(t, cmd)
+	msg, ok := cmd().(nav.OpenApply)
+	require.True(t, ok, "A opens the apply-all confirmation")
+	assert.True(t, msg.Global)
+	assert.ElementsMatch(t, []string{"param", "secret"}, msg.Services)
+}
+
+// TestUpdate_AutoUnstagedNotice pins the dismissible auto-unstaged notice: it
+// shows after a review that auto-unstaged an entry, and esc dismisses it.
+func TestUpdate_AutoUnstagedNotice(t *testing.T) {
+	t.Parallel()
+
+	sec := &stubService{
+		service: "param", label: "Param", svcCap: capFor("aws", "param"),
+		review: data.StagingReview{
+			Entries: []data.StagedDiffRow{{Name: "/app/web/OLD_FLAG", Type: data.StagedDiffAutoUnstaged}},
+		},
+	}
+	m := newModel(t, sec)
+
+	require.True(t, m.noticeVisible(), "an auto-unstaged entry shows the notice")
+	assert.Contains(t, m.View(100, 30), "/app/web/OLD_FLAG", "the notice names the auto-unstaged entry")
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	assert.False(t, m.noticeVisible(), "esc dismisses the notice")
+}
+
+// TestUpdate_BadgeCountAuthoritative pins that a section reports the exact staged
+// count — entries plus tag changes counted separately (an item with both is two,
+// not one) — fixing the browser probe's dedup undercount.
+func TestUpdate_BadgeCountAuthoritative(t *testing.T) {
+	t.Parallel()
+
+	sec := &stubService{
+		service: "param", label: "Param", svcCap: capFor("aws", "param"),
+		review: data.StagingReview{
+			Entries: []data.StagedDiffRow{{Name: "/x", Type: data.StagedDiffNormal, Operation: "update"}},
+			Tags:    []data.StagedTagRow{{Name: "/x", Adds: []data.Tag{{Key: "k", Value: "v"}}}},
+		},
+	}
+
+	m := New(context.Background(), []data.StagingService{sec}, styles.New(), keys.Default())
+	_, cmd := m.Update(reviewLoadedMsg{section: 0, seq: m.sections[0].loadSeq, review: sec.review})
+
+	require.NotNil(t, cmd)
+	msg, ok := cmd().(nav.StagedCount)
+	require.True(t, ok, "the section reports a staged count")
+	assert.Equal(t, "param", msg.Service)
+	assert.Equal(t, 2, msg.Count, "one entry + one tag change counts as two")
+}
+
+// TestUpdate_MouseClickApplyResetCancelTag pins the mouse rule: a click on a
+// section's apply/reset button and on a tag-cancel row reduces to the SAME
+// internal action its key equivalent performs, with coordinates read from the
+// rendered geometry (never hard-coded).
+func TestUpdate_MouseClickApplyResetCancelTag(t *testing.T) {
+	t.Parallel()
+
+	sec := &stubService{
+		service: "param", label: "Param", svcCap: capFor("aws", "param"),
+		review: data.StagingReview{
+			Entries: []data.StagedDiffRow{{
+				Name: "/app/web/CDN_URL", Type: data.StagedDiffNormal, Operation: "update",
+				RemoteValue: "old", StagedValue: "new",
+			}},
+			Tags: []data.StagedTagRow{{Name: "/app/api/DB", Adds: []data.Tag{{Key: "owner", Value: "platform"}}}},
+		},
+	}
+	m := newModel(t, sec)
+
+	// Click the section header's apply button → apply confirmation for the section.
+	headerLine, header := findHeaderLine(m)
+	require.GreaterOrEqual(t, headerLine, 0, "a section header was rendered")
+
+	x := (header.apply[0] + header.apply[1]) / 2
+	_, cmd := m.Update(tea.MouseClickMsg{X: x, Y: m.geom.bodyTop + headerLine, Button: tea.MouseLeft})
+	require.NotNil(t, cmd)
+	applyMsg, ok := cmd().(nav.OpenApply)
+	require.True(t, ok, "clicking apply opens the apply confirmation")
+	assert.Equal(t, []string{"param"}, applyMsg.Services)
+	assert.False(t, applyMsg.Global)
+
+	// Click the reset button → reset confirmation.
+	x = (header.reset[0] + header.reset[1]) / 2
+	_, cmd = m.Update(tea.MouseClickMsg{X: x, Y: m.geom.bodyTop + headerLine, Button: tea.MouseLeft})
+	require.NotNil(t, cmd)
+	_, ok = cmd().(nav.OpenReset)
+	assert.True(t, ok, "clicking reset opens the reset confirmation")
+
+	// Click the tag-add row → cancel that add (reduces to the `x` key path).
+	tagLine := findRowLine(m, 1) // row 1 is the tag add (row 0 is the entry)
+	require.GreaterOrEqual(t, tagLine, 0, "the tag row was rendered")
+
+	_, cmd = m.Update(tea.MouseClickMsg{X: 4, Y: m.geom.bodyTop + tagLine, Button: tea.MouseLeft})
+	require.NotNil(t, cmd)
+	_ = cmd()
+
+	require.Len(t, sec.cancelAdds, 1, "clicking the tag row cancels its staged add")
+	assert.Equal(t, "owner", sec.cancelAdds[0].tagKey)
+}
+
+// findHeaderLine returns the body-relative line index of the first section header
+// and its descriptor.
+func findHeaderLine(m *Model) (int, lineDesc) {
+	for i, d := range m.geom.lines {
+		if d.section >= 0 {
+			return i, d
+		}
+	}
+
+	return -1, lineDesc{}
+}
+
+// findRowLine returns the body-relative line index of the given selectable row.
+func findRowLine(m *Model, row int) int {
+	for i, d := range m.geom.lines {
+		if d.row == row {
+			return i
+		}
+	}
+
+	return -1
+}

--- a/internal/tui/pages/staging/update.go
+++ b/internal/tui/pages/staging/update.go
@@ -1,0 +1,343 @@
+package staging
+
+import (
+	"charm.land/bubbles/v2/key"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/mpyw/suve/internal/tui/components"
+	"github.com/mpyw/suve/internal/tui/data"
+	"github.com/mpyw/suve/internal/tui/nav"
+)
+
+// Update handles forwarded messages. It returns itself as the page (the app
+// stores it back on the stack).
+func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+
+		return m, nil
+	case reviewLoadedMsg:
+		return m, m.onReviewLoaded(msg)
+	case actionDoneMsg:
+		return m, m.onActionDone(msg)
+	case nav.Reload:
+		return m, m.reload()
+	case tea.KeyPressMsg:
+		return m.handleKey(msg)
+	case tea.MouseClickMsg:
+		return m.handleMouseClick(msg)
+	case tea.MouseWheelMsg:
+		return m.handleMouseWheel(msg)
+	default:
+		return m, nil
+	}
+}
+
+// onReviewLoaded applies a staged-review response when fresh, rebuilds the rows,
+// and reports the section's authoritative staged count (entries + tag changes,
+// counted separately) so the Staging tab badge is exact — fixing the browser's
+// best-effort undercount, which deduplicates an item that has both an entry and
+// a tag change into one.
+func (m *Model) onReviewLoaded(msg reviewLoadedMsg) tea.Cmd {
+	if msg.section >= len(m.sections) {
+		return nil
+	}
+
+	sec := m.sections[msg.section]
+	if msg.seq != sec.loadSeq {
+		return nil // stale response superseded by a newer load
+	}
+
+	sec.loaded = true
+
+	if msg.err != nil {
+		sec.err = msg.err.Error()
+		sec.review = data.StagingReview{}
+	} else {
+		sec.err = ""
+		sec.review = msg.review
+	}
+
+	m.rebuildRows()
+
+	service := sec.service
+	count := sec.review.EntryCount() + sec.review.TagCount()
+
+	return func() tea.Msg { return nav.StagedCount{Service: service, Count: count} }
+}
+
+// onActionDone clears the busy guard and, on success, reloads so the section and
+// the badges reflect the change; an error is surfaced on the section line.
+func (m *Model) onActionDone(msg actionDoneMsg) tea.Cmd {
+	m.actionBusy = false
+
+	if msg.err != nil {
+		if msg.section < len(m.sections) {
+			m.sections[msg.section].err = msg.err.Error()
+		}
+
+		return nil
+	}
+
+	return m.reload()
+}
+
+// handleKey routes a key press to a page action.
+func (m *Model) handleKey(msg tea.KeyPressMsg) (*Model, tea.Cmd) {
+	// The auto-unstaged notice dismisses on esc while it is showing.
+	if key.Matches(msg, m.keys.Back) && m.noticeVisible() {
+		m.noticeDismissed = true
+
+		return m, nil
+	}
+
+	switch {
+	case key.Matches(msg, m.keys.Up):
+		m.moveSelection(-1)
+
+		return m, nil
+	case key.Matches(msg, m.keys.Down):
+		m.moveSelection(1)
+
+		return m, nil
+	case key.Matches(msg, viewKey):
+		m.diffView = !m.diffView
+		m.reveal = false
+
+		return m, nil
+	case key.Matches(msg, m.keys.Select):
+		return m, m.onEnter()
+	case key.Matches(msg, revealKey):
+		return m, m.onReveal()
+	}
+
+	return m.handleActionKey(msg)
+}
+
+// handleActionKey handles the row/section action keys.
+func (m *Model) handleActionKey(msg tea.KeyPressMsg) (*Model, tea.Cmd) {
+	switch {
+	case key.Matches(msg, unstageKey):
+		return m, m.unstageSelected()
+	case key.Matches(msg, editKey):
+		return m, m.editSelected()
+	case key.Matches(msg, tagKey):
+		return m, m.tagSelected()
+	case key.Matches(msg, applyKey):
+		return m, m.apply(false)
+	case key.Matches(msg, applyAllKey):
+		return m, m.apply(true)
+	case key.Matches(msg, resetKey):
+		return m, m.reset(false)
+	case key.Matches(msg, resetAllKey):
+		return m, m.reset(true)
+	case key.Matches(msg, refreshKey):
+		return m, m.reload()
+	}
+
+	return m, nil
+}
+
+// moveSelection shifts the selection by delta (clamped) and keeps it visible.
+func (m *Model) moveSelection(delta int) {
+	if len(m.rows) == 0 {
+		return
+	}
+
+	m.selected = max(0, min(m.selected+delta, len(m.rows)-1))
+	m.scrollToSelection = true
+}
+
+// onReveal toggles value-view masking, or — on a staged tag-add row — cancels
+// that add (the `x` cancel affordance).
+func (m *Model) onReveal() tea.Cmd {
+	if row, ok := m.selectedRow(); ok && row.kind == rowTagAdd {
+		return m.cancelTag(row)
+	}
+
+	m.reveal = !m.reveal
+
+	return nil
+}
+
+// onEnter opens the full-diff detail for an entry row, or cancels a staged tag
+// change for a tag row (the `↩` cancel affordance).
+func (m *Model) onEnter() tea.Cmd {
+	row, ok := m.selectedRow()
+	if !ok {
+		return nil
+	}
+
+	switch row.kind {
+	case rowEntry:
+		return m.openDetail(row)
+	case rowTagAdd, rowTagRemove:
+		return m.cancelTag(row)
+	default:
+		return nil
+	}
+}
+
+// cancelTag cancels the selected tag add/removal (busy-guarded).
+func (m *Model) cancelTag(row rowRef) tea.Cmd {
+	if m.actionBusy {
+		return nil
+	}
+
+	m.actionBusy = true
+
+	if row.kind == rowTagRemove {
+		return m.cancelRemoveTagCmd(row.section, row.key, row.tagKey)
+	}
+
+	return m.cancelAddTagCmd(row.section, row.key, row.tagKey)
+}
+
+// unstageSelected unstages the selected row's item (entry + its tags).
+func (m *Model) unstageSelected() tea.Cmd {
+	row, ok := m.selectedRow()
+	if !ok || m.actionBusy {
+		return nil
+	}
+
+	m.actionBusy = true
+
+	return m.unstageCmd(row.section, row.key)
+}
+
+// editSelected reuses the Step-4 entry form to edit a staged create/update's
+// value; it is a no-op on a tag row or a staged delete (nothing to edit).
+func (m *Model) editSelected() tea.Cmd {
+	row, ok := m.selectedRow()
+	if !ok || row.kind != rowEntry || row.entry.Operation == operationDelete {
+		return nil
+	}
+
+	sec := m.sections[row.section]
+
+	return func() tea.Msg {
+		return nav.OpenEntryForm{
+			Service:   sec.service,
+			Edit:      true,
+			Name:      row.entry.Name,
+			Namespace: row.entry.Namespace,
+			Value:     row.entry.StagedValue,
+		}
+	}
+}
+
+// tagSelected reuses the Step-4 tag form to stage a tag add on the selected
+// row's item.
+func (m *Model) tagSelected() tea.Cmd {
+	row, ok := m.selectedRow()
+	if !ok {
+		return nil
+	}
+
+	sec := m.sections[row.section]
+
+	return func() tea.Msg {
+		return nav.OpenTag{Service: sec.service, Name: row.key.Name, Namespace: row.key.Namespace}
+	}
+}
+
+// openDetail pushes the full remote-vs-staged diff for an entry row.
+func (m *Model) openDetail(row rowRef) tea.Cmd {
+	sec := m.sections[row.section]
+
+	req := nav.OpenStagingDetail{
+		Title:    row.entry.Name,
+		OldLabel: "remote",
+		NewLabel: "staged",
+		OldValue: row.entry.RemoteValue,
+		NewValue: row.entry.StagedValue,
+		Secret:   sec.secret,
+	}
+
+	return func() tea.Msg { return req }
+}
+
+// apply opens the apply confirmation for the selected section (global=false) or
+// every section (global=true).
+func (m *Model) apply(global bool) tea.Cmd {
+	return m.applyServices(m.targetServices(global), global)
+}
+
+// applyServices opens the apply confirmation for a set of services, carrying the
+// staged counts for the confirmation. A key press and a click on a section's
+// apply button both reduce to this, so mouse and keyboard stay in lockstep.
+func (m *Model) applyServices(services []string, global bool) tea.Cmd {
+	if len(services) == 0 {
+		return nil
+	}
+
+	entries, tags := m.totalCounts(serviceSet(services))
+	if entries == 0 && tags == 0 {
+		return nil
+	}
+
+	req := nav.OpenApply{Services: services, Global: global, EntryCount: entries, TagCount: tags}
+
+	return func() tea.Msg { return req }
+}
+
+// reset opens the reset confirmation for the selected section or every section.
+func (m *Model) reset(global bool) tea.Cmd {
+	return m.resetServices(m.targetServices(global), global)
+}
+
+// resetServices opens the reset confirmation for a set of services (the reduction
+// target for both the reset keys and a click on a section's reset button).
+func (m *Model) resetServices(services []string, global bool) tea.Cmd {
+	if len(services) == 0 {
+		return nil
+	}
+
+	req := nav.OpenReset{Services: services, Global: global}
+
+	return func() tea.Msg { return req }
+}
+
+// targetServices resolves the service keys an apply/reset targets: every section
+// for a global action, else just the selected row's section.
+func (m *Model) targetServices(global bool) []string {
+	if global {
+		services := make([]string, 0, len(m.sections))
+		for _, sec := range m.sections {
+			services = append(services, sec.service)
+		}
+
+		return services
+	}
+
+	if len(m.sections) == 0 {
+		return nil
+	}
+
+	return []string{m.sections[m.selectedSection()].service}
+}
+
+// serviceSet builds a set of the given service keys.
+func serviceSet(services []string) map[string]bool {
+	set := make(map[string]bool, len(services))
+	for _, s := range services {
+		set[s] = true
+	}
+
+	return set
+}
+
+// noticeVisible reports whether the auto-unstaged notice is currently shown.
+func (m *Model) noticeVisible() bool {
+	return !m.noticeDismissed && len(m.autoUnstaged()) > 0
+}
+
+// maskValue masks a secret value for value-view rendering unless revealed.
+func (m *Model) maskValue(value string, secret bool) string {
+	if secret && !m.reveal {
+		return components.MaskValue(value)
+	}
+
+	return value
+}

--- a/internal/tui/pages/staging/update.go
+++ b/internal/tui/pages/staging/update.go
@@ -105,7 +105,15 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) (*Model, tea.Cmd) {
 		m.diffView = !m.diffView
 		m.reveal = false
 
-		return m, nil
+		// Toggling diff↔value rewrites every row's layout (diff spreads a value
+		// over ±lines; value packs it onto the header line). Bubble Tea's cell
+		// renderer would service that with a scroll-region optimization
+		// (ESC[…r + ESC[nS) whose result depends on the exact prior frame, so
+		// under a terminal that negotiates synchronized output differently (CI)
+		// the targeted cell writes land wrong and the staged values render
+		// empty. Force a full repaint so the toggle frame is
+		// environment-independent, exactly like the initial full paint.
+		return m, tea.ClearScreen
 	case key.Matches(msg, m.keys.Select):
 		return m, m.onEnter()
 	case key.Matches(msg, revealKey):

--- a/internal/tui/pages/staging/view.go
+++ b/internal/tui/pages/staging/view.go
@@ -1,0 +1,383 @@
+package staging
+
+import (
+	"strconv"
+	"strings"
+
+	"charm.land/lipgloss/v2"
+
+	"github.com/mpyw/suve/internal/provider/azure/appconfig/aznamespace"
+	"github.com/mpyw/suve/internal/tui/data"
+)
+
+// Operation keys (the neutral staging operation strings).
+const (
+	operationCreate = "create"
+	operationUpdate = "update"
+	operationDelete = "delete"
+)
+
+// lineDesc maps one rendered body line to what a mouse click on it acts on.
+type lineDesc struct {
+	// row is the selectable row index this line belongs to, or -1.
+	row int
+	// section is the section index when this line is a section header (whose
+	// apply/reset buttons are hit-tested), or -1.
+	section int
+	// apply/reset are the [start,end) column ranges of the header's apply/reset
+	// buttons (only meaningful when section >= 0).
+	apply [2]int
+	reset [2]int
+}
+
+// stagingGeom records the last-rendered hit-map so mouse handlers hit-test what
+// is on screen (the browser geom pattern; #663 migrates it to the compositor).
+type stagingGeom struct {
+	// bodyTop is the page-local screen row the scroll body starts on.
+	bodyTop int
+	// bodyRows is the visible body height.
+	bodyRows int
+	// lines maps a body-relative screen row to its descriptor.
+	lines []lineDesc
+	// noticeRow is the page-local row of the dismissible notice, or -1.
+	noticeRow int
+}
+
+// View renders the staging page into the content area and records the geometry.
+func (m *Model) View(width, height int) string {
+	m.width, m.height = width, height
+	if width <= 0 || height <= 0 {
+		return ""
+	}
+
+	m.geom = stagingGeom{noticeRow: -1}
+
+	head := []string{m.headerLine(width)}
+
+	if m.noticeVisible() {
+		m.geom.noticeRow = len(head)
+		head = append(head, m.noticeLine(width))
+	}
+
+	bodyTop := len(head)
+	bodyH := max(height-bodyTop, 0)
+	m.geom.bodyTop = bodyTop
+	m.geom.bodyRows = bodyH
+
+	lines, descs, rowFirst := m.bodyLines(width)
+	m.clampScroll(len(lines), bodyH, rowFirst)
+
+	visible, visDescs := window(lines, descs, m.scroll, bodyH)
+	m.geom.lines = visDescs
+
+	return strings.Join(append(head, visible...), "\n")
+}
+
+// headerLine renders the fixed top line: the view toggle and the global
+// apply-all / reset-all / refresh affordances.
+func (m *Model) headerLine(width int) string {
+	toggle := "view: " + m.styles.PaneTitle.Render(bracket("diff", m.diffView)) + " " + bracket("value", !m.diffView)
+	actions := m.styles.PageHint.Render("A apply-all · R reset-all · ctrl+r refresh")
+
+	return clip(toggle+"   "+actions, width)
+}
+
+// noticeLine renders the dismissible auto-unstaged notice.
+func (m *Model) noticeLine(width int) string {
+	keys := m.autoUnstaged()
+	names := make([]string, 0, len(keys))
+
+	for _, k := range keys {
+		names = append(names, keyLabel(k))
+	}
+
+	text := "⚠ auto-unstaged: " + strings.Join(names, ", ") + " (staged value now equals remote)  esc: dismiss"
+
+	return m.styles.Banner.Render(clip(text, width))
+}
+
+// bodyLines builds every section's lines (unclipped by scroll) plus their
+// descriptors and the body-line index each selectable row starts on. The running
+// rowIdx advances one per selectable row (an entry, or a single tag change), so
+// each line's descriptor maps to the exact row a click selects.
+func (m *Model) bodyLines(width int) ([]string, []lineDesc, []int) {
+	var (
+		lines    []string
+		descs    []lineDesc
+		rowFirst = make([]int, len(m.rows))
+		rowIdx   int
+	)
+
+	add := func(text string, d lineDesc) {
+		lines = append(lines, clip(text, width))
+		descs = append(descs, d)
+	}
+	lineCount := func() int { return len(lines) }
+
+	for i, sec := range m.sections {
+		if i > 0 {
+			add("", lineDesc{row: -1, section: -1})
+		}
+
+		header, applyR, resetR := m.sectionHeader(sec, width)
+		add(header, lineDesc{row: -1, section: i, apply: applyR, reset: resetR})
+
+		if sec.err != "" {
+			add("  "+m.styles.ErrorText.Render(sec.err), lineDesc{row: -1, section: -1})
+
+			continue
+		}
+
+		if !sec.loaded {
+			add("  "+m.styles.PageHint.Render("loading…"), lineDesc{row: -1, section: -1})
+
+			continue
+		}
+
+		rowIdx = m.appendSectionRows(sec, rowIdx, rowFirst, add, lineCount)
+	}
+
+	return lines, descs, rowFirst
+}
+
+// appendSectionRows appends a section's entry and tag rows, recording each
+// selectable row's first body-line index (read from lineCount before its lines
+// are added), and returns the running global row index.
+func (m *Model) appendSectionRows(
+	sec *section, rowIdx int, rowFirst []int, add func(string, lineDesc), lineCount func() int,
+) int {
+	entries := sec.entryRows()
+	tags := sec.review.Tags
+
+	if len(entries) == 0 && len(tags) == 0 {
+		add("  "+m.styles.PageHint.Render("(nothing staged)"), lineDesc{row: -1, section: -1})
+
+		return rowIdx
+	}
+
+	for _, e := range entries {
+		rowFirst[rowIdx] = lineCount()
+
+		for _, text := range m.entryLines(sec, e, rowIdx) {
+			add(text, lineDesc{row: rowIdx, section: -1})
+		}
+
+		rowIdx++
+	}
+
+	for _, t := range tags {
+		name := t.Name + nsBadge(sec, t.Namespace)
+
+		for _, ad := range t.Adds {
+			rowFirst[rowIdx] = lineCount()
+			change := m.styles.DiffAdded.Render("+" + ad.Key + "=" + ad.Value)
+			add(m.tagLine(rowIdx, name, change, "x cancel"), lineDesc{row: rowIdx, section: -1})
+			rowIdx++
+		}
+
+		for _, rem := range t.Removes {
+			rowFirst[rowIdx] = lineCount()
+
+			change := m.styles.DiffRemoved.Render("−" + rem.Key)
+			if rem.Value != "" {
+				change += m.styles.PageHint.Render(" (was " + rem.Value + ")")
+			}
+
+			add(m.tagLine(rowIdx, name, change, "↩ cancel"), lineDesc{row: rowIdx, section: -1})
+			rowIdx++
+		}
+	}
+
+	return rowIdx
+}
+
+// entryLines renders one staged entry row (its header line plus, in diff view,
+// the ± value lines). Every line belongs to the same selectable row.
+func (m *Model) entryLines(sec *section, e data.StagedDiffRow, rowIdx int) []string {
+	head := m.cursor(rowIdx) + m.opMarker(e.Operation) + "  " + e.Name + nsBadge(sec, e.Namespace)
+
+	if e.Type == data.StagedDiffWarning {
+		return []string{head, "    " + m.styles.ErrorText.Render("⚠ "+e.Warning)}
+	}
+
+	if !m.diffView {
+		value := m.maskValue(e.StagedValue, sec.secret)
+		if e.Operation == operationDelete {
+			value = m.styles.PageHint.Render("(delete)")
+		}
+
+		return []string{head + "   " + value}
+	}
+
+	return append([]string{head}, m.diffLines(sec, e)...)
+}
+
+// diffLines renders an entry's Remote-vs-Staged ± lines (masked for secrets).
+func (m *Model) diffLines(sec *section, e data.StagedDiffRow) []string {
+	var lines []string
+
+	remote := m.maskValue(e.RemoteValue, sec.secret)
+	staged := m.maskValue(e.StagedValue, sec.secret)
+
+	if e.Operation != operationCreate {
+		lines = append(lines, "    "+m.styles.DiffRemoved.Render("- "+firstLine(remote)))
+	}
+
+	if e.Operation != operationDelete {
+		lines = append(lines, "    "+m.styles.DiffAdded.Render("+ "+firstLine(staged)))
+	}
+
+	return lines
+}
+
+// tagLine renders one tag-change row: cursor, "tags", the item name, the change,
+// and the cancel affordance.
+func (m *Model) tagLine(rowIdx int, name, change, cancel string) string {
+	return m.cursor(rowIdx) + m.styles.FieldLabel.Render("tags") + "  " + name + "  " + change +
+		"   " + m.styles.PageHint.Render(cancel)
+}
+
+// sectionHeader renders a section header and returns the apply/reset button
+// column ranges (computed from the plain layout so hit-testing is color-safe).
+func (m *Model) sectionHeader(sec *section, width int) (string, [2]int, [2]int) {
+	title := sec.label + " (" + strconv.Itoa(sec.review.EntryCount()+sec.review.TagCount()) + ")"
+
+	const applyText = "a apply"
+
+	const resetText = "r reset"
+
+	buttons := applyText + " · " + resetText
+	gap := max(width-lipgloss.Width(title)-lipgloss.Width(buttons)-1, 1)
+	plain := title + strings.Repeat(" ", gap) + buttons
+
+	applyStart := strings.Index(plain, applyText)
+	resetStart := strings.LastIndex(plain, resetText)
+
+	styled := m.styles.PaneTitle.Render(title) + strings.Repeat(" ", gap) +
+		m.styles.PageHint.Render(applyText+" · "+resetText)
+
+	return clip(styled, width),
+		[2]int{applyStart, applyStart + len(applyText)},
+		[2]int{resetStart, resetStart + len(resetText)}
+}
+
+// opMarker renders a color-coded operation marker with a plain-text fallback
+// under NO_COLOR.
+func (m *Model) opMarker(op string) string {
+	switch op {
+	case operationCreate:
+		return m.styles.DiffAdded.Render("create")
+	case operationDelete:
+		return m.styles.DiffRemoved.Render("delete")
+	default:
+		return m.styles.Banner.Render("update")
+	}
+}
+
+// cursor renders the selection cursor for a row.
+func (m *Model) cursor(rowIdx int) string {
+	if rowIdx == m.selected {
+		return m.styles.StatusValue.Render("▸ ")
+	}
+
+	return "  "
+}
+
+// clampScroll keeps the scroll offset in range and, when the selection just
+// moved, scrolls so the selected row's first line is visible.
+func (m *Model) clampScroll(total, bodyH int, rowFirst []int) {
+	maxScroll := max(total-bodyH, 0)
+
+	if m.scrollToSelection && m.selected < len(rowFirst) {
+		first := rowFirst[m.selected]
+		if first < m.scroll {
+			m.scroll = first
+		}
+
+		if first >= m.scroll+bodyH {
+			m.scroll = first - bodyH + 1
+		}
+
+		m.scrollToSelection = false
+	}
+
+	m.scroll = max(0, min(m.scroll, maxScroll))
+}
+
+// window returns the visible slice of body lines/descs for the scroll offset,
+// padding with blanks so the body fills its height (keeping the layout stable).
+func window(lines []string, descs []lineDesc, offset, height int) ([]string, []lineDesc) {
+	if height <= 0 {
+		return nil, nil
+	}
+
+	end := min(offset+height, len(lines))
+
+	var (
+		outLines []string
+		outDescs []lineDesc
+	)
+
+	if offset < len(lines) {
+		outLines = append(outLines, lines[offset:end]...)
+		outDescs = append(outDescs, descs[offset:end]...)
+	}
+
+	for len(outLines) < height {
+		outLines = append(outLines, "")
+		outDescs = append(outDescs, lineDesc{row: -1, section: -1})
+	}
+
+	return outLines, outDescs
+}
+
+// bracket renders a "[on]"/"off" toggle option.
+func bracket(label string, on bool) string {
+	if on {
+		return "[" + label + "]"
+	}
+
+	return label
+}
+
+// nsBadge renders an App Configuration namespace badge (empty for other
+// providers/services).
+func nsBadge(sec *section, namespace string) string {
+	if !sec.svc.Capability().HasNamespaces {
+		return ""
+	}
+
+	if namespace == "" {
+		return " " + aznamespace.NullDisplay
+	}
+
+	return " [" + namespace + "]"
+}
+
+// keyLabel renders a staged key with its namespace badge for the notice.
+func keyLabel(k data.StagedKey) string {
+	if k.Namespace == "" {
+		return k.Name
+	}
+
+	return k.Name + " [" + k.Namespace + "]"
+}
+
+// firstLine collapses a multi-line value to its first line with an ellipsis, so
+// a diff row stays one line.
+func firstLine(s string) string {
+	if head, _, found := strings.Cut(s, "\n"); found {
+		return head + " …"
+	}
+
+	return s
+}
+
+// clip clamps a (possibly styled) line to width display columns.
+func clip(s string, width int) string {
+	if width <= 0 || lipgloss.Width(s) <= width {
+		return s
+	}
+
+	return lipgloss.NewStyle().MaxWidth(width).Render(s)
+}

--- a/internal/tui/pages/staging/view.go
+++ b/internal/tui/pages/staging/view.go
@@ -59,8 +59,13 @@ func (m *Model) View(width, height int) string {
 		head = append(head, m.noticeLine(width))
 	}
 
+	// Reserve the last page row for the row-action hint so the page-local
+	// bindings (e/u/t/x/enter/v, apply/reset) are discoverable — they are not in
+	// the global keys.Map the help bar renders (#655).
+	footer := m.hintLine(width)
+
 	bodyTop := len(head)
-	bodyH := max(height-bodyTop, 0)
+	bodyH := max(height-bodyTop-1, 0)
 	m.geom.bodyTop = bodyTop
 	m.geom.bodyRows = bodyH
 
@@ -70,7 +75,19 @@ func (m *Model) View(width, height int) string {
 	visible, visDescs := window(lines, descs, m.scroll, bodyH)
 	m.geom.lines = visDescs
 
-	return strings.Join(append(head, visible...), "\n")
+	out := append(head, visible...) //nolint:gocritic // head is a fresh slice; appending body then footer is intentional
+	out = append(out, footer)
+
+	return strings.Join(out, "\n")
+}
+
+// hintLine renders the bottom row-action hint: the per-row bindings plus
+// apply/reset. These are page-local (not in keys.Map), so the global help bar
+// never lists them; this line makes them discoverable (#655).
+func (m *Model) hintLine(width int) string {
+	const hint = "e edit · u unstage · t tags · x cancel-tag · enter detail · v view · a apply · r reset"
+
+	return m.styles.PageHint.Render(clip(hint, width))
 }
 
 // headerLine renders the fixed top line: the view toggle and the global

--- a/internal/tui/pages_wire.go
+++ b/internal/tui/pages_wire.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mpyw/suve/internal/tui/nav"
 	"github.com/mpyw/suve/internal/tui/pages/browser"
 	"github.com/mpyw/suve/internal/tui/pages/diff"
+	"github.com/mpyw/suve/internal/tui/pages/staging"
 	"github.com/mpyw/suve/internal/tui/styles"
 )
 
@@ -51,6 +52,33 @@ func (p diffPage) Init() tea.Cmd                 { return p.m.Init() }
 // capturesInput is always false: the diff page has no text input (its keys are
 // scroll/parse-json/back, all safe to route through the global map).
 func (p diffPage) capturesInput() bool { return false }
+
+// stagingPage adapts *staging.Model to the app's page interface.
+type stagingPage struct{ m *staging.Model }
+
+func (p stagingPage) Update(msg tea.Msg) (page, tea.Cmd) {
+	m, cmd := p.m.Update(msg)
+
+	return stagingPage{m: m}, cmd
+}
+
+func (p stagingPage) View(width, height int) string { return p.m.View(width, height) }
+func (p stagingPage) Init() tea.Cmd                 { return p.m.Init() }
+
+// capturesInput is always false: the staging page has no text input.
+func (p stagingPage) capturesInput() bool { return false }
+
+// newStagingPage builds the staging page adapter over the offered services'
+// staging seams.
+func newStagingPage(ctx context.Context, services []data.StagingService, st styles.Styles, km keys.Map) stagingPage {
+	return stagingPage{m: staging.New(ctx, services, st, km)}
+}
+
+// newStaticDiffPage builds a diff page over already-known content (the staging
+// page's remote-vs-staged detail).
+func newStaticDiffPage(content data.DiffContent, st styles.Styles, km keys.Map) diffPage {
+	return diffPage{m: diff.NewStatic(content, st, km)}
+}
 
 // newBrowserPage builds the browser page adapter for a service source.
 func newBrowserPage(

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -53,6 +53,7 @@ func Run(ctx context.Context, scope provider.Scope, service string) error {
 		fetchIdentity: awsIdentityFetcher(ctx),
 		sourceFor:     factory.sourceFor,
 		mutatorFor:    factory.mutatorFor,
+		stagingFor:    factory.stagingService,
 		runCtx:        ctx,
 	})
 

--- a/internal/tui/sources.go
+++ b/internal/tui/sources.go
@@ -82,6 +82,83 @@ func (f *sourceFactory) mutatorFor(service string) data.Mutator {
 	}
 }
 
+// stagingService returns the review/apply/reset seam for a service tab, or nil
+// when the service is unavailable or has no staging workflow. Resolution of the
+// store and strategy is deferred into a StagingResolver so building the page
+// never touches the keychain/registry on the update loop; a key-loss surfaces as
+// the review's error.
+func (f *sourceFactory) stagingService(service string) data.StagingService {
+	svcCap, ok := capabilityFor(f.scope.Provider, service)
+	if !ok || !svcCap.HasStaging {
+		return nil
+	}
+
+	switch service {
+	case string(staging.ServiceParam):
+		return data.NewStagingService(svcCap, svcCap.DisplayName, f.paramStagingResolver())
+	case string(staging.ServiceSecret):
+		return data.NewStagingService(svcCap, svcCap.DisplayName, f.secretStagingResolver())
+	default:
+		return nil
+	}
+}
+
+// paramStagingResolver builds the param service's staging resources: the cached
+// staging store paired with the provider-specific strategy, plus a per-namespace
+// strategy resolver for Azure App Configuration (whose settings share one store
+// across namespaces).
+func (f *sourceFactory) paramStagingResolver() data.StagingResolver {
+	build := f.paramStrategyBuilder()
+	resolveStore := f.paramResolver()
+
+	return func(ctx context.Context) (data.StagingResources, error) {
+		st, err := f.stagingStore(provider.KindParam)
+		if err != nil {
+			return data.StagingResources{}, err
+		}
+
+		base, err := resolveStore(ctx, "")
+		if err != nil {
+			return data.StagingResources{}, err
+		}
+
+		res := data.StagingResources{Store: st, Strategy: build(base)}
+
+		if f.scope.Provider == provider.ProviderAzure && f.scope.StoreName != "" {
+			res.StrategyFor = func(namespace string) (staging.FullStrategy, error) {
+				s, err := resolveStore(ctx, namespace)
+				if err != nil {
+					return nil, err
+				}
+
+				return build(s), nil
+			}
+		}
+
+		return res, nil
+	}
+}
+
+// secretStagingResolver builds the secret service's staging resources (no
+// namespace axis, so a single strategy handles every entry).
+func (f *sourceFactory) secretStagingResolver() data.StagingResolver {
+	build := f.secretStrategyBuilder()
+
+	return func(ctx context.Context) (data.StagingResources, error) {
+		st, err := f.stagingStore(provider.KindSecret)
+		if err != nil {
+			return data.StagingResources{}, err
+		}
+
+		base, err := registry.Store(ctx, f.scope, provider.KindSecret)
+		if err != nil {
+			return data.StagingResources{}, err
+		}
+
+		return data.StagingResources{Store: st, Strategy: build(base)}, nil
+	}
+}
+
 // stagingStoreResolver returns a lazy resolver for the service's cached staging
 // store, or nil when the service has no staging workflow (so a staged write is
 // never offered). Deferring the build keeps dialog open off the keychain.

--- a/internal/tui/staging_golden_test.go
+++ b/internal/tui/staging_golden_test.go
@@ -1,0 +1,276 @@
+//nolint:testpackage // white-box: drives the staging page/dialogs over stubs and shares the vt golden harness
+package tui
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/exp/golden"
+	teatest "github.com/charmbracelet/x/exp/teatest/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/capability"
+	"github.com/mpyw/suve/internal/domain"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/providermock"
+	"github.com/mpyw/suve/internal/staging"
+	"github.com/mpyw/suve/internal/staging/store"
+	"github.com/mpyw/suve/internal/staging/store/testutil"
+	"github.com/mpyw/suve/internal/tui/data"
+	"github.com/mpyw/suve/internal/tui/dialogs"
+	"github.com/mpyw/suve/internal/tui/styles"
+)
+
+// secretStagedValue is the secret staged value the value/diff-view goldens must
+// NEVER render revealed.
+const secretStagedValue = "super-secret-token-value"
+
+// goldenStaging is a golden-only data.StagingService returning a fixed review
+// and (for the results golden) a fixed apply result. It never touches a store.
+type goldenStaging struct {
+	service     string
+	label       string
+	svcCap      capability.ServiceCapability
+	review      data.StagingReview
+	applyResult data.StagingApplyResult
+}
+
+func (s *goldenStaging) Service() string                          { return s.service }
+func (s *goldenStaging) Label() string                            { return s.label }
+func (s *goldenStaging) Capability() capability.ServiceCapability { return s.svcCap }
+func (s *goldenStaging) Review(context.Context) (data.StagingReview, error) {
+	return s.review, nil
+}
+
+func (s *goldenStaging) Apply(context.Context, bool) (data.StagingApplyResult, error) {
+	return s.applyResult, nil
+}
+
+func (s *goldenStaging) Reset(context.Context) (data.StagingResetResult, error) {
+	return data.StagingResetResult{}, nil
+}
+func (s *goldenStaging) Unstage(context.Context, data.StagedKey) error              { return nil }
+func (s *goldenStaging) CancelAddTag(context.Context, data.StagedKey, string) error { return nil }
+func (s *goldenStaging) CancelRemoveTag(context.Context, data.StagedKey, string) error {
+	return nil
+}
+
+// stagingFixture builds the two AWS staged sections: param (an update, a create,
+// an auto-unstaged entry, and a tag add + removal) and secret (a delete plus a
+// masked-value update).
+func stagingFixture() func(string) data.StagingService {
+	param := &goldenStaging{
+		service: "param", label: "Param", svcCap: goldenCap("aws", "param"),
+		review: data.StagingReview{
+			Entries: []data.StagedDiffRow{
+				{
+					Name: "/app/web/CDN_URL", Type: data.StagedDiffNormal, Operation: "update",
+					RemoteValue: "https://cdn-old.example.com", StagedValue: "https://cdn-new.example.com",
+				},
+				{Name: "/app/web/NEW_FLAG", Type: data.StagedDiffCreate, Operation: "create", StagedValue: "true"},
+				{Name: "/app/web/OLD_FLAG", Type: data.StagedDiffAutoUnstaged},
+			},
+			Tags: []data.StagedTagRow{{
+				Name:    "/app/api/DATABASE_URL",
+				Adds:    []data.Tag{{Key: "owner", Value: "platform"}},
+				Removes: []data.TagRemoval{{Key: "env", Value: "prod"}},
+			}},
+		},
+	}
+	secret := &goldenStaging{
+		service: "secret", label: "Secret", svcCap: goldenCap("aws", "secret"),
+		review: data.StagingReview{
+			Entries: []data.StagedDiffRow{
+				{Name: "prod/api/old-key", Type: data.StagedDiffNormal, Operation: "delete", RemoteValue: secretStagedValue},
+				{
+					Name: "prod/api/session", Type: data.StagedDiffNormal, Operation: "update",
+					RemoteValue: "old-" + secretStagedValue, StagedValue: secretStagedValue,
+				},
+			},
+		},
+	}
+
+	return func(service string) data.StagingService {
+		switch service {
+		case "param":
+			return param
+		case "secret":
+			return secret
+		default:
+			return nil
+		}
+	}
+}
+
+// stagingApp builds an AWS app landed on the Staging tab with the fixture wired.
+func stagingApp() *App {
+	return newApp(config{
+		scope:      provider.Scope{Provider: provider.ProviderAWS},
+		service:    "staging",
+		identity:   awsIdentityFixture(),
+		stagingFor: stagingFixture(),
+	})
+}
+
+// TestStaging_DiffViewGolden renders the staging page in the default diff view.
+// Secret values are masked on both diff sides, so the secret value never appears.
+func TestStaging_DiffViewGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
+	goldenEnv(t)
+
+	raw := captureStaging(t, stagingApp(), "prod/api/session", false)
+	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+
+	assert.NotContains(t, screen, secretStagedValue, "no revealed secret value in the diff-view golden")
+	golden.RequireEqual(t, screen)
+}
+
+// TestStaging_ValueViewGolden renders the staging page after toggling to value
+// view; the secret staged value is masked (never revealed).
+func TestStaging_ValueViewGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
+	goldenEnv(t)
+
+	raw := captureStaging(t, stagingApp(), "prod/api/session", true)
+	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+
+	assert.NotContains(t, screen, secretStagedValue, "no revealed secret value in the value-view golden")
+	golden.RequireEqual(t, screen)
+}
+
+// captureStaging drives a staging app to its loaded state (optionally toggling to
+// value view with `v`) and returns the captured byte stream.
+func captureStaging(t *testing.T, m *App, marker string, valueView bool) []byte {
+	t.Helper()
+
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(browserTermWidth, browserTermHeight))
+
+	var buf bytes.Buffer
+
+	waitFor(t, tm, &buf, marker)
+
+	if valueView {
+		tm.Send(keyPress('v'))
+		time.Sleep(100 * time.Millisecond)
+
+		_, _ = io.Copy(&buf, tm.Output())
+	}
+
+	tm.Send(keyPress('q'))
+	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
+
+	_, _ = io.Copy(&buf, tm.Output())
+
+	return buf.Bytes()
+}
+
+// waitFor accumulates output until marker appears (or the deadline).
+func waitFor(t *testing.T, tm *teatest.TestModel, buf *bytes.Buffer, marker string) {
+	t.Helper()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		_, _ = io.Copy(buf, tm.Output())
+		if bytes.Contains(buf.Bytes(), []byte(marker)) {
+			break
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	require.Contains(t, buf.String(), marker, "staging content never rendered")
+}
+
+// TestStaging_ApplyConfirmGolden renders the apply confirmation dialog (target
+// identity + ignore-conflicts checkbox), hosted standalone.
+func TestStaging_ApplyConfirmGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
+	goldenEnv(t)
+
+	d := dialogs.NewApply(dialogs.ApplyInput{
+		Ctx: context.Background(), Targets: []data.StagingService{&goldenStaging{service: "param", label: "Param"}},
+		TargetLine: "aws · account 123456789012 · region ap-northeast-1",
+		Title:      "Apply staged changes — Param", EntryCount: 2, TagCount: 1, Styles: styles.New(),
+	})
+
+	dialogGolden(t, newDialogHost(d, nil), "Ignore conflicts")
+}
+
+// TestStaging_ApplyResultsGolden renders the apply results dialog including a
+// per-entry failure, a conflict, and a post-apply UnstageError warning.
+func TestStaging_ApplyResultsGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
+	goldenEnv(t)
+
+	svc := &goldenStaging{
+		service: "param", label: "Param",
+		applyResult: data.StagingApplyResult{
+			ServiceLabel: "Param",
+			Entries: []data.ApplyEntryResult{
+				{Name: "/app/web/CDN_URL", Status: "updated"},
+				{Name: "/app/web/NEW_FLAG", Status: "created", UnstageError: "keychain write failed"},
+			},
+			Tags:      []data.ApplyTagResult{{Name: "/app/api/DATABASE_URL", Error: "AccessDenied"}},
+			Conflicts: []string{"/app/api/REDIS_URL"},
+		},
+	}
+
+	d := dialogs.NewApply(dialogs.ApplyInput{
+		Ctx: context.Background(), Targets: []data.StagingService{svc},
+		TargetLine: "aws", Title: "Apply staged changes — Param", EntryCount: 2, TagCount: 1, Styles: styles.New(),
+	})
+
+	// Focus Apply (row 1) and confirm to reach the results view.
+	raw := captureDialogWithKeys(t, newDialogHost(d, nil), "Apply results",
+		keyDownMsg(), keyEnterMsg())
+	golden.RequireEqual(t, renderVisibleScreen(t, raw))
+}
+
+// TestStaging_RoundTrip stages a secret create through the Step-4 mutator, then
+// applies it through the staging service over providermock: the section empties
+// and its authoritative count drops to zero.
+func TestStaging_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	mockStore := testutil.NewMockStore()
+	svcCap := goldenCap("aws", "secret")
+
+	prov := &providermock.Store{
+		GetFunc: func(context.Context, string, provider.VersionRef) (*domain.Entry, error) {
+			return nil, provider.ErrNotFound // the secret does not exist yet → a staged create
+		},
+		ResolveFunc: func(context.Context, string, string) (provider.VersionRef, error) {
+			return provider.VersionRef{}, provider.ErrNotFound
+		},
+		CreateFunc: func(context.Context, string, string, domain.ValueType, string, ...provider.WriteOption) (domain.Version, error) {
+			return domain.Version{ID: "1"}, nil
+		},
+	}
+
+	newStrategy := func(s provider.Store) staging.FullStrategy { return staging.NewAWSSecretStrategy(s) }
+
+	ctx := context.Background()
+
+	// Stage a create through the Step-4 write-path mutator (staged=true).
+	mut := data.NewSecretMutator(svcCap, prov, newStrategy, func() (store.ReadWriteOperator, error) {
+		return mockStore, nil
+	})
+	_, err := mut.Create(ctx, data.StagedKey{Name: "prod/api/new-key"}, "v1", "", "", true)
+	require.NoError(t, err)
+
+	svc := data.NewStagingService(svcCap, "Secret", func(context.Context) (data.StagingResources, error) {
+		return data.StagingResources{Store: mockStore, Strategy: staging.NewAWSSecretStrategy(prov)}, nil
+	})
+
+	before, err := svc.Review(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 1, before.EntryCount(), "the staged create is present before apply")
+
+	res, err := svc.Apply(ctx, false)
+	require.NoError(t, err)
+	require.Empty(t, res.Conflicts, "no conflict for a create")
+
+	after, err := svc.Review(ctx)
+	require.NoError(t, err)
+	assert.Zero(t, after.EntryCount()+after.TagCount(), "the section is empty after apply")
+}

--- a/internal/tui/testdata/TestShell_AWSGolden.golden
+++ b/internal/tui/testdata/TestShell_AWSGolden.golden
@@ -13,7 +13,7 @@ suve  aws · profile:dev · account:123456789012 · region:ap-northeast-1
 
 
 
-                                   (browser page lands in Step 3)
+                            (no data source available for this service)
 
 
 

--- a/internal/tui/testdata/TestShell_AzureStoreOnlyGolden.golden
+++ b/internal/tui/testdata/TestShell_AzureStoreOnlyGolden.golden
@@ -13,7 +13,7 @@ suve  azure · store:mystore
 
 
 
-                                   (browser page lands in Step 3)
+                            (no data source available for this service)
 
 
 

--- a/internal/tui/testdata/TestShell_AzureVaultOnlyGolden.golden
+++ b/internal/tui/testdata/TestShell_AzureVaultOnlyGolden.golden
@@ -13,7 +13,7 @@ suve  azure · vault:myvault
 
 
 
-                                   (browser page lands in Step 3)
+                            (no data source available for this service)
 
 
 

--- a/internal/tui/testdata/TestStaging_ApplyConfirmGolden.golden
+++ b/internal/tui/testdata/TestStaging_ApplyConfirmGolden.golden
@@ -1,0 +1,12 @@
+╭───────────────────────────────────────────────────────────╮
+│Apply staged changes — Param                               │
+│                                                           │
+│Target   aws · account 123456789012 · region ap-northeast-1│
+│Changes  2 entries · 1 tag change                          │
+│                                                           │
+│▸ [ ] Ignore conflicts                                     │
+│                                                           │
+│  [ Apply ]      [ Cancel ]                                │
+│                                                           │
+│↑↓: move · space/enter: toggle/confirm · esc: cancel       │
+╰───────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestStaging_ApplyResultsGolden.golden
+++ b/internal/tui/testdata/TestStaging_ApplyResultsGolden.golden
@@ -1,0 +1,11 @@
+╭───────────────────────────────────────────────────────────────────────────────────────────────────
+│Apply results
+│
+│✓ updated  /app/web/CDN_URL
+│✓ created  /app/web/NEW_FLAG
+│✗ tags  /app/api/DATABASE_URL   AccessDenied
+│⚠ conflict: /app/api/REDIS_URL was modified remotely after staging — re-apply with "Ignore conflict
+│⚠ /app/web/NEW_FLAG applied but could not be unstaged: keychain write failed — clear it manually.
+│
+│enter/esc: close
+╰───────────────────────────────────────────────────────────────────────────────────────────────────

--- a/internal/tui/testdata/TestStaging_ApplyResultsGolden.golden
+++ b/internal/tui/testdata/TestStaging_ApplyResultsGolden.golden
@@ -1,11 +1,13 @@
-╭───────────────────────────────────────────────────────────────────────────────────────────────────
-│Apply results
-│
-│✓ updated  /app/web/CDN_URL
-│✓ created  /app/web/NEW_FLAG
-│✗ tags  /app/api/DATABASE_URL   AccessDenied
-│⚠ conflict: /app/api/REDIS_URL was modified remotely after staging — re-apply with "Ignore conflict
-│⚠ /app/web/NEW_FLAG applied but could not be unstaged: keychain write failed — clear it manually.
-│
-│enter/esc: close
-╰───────────────────────────────────────────────────────────────────────────────────────────────────
+╭────────────────────────────────────────────────────────────────────────────────────────────────╮
+│Apply results                                                                                   │
+│                                                                                                │
+│✓ updated  /app/web/CDN_URL                                                                     │
+│✓ created  /app/web/NEW_FLAG                                                                    │
+│✗ tags  /app/api/DATABASE_URL   AccessDenied                                                    │
+│⚠ conflict: /app/api/REDIS_URL was modified remotely after staging — re-apply with "Ignore      │
+│conflicts" to overwrite.                                                                        │
+│⚠ /app/web/NEW_FLAG applied but could not be unstaged: keychain write failed — clear it         │
+│manually.                                                                                       │
+│                                                                                                │
+│enter/esc: close                                                                                │
+╰────────────────────────────────────────────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestStaging_DiffViewGolden.golden
+++ b/internal/tui/testdata/TestStaging_DiffViewGolden.golden
@@ -30,5 +30,5 @@ Secret (2)                                                                      
 
 
 
-
+e edit · u unstage · t tags · x cancel-tag · enter detail · v view · a apply · r reset
  tab next tab • 1/2/3 jump to tab • ? help • q quit

--- a/internal/tui/testdata/TestStaging_DiffViewGolden.golden
+++ b/internal/tui/testdata/TestStaging_DiffViewGolden.golden
@@ -1,0 +1,34 @@
+suve  aws · profile:dev · account:123456789012 · region:ap-northeast-1
+ Param Secret Staging(5)
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+view: [diff] value   A apply-all · R reset-all · ctrl+r refresh
+⚠ auto-unstaged: /app/web/OLD_FLAG (staged value now equals remote)  esc: dismiss
+Param (3)                                                                                             a apply · r reset
+▸ update  /app/web/CDN_URL
+    - https://cdn-old.example.com
+    + https://cdn-new.example.com
+  create  /app/web/NEW_FLAG
+    + true
+  tags  /app/api/DATABASE_URL  +owner=platform   x cancel
+  tags  /app/api/DATABASE_URL  −env (was prod)   ↩ cancel
+
+Secret (2)                                                                                            a apply · r reset
+  delete  prod/api/old-key
+    - ••••••••••••••••••••••••
+  update  prod/api/session
+    - ••••••••••••••••••••••••
+    + ••••••••••••••••••••••••
+
+
+
+
+
+
+
+
+
+
+
+
+
+ tab next tab • 1/2/3 jump to tab • ? help • q quit

--- a/internal/tui/testdata/TestStaging_ValueViewGolden.golden
+++ b/internal/tui/testdata/TestStaging_ValueViewGolden.golden
@@ -1,0 +1,34 @@
+suve  aws · profile:dev · account:123456789012 · region:ap-northeast-1
+ Param Secret Staging(5)
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+view: diff [value]   A apply-all · R reset-all · ctrl+r refresh
+⚠ auto-unstaged: /app/web/OLD_FLAG (staged value now equals remote)  esc: dismiss
+Param (3)                                                                                             a apply · r reset
+▸ update  /app/web/CDN_URL   https://cdn-new.example.com
+  create  /app/web/NEW_FLAG   true
+  tags  /app/api/DATABASE_URL  +owner=platform   x cancel
+  tags  /app/api/DATABASE_URL  −env (was prod)   ↩ cancel
+
+Secret (2)                                                                                            a apply · r reset
+  delete  prod/api/old-key   (delete)
+  update  prod/api/session   ••••••••••••••••••••••••
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+ tab next tab • 1/2/3 jump to tab • ? help • q quit

--- a/internal/tui/testdata/TestStaging_ValueViewGolden.golden
+++ b/internal/tui/testdata/TestStaging_ValueViewGolden.golden
@@ -30,5 +30,5 @@ Secret (2)                                                                      
 
 
 
-
+e edit · u unstage · t tags · x cancel-tag · enter detail · v view · a apply · r reset
  tab next tab • 1/2/3 jump to tab • ? help • q quit


### PR DESCRIPTION
Part of Epic #650. Closes #655. Targets **`epic/tui`**.

Completes the stage → review → apply loop: the Staging page over `internal/usecase/staging`.

## Highlights
- Per-service sections from the staging `DiffUseCase` (one call feeds diff + value views). Diff view: Remote `-`/Staged `+` (secrets masked); value view: raw staged values (masked, `x` reveals). Operation markers color-coded w/ NO_COLOR fallback; App Config namespace badges.
- Tag rows: staged add (`+k=v`, cancel `x`) / removal (`−k (was v)`, cancel `↩`); dismissible auto-unstaged notice.
- **Apply** `a`/`A`: confirm dialog naming the target identity + ignore-conflicts → busy (double-fire guarded) → results with per-entry status, **Conflicts** list, and **UnstageError** warnings. Global apply fans out one Apply per service in a single goroutine (race-free), aggregated client-side.
- **Reset** `r`/`R` with confirm; voiced `ResetResultType`.
- Staging tab badge authoritative count fix (entries + tag changes counted separately).
- Mouse follows the browser hand-rolled `geom` pattern (so #663 migrates browser+staging uniformly to the compositor).
- Per-`scope.Key()`-cached store + scope-paired strategy (lazy resolve off the update loop); key-loss surfaces on the section error line.

## Tests (each #655-enumerated item mapped)
view toggle, cancel-tag, fan-out aggregation, conflict→ignore-conflicts re-apply, mouse click on apply/reset/cancel-tag; goldens for diff/value/apply-confirm/results(conflict+UnstageError); round-trip (stage→apply→empty). `go test -race ./internal/tui/...` clean (twice); no secret in any golden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)