### PR TITLE
fix(tui): memoize AWS STS identity for the launch lifetime (#696)

### DIFF
--- a/internal/tui/sources.go
+++ b/internal/tui/sources.go
@@ -23,13 +23,28 @@ type sourceFactory struct {
 	ctx   context.Context //nolint:containedctx // the TUI resolves stores lazily against the Run context
 	scope provider.Scope
 
+	// resolveAWSIdentity resolves the AWS caller identity that keys the AWS staging
+	// scope. It is a field so tests can substitute a call-counting stub; production
+	// wires infra.GetAWSIdentity.
+	resolveAWSIdentity func(context.Context) (*infra.AWSIdentity, error)
+
 	mu            sync.Mutex
 	stagingStores map[string]store.ReadWriteOperator
+	// awsStagingScope memoizes the AWS staging scope resolved from the STS caller
+	// identity. The launched provider/scope are fixed for the process lifetime, so
+	// the identity is resolved once — not on every staging-store access. A
+	// transient STS failure is not cached, so it retries on the next access.
+	awsStagingScope *provider.Scope
 }
 
 // newSourceFactory builds a factory for a launched scope and Run context.
 func newSourceFactory(ctx context.Context, scope provider.Scope) *sourceFactory {
-	return &sourceFactory{ctx: ctx, scope: scope, stagingStores: map[string]store.ReadWriteOperator{}}
+	return &sourceFactory{
+		ctx:                ctx,
+		scope:              scope,
+		resolveAWSIdentity: infra.GetAWSIdentity,
+		stagingStores:      map[string]store.ReadWriteOperator{},
+	}
 }
 
 // sourceFor returns the read source and (best-effort) staging probe for a
@@ -289,12 +304,31 @@ func (f *sourceFactory) stagingScope(kind provider.Kind) (provider.Scope, error)
 		return f.scope, nil
 	}
 
-	identity, err := infra.GetAWSIdentity(f.ctx)
+	return f.resolveAWSStagingScope()
+}
+
+// resolveAWSStagingScope resolves (and memoizes) the AWS staging scope from the
+// STS caller identity. Because the launched provider/scope are fixed for the
+// process lifetime, the identity is resolved once and reused across every
+// staging-store access rather than issuing a fresh GetCallerIdentity per probe.
+// Only a successful resolution is cached, so a transient STS failure retries.
+func (f *sourceFactory) resolveAWSStagingScope() (provider.Scope, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	if f.awsStagingScope != nil {
+		return *f.awsStagingScope, nil
+	}
+
+	identity, err := f.resolveAWSIdentity(f.ctx)
 	if err != nil {
 		return provider.Scope{}, err
 	}
 
-	return provider.AWSScope(identity.AccountID, identity.Region), nil
+	scope := provider.AWSScope(identity.AccountID, identity.Region)
+	f.awsStagingScope = &scope
+
+	return scope, nil
 }
 
 // lazyStagingProbe defers building the real probe (and thus the on-disk store)

