### PR TITLE
fix(tui): browser selection by identity + loadMore in-flight guard (#699, #700)

### DIFF
--- a/internal/tui/pages/browser/browser_test.go
+++ b/internal/tui/pages/browser/browser_test.go
@@ -299,6 +299,177 @@ func TestSelectedItemByIndexWithDuplicateNames(t *testing.T) {
 	assert.Equal(t, "prod", got.Namespace, "index 2 resolves to the prod duplicate")
 }
 
+// TestSelectionSurvivesReloadByIdentity pins #699: a mutation reload that inserts
+// a row above the selection must keep the detail on the SAME entry. Selecting
+// /zzz then reloading with /aaa inserted at the top (which shifts /zzz down one
+// index) re-resolves the selection to /zzz's new index rather than leaving the
+// clamped index pointing at the neighbor that inherited /zzz's old slot.
+func TestSelectionSurvivesReloadByIdentity(t *testing.T) {
+	t.Parallel()
+
+	m := newModel(t, &stubSource{svcCap: awsParamCap()})
+
+	// Initial list; select /zzz (index 1).
+	m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{
+		{Name: "/bbb"}, {Name: "/zzz"},
+	}}})
+	m.list.SelectIndex(1)
+	sel, ok := m.selectedItem()
+	require.True(t, ok)
+	require.Equal(t, "/zzz", sel.Name)
+
+	// A mutation reload inserts /aaa at the top: /zzz moves from index 1 to 2.
+	_ = m.loadListCmd(false) // advance listSeq as a reload would
+	m, cmd := update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{
+		{Name: "/aaa"}, {Name: "/bbb"}, {Name: "/zzz"},
+	}}})
+
+	got, ok := m.selectedItem()
+	require.True(t, ok)
+	assert.Equal(t, "/zzz", got.Name, "selection re-resolves to the same entry after an insert above it")
+	assert.Equal(t, 2, m.list.Selected(), "the selection index followed /zzz to its new position")
+	assert.NotNil(t, cmd, "the reload (re)loads the resolved selection's detail")
+}
+
+// TestSelectionSurvivesReloadWithDuplicateNamespaces pins that the re-resolve is
+// keyed on name+namespace, not name alone: App Configuration lists the same key
+// under several namespaces, so an insert above the selection must keep it on the
+// exact (name, namespace) pair, never collapsing onto the first same-name row.
+func TestSelectionSurvivesReloadWithDuplicateNamespaces(t *testing.T) {
+	t.Parallel()
+
+	m := newModel(t, &stubSource{svcCap: appConfigCap()})
+
+	m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{
+		{Name: "app/Feature", Namespace: ""},
+		{Name: "app/Feature", Namespace: "prod"},
+	}}})
+	m.list.SelectIndex(1) // the prod duplicate
+	sel, ok := m.selectedItem()
+	require.True(t, ok)
+	require.Equal(t, "prod", sel.Namespace)
+
+	// Reload inserts a staging duplicate above prod: prod moves from 1 to 2.
+	_ = m.loadListCmd(false)
+	m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{
+		{Name: "app/Feature", Namespace: ""},
+		{Name: "app/Feature", Namespace: "staging"},
+		{Name: "app/Feature", Namespace: "prod"},
+	}}})
+
+	got, ok := m.selectedItem()
+	require.True(t, ok)
+	assert.Equal(t, "prod", got.Namespace, "selection stays on the exact (name, namespace), not the first same-name row")
+	assert.Equal(t, 2, m.list.Selected())
+}
+
+// TestSelectionSurvivesDeleteAboveSelection pins that a deletion which removes a
+// row ABOVE the selection keeps the detail on the same entry. Selecting /bbb then
+// deleting /aaa shifts /bbb from index 1 to 0; the OLD index-clamp would have held
+// index 1 and landed on /zzz, so this fails against the pre-fix behavior (#699).
+func TestSelectionSurvivesDeleteAboveSelection(t *testing.T) {
+	t.Parallel()
+
+	m := newModel(t, &stubSource{svcCap: awsParamCap()})
+
+	m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{
+		{Name: "/aaa"}, {Name: "/bbb"}, {Name: "/zzz"},
+	}}})
+	m.list.SelectIndex(1) // select /bbb
+	sel, ok := m.selectedItem()
+	require.True(t, ok)
+	require.Equal(t, "/bbb", sel.Name)
+
+	// Delete /aaa (above the selection): /bbb moves from index 1 to 0.
+	_ = m.loadListCmd(false)
+	m, cmd := update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{
+		{Name: "/bbb"}, {Name: "/zzz"},
+	}}})
+
+	got, ok := m.selectedItem()
+	require.True(t, ok)
+	assert.Equal(t, "/bbb", got.Name, "selection follows /bbb after the row above it is deleted")
+	assert.Equal(t, 0, m.list.Selected())
+	assert.NotNil(t, cmd, "the resolved selection's detail (re)loads")
+}
+
+// TestSelectionFallsBackWhenSelectedDeleted pins the graceful fallback half of
+// #699: when the SELECTED entry itself is gone after a reload, the selection
+// clamps into range and the fallback detail loads; when the list drains to empty
+// the detail is cleared (no stale value, no phantom-entry data).
+func TestSelectionFallsBackWhenSelectedDeleted(t *testing.T) {
+	t.Parallel()
+
+	m := newModel(t, &stubSource{svcCap: awsParamCap()})
+
+	m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{
+		{Name: "/aaa"}, {Name: "/bbb"}, {Name: "/zzz"},
+	}}})
+	m.list.SelectIndex(1) // select /bbb
+	sel, ok := m.selectedItem()
+	require.True(t, ok)
+	require.Equal(t, "/bbb", sel.Name)
+
+	// Delete /bbb (the selected entry): it is gone, so the selection clamps.
+	_ = m.loadListCmd(false)
+	m, cmd := update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{
+		{Name: "/aaa"}, {Name: "/zzz"},
+	}}})
+
+	got, ok := m.selectedItem()
+	require.True(t, ok, "a non-empty list still has a selection")
+	assert.Equal(t, "/zzz", got.Name, "selection clamps into range when the selected entry is gone")
+	assert.NotNil(t, cmd, "the fallback selection loads its detail")
+
+	// A further reload draining the list to empty clears the detail rather than
+	// pointing it at a phantom entry.
+	m.detailOK = true // pretend a detail is currently shown
+	_ = m.loadListCmd(false)
+	m, cmd = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{}}})
+	_, ok = m.selectedItem()
+	assert.False(t, ok, "an empty list has no selection")
+	assert.False(t, m.detailOK, "the detail is cleared when nothing is selected")
+	assert.Nil(t, cmd, "an empty list issues no detail load")
+}
+
+// TestLoadMoreInFlightGuard pins #700: loadMore issues an append when a next page
+// is present, but a second loadMore fired while that append is still pending is a
+// no-op — no new fetch (listSeq does not advance), so a hammered `L` can never
+// splice a duplicate or stale page.
+func TestLoadMoreInFlightGuard(t *testing.T) {
+	t.Parallel()
+
+	m := newModel(t, &stubSource{svcCap: awsSecretCap()})
+
+	// A loaded page reports a real next page.
+	m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{
+		Items: []data.Item{{Name: "prod/a"}}, NextToken: "tok",
+	}})
+	require.Equal(t, "tok", m.nextToken)
+	require.False(t, m.loading, "no fetch is in flight after the page loads")
+
+	// First loadMore issues the append and marks the fetch in flight.
+	seqBefore := m.listSeq
+	cmd := m.loadMore()
+	require.NotNil(t, cmd, "loadMore with a next page issues an append")
+	require.True(t, m.loading, "the append is now in flight")
+	require.Equal(t, seqBefore+1, m.listSeq, "the append advanced the list sequence")
+
+	// A second loadMore while the first is still pending is a no-op.
+	seqDuring := m.listSeq
+	assert.Nil(t, m.loadMore(), "a second loadMore while one is in-flight is a no-op")
+	assert.Equal(t, seqDuring, m.listSeq, "the blocked loadMore issues no fetch (no duplicate/stale splice)")
+
+	// loadMore is likewise suppressed during an ordinary (non-append) reload.
+	m2 := newModel(t, &stubSource{svcCap: awsSecretCap()})
+	m2, _ = update(t, m2, listLoadedMsg{seq: m2.listSeq, res: data.ListResult{
+		Items: []data.Item{{Name: "prod/a"}}, NextToken: "tok",
+	}})
+	_ = m2.loadListCmd(false) // a filter/mutation reload is now in flight
+	require.True(t, m2.loading)
+	assert.Nil(t, m2.loadMore(), "loadMore is a no-op while a full reload is pending")
+}
+
 // TestStagingJump pins that S emits the OpenStaging navigation request.
 func TestStagingJump(t *testing.T) {
 	t.Parallel()

--- a/internal/tui/pages/browser/cmds.go
+++ b/internal/tui/pages/browser/cmds.go
@@ -154,3 +154,31 @@ func (m *Model) selectedItem() (data.Item, bool) {
 
 	return m.items[idx], true
 }
+
+// selectedKey returns the identity (name+namespace) of the currently-selected
+// item, so a reload can re-resolve the SAME entry to its new index rather than
+// trusting the clamped index (#699).
+func (m *Model) selectedKey() (data.StagedKey, bool) {
+	item, ok := m.selectedItem()
+	if !ok {
+		return data.StagedKey{}, false
+	}
+
+	return dataStagedKey(item), true
+}
+
+// reselect moves the selection to the row whose identity matches key, called
+// after a rebuild so an insert/remove above the previous selection keeps the
+// detail on the same entry. When the entry is gone (e.g. it was the one just
+// deleted), it leaves the clamped selection SetRows already produced —
+// selectionCmd then loads whatever is now selected, or clears the detail when
+// the list is empty (the graceful, GUI-parity fallback).
+func (m *Model) reselect(key data.StagedKey) {
+	for i, it := range m.items {
+		if dataStagedKey(it) == key {
+			m.list.SelectIndex(i)
+
+			return
+		}
+	}
+}

--- a/internal/tui/pages/browser/update.go
+++ b/internal/tui/pages/browser/update.go
@@ -79,6 +79,14 @@ func (m *Model) onListLoaded(msg listLoadedMsg) tea.Cmd {
 
 	m.err = ""
 
+	// Preserve the selection by IDENTITY, not index. A replace can insert or
+	// remove rows above the selection, so capture the selected entry's key first
+	// and re-resolve it to its new index after the rows rebuild — otherwise the
+	// clamped index silently slides the detail onto a neighbor after a mutation
+	// reload (the GUI tracks selection by name; #699). On append the existing
+	// rows keep their indices, so the selection index is already correct.
+	prevKey, hadSelection := m.selectedKey()
+
 	if msg.append {
 		m.items = append(m.items, msg.res.Items...)
 	} else {
@@ -87,6 +95,10 @@ func (m *Model) onListLoaded(msg listLoadedMsg) tea.Cmd {
 
 	m.nextToken = msg.res.NextToken
 	m.rebuildRows()
+
+	if !msg.append && hadSelection {
+		m.reselect(prevKey)
+	}
 
 	return m.selectionCmd()
 }
@@ -479,9 +491,14 @@ func (m *Model) openDiff() tea.Cmd {
 	return func() tea.Msg { return req }
 }
 
-// loadMore appends the next secret page when a NextToken is present.
+// loadMore appends the next secret page when a NextToken is present. It is a
+// no-op while a list fetch is already in flight: m.loading is set by loadListCmd
+// for BOTH a full reload and a previous append, so a single guard mirrors the
+// GUI's `loading || loadingMore` check and stops a hammered `L` from splicing a
+// duplicate or stale page (#700). The stale-seq guard in onListLoaded is the
+// backstop; this keeps a superseded append from ever being issued.
 func (m *Model) loadMore() tea.Cmd {
-	if m.nextToken == "" {
+	if m.nextToken == "" || m.loading {
 		return nil
 	}
 


### PR DESCRIPTION
Closes #699
Closes #700

Two bugs in the TUI browser page's list/pagination logic, fixed together because they share the reload/`loadMore` code.

## #699 — selection survived reloads by index, not identity

`components/entrylist.go` `SetRows` only *clamped* the numeric selection into range, and `browser/cmds.go` `selectedItem` resolved the selection by index. After a mutation reload that inserted or removed a row above the selection (e.g. select `/zzz`, create `/aaa`), the clamped index pointed at a neighbor and the detail pane silently loaded the wrong entry's value/history.

The GUI (`ParamView.svelte` / `SecretView.svelte`) tracks selection by `selectedParam` + `selectedEntryNamespace` and binds the detail pane to that identity, so it survives a `loadParams` reload. This mirrors that:

- `onListLoaded` (non-append path) now captures the selected entry's `StagedKey{Name, Namespace}` **before** `m.items` is replaced and **before** `rebuildRows`, then calls `reselect` to re-resolve that key to its new index after the rebuild.
- The key is `Name`+`Namespace`, so App Configuration's same-key-across-namespaces case resolves to the exact pair, never the first same-name row.
- Graceful fallback: when the entry is gone (it was the one deleted), `reselect` is a no-op and the clamp `SetRows` produced stands, so `selectionCmd` loads the surviving neighbor; when the list drains empty the detail clears (`detailOK=false`). Append is skipped (existing rows keep their indices).

## #700 — `loadMore` lacked the GUI's in-flight guard

`loadMore` guarded only on `nextToken == ""`. The GUI guards `!nextToken || loadingMore || loading`. In the TUI, `loadListCmd` sets `m.loading` for **both** a full reload and an append (and `onListLoaded` clears it only on the latest seq), so a single `m.loading` check is equivalent to the GUI's two-flag guard — a separate `loadingMore` flag would never diverge from `m.loading`. A hammered `L`, or `L` during a filter reload, can no longer splice a duplicate/stale page before any provider gains real pagination.

## Tests (Update-level regression, `internal/tui/pages/browser`)

- `TestSelectionSurvivesReloadByIdentity` — insert above the selection; detail stays on the same entry.
- `TestSelectionSurvivesReloadWithDuplicateNamespaces` — re-resolve keyed on (name, namespace), not name alone.
- `TestSelectionSurvivesDeleteAboveSelection` — delete a row above the selection; detail follows the entry.
- `TestSelectionFallsBackWhenSelectedDeleted` — selected entry deleted → clamp + load neighbor; drain-to-empty → detail cleared.
- `TestLoadMoreInFlightGuard` — second `loadMore` while an append (or a full reload) is pending is a no-op; `listSeq` does not advance.

All three identity tests were confirmed to **fail** against the pre-fix behavior (with `reselect` disabled) and pass with the fix.

## Verification

```
$ go test ./internal/tui/pages/browser/... -run 'TestSelection|TestLoadMoreInFlightGuard' -v
--- PASS: TestSelectionSurvivesReloadByIdentity (0.00s)
--- PASS: TestSelectionFallsBackWhenSelectedDeleted (0.00s)
--- PASS: TestSelectionSurvivesDeleteAboveSelection (0.00s)
--- PASS: TestSelectionSurvivesReloadWithDuplicateNamespaces (0.00s)
--- PASS: TestLoadMoreInFlightGuard (0.00s)
PASS
ok  	github.com/mpyw/suve/internal/tui/pages/browser	0.243s
```

Load-bearing check — identity tests against pre-fix behavior (`reselect` disabled):
```
--- FAIL: TestSelectionSurvivesReloadWithDuplicateNamespaces (0.00s)
--- FAIL: TestSelectionSurvivesDeleteAboveSelection (0.00s)
--- FAIL: TestSelectionSurvivesReloadByIdentity (0.00s)
FAIL	github.com/mpyw/suve/internal/tui/pages/browser
```

```
$ go test -race ./internal/tui/...
ok  	github.com/mpyw/suve/internal/tui
ok  	github.com/mpyw/suve/internal/tui/data
ok  	github.com/mpyw/suve/internal/tui/dialogs
ok  	github.com/mpyw/suve/internal/tui/pages/browser
ok  	github.com/mpyw/suve/internal/tui/pages/diff
ok  	github.com/mpyw/suve/internal/tui/pages/staging

$ mise test
ok  	github.com/mpyw/suve/internal/tui  ... (all packages ok)

$ golangci-lint run --allow-parallel-runners --timeout=10m
0 issues.

$ mise build-gui
✓ built in 1.50s
Built bin/suve — run 'suve --gui'.
```
