### PR TITLE
fix(tui): staging-page QA follow-ups (#669, #670, #671)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -497,6 +497,17 @@ func (m *App) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 
 		if key.Matches(msg, m.keys.Back) && !m.topDialogBusy() {
+			// A dialog that has already mutated (the apply results view) closes on
+			// Back with the same reload+voice as enter, so the staging page and its
+			// badge refresh; the returned command emits MutationDoneMsg, which
+			// onMutationDone turns into the single pop+reload+voice. Every other
+			// dialog is bare-dismissed.
+			if d, ok := m.dialogs[len(m.dialogs)-1].(dialogs.DismissReloader); ok {
+				if cmd := d.DismissCmd(); cmd != nil {
+					return m, cmd
+				}
+			}
+
 			m.popDialog()
 
 			return m, nil

--- a/internal/tui/dialogs/apply.go
+++ b/internal/tui/dialogs/apply.go
@@ -104,6 +104,18 @@ func NewApply(in ApplyInput) Model {
 
 func (d *applyDialog) Busy() bool { return d.phase == phaseBusy }
 
+// DismissCmd makes Back (Esc) on the results view close with the same
+// reload+voice as enter: the results view has already applied, so a bare pop
+// would leave the staging page and its badge stale. Any other phase returns nil
+// so the shell bare-dismisses (confirm → cancel; busy is already suppressed).
+func (d *applyDialog) DismissCmd() tea.Cmd {
+	if d.phase == phaseResults {
+		return doneCmd("", d.summary(), true)
+	}
+
+	return nil
+}
+
 func (d *applyDialog) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:

--- a/internal/tui/dialogs/apply_test.go
+++ b/internal/tui/dialogs/apply_test.go
@@ -30,6 +30,11 @@ type stubStaging struct {
 	conflict data.StagingApplyResult
 
 	applied []bool
+
+	// resetResult is returned by Reset; resets counts how many times Reset ran
+	// (so a fan-out test can assert every target was reset).
+	resetResult data.StagingResetResult
+	resets      int
 }
 
 func (s *stubStaging) Service() string { return s.service }
@@ -52,7 +57,9 @@ func (s *stubStaging) Review(context.Context) (data.StagingReview, error) {
 	return data.StagingReview{}, nil
 }
 func (s *stubStaging) Reset(context.Context) (data.StagingResetResult, error) {
-	return data.StagingResetResult{}, nil
+	s.resets++
+
+	return s.resetResult, nil
 }
 func (s *stubStaging) Unstage(context.Context, data.StagedKey) error              { return nil }
 func (s *stubStaging) CancelAddTag(context.Context, data.StagedKey, string) error { return nil }
@@ -163,27 +170,99 @@ func TestApply_ConflictThenIgnoreReapply(t *testing.T) {
 	assert.NotContains(t, d2.View(), "conflict", "no conflict on the ignore-conflicts re-apply")
 }
 
+// TestApply_DismissReloadsOnResults pins that closing the apply dialog with Back
+// (Esc) reloads only once it has applied: in the results phase DismissCmd emits
+// a MutationDoneMsg (so the shell pops+reloads+voices, matching enter), while in
+// the confirm phase it returns nil (a bare cancel, nothing applied yet).
+func TestApply_DismissReloadsOnResults(t *testing.T) {
+	t.Parallel()
+
+	svc := &stubStaging{
+		service: "param", label: "Param",
+		result: data.StagingApplyResult{
+			ServiceLabel: "Param",
+			Entries:      []data.ApplyEntryResult{{Name: "a", Status: "updated"}},
+		},
+	}
+
+	d := NewApply(ApplyInput{
+		Ctx: context.Background(), Targets: []data.StagingService{svc},
+		Title: "Apply staged changes — Param", EntryCount: 1, Styles: styles.New(),
+	})
+
+	dr, ok := d.(DismissReloader)
+	require.True(t, ok, "the apply dialog is a DismissReloader")
+	assert.Nil(t, dr.DismissCmd(), "confirm phase: Back is a bare cancel")
+
+	d, _ = d.Update(pressDown()) // focus Apply
+	d, cmd := d.Update(pressEnter())
+	require.NotNil(t, cmd)
+	d, _ = d.Update(cmd()) // deliver applyResultsMsg → results phase
+
+	dr, ok = d.(DismissReloader)
+	require.True(t, ok)
+
+	reload := dr.DismissCmd()
+	require.NotNil(t, reload, "results phase: Back reloads")
+
+	done, ok := reload().(MutationDoneMsg)
+	require.True(t, ok, "results-phase Back emits MutationDoneMsg (pop+reload+voice)")
+	assert.Contains(t, done.Status, "Applied", "the outcome is voiced, matching enter")
+}
+
 // TestReset_FanOutAggregation pins that reset-all fans out one reset per service
 // and voices the combined unstaged count.
 func TestReset_FanOutAggregation(t *testing.T) {
 	t.Parallel()
 
-	param := &stubStaging{service: "param", label: "Param"}
-	secret := &stubStaging{service: "secret", label: "Secret"}
+	param := &stubStaging{
+		service: "param", label: "Param",
+		resetResult: data.StagingResetResult{Type: data.StagingResetUnstagedAll, Count: 2},
+	}
+	secret := &stubStaging{
+		service: "secret", label: "Secret",
+		resetResult: data.StagingResetResult{Type: data.StagingResetUnstagedAll, Count: 3},
+	}
 
 	d := NewReset(ResetInput{
 		Ctx: context.Background(), Targets: []data.StagingService{param, secret},
 		Title: "Reset staged changes — all", Styles: styles.New(),
 	})
 
-	d, cmd := d.Update(pressEnter()) // focus is on Reset by default
+	d, _ = d.Update(pressDown()) // focus defaults to Cancel; move to Reset
+	d, cmd := d.Update(pressEnter())
 	require.True(t, d.Busy())
+	require.NotNil(t, cmd)
 
 	next, doneCmd := d.Update(cmd())
-	require.NotNil(t, doneCmd)
 
+	assert.Equal(t, 1, param.resets, "param was reset exactly once")
+	assert.Equal(t, 1, secret.resets, "secret was reset exactly once")
+
+	require.NotNil(t, doneCmd)
 	done, ok := doneCmd().(MutationDoneMsg)
 	require.True(t, ok, "reset emits a done message")
-	assert.NotEmpty(t, done.Status, "the reset outcome is voiced")
+	assert.Contains(t, done.Status, "5", "the aggregate voices the summed unstaged count (2+3)")
 	assert.False(t, next.Busy(), "the dialog clears busy once the reset finishes")
+}
+
+// TestReset_DefaultFocusCancels pins that the reset confirm opens focused on
+// Cancel, so an accidental enter (e.g. an "R enter" double-tap) cancels instead
+// of wiping staged changes — parity with the delete/apply confirms.
+func TestReset_DefaultFocusCancels(t *testing.T) {
+	t.Parallel()
+
+	param := &stubStaging{service: "param", label: "Param"}
+
+	d := NewReset(ResetInput{
+		Ctx: context.Background(), Targets: []data.StagingService{param},
+		Title: "Reset staged changes — Param", Styles: styles.New(),
+	})
+
+	_, cmd := d.Update(pressEnter()) // enter on the default focus
+
+	require.NotNil(t, cmd)
+	_, ok := cmd().(CanceledMsg)
+	assert.True(t, ok, "enter on the default focus cancels")
+	assert.Equal(t, 0, param.resets, "no reset ran")
 }

--- a/internal/tui/dialogs/dialogs.go
+++ b/internal/tui/dialogs/dialogs.go
@@ -37,6 +37,16 @@ type Model interface {
 	Busy() bool
 }
 
+// DismissReloader is an optional dialog capability. A dialog that has already
+// mutated by the time it can be dismissed — the apply results view — returns a
+// non-nil command from DismissCmd so that closing it with Back (Esc) runs the
+// same pop+reload+voice as its confirm key, instead of the shell's bare pop
+// (which would leave the staging page rendering just-applied items as still
+// staged). Returning nil means "fall back to a bare dismiss".
+type DismissReloader interface {
+	DismissCmd() tea.Cmd
+}
+
 // MutationDoneMsg is emitted when a mutation succeeds. The app pops the dialog,
 // reloads the affected service's browser (list/detail/staged badges), refreshes
 // the staging tab count, and voices Status.

--- a/internal/tui/dialogs/reset.go
+++ b/internal/tui/dialogs/reset.go
@@ -48,13 +48,17 @@ type ResetInput struct {
 	Styles styles.Styles
 }
 
-// NewReset builds a reset dialog.
+// NewReset builds a reset dialog. Focus starts on Cancel so an accidental
+// enter (e.g. an "R enter" double-tap) does not wipe staged changes — parity
+// with the delete/apply confirms, which also default to a non-destructive
+// control.
 func NewReset(in ResetInput) Model {
 	return &resetDialog{
 		ctx:     in.Ctx,
 		targets: in.Targets,
 		title:   in.Title,
 		styles:  in.Styles,
+		focus:   int(ctrlResetCancel),
 	}
 }
 

--- a/internal/tui/pages/staging/staging_test.go
+++ b/internal/tui/pages/staging/staging_test.go
@@ -148,6 +148,30 @@ func TestUpdate_ViewToggle(t *testing.T) {
 	assert.True(t, m.diffView, "v switches back to diff view")
 }
 
+// TestUpdate_ValueViewCollapsesMultiline pins that value view collapses a
+// multi-line staged value to a single physical row (first line + " …"), so the
+// body cannot overflow its box and desync the mouse hit-map. The full value
+// stays reachable via the diff-detail page (enter).
+func TestUpdate_ValueViewCollapsesMultiline(t *testing.T) {
+	t.Parallel()
+
+	sec := &stubService{
+		service: "param", label: "Param", svcCap: capFor("aws", "param"),
+		review: data.StagingReview{Entries: []data.StagedDiffRow{{
+			Name: "/app/web/BLOB", Type: data.StagedDiffNormal, Operation: "create",
+			StagedValue: "first-line\nSECOND_LINE_MARKER\nthird-line",
+		}}},
+	}
+	m := newModel(t, sec)
+
+	m, _ = m.Update(keyPress('v'))
+	require.False(t, m.diffView, "switched to value view")
+
+	screen := m.View(100, 30)
+	assert.Contains(t, screen, "first-line …", "value collapses to its first line")
+	assert.NotContains(t, screen, "SECOND_LINE_MARKER", "later lines never render as extra rows")
+}
+
 // TestUpdate_CancelTagOps pins that `x` cancels a staged tag add and enter
 // cancels a staged tag removal, each addressing the correct (item, tagKey).
 func TestUpdate_CancelTagOps(t *testing.T) {

--- a/internal/tui/pages/staging/view.go
+++ b/internal/tui/pages/staging/view.go
@@ -218,7 +218,11 @@ func (m *Model) entryLines(sec *section, e data.StagedDiffRow, rowIdx int) []str
 	}
 
 	if !m.diffView {
-		value := m.maskValue(e.StagedValue, sec.secret)
+		// Collapse to the first line (as diff view does): a multi-line staged
+		// value must stay one physical row, else the body overflows its box and
+		// the mouse hit-map (logical rows) desyncs from the screen rows. Full
+		// values are viewable via enter → the diff detail page.
+		value := firstLine(m.maskValue(e.StagedValue, sec.secret))
 		if e.Operation == operationDelete {
 			value = m.styles.PageHint.Render("(delete)")
 		}


### PR DESCRIPTION
Fixes the three Medium findings from the Step 5 (staging page) post-merge QA. Targets `epic/tui`.

## Fixes
- **#669** — Closing the apply **results** dialog with Back (Esc) now reloads the active page like Enter, so sections and the `Staging(n)` badge refresh instead of leaving just-applied items rendered as still staged. Adds an optional `DismissReloader` dialog capability; the shell routes Back through it (a single pop+reload+voice via `MutationDoneMsg`) and bare-dismisses every other dialog. Esc is now equivalent to Enter, matching the `enter/esc: close` hint.
- **#670** — The reset confirm dialog now opens focused on **Cancel**, so an accidental `R`+`Enter` no longer wipes staged changes — parity with the delete/apply confirms.
- **#671** — Value view collapses a multi-line staged value to its first line (as diff view already does), so the body can't overflow its box and desync the mouse hit-map. The full value stays reachable via `enter` → the diff detail page.

## Tests
- `TestApply_DismissReloadsOnResults` — DismissCmd emits `MutationDoneMsg` in the results phase, nil in confirm.
- `TestReset_DefaultFocusCancels` — Enter on the default focus cancels; no reset runs.
- `TestReset_FanOutAggregation` — strengthened: the stub now counts resets, so the test asserts each target was reset once and the aggregate count is voiced (the QA-noted weak spot).
- `TestUpdate_ValueViewCollapsesMultiline` — a multi-line staged value renders as one physical row (`first-line …`), later lines never appear.

## Gates
- `go test -race -count=1 ./internal/tui/...` — all green.
- `golangci-lint run ./internal/tui/...` — 0 issues.

Closes #669, #670, #671.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
