### PR TITLE
fix(tui): make the Type select reachable and carry the staged value type (#680)

### DIFF
--- a/internal/tui/data/mutate.go
+++ b/internal/tui/data/mutate.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/mpyw/suve/internal/capability"
 	"github.com/mpyw/suve/internal/cli/commands/aws/param/paramtype"
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/maputil"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/azure/appconfig/aznamespace"
@@ -129,7 +130,9 @@ func (m *paramMutator) Create(
 	}
 
 	if staged {
-		return m.stageEntry(ctx, StagedKey{Name: key.Name, Namespace: ns}, value, description, stageOpCreate)
+		return m.stageEntry(
+			ctx, StagedKey{Name: key.Name, Namespace: ns}, value, description, stagedValueType(typeLabel), stageOpCreate,
+		)
 	}
 
 	store, err := m.resolveStore(ctx, ns)
@@ -155,7 +158,9 @@ func (m *paramMutator) Update(
 	}
 
 	if staged {
-		return m.stageEntry(ctx, StagedKey{Name: key.Name, Namespace: ns}, value, description, stageOpEdit)
+		return m.stageEntry(
+			ctx, StagedKey{Name: key.Name, Namespace: ns}, value, description, stagedValueType(typeLabel), stageOpEdit,
+		)
 	}
 
 	store, err := m.resolveStore(ctx, ns)
@@ -261,14 +266,14 @@ func (m *paramMutator) stageStrategy(
 }
 
 func (m *paramMutator) stageEntry(
-	ctx context.Context, key StagedKey, value, description string, op stageOp,
+	ctx context.Context, key StagedKey, value, description string, valueType domain.ValueType, op stageOp,
 ) (WriteOutcome, error) {
 	strategy, st, err := m.stageStrategy(ctx, key.Namespace)
 	if err != nil {
 		return WriteOutcome{}, err
 	}
 
-	return stageEntry(ctx, strategy, st, key, value, description, op)
+	return stageEntry(ctx, strategy, st, key, value, description, valueType, op)
 }
 
 func (m *paramMutator) stageDelete(
@@ -330,7 +335,8 @@ func (m *secretMutator) Create(
 ) (WriteOutcome, error) {
 	if staged {
 		return m.stage(func(strategy staging.FullStrategy, st store.ReadWriteOperator) (WriteOutcome, error) {
-			return stageEntry(ctx, strategy, st, key, value, description, stageOpCreate)
+			// Secrets have no value-type axis, so no value type is staged.
+			return stageEntry(ctx, strategy, st, key, value, description, "", stageOpCreate)
 		})
 	}
 
@@ -345,7 +351,8 @@ func (m *secretMutator) Update(
 ) (WriteOutcome, error) {
 	if staged {
 		return m.stage(func(strategy staging.FullStrategy, st store.ReadWriteOperator) (WriteOutcome, error) {
-			return stageEntry(ctx, strategy, st, key, value, description, stageOpEdit)
+			// Secrets have no value-type axis, so no value type is staged.
+			return stageEntry(ctx, strategy, st, key, value, description, "", stageOpEdit)
 		})
 	}
 
@@ -441,24 +448,48 @@ const (
 	stageOpEdit
 )
 
+// stagedValueType maps a Type display label to the value type to stage. The
+// dialog passes an empty label when it presents no Type control (a secret, an App
+// Configuration setting, or the staging-review edit that cannot seed the current
+// type); an empty value means "no explicit type", which the staging apply treats
+// as plaintext for a create and as "preserve the existing type" for an edit — so
+// an edit from a surface with no Type control never downgrades a staged
+// SecureString. A non-empty label (an offered Type select) is mapped through
+// paramtype.Parse so the chosen type is stored and applied.
+func stagedValueType(typeLabel string) domain.ValueType {
+	if typeLabel == "" {
+		return ""
+	}
+
+	return paramtype.Parse(typeLabel)
+}
+
 // stageEntry stages a create or edit and maps the use-case outcome (Skipped/
-// Unstaged for edit) onto the neutral WriteOutcome.
+// Unstaged for edit) onto the neutral WriteOutcome. valueType carries the AWS SSM
+// param value type (String / SecureString / StringList) into the staging store so
+// a staged SecureString create/edit applies as SecureString; an empty value
+// preserves the existing type on edit (and applies plaintext on create). It is
+// empty for providers with no value-type axis (secret, App Configuration).
 func stageEntry(
 	ctx context.Context, strategy staging.FullStrategy, st store.ReadWriteOperator,
-	key StagedKey, value, description string, op stageOp,
+	key StagedKey, value, description string, valueType domain.ValueType, op stageOp,
 ) (WriteOutcome, error) {
 	entryKey := staging.EntryKey{Name: key.Name, Namespace: key.Namespace}
 
 	if op == stageOpCreate {
 		uc := &stagingusecase.AddUseCase{Strategy: strategy, Store: st}
-		_, err := uc.Execute(ctx, stagingusecase.AddInput{Key: entryKey, Value: value, Description: description})
+		_, err := uc.Execute(ctx, stagingusecase.AddInput{
+			Key: entryKey, Value: value, Description: description, ValueType: valueType,
+		})
 
 		return WriteOutcome{}, err
 	}
 
 	uc := &stagingusecase.EditUseCase{Strategy: strategy, Store: st}
 
-	out, err := uc.Execute(ctx, stagingusecase.EditInput{Key: entryKey, Value: value, Description: description})
+	out, err := uc.Execute(ctx, stagingusecase.EditInput{
+		Key: entryKey, Value: value, Description: description, ValueType: valueType,
+	})
 	if err != nil {
 		return WriteOutcome{}, err
 	}

--- a/internal/tui/data/mutate_test.go
+++ b/internal/tui/data/mutate_test.go
@@ -229,6 +229,100 @@ func TestParamMutator_StagedRoundTrip(t *testing.T) {
 	})
 }
 
+// TestParamMutator_StagedCarriesValueType pins the #664/#680 end-to-end fix: a
+// staged SecureString create routed through the TUI param mutator stores the
+// SecureString value type in the working staging store AND, on apply through the
+// AWS SSM param strategy, writes the parameter as SecureString (domain
+// ValueTypeSecret) rather than silently downgrading it to plaintext String.
+//
+//nolint:paralleltest // sets HOME / SUVE_STAGING_KEY via t.Setenv
+func TestParamMutator_StagedCarriesValueType(t *testing.T) {
+	ctx := context.Background()
+
+	var (
+		appliedType  domain.ValueType
+		appliedValue string
+	)
+
+	provStore := &providermock.Store{
+		GetFunc: func(context.Context, string, provider.VersionRef) (*domain.Entry, error) {
+			return nil, provider.ErrNotFound
+		},
+		CreateFunc: func(
+			_ context.Context, _, value string, valueType domain.ValueType, _ string, _ ...provider.WriteOption,
+		) (domain.Version, error) {
+			appliedValue, appliedType = value, valueType
+
+			return domain.Version{ID: "1"}, nil
+		},
+	}
+
+	mut, st := newParamMutator(t, provStore)
+
+	// TUI staged create with Type = SecureString.
+	_, err := mut.Create(ctx, data.StagedKey{Name: "/app/SECRET"}, "s3cr3t", "SecureString", "", true)
+	require.NoError(t, err)
+
+	// The staged entry carries the SecureString value type end-to-end.
+	entry, err := st.GetEntry(ctx, staging.ServiceParam, staging.EntryKey{Name: "/app/SECRET"})
+	require.NoError(t, err)
+	assert.Equal(t, staging.OperationCreate, entry.Operation)
+	assert.Equal(t, domain.ValueTypeSecret, entry.ValueType, "staged create carries the SecureString type")
+
+	// Apply the staged create through the AWS SSM param strategy: the parameter is
+	// written as SecureString, not the old hardcoded plaintext String.
+	strategy := staging.NewAWSParamStrategy(provStore)
+	require.NoError(t, strategy.Apply(ctx, "/app/SECRET", *entry))
+	assert.Equal(t, "s3cr3t", appliedValue)
+	assert.Equal(t, domain.ValueTypeSecret, appliedType, "apply writes the parameter as SecureString")
+}
+
+// TestParamMutator_StagedEditValueType pins the staged-edit value-type rules: an
+// explicit type is stored (so a staged edit can change the type), while an empty
+// type — passed by the staging-review edit, which cannot seed the current type —
+// preserves the existing staged type instead of downgrading it.
+//
+//nolint:paralleltest // sets HOME / SUVE_STAGING_KEY via t.Setenv
+func TestParamMutator_StagedEditValueType(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("explicit type is stored", func(t *testing.T) {
+		mut, st := newParamMutator(t, existingParamStore("old"))
+
+		_, err := mut.Update(ctx, data.StagedKey{Name: existingParamName}, "new", "SecureString", "", true)
+		require.NoError(t, err)
+
+		entry, err := st.GetEntry(ctx, staging.ServiceParam, staging.EntryKey{Name: existingParamName})
+		require.NoError(t, err)
+		assert.Equal(t, staging.OperationUpdate, entry.Operation)
+		assert.Equal(t, domain.ValueTypeSecret, entry.ValueType, "an explicit staged-edit type is stored")
+	})
+
+	t.Run("empty type preserves a staged SecureString create", func(t *testing.T) {
+		mut, st := newParamMutator(t, &providermock.Store{
+			GetFunc: func(context.Context, string, provider.VersionRef) (*domain.Entry, error) {
+				return nil, provider.ErrNotFound
+			},
+		})
+
+		// Stage a SecureString create, then edit its value with no type (the
+		// staging-review edit path passes an empty type): the create's SecureString
+		// type must survive rather than downgrade to plaintext.
+		_, err := mut.Create(ctx, data.StagedKey{Name: "/app/NEW"}, "v1", "SecureString", "", true)
+		require.NoError(t, err)
+
+		_, err = mut.Update(ctx, data.StagedKey{Name: "/app/NEW"}, "v2", "", "", true)
+		require.NoError(t, err)
+
+		entry, err := st.GetEntry(ctx, staging.ServiceParam, staging.EntryKey{Name: "/app/NEW"})
+		require.NoError(t, err)
+		assert.Equal(t, staging.OperationCreate, entry.Operation, "editing a staged create keeps it a create")
+		require.NotNil(t, entry.Value)
+		assert.Equal(t, "v2", *entry.Value, "the edit updates the draft value")
+		assert.Equal(t, domain.ValueTypeSecret, entry.ValueType, "an empty edit type preserves the staged SecureString")
+	})
+}
+
 // TestParamMutator_ImmediateRouting asserts an immediate write reaches the
 // provider store directly and never touches the staging store.
 //

--- a/internal/tui/dialog_golden_test.go
+++ b/internal/tui/dialog_golden_test.go
@@ -175,11 +175,10 @@ func goldenCap(prov, service string) capability.ServiceCapability {
 }
 
 // TestDialog_EntryFormAWSParamGolden renders the create form for AWS SSM param in
-// its default (staged) mode: name, value textarea, Description, and the mode
-// toggle. The Type select is NOT drawn — it is offered only in immediate mode
-// (#664 containment: a staged write drops the value type, so a staged
-// SecureString would silently downgrade to plaintext). No value is seeded, so no
-// secret is rendered.
+// its default (staged) mode: name, the Type select, value textarea, Description,
+// and the mode toggle. The Type select is drawn in both modes — the value type
+// flows through the staged path as well as the immediate path (the #664/#680
+// fix). No value is seeded, so no secret is rendered.
 func TestDialog_EntryFormAWSParamGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
 	goldenEnv(t)
 

--- a/internal/tui/dialogs/dialogs_test.go
+++ b/internal/tui/dialogs/dialogs_test.go
@@ -123,6 +123,24 @@ func newEntry(t *testing.T, svcCap capability.ServiceCapability, edit bool) (*en
 	return d, mut
 }
 
+// newStagedOnlyEntry builds a staged-only edit form (the staging review page's
+// edit path): the mode toggle is hidden and the write is forced staged.
+func newStagedOnlyEntry(t *testing.T, svcCap capability.ServiceCapability) *entryForm {
+	t.Helper()
+
+	mut := &fakeMutator{svcCap: svcCap}
+
+	m, _ := NewEntryForm(EntryFormInput{
+		Ctx: context.Background(), Mutator: mut, Service: svcCap.Service, Styles: styles.New(),
+		Edit: true, Name: "/app/X", Value: "old", StagedOnly: true,
+	})
+
+	d, ok := m.(*entryForm)
+	require.True(t, ok)
+
+	return d
+}
+
 // execCmd runs a command for its side effect on the recording mutator.
 func execCmd(t *testing.T, cmd tea.Cmd) {
 	t.Helper()
@@ -245,19 +263,19 @@ func TestEntryForm_NamespaceReadOnlyOnEdit(t *testing.T) {
 	assert.Equal(t, "(default)", namespaceDisplay(""))
 }
 
-// TestEntryForm_TypeSelectGating pins the Type select is offered only for the
-// typed AWS SSM param service (App Configuration is untyped; secret has none)
-// AND only in immediate mode: containment for #664, since the staged path drops
-// the value type (staging apply hardcodes a plaintext String), so a staged
-// SecureString would silently downgrade to plaintext. Staged mode must not
-// present a Type control that can't take effect.
+// TestEntryForm_TypeSelectGating pins the Type select is offered for the typed
+// AWS SSM param service (App Configuration is untyped; secret has none) in BOTH
+// modes: the value type flows through the staged path as well as the immediate
+// path (the #664 fix), so the select is reachable regardless of the mode toggle
+// — where it was previously hidden in staged mode as a #664 containment. It must
+// stay absent for the untyped services.
 func TestEntryForm_TypeSelectGating(t *testing.T) {
 	t.Parallel()
 
 	awsParam, _ := newEntry(t, awsParamCap(), false)
 	require.True(t, awsParam.staged, "AWS param defaults to staged")
-	assert.False(t, awsParam.showType(), "staged mode hides the Type select (#664 containment)")
-	assert.NotContains(t, awsParam.View(), "Type", "staged form draws no Type row")
+	assert.True(t, awsParam.showType(), "staged mode still offers the Type select")
+	assert.Contains(t, awsParam.View(), "Type", "the staged form draws the Type row (default mode)")
 
 	awsParam.staged = false
 	require.NotNil(t, awsParam.rebuildForm())
@@ -265,14 +283,65 @@ func TestEntryForm_TypeSelectGating(t *testing.T) {
 	assert.Contains(t, awsParam.View(), "Type", "immediate form draws the Type row")
 
 	appConfig, _ := newEntry(t, appConfigCap(), false)
+	assert.False(t, appConfig.showType(), "App Configuration is untyped in either mode")
 	appConfig.staged = false
 	require.NotNil(t, appConfig.rebuildForm())
-	assert.False(t, appConfig.showType(), "App Configuration is untyped even in immediate mode")
+	assert.False(t, appConfig.showType(), "App Configuration is untyped in either mode")
 
 	secret, _ := newEntry(t, awsSecretCap(), false)
+	assert.False(t, secret.showType(), "secret has no value type in either mode")
 	secret.staged = false
 	require.NotNil(t, secret.rebuildForm())
-	assert.False(t, secret.showType(), "secret has no value type even in immediate mode")
+	assert.False(t, secret.showType(), "secret has no value type in either mode")
+
+	// A staged-only surface (the staging review page's edit) hides the Type select:
+	// the write is always a staged edit that preserves the existing type, and the
+	// dialog cannot seed the entry's current type.
+	stagedOnly := newStagedOnlyEntry(t, awsParamCap())
+	assert.False(t, stagedOnly.showType(), "a staged-only edit hides the Type select")
+	assert.NotContains(t, stagedOnly.View(), "Type", "a staged-only edit draws no Type row")
+}
+
+// TestEntryForm_StagedCarriesType pins that a staged param create routes the
+// selected value type (e.g. SecureString) through to the mutator — the TUI half
+// of the #664/#680 fix. Previously the staged path dropped the type, silently
+// creating the parameter as plaintext String.
+func TestEntryForm_StagedCarriesType(t *testing.T) {
+	t.Parallel()
+
+	d, mut := newEntry(t, awsParamCap(), false)
+	d.name = "/app/SECRET"
+	d.value = "s3cr3t"
+	d.valueType = "SecureString"
+	d.staged = true
+
+	execCmd(t, d.submit())
+
+	assert.True(t, mut.createCalled)
+	assert.True(t, mut.staged, "the write is staged")
+	assert.Equal(t, "SecureString", mut.typeLabel, "the staged create carries the selected type")
+}
+
+// TestEntryForm_StagedOnlyEditPreservesType pins that a staged-only edit (the
+// staging review page's edit, which shows no Type control and cannot seed the
+// entry's current type) submits an EMPTY type label. An empty label preserves the
+// existing staged/cloud type in the staging apply, so re-editing a staged
+// SecureString from the review page never silently downgrades it to plaintext —
+// the failure this would otherwise reintroduce once the Type select is reachable.
+func TestEntryForm_StagedOnlyEditPreservesType(t *testing.T) {
+	t.Parallel()
+
+	d := newStagedOnlyEntry(t, awsParamCap())
+	d.value = "new"
+
+	mut, ok := d.mutator.(*fakeMutator)
+	require.True(t, ok)
+
+	execCmd(t, d.submit())
+
+	assert.True(t, mut.updateCalled)
+	assert.True(t, mut.staged, "a staged-only edit is staged")
+	assert.Empty(t, mut.typeLabel, "a staged-only edit passes no type, so the existing type is preserved")
 }
 
 // TestEntryForm_DescriptionGating pins that the Description field is drawn only

--- a/internal/tui/dialogs/entryform.go
+++ b/internal/tui/dialogs/entryform.go
@@ -125,15 +125,17 @@ func NewEntryForm(in EntryFormInput) (Model, tea.Cmd) {
 
 // showType reports whether the typed-param Type select is offered: only the AWS
 // SSM param service has a value type (App Configuration is untyped; secret has
-// none) — parity with the GUI's ParamTypeOptions — AND only in immediate mode.
+// none) — parity with the GUI's ParamTypeOptions. It does NOT depend on the mode
+// toggle, so the select is reachable for a staged create and flows through to
+// apply (the #664/#680 fix); the immediate path maps it via paramtype.Parse and
+// the staged create carries it into the staging store.
 //
-// Containment for #664: the staged write path drops the value type (staging
-// apply hardcodes a plaintext String), so a staged SecureString create would
-// silently apply as plaintext String. Until the systemic staged-type fix lands
-// (#664), the Type select is offered only in immediate mode, where it takes
-// effect; staged mode never presents a Type control that can't be honored.
+// It is hidden on a staged-only surface (the staging review page's edit): there
+// the write is always a staged edit, which preserves the existing type rather
+// than taking a new one, and the dialog cannot seed the entry's current type — so
+// a Type control there could neither be honored nor shown accurately.
 func (d *entryForm) showType() bool {
-	return d.svcCap.Service == serviceParam && !d.svcCap.HasNamespaces && !d.staged
+	return d.svcCap.Service == serviceParam && !d.svcCap.HasNamespaces && !d.stagedOnly
 }
 
 // defaultTypeLabel picks the Type select's initial value: the seeded label when
@@ -267,7 +269,17 @@ func (d *entryForm) valueFieldFocused() bool {
 func (d *entryForm) submit() tea.Cmd {
 	key := data.StagedKey{Name: d.name, Namespace: d.namespace}
 	staged := d.staged
-	value, valueType, description := d.value, d.valueType, d.description
+	// Pass the value type only when a Type control was actually offered. When it
+	// was not (a secret, an App Configuration setting, or a staging-review edit
+	// that cannot seed the entry's current type), an empty label signals "no
+	// explicit type" so the staged edit preserves the existing type instead of
+	// forcing the select's default and downgrading it.
+	valueType := ""
+	if d.showType() {
+		valueType = d.valueType
+	}
+
+	value, description := d.value, d.description
 	edit := d.edit
 	mut, ctx := d.mutator, d.ctx
 

--- a/internal/tui/testdata/TestDialog_EntryFormAWSParamGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormAWSParamGolden.golden
@@ -4,6 +4,11 @@
 │┃ Name                                                │
 │┃ >                                                   │
 │                                                      │
+│  Type                                                │
+│  > String                                            │
+│    SecureString                                      │
+│    StringList                                        │
+│                                                      │
 │  Value                                               │
 │                                                      │
 │                                                      │


### PR DESCRIPTION
Closes #680.

## Problem

The create/edit entry form gated its value-Type select on immediate mode (`showType()` required `!d.staged` — the #664 containment), and the mode toggle went through `forwardToForm`, which never rebuilds the form. Since AWS SSM param defaults to staged, **there was no reachable UI state that showed the Type select**: every param created through the TUI was silently a plaintext `String`, and SecureString/StringList creation was impossible (`internal/tui/dialogs/entryform.go`, `internal/tui/data/mutate.go`).

`epic/tui` now carries the #664 ValueType plumbing (via #706): `AddInput`/`EditInput` have a `ValueType`, and the AWS param staging apply honors it. This PR lifts the TUI containment and threads the type through the staged write path.

## Fix

- **`internal/tui/dialogs/entryform.go`** — `showType()` no longer depends on the mode toggle, so the Type select is reachable for a **staged create** (it renders in both modes, so no rebuild-on-toggle is needed). It stays hidden only on the staging-review **staged-only** edit surface, which cannot seed the entry's current type and whose staged edit *preserves* rather than sets the type. `submit()` passes the value type only when the Type control was actually offered.
- **`internal/tui/data/mutate.go`** — the staged create/edit path threads the value type into the staging store (`AddInput.ValueType` / `EditInput.ValueType`). An empty label means "no explicit type", which the apply treats as plaintext for a create and as *preserve the existing type* for an edit — so a staged edit from a surface with no Type control never downgrades a staged SecureString. Secret/App-Configuration paths pass empty (no value-type axis).

### Value type flows end-to-end (the #664 goal)

TUI staged create (SecureString) → `AddUseCase` stores `ValueType=secret` → AWS param staging apply calls `store.Create(..., domain.ValueTypeSecret, ...)`. Verified by a data-layer test driving the mutator + a real working staging store + the real `AWSParamStrategy`.

## Tests

- `TestEntryForm_TypeSelectGating` — Type reachable in both create modes; hidden for secret / App Configuration / staged-only edit.
- `TestEntryForm_StagedCarriesType` — a staged create carries the selected SecureString type to the mutator.
- `TestEntryForm_StagedOnlyEditPreservesType` — a staged-only edit passes an empty type (preserve, no downgrade).
- `TestParamMutator_StagedCarriesValueType` — staged SecureString create is stored **and applied** as SecureString.
- `TestParamMutator_StagedEditValueType` — an explicit staged-edit type is stored; an empty edit type preserves a staged SecureString create.
- `TestDialog_EntryFormAWSParamGolden` (teatest golden) — the default (staged) create form now draws the Type row.

## Verification (real output)

\`\`\`
$ go test -race ./internal/tui/...
ok  	github.com/mpyw/suve/internal/tui	3.281s
ok  	github.com/mpyw/suve/internal/tui/data	1.355s
ok  	github.com/mpyw/suve/internal/tui/dialogs	2.402s
ok  	github.com/mpyw/suve/internal/tui/pages/browser	1.939s
ok  	github.com/mpyw/suve/internal/tui/pages/diff	2.161s
ok  	github.com/mpyw/suve/internal/tui/pages/staging	1.744s

$ golangci-lint run --allow-parallel-runners --timeout=10m
0 issues.

$ mise test
# (no FAIL / panic; full unit suite green)

$ mise build-gui
Built bin/suve — run 'suve --gui'.
\`\`\`

Staged create form golden (`TestDialog_EntryFormAWSParamGolden`), Type row now present in the default staged mode:

\`\`\`
New parameter
┃ Name
┃ >
  Type
  > String
    SecureString
    StringList
  Value
  ...
  Description
  > (optional)
  Mode
  (•) Stage    ( ) Apply immediately
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)