### PR TITLE
docs(tui): Step 6 — TUI docs + comment polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 > [!NOTE]
 > This project was written by AI (Claude Code).
 
-A **Git-like CLI/GUI** for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration. Familiar commands like `show`, `log`, `diff`, and a **staging workflow** for safe, reviewable changes.
+A **Git-like CLI/TUI/GUI** for AWS Parameter Store / Secrets Manager, Google Cloud Secret Manager, and Azure Key Vault / App Configuration. Familiar commands like `show`, `log`, `diff`, and a **staging workflow** for safe, reviewable changes.
 
 <p align="center">
   <img src="demo/cli-demo.gif" alt="CLI Demo" width="800">
@@ -31,6 +31,7 @@ A **Git-like CLI/GUI** for AWS Parameter Store / Secrets Manager, Google Cloud S
 - **Colored diff output**: Easy-to-read unified diff format
 - **Multi-cloud**: [AWS SSM Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) / [Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html), [Google Cloud Secret Manager](https://cloud.google.com/secret-manager/docs), and [Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/) / [App Configuration](https://learn.microsoft.com/en-us/azure/azure-app-configuration/)
 - **Secure staging**: Working staging state is encrypted at rest with a data key stored in the OS keychain (override with `SUVE_STAGING_KEY`). When no key is available (no keychain backend and no `SUVE_STAGING_KEY`), an interactive session falls back to plaintext with a warning, while a non-interactive one refuses to write unencrypted unless `SUVE_STAGING_ALLOW_PLAINTEXT` is set. Exported snapshot files carry a separately passphrase-encrypted payload ([Argon2](https://en.wikipedia.org/wiki/Argon2) + [AES-GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode); an empty passphrase writes plaintext).
+- **TUI mode**: Keyboard-driven terminal UI via `--tui` flag (built with [Bubble Tea](https://github.com/charmbracelet/bubbletea)); ships in every build, including the dependency-free CLI-only one
 - **GUI mode**: Desktop application via `--gui` flag (built with [Wails](https://wails.io/))
 
 ### Metadata terminology
@@ -50,7 +51,7 @@ All key=value metadata is unified as **tags**; suve adds no per-provider command
 ## Installation
 
 > [!NOTE]
-> On Linux, `suve` requires GTK3 and WebKit2GTK for GUI support. Use the CLI-only version if you only need CLI functionality.
+> On Linux, `suve` requires GTK3 and WebKit2GTK for GUI support. Use the CLI-only version if you only need CLI functionality. The keyboard-driven **TUI (`--tui`) is pure Go and ships in every build**, including the CLI-only one — only the desktop **GUI (`--gui`)** needs the GTK3/WebKit2GTK dependencies.
 
 ### Using [mise](https://mise.jdx.dev/) (macOS/Linux/Windows)
 
@@ -681,15 +682,69 @@ Examples (`—` = alias not exposed):
 
 `suve --help` lists which aliases are active in the current environment.
 
+### TUI mode
+
+`--tui` launches a keyboard-driven terminal UI over the same use cases as the CLI and GUI. It is pure Go (no GTK/WebKit) and ships in every build. The provider and scope are fixed for the session at launch — switch provider by relaunching.
+
+Launch forms:
+
+```bash
+suve --tui                 # only when exactly one provider is active (see Provider selection)
+suve aws --tui             # explicit provider group (always available)
+suve gcloud --tui
+suve azure --tui
+suve aws param --tui       # a service subgroup preselects that tab (Param / Secret)
+suve azure secret --tui    # opens on the Key Vault tab
+```
+
+- **Unique-provider rule:** bare `suve --tui` follows the same detection as the bare aliases — it launches only when exactly one provider is active across the union of the param/secret/stage axes (AWS is accepted via `~/.aws/credentials` when nothing else is set). With two or more active, it lists the explicit `suve <group> --tui` forms instead; there is no silent priority.
+- **Scope / env:** the TUI consumes the same scope inputs as the CLI — `GOOGLE_CLOUD_PROJECT` for Google Cloud, `--vault-name` / `AZURE_KEYVAULT_NAME` and `--store-name` / `AZURE_APPCONFIG_NAME` (plus `--namespace` / `AZURE_APPCONFIG_NAMESPACE`) for Azure. AWS uses the ambient shared config.
+- **Azure tab gating:** the Param (App Configuration) and Secret (Key Vault) tabs appear only for the services the launch scope resolves — set `--vault-name` for the Key Vault tab, `--store-name` for the App Configuration tab, either or both as needed. The Staging tab is always present.
+- **Shared staging area:** staged edits made in the TUI use the same per-scope staging store as the CLI/GUI, so `suve stage status` sees them and `stage apply` from either side applies the same working set.
+- The TUI adds **no new commands** and does not cover export/import (use the CLI/GUI for those). It requires an interactive terminal (a TTY on stdin and stdout).
+
+Keymap (the in-app `?` toggles full help, which is the source of truth):
+
+| Scope | Key | Action |
+|-------|-----|--------|
+| Global | `?` | toggle help |
+| Global | `q` / `ctrl+c` | quit |
+| Global | `tab` / `shift+tab` | next / previous tab |
+| Global | `1` `2` `3` | jump to tab |
+| Global | `↑`/`k`, `↓`/`j` | move selection |
+| Global | `enter` | select / open detail |
+| Global | `esc` | back / close |
+| Global | `y` | copy value (revealed first; masked never auto-copied) |
+| Browser | `p` / `/` | edit prefix / filter |
+| Browser | `v` | toggle value display |
+| Browser | `r` | recursive toggle / refresh |
+| Browser | `L` | load more (paged secrets) |
+| Browser | `x` | reveal a masked value |
+| Browser | `c`, `space`, `enter` | compare mode: toggle, pick a version, open diff |
+| Browser | `space` | pick namespace (App Configuration) |
+| Browser | `S` | jump to the Staging tab |
+| Browser | `n` / `e` / `d` / `t` / `R` | new / edit / delete / tag / restore |
+| Diff | `J` | re-diff with JSON normalization (parity with `--parse-json`) |
+| Staging | `v` | toggle diff / value view |
+| Staging | `e` / `u` / `t` | edit staged / unstage (entry + tags) / add staged tag |
+| Staging | `x` | cancel a staged tag change |
+| Staging | `enter` | open the full-diff detail |
+| Staging | `a` / `A` | apply this section / apply all |
+| Staging | `r` / `R` | reset this section / reset all |
+| Staging | `ctrl+r` | refresh |
+| Dialogs | `ctrl+e` | open the value in `$EDITOR` (create/edit) |
+
+Mutations are **staged by default** (an "Apply immediately" toggle is offered where the backend supports staging); operation markers and unsupported controls follow each backend's capabilities. Rendering honors `NO_COLOR` and degrades gracefully on narrow terminals.
+
 ### Feature support
 
-| Backend | Command | Versioning | Labels / Tags | Staging | GUI | Auth |
-|---------|---------|------------|---------------|---------|------|------|
-| [AWS Parameter Store](docs/aws.md) | `aws param` | ✅ numeric | ✅ tags | ✅ | ✅ | shared config/env/role |
-| [AWS Secrets Manager](docs/aws.md) | `aws secret` | ✅ UUID + staging labels | ✅ tags | ✅ | ✅ | shared config/env/role |
-| [Google Cloud Secret Manager](docs/gcloud.md) | `gcloud secret` | ✅ integer (`latest`) | ✅ labels | ✅ | ✅ | Application Default Credentials |
-| [Azure Key Vault](docs/azure.md) | `azure secret` | ✅ opaque id | ✅ tags | ✅ | ✅ | DefaultAzureCredential |
-| [Azure App Configuration](docs/azure.md) | `azure param` | ❌ unversioned | ✅ tags¹ | ✅² | ✅ | DefaultAzureCredential |
+| Backend | Command | Versioning | Labels / Tags | Staging | TUI | GUI | Auth |
+|---------|---------|------------|---------------|---------|------|------|------|
+| [AWS Parameter Store](docs/aws.md) | `aws param` | ✅ numeric | ✅ tags | ✅ | ✅ | ✅ | shared config/env/role |
+| [AWS Secrets Manager](docs/aws.md) | `aws secret` | ✅ UUID + staging labels | ✅ tags | ✅ | ✅ | ✅ | shared config/env/role |
+| [Google Cloud Secret Manager](docs/gcloud.md) | `gcloud secret` | ✅ integer (`latest`) | ✅ labels | ✅ | ✅ | ✅ | Application Default Credentials |
+| [Azure Key Vault](docs/azure.md) | `azure secret` | ✅ opaque id | ✅ tags | ✅ | ✅ | ✅ | DefaultAzureCredential |
+| [Azure App Configuration](docs/azure.md) | `azure param` | ❌ unversioned | ✅ tags¹ | ✅² | ✅ | ✅ | DefaultAzureCredential |
 
 Read/write operations (`show`, `log`, `diff`, `list`, `create`, `update`, `delete`, `tag`, `untag`) are available on every backend, with these caveats: `restore` is available on AWS Secrets Manager and Azure Key Vault (soft-delete recovery); on Azure App Configuration `log` reports history unsupported and `#`/`~`/`:` are treated as literal key characters (not version specifiers). Only AWS Secrets Manager has staging labels (`:AWSCURRENT` etc.).
 

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -6,6 +6,10 @@
 > AWS is invoked as `suve aws param` (`ssm`, `ps`), `suve aws secret` (`sm`, `secretsmanager`), and `suve aws stage` (`stg`).
 > You can drop the `aws` prefix — `suve param`, `suve secret`, `suve stage` — when AWS is the only provider active in your environment. The exact rules are in [Provider selection](../README.md#provider-selection).
 
+## TUI
+
+Launch the terminal UI for AWS with `suve aws --tui` (or bare `suve --tui` when AWS is the only active provider). A service subgroup preselects the tab: `suve aws param --tui` opens on Param, `suve aws secret --tui` on Secret. Scope comes from the ambient shared config/credentials (profile, account, region) — the same resolution as the CLI — and the status bar shows `profile · account · region`. See [TUI mode](../README.md#tui-mode) for the keymap.
+
 ## suve aws param show
 
 Display parameter value with metadata.

--- a/docs/azure.md
+++ b/docs/azure.md
@@ -45,6 +45,10 @@ export AZURE_KEYVAULT_NAME=my-vault
 suve azure secret list
 ```
 
+## TUI
+
+Launch the terminal UI with `suve azure --tui` (or bare `suve --tui` when Azure is the only active provider). It consumes the same scope as the CLI: `--vault-name` / `AZURE_KEYVAULT_NAME` for the Key Vault (Secret) tab and `--store-name` / `AZURE_APPCONFIG_NAME` (plus `--namespace` / `AZURE_APPCONFIG_NAMESPACE`) for the App Configuration (Param) tab. Each tab appears only when its store name is set — set either or both. `suve azure secret --tui` preselects Key Vault, `suve azure param --tui` preselects App Configuration. See [TUI mode](../README.md#tui-mode) for the keymap.
+
 ---
 
 # suve azure secret (Key Vault)

--- a/docs/gcloud.md
+++ b/docs/gcloud.md
@@ -37,6 +37,10 @@ export GOOGLE_CLOUD_PROJECT=my-project
 suve gcloud secret list
 ```
 
+## TUI
+
+Launch the terminal UI with `suve gcloud --tui` (or bare `suve --tui` when Google Cloud is the only active provider). It consumes the same project scope as the CLI — `--project` or `GOOGLE_CLOUD_PROJECT` — and offers the Secret tab (Google Cloud has no param service). See [TUI mode](../README.md#tui-mode) for the keymap.
+
 ## Version Specification
 
 Google Cloud secrets are integer-versioned. The version spec is:

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -65,8 +65,8 @@ type config struct {
 	identity *components.AWSIdentity
 	// sourceFor builds the read source and staging probe for a service tab. It is
 	// the data seam: production wires it to the registry-backed sourceFactory,
-	// tests to a providermock-backed one. When nil (the Step 2 skeleton and the
-	// staging tab), a tab shows its placeholder.
+	// tests to a providermock-backed one. When nil (an uninitialized shell and
+	// the staging tab), a tab shows its placeholder.
 	sourceFor func(service string) (data.Source, data.StagingProbe)
 	// mutatorFor builds the write-path Mutator for a service tab (the mutation
 	// dialogs' seam). Production wires it to the registry-backed sourceFactory,
@@ -382,7 +382,7 @@ func (m *App) openRestore(req nav.OpenRestore) tea.Cmd {
 }
 
 // mutatorForService resolves the write seam for a service, or nil when none is
-// wired (the Step 2 skeleton, or a service with no mutator).
+// wired (an uninitialized shell, or a service with no mutator).
 func (m *App) mutatorForService(service string) data.Mutator {
 	if m.mutatorFor == nil {
 		return nil

--- a/internal/tui/data/data.go
+++ b/internal/tui/data/data.go
@@ -365,9 +365,10 @@ func (s *paramSource) VersionContents(
 	}, nil
 }
 
-// TODO(step-6/followup): a param value can be a SecureString (secret); mask its
-// diff too once a real value-type capability flag replaces the !HasNamespaces
-// proxy. Until then a param diff is treated as non-secret (plaintext content).
+// TODO(#677): a param value can be a SecureString (secret) but is currently
+// treated as non-secret here, so its diff renders in plaintext. Fix by
+// surfacing the value type from param.DiffUseCase and setting DiffContent.Secret
+// from it (the diff page already masks on that flag).
 
 func (s *paramSource) Namespaces(ctx context.Context) ([]string, error) {
 	if !s.svcCap.HasNamespaces {

--- a/internal/tui/data/staging.go
+++ b/internal/tui/data/staging.go
@@ -19,7 +19,7 @@ type StagedKey struct {
 // StagingProbe reports which items in the current service have staged changes
 // (an entry or a tag change), so the browser can show a [staged] badge and the
 // detail pane a staged-changes banner. It is read-only — the parity of the
-// GUI's StagingCheckStatus/StagingStatus reads (#Step-5 owns the mutations).
+// GUI's StagingCheckStatus/StagingStatus reads (the staging page owns the mutations).
 type StagingProbe interface {
 	// StagedKeys returns the set of staged (name, namespace) keys for the service.
 	StagedKeys(ctx context.Context) (map[StagedKey]struct{}, error)

--- a/internal/tui/pages/browser/cmds.go
+++ b/internal/tui/pages/browser/cmds.go
@@ -145,7 +145,7 @@ func (m *Model) selectionCmd() tea.Cmd {
 // rebuildRows builds the rows one-to-one from m.items in order, so the selected
 // index maps back to its item even when App Configuration lists the same key
 // under several namespaces (a name lookup would resolve every duplicate to the
-// first, loading the wrong namespace, #Step-3 review).
+// first, loading the wrong namespace).
 func (m *Model) selectedItem() (data.Item, bool) {
 	idx := m.list.Selected()
 	if idx < 0 || idx >= len(m.items) {

--- a/internal/tui/pages/browser/update.go
+++ b/internal/tui/pages/browser/update.go
@@ -176,7 +176,7 @@ func (m *Model) onNamespacesLoaded(msg namespacesLoadedMsg) {
 
 	// Preserve the currently-selected namespace VALUE across the rebuild, so an
 	// inserted discovered namespace never silently changes what the current index
-	// points at (#Step-3 review).
+	// points at.
 	current := m.currentNamespace()
 	m.namespaces = namespaceOptions(msg.names)
 

--- a/internal/tui/pages/staging/update.go
+++ b/internal/tui/pages/staging/update.go
@@ -214,7 +214,7 @@ func (m *Model) unstageSelected() tea.Cmd {
 	return m.unstageCmd(row.section, row.key)
 }
 
-// editSelected reuses the Step-4 entry form to edit a staged create/update's
+// editSelected reuses the mutation entry form to edit a staged create/update's
 // value; it is a no-op on a tag row or a staged delete (nothing to edit).
 func (m *Model) editSelected() tea.Cmd {
 	row, ok := m.selectedRow()
@@ -235,7 +235,7 @@ func (m *Model) editSelected() tea.Cmd {
 	}
 }
 
-// tagSelected reuses the Step-4 tag form to stage a tag add on the selected
+// tagSelected reuses the tag form to stage a tag add on the selected
 // row's item.
 func (m *Model) tagSelected() tea.Cmd {
 	row, ok := m.selectedRow()


### PR DESCRIPTION
Step 6 (partial): TUI docs + comment polish. Targets `epic/tui`.

The demo GIF and the final `epic/tui → main` merge are intentionally **not** in this PR (demo needs a machine with vhs + emulators; the merge is gated on the review blocker below).

## Docs (current-state-only)
- **README**: retitle to CLI/TUI/GUI; TUI feature bullet; note the TUI is pure Go and ships in every build (only `--gui` needs GTK/WebKit); a **TUI mode** section under Command Reference (launch forms, unique-provider rule, scope/env, Azure tab gating, shared staging area) with a full keymap table; a TUI column in the feature-support matrix.
- **docs/{aws,gcloud,azure}.md**: a per-provider TUI subsection (launch form + scope fields/env vars consumed).

## Polish
- Scrub the epic's internal step numbering from production comments (current-state-only).
- Verified: no `TODO(epic/tui)` markers and no TUI/capability entries in `.github/deadcode-allow.txt` (already clean).

## Review outcome (context-isolated, whole-epic)
`go test -race ./internal/tui/...` clean; launch/scope, NO_COLOR, narrow-terminal, editor/capability refactors, and Secret-**service** masking all verified clean. Findings:
- **#677 (High, blocks epic→main)** — SecureString **param** values leak in plaintext in the diff view and staging review (masking keyed off the service axis, not the value type). Needs a cross-layer fix; filed separately.
- Browser write actions (`n`/`e`/`d`/`t`/`R`) are undiscoverable — no hint line like the staging page has. (Follow-up candidate.)
- Release note: `stage param add|edit --type/--secure` was removed (staged value-type axis dropped for #664).

## Follow-ups filed
#673 (export/import), #674 (side-by-side diff), #675 (configurable keybindings), #676 (emulator e2e), #677 (the masking blocker) — linked from epic #657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