--- a/internal/tui/sources_test.go
+++ b/internal/tui/sources_test.go
@@ -1,0 +1,96 @@
+//nolint:testpackage // white-box: exercises sourceFactory.stagingScope and the memoized AWS identity seam
+package tui
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/aws/infra"
+)
+
+// TestStagingScope_AWSIdentityMemoized proves the AWS caller identity that keys
+// the staging scope is resolved once per launch, not on every staging-store
+// access: repeated stagingScope calls across both service kinds trigger exactly
+// one GetCallerIdentity (mocked here), and every call returns the same scope key.
+func TestStagingScope_AWSIdentityMemoized(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+
+	f := newSourceFactory(t.Context(), provider.Scope{Provider: provider.ProviderAWS})
+	f.resolveAWSIdentity = func(context.Context) (*infra.AWSIdentity, error) {
+		calls++
+
+		return &infra.AWSIdentity{AccountID: "123456789012", Region: "us-east-1"}, nil
+	}
+
+	want := provider.AWSScope("123456789012", "us-east-1").Key()
+
+	// Every staging-store access resolves the scope; simulate several probes/writes
+	// across both param and secret services.
+	for _, kind := range []provider.Kind{provider.KindParam, provider.KindSecret, provider.KindParam} {
+		for range 3 {
+			scope, err := f.stagingScope(kind)
+			require.NoError(t, err)
+			assert.Equal(t, want, scope.Key())
+		}
+	}
+
+	assert.Equal(t, 1, calls, "STS GetCallerIdentity should resolve once per launch, not per staging-store access")
+}
+
+// TestStagingScope_AWSIdentityErrorNotCached proves a transient STS failure is
+// not memoized: the next staging-store access retries and can succeed.
+func TestStagingScope_AWSIdentityErrorNotCached(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+
+	f := newSourceFactory(t.Context(), provider.Scope{Provider: provider.ProviderAWS})
+	f.resolveAWSIdentity = func(context.Context) (*infra.AWSIdentity, error) {
+		calls++
+		if calls == 1 {
+			return nil, errors.New("transient STS failure")
+		}
+
+		return &infra.AWSIdentity{AccountID: "123456789012", Region: "us-east-1"}, nil
+	}
+
+	_, err := f.stagingScope(provider.KindParam)
+	require.Error(t, err)
+
+	scope, err := f.stagingScope(provider.KindParam)
+	require.NoError(t, err)
+	assert.Equal(t, provider.AWSScope("123456789012", "us-east-1").Key(), scope.Key())
+
+	// Once resolved, it stays memoized: no third resolution.
+	_, err = f.stagingScope(provider.KindParam)
+	require.NoError(t, err)
+	assert.Equal(t, 2, calls, "identity should resolve on retry after a transient failure, then stay memoized")
+}
+
+// TestStagingScope_AWSPrehydratedSkipsResolution proves a launch scope that
+// already carries account+region never issues an STS call.
+func TestStagingScope_AWSPrehydratedSkipsResolution(t *testing.T) {
+	t.Parallel()
+
+	var calls int
+
+	scope := provider.AWSScope("999999999999", "eu-west-1")
+	f := newSourceFactory(t.Context(), scope)
+	f.resolveAWSIdentity = func(context.Context) (*infra.AWSIdentity, error) {
+		calls++
+
+		return &infra.AWSIdentity{AccountID: "123456789012", Region: "us-east-1"}, nil
+	}
+
+	got, err := f.stagingScope(provider.KindParam)
+	require.NoError(t, err)
+	assert.Equal(t, scope.Key(), got.Key())
+	assert.Equal(t, 0, calls, "a pre-hydrated AWS scope must not call STS")
+}


### PR DESCRIPTION
Closes #696

## Problem

For AWS the launch scope carries no account/region, so `sourceFactory.stagingScope`
resolved the STS caller identity (`GetCallerIdentity`) on **every** staging-store
access — every staged-badge probe, staged write, and staging review triggered a
fresh network round-trip. A transient STS failure mid-session flipped staged
badges into a store error, despite the provider/scope being fixed at launch.

## Fix

`internal/tui/sources.go` — the launched provider/scope are fixed for the process
lifetime, so the AWS staging scope resolved from the STS identity is now memoized
under the existing `f.mu` (`resolveAWSStagingScope`). The identity is resolved
**once** and reused across every access instead of once per probe.

- Only a **successful** resolution is cached, so a transient STS failure still
  retries on the next access (robustness, not just latency).
- The computed scope key is byte-identical to the prior per-call result
  (`provider.AWSScope(accountID, region)`), so the staging store layout is
  unchanged — behavior identical when STS is healthy.
- A `resolveAWSIdentity` function-field seam (defaulting to `infra.GetAWSIdentity`)
  lets the unit test count STS resolutions.

No lock re-entrancy: `stagingStore` calls `stagingScope` (which locks/unlocks
`f.mu`) and only afterwards locks `f.mu` itself — the two critical sections are
sequential, not nested.

## Regression test

`internal/tui/sources_test.go` (Go unit — the bug lives entirely in the TUI
source seam; not GUI/CLI-visible):

- `TestStagingScope_AWSIdentityMemoized` — 9 `stagingScope` calls across
  param+secret kinds trigger exactly **one** `GetCallerIdentity`; every call
  returns the same scope key.
- `TestStagingScope_AWSIdentityErrorNotCached` — a transient failure is not
  cached: the next access retries and succeeds, then stays memoized.
- `TestStagingScope_AWSPrehydratedSkipsResolution` — a pre-hydrated AWS scope
  issues zero STS calls.

## Verification

```
$ go test ./internal/tui/ -run TestStagingScope -race -count=1
ok  	github.com/mpyw/suve/internal/tui	1.431s

$ go test -race ./internal/tui/...
ok  	github.com/mpyw/suve/internal/tui	3.191s
ok  	github.com/mpyw/suve/internal/tui/data	1.328s
ok  	github.com/mpyw/suve/internal/tui/dialogs	1.732s
ok  	github.com/mpyw/suve/internal/tui/pages/browser	1.909s
ok  	github.com/mpyw/suve/internal/tui/pages/diff	2.266s
ok  	github.com/mpyw/suve/internal/tui/pages/staging	2.178s

$ mise test
... (all packages ok)
ok  	github.com/mpyw/suve/internal/tui	2.855s

$ golangci-lint run --allow-parallel-runners --timeout=10m
0 issues.

$ mise build-gui
... Built bin/suve — run 'suve --gui'.
```
