### PR TITLE
fix(tui): make browser pane focus visible and stop the error line from sticking (#685, #688)

### DIFF
--- a/internal/tui/browser_golden_test.go
+++ b/internal/tui/browser_golden_test.go
@@ -87,6 +87,26 @@ func TestBrowser_AWSParamGolden(t *testing.T) { //nolint:paralleltest // goldenE
 	browserGolden(t, m, "SecureString")
 }
 
+// TestBrowser_AWSParamHistoryFocusGolden renders the AWS param browser after
+// pressing enter to move focus into the version history (#685): the history pane
+// carries the active selection cursor (▸) and the `esc: list` hint, while the
+// list drops to the dimmed cursor (▹) — so the focused pane is unambiguous.
+func TestBrowser_AWSParamHistoryFocusGolden(t *testing.T) { //nolint:paralleltest // goldenEnv calls t.Setenv (NO_COLOR/TZ), which forbids t.Parallel
+	goldenEnv(t)
+
+	probe := staticProbe{keys: map[data.StagedKey]struct{}{{Name: "/app/web/BASE_URL"}: {}}}
+
+	m := newApp(config{
+		scope:     provider.Scope{Provider: provider.ProviderAWS},
+		identity:  awsIdentityFixture(),
+		sourceFor: sourceForShape("param", awsParamSource(), probe),
+	})
+
+	// Drive to the loaded state, then press enter to focus the history pane.
+	raw := captureBrowserAfterKeys(t, m, "SecureString", keyEnterMsg())
+	golden.RequireEqual(t, renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight))
+}
+
 // TestBrowser_AWSSecretGolden renders the AWS secret browser (staging labels +
 // ARN, masked value).
 func TestBrowser_AWSSecretGolden(t *testing.T) { //nolint:paralleltest // goldenEnv calls t.Setenv (NO_COLOR/TZ), which forbids t.Parallel
@@ -242,6 +262,33 @@ func browserGolden(t *testing.T, m *App, marker string) {
 
 	raw := captureUntil(t, m, marker, browserTermWidth, browserTermHeight)
 	golden.RequireEqual(t, renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight))
+}
+
+// captureBrowserAfterKeys drives a browser app to its loaded state (waiting for
+// marker), sends follow-up key presses (e.g. enter to focus the history), lets
+// the frame settle, then quits and returns the full captured stream.
+func captureBrowserAfterKeys(t *testing.T, m *App, marker string, keys ...tea.KeyPressMsg) []byte {
+	t.Helper()
+
+	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(browserTermWidth, browserTermHeight))
+
+	var buf bytes.Buffer
+
+	waitFor(t, tm, &buf, marker)
+
+	for _, k := range keys {
+		tm.Send(k)
+		time.Sleep(100 * time.Millisecond)
+
+		_, _ = io.Copy(&buf, tm.Output())
+	}
+
+	tm.Send(keyPress('q'))
+	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
+
+	_, _ = io.Copy(&buf, tm.Output())
+
+	return buf.Bytes()
 }
 
 // diffGolden drives a diff host to its loaded state at the shell size and

--- a/internal/tui/components/entrylist.go
+++ b/internal/tui/components/entrylist.go
@@ -32,6 +32,10 @@ type EntryList struct {
 	width    int
 	height   int
 	styles   styles.Styles
+	// focused reports whether the list pane currently holds keyboard focus. The
+	// selected row is drawn with the active cursor when focused and a dimmed cursor
+	// when not, so the list and history never look equally selected at once.
+	focused bool
 	// hasMore, when true, appends a "… load more (L)" footer occupying the last
 	// visible row. It is set only when the source reports a real next page (a
 	// non-empty NextToken); the un-loaded count is unknown, so no phantom number
@@ -52,6 +56,10 @@ func (l *EntryList) SetRows(rows []ListRow, hasMore bool) {
 	l.clampSelection()
 	l.ensureVisible()
 }
+
+// SetFocused sets whether the list pane holds keyboard focus, which selects the
+// active vs dimmed selection style the next View draws with.
+func (l *EntryList) SetFocused(focused bool) { l.focused = focused }
 
 // SetSize sets the list's inner content size (inside its border).
 func (l *EntryList) SetSize(width, height int) {
@@ -164,13 +172,18 @@ func (l *EntryList) renderRow(idx int) string {
 	row := l.rows[idx]
 
 	cursor := "  "
-	if idx == l.selected {
-		cursor = l.styles.StatusValue.Render("▸ ")
-	}
-
 	name := row.Name
+
 	if idx == l.selected {
-		name = l.styles.StatusValue.Render(name)
+		// A filled cursor + active style when focused; a hollow cursor + dimmed
+		// style when not, so the selection stays visible but clearly idle.
+		if l.focused {
+			cursor = l.styles.Selection.Render("▸ ")
+			name = l.styles.Selection.Render(name)
+		} else {
+			cursor = l.styles.SelectionInactive.Render("▹ ")
+			name = l.styles.SelectionInactive.Render(name)
+		}
 	}
 
 	left := cursor + name

--- a/internal/tui/components/historytable.go
+++ b/internal/tui/components/historytable.go
@@ -38,6 +38,10 @@ type HistoryTable struct {
 	height   int
 	styles   styles.Styles
 	compare  bool
+	// focused reports whether the history pane currently holds keyboard focus. The
+	// selected row is drawn with the active cursor when focused and a dimmed cursor
+	// when not, so the list and history never look equally selected at once.
+	focused bool
 	// picks holds the row indices selected for comparison (0, 1, or 2 entries).
 	picks []int
 }
@@ -55,6 +59,10 @@ func (t *HistoryTable) SetRows(rows []HistoryEntry) {
 	t.picks = nil
 	t.ensureVisible()
 }
+
+// SetFocused sets whether the history pane holds keyboard focus, which selects
+// the active vs dimmed selection style the next View draws with.
+func (t *HistoryTable) SetFocused(focused bool) { t.focused = focused }
 
 // SetSize sets the table's inner content size.
 func (t *HistoryTable) SetSize(width, height int) {
@@ -215,13 +223,21 @@ func (t *HistoryTable) renderRow(idx int) string {
 	switch {
 	case t.compare && indexOf(t.picks, idx) >= 0:
 		marker = t.styles.StatusValue.Render("◉ ")
+	case idx == t.selected && t.focused:
+		marker = t.styles.Selection.Render("▸ ")
 	case idx == t.selected:
-		marker = t.styles.StatusValue.Render("▸ ")
+		// Selected but the history pane is idle: a hollow, dimmed cursor.
+		marker = t.styles.SelectionInactive.Render("▹ ")
 	}
 
 	label := row.Label
+
 	if idx == t.selected {
-		label = t.styles.StatusValue.Render(label)
+		if t.focused {
+			label = t.styles.Selection.Render(label)
+		} else {
+			label = t.styles.SelectionInactive.Render(label)
+		}
 	}
 
 	parts := []string{marker + label}

--- a/internal/tui/components/pane.go
+++ b/internal/tui/components/pane.go
@@ -15,6 +15,19 @@ import (
 // that split a right-aligned badge onto its own row. Centralizing the framing
 // keeps every pane identical, which also keeps goldens stable.
 func Pane(st styles.Styles, title, body string, width, height int) string {
+	return renderPane(st.Pane, st, title, body, width, height)
+}
+
+// PaneFocused frames a pane exactly like Pane but with the focused border, so the
+// pane that currently holds keyboard focus is visually distinct from the idle one.
+func PaneFocused(st styles.Styles, title, body string, width, height int) string {
+	return renderPane(st.PaneFocused, st, title, body, width, height)
+}
+
+// renderPane is the shared framing body: frame is the border style to draw with
+// (Pane or PaneFocused), so the inner content sizing/normalization stays identical
+// and goldens stay stable regardless of the focus border.
+func renderPane(frame lipgloss.Style, st styles.Styles, title, body string, width, height int) string {
 	innerW, innerH := PaneInner(width, height)
 	if innerW <= 0 || innerH < 0 {
 		return ""
@@ -31,7 +44,7 @@ func Pane(st styles.Styles, title, body string, width, height int) string {
 		rows = append(rows, strings.Repeat(" ", innerW))
 	}
 
-	return st.Pane.Render(strings.Join(rows, "\n"))
+	return frame.Render(strings.Join(rows, "\n"))
 }
 
 // Pane chrome sizes: two border columns, and two border rows plus one title row.

--- a/internal/tui/pages/browser/browser.go
+++ b/internal/tui/pages/browser/browser.go
@@ -125,7 +125,16 @@ type Model struct {
 	detail          data.Detail
 	detailOK        bool
 
-	err string
+	// Error state is split per source (mirroring the staging page's per-section
+	// err and the GUI's per-source error fields) so a transient detail/history
+	// failure clears the moment that source next succeeds and never lingers over
+	// another source's correct data. listErr/detailErr/historyErr track the three
+	// content loads; stagedErr holds the launch-time staging-store hard-fail, which
+	// is a persistent condition and is not cleared by a selection change.
+	listErr    string
+	detailErr  string
+	historyErr string
+	stagedErr  string
 
 	// Monotonic sequence guards (GUI loadSeq pattern): a response is applied only
 	// when its seq still matches the latest issued one.

--- a/internal/tui/pages/browser/browser_test.go
+++ b/internal/tui/pages/browser/browser_test.go
@@ -190,6 +190,162 @@ func TestCompareSelectionOpensDiff(t *testing.T) {
 // keyForSpace builds the space key press (Bubble Tea v2 spells it "space").
 func keyForSpace() tea.KeyPressMsg { return tea.KeyPressMsg{Code: ' '} }
 
+// loadedHistoryModel builds a browser over a versioned source with a loaded
+// selection and history, rendered once so the widgets carry the page's focus.
+func loadedHistoryModel(t *testing.T) *Model {
+	t.Helper()
+
+	src := &stubSource{
+		svcCap: awsParamCap(),
+		history: []data.HistoryRow{
+			{Version: "14", Label: "#14", IsCurrent: true},
+			{Version: "13", Label: "#13"},
+		},
+	}
+	m := newModel(t, src)
+	m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{{Name: "/app/x"}}}})
+	m, _ = update(t, m, detailLoadedMsg{seq: m.detailSeq, d: data.Detail{Name: "/app/x"}})
+	m, _ = update(t, m, historyLoadedMsg{seq: m.historySeq, rows: src.history})
+
+	return m
+}
+
+// TestFocusHighlightDistinctBetweenPanes pins #685: the focused pane carries the
+// active selection cursor (▸) and the unfocused pane a dimmed one (▹), and the
+// two swap as focus moves list↔history — so the two panes never look equally
+// selected at once. Rendering the page sets each widget's focus from the page's
+// current focus, which the widget's own View then reflects.
+func TestFocusHighlightDistinctBetweenPanes(t *testing.T) {
+	t.Parallel()
+
+	m := loadedHistoryModel(t)
+	require.Equal(t, focusList, m.focus, "focus starts on the list")
+
+	_ = m.View(m.width, m.height)
+
+	assert.Contains(t, m.list.View(), "▸", "the focused list shows the active cursor")
+	assert.NotContains(t, m.list.View(), "▹", "the focused list does not show the dimmed cursor")
+	assert.Contains(t, m.history.View(), "▹", "the unfocused history shows the dimmed cursor")
+	assert.NotContains(t, m.history.View(), "▸", "the unfocused history does not show the active cursor")
+
+	// Enter moves focus into the history; the highlights swap.
+	m, _ = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.Equal(t, focusHistory, m.focus, "enter moves focus into the history")
+
+	_ = m.View(m.width, m.height)
+
+	assert.Contains(t, m.history.View(), "▸", "the focused history shows the active cursor")
+	assert.NotContains(t, m.history.View(), "▹", "the focused history does not show the dimmed cursor")
+	assert.Contains(t, m.list.View(), "▹", "the unfocused list shows the dimmed cursor")
+	assert.NotContains(t, m.list.View(), "▸", "the unfocused list does not show the active cursor")
+}
+
+// TestHistoryHeaderHintAdaptsToFocus pins #685's discoverability affordance: the
+// history header advertises `enter: history` while the list is focused and
+// `esc: list` once focus is in the history, so the enter→history / esc→list
+// transitions are visible rather than trial-and-error.
+func TestHistoryHeaderHintAdaptsToFocus(t *testing.T) {
+	t.Parallel()
+
+	m := loadedHistoryModel(t)
+
+	const width = 80
+
+	assert.Contains(t, m.historyHeaderLine(width), "enter: history", "the list advertises how to enter the history")
+	assert.NotContains(t, m.historyHeaderLine(width), "esc: list")
+
+	m, _ = update(t, m, tea.KeyPressMsg{Code: tea.KeyEnter})
+	require.Equal(t, focusHistory, m.focus)
+
+	assert.Contains(t, m.historyHeaderLine(width), "esc: list", "the history advertises how to return to the list")
+	assert.NotContains(t, m.historyHeaderLine(width), "enter: history")
+}
+
+// TestHistoryHeaderHintSuppressedWhenEmpty pins that the enter→history affordance
+// is not advertised for an entry with no versions: onSelect no-ops there, so the
+// header must not promise a transition that does nothing.
+func TestHistoryHeaderHintSuppressedWhenEmpty(t *testing.T) {
+	t.Parallel()
+
+	src := &stubSource{svcCap: awsParamCap()} // no history rows
+	m := newModel(t, src)
+	m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{{Name: "/app/x"}}}})
+	m, _ = update(t, m, detailLoadedMsg{seq: m.detailSeq, d: data.Detail{Name: "/app/x"}})
+	m, _ = update(t, m, historyLoadedMsg{seq: m.historySeq, rows: nil})
+	require.Zero(t, m.history.Len(), "the entry has no versions")
+
+	line := m.historyHeaderLine(80)
+	assert.Contains(t, line, "History", "the header title still renders")
+	assert.NotContains(t, line, "enter: history", "no false enter→history affordance for a version-less entry")
+}
+
+// TestStaleErrorClearedByLaterSuccessfulLoad pins #688: a transient history (or
+// detail) error must not linger over a later successful load. The single
+// selection funnel clears the per-source detail/history errors up front, and each
+// source also clears its own error when it next succeeds.
+func TestStaleErrorClearedByLaterSuccessfulLoad(t *testing.T) {
+	t.Parallel()
+
+	src := &stubSource{svcCap: awsParamCap()}
+	m := newModel(t, src)
+
+	items := []data.Item{{Name: "/a"}, {Name: "/b"}}
+	m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: items}})
+
+	// Entry A: the detail loads, but the history fetch fails transiently.
+	m, _ = update(t, m, detailLoadedMsg{seq: m.detailSeq, d: data.Detail{Name: "/a"}})
+	m, _ = update(t, m, historyLoadedMsg{seq: m.historySeq, err: errors.New("history fetch failed")})
+	require.Contains(t, m.historyErr, "history fetch failed")
+	require.NotEmpty(t, m.errLines(), "the transient history error is shown")
+
+	// Select entry B: the selection funnel clears the stale per-source errors up
+	// front, before B's responses even land.
+	_ = m.move(1)
+	assert.Empty(t, m.historyErr, "selecting a new entry clears the stale history error immediately")
+	assert.Empty(t, m.detailErr)
+
+	// B's detail and history both succeed → the error line stays clear.
+	m, _ = update(t, m, detailLoadedMsg{seq: m.detailSeq, d: data.Detail{Name: "/b"}})
+	m, _ = update(t, m, historyLoadedMsg{seq: m.historySeq, rows: nil})
+	assert.Empty(t, m.errLines(), "a successful load after an error clears the error line")
+}
+
+// TestDetailErrorClearedOnItsOwnSuccessfulLoad pins that a detail error clears the
+// moment a detail load succeeds, independent of the selection funnel — the
+// per-source clearing path onDetailLoaded owns.
+func TestDetailErrorClearedOnItsOwnSuccessfulLoad(t *testing.T) {
+	t.Parallel()
+
+	m := newModel(t, &stubSource{svcCap: awsParamCap()})
+	m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{{Name: "/a"}}}})
+
+	m, _ = update(t, m, detailLoadedMsg{seq: m.detailSeq, err: errors.New("show failed")})
+	require.Contains(t, m.detailErr, "show failed")
+
+	m, _ = update(t, m, detailLoadedMsg{seq: m.detailSeq, d: data.Detail{Name: "/a"}})
+	assert.Empty(t, m.detailErr, "a successful detail load clears its own error")
+	assert.True(t, m.detailOK)
+}
+
+// TestStagedErrorSurvivesSelectionChange pins the deliberate divergence: the
+// staging-store hard-fail (a launch-time key-loss) is a persistent condition, so
+// a selection change clears the transient detail/history errors but NOT the
+// staged error.
+func TestStagedErrorSurvivesSelectionChange(t *testing.T) {
+	t.Parallel()
+
+	m := newModel(t, &stubSource{svcCap: awsParamCap()})
+	m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{{Name: "/a"}, {Name: "/b"}}}})
+
+	m.stagedErr = "cannot access the staging encryption key"
+	m.detailErr = "stale detail error"
+
+	_ = m.move(1)
+
+	assert.Empty(t, m.detailErr, "the selection funnel clears the transient detail error")
+	assert.Contains(t, m.stagedErr, "staging encryption key", "the persistent staged hard-fail survives a selection change")
+}
+
 // TestMaskToggle pins that x flips the detail value pane's mask for a secret and
 // that the golden default is masked.
 func TestMaskToggle(t *testing.T) {
@@ -494,12 +650,12 @@ func TestOnStagedLoadedSurfacesStoreHardFail(t *testing.T) {
 
 	// A transient probe read error is swallowed.
 	m, _ = update(t, m, stagedLoadedMsg{seq: m.stagedSeq, err: errors.New("probe timeout")})
-	assert.Empty(t, m.err, "a transient probe error does not spam the error line")
+	assert.Empty(t, m.stagedErr, "a transient probe error does not spam the error line")
 
 	// A store-construction hard-fail (key-loss) is surfaced.
 	hard := &data.StoreUnavailableError{Err: errors.New("cannot access the staging encryption key")}
 	m, _ = update(t, m, stagedLoadedMsg{seq: m.stagedSeq, err: hard})
-	assert.Contains(t, m.err, "staging encryption key", "a key-loss hard-fail is surfaced on the read path")
+	assert.Contains(t, m.stagedErr, "staging encryption key", "a key-loss hard-fail is surfaced on the read path")
 }
 
 // TestOpenNewBlocksAllNamespaces pins the App Configuration create-block: a write

--- a/internal/tui/pages/browser/cmds.go
+++ b/internal/tui/pages/browser/cmds.go
@@ -126,8 +126,14 @@ func (m *Model) loadNamespacesCmd() tea.Cmd {
 }
 
 // selectionCmd loads the detail and history for the currently-selected item, as
-// two independent fetches.
+// two independent fetches. It clears the per-source detail/history errors up
+// front (the single selection funnel, mirroring the GUI clearing its error at the
+// start of selectParam) so a stale error from the previous entry never lingers
+// over the new selection's loads.
 func (m *Model) selectionCmd() tea.Cmd {
+	m.detailErr = ""
+	m.historyErr = ""
+
 	item, ok := m.selectedItem()
 	if !ok {
 		m.detailOK = false

--- a/internal/tui/pages/browser/update.go
+++ b/internal/tui/pages/browser/update.go
@@ -72,12 +72,12 @@ func (m *Model) onListLoaded(msg listLoadedMsg) tea.Cmd {
 	m.loading = false
 
 	if msg.err != nil {
-		m.err = msg.err.Error()
+		m.listErr = msg.err.Error()
 
 		return nil
 	}
 
-	m.err = ""
+	m.listErr = ""
 
 	// Preserve the selection by IDENTITY, not index. A replace can insert or
 	// remove rows above the selection, so capture the selected entry's key first
@@ -103,37 +103,42 @@ func (m *Model) onListLoaded(msg listLoadedMsg) tea.Cmd {
 	return m.selectionCmd()
 }
 
-// onDetailLoaded applies a detail response and loads it into the value pane.
+// onDetailLoaded applies a detail response and loads it into the value pane. A
+// successful load clears the detail error so a prior transient failure never
+// lingers over the freshly-loaded value.
 func (m *Model) onDetailLoaded(msg detailLoadedMsg) {
 	if msg.seq != m.detailSeq {
 		return
 	}
 
 	if msg.err != nil {
-		m.err = msg.err.Error()
+		m.detailErr = msg.err.Error()
 		m.detailOK = false
 
 		return
 	}
 
+	m.detailErr = ""
 	m.detail = msg.d
 	m.detailOK = true
 	m.valuePane.SetValue(msg.d.Value, msg.d.Secret)
 }
 
-// onHistoryLoaded applies a history response. A history error is surfaced on the
-// error line but never clears the already-loaded value.
+// onHistoryLoaded applies a history response. A history error is surfaced on its
+// own error line (never clearing the already-loaded value); a successful load
+// clears it so a prior transient failure never lingers over good history.
 func (m *Model) onHistoryLoaded(msg historyLoadedMsg) {
 	if msg.seq != m.historySeq {
 		return
 	}
 
 	if msg.err != nil {
-		m.err = msg.err.Error()
+		m.historyErr = msg.err.Error()
 
 		return
 	}
 
+	m.historyErr = ""
 	m.history.SetRows(historyEntries(m.styles, msg.rows, m.svcCap.TagsPerVersion))
 	m.historyVersions = versionIDs(msg.rows)
 }
@@ -152,12 +157,13 @@ func (m *Model) onStagedLoaded(msg stagedLoadedMsg) tea.Cmd {
 	if msg.err != nil {
 		var storeErr *data.StoreUnavailableError
 		if errors.As(msg.err, &storeErr) {
-			m.err = storeErr.Error()
+			m.stagedErr = storeErr.Error()
 		}
 
 		return nil
 	}
 
+	m.stagedErr = ""
 	m.stagedKeys = msg.keys
 	m.rebuildRows()
 
@@ -165,6 +171,22 @@ func (m *Model) onStagedLoaded(msg stagedLoadedMsg) tea.Cmd {
 	count := len(msg.keys)
 
 	return func() tea.Msg { return nav.StagedCount{Service: service, Count: count} }
+}
+
+// errLines returns the active error lines in a stable order — list, detail,
+// history, then the staging-store hard-fail — each owned by its own source so a
+// transient failure clears when that source next succeeds without masking or
+// lingering over another source's state.
+func (m *Model) errLines() []string {
+	lines := make([]string, 0, 4) //nolint:mnd // the four error sources
+
+	for _, e := range []string{m.listErr, m.detailErr, m.historyErr, m.stagedErr} {
+		if e != "" {
+			lines = append(lines, e)
+		}
+	}
+
+	return lines
 }
 
 // reload re-fetches the list and staged flags after a mutation (the app forwards

--- a/internal/tui/pages/browser/view.go
+++ b/internal/tui/pages/browser/view.go
@@ -24,8 +24,8 @@ func (m *Model) View(width, height int) string {
 	parts := []string{header}
 	offset := headerH
 
-	if m.err != "" {
-		parts = append(parts, m.styles.ErrorText.Render(clip(m.err, width)))
+	for _, line := range m.errLines() {
+		parts = append(parts, m.styles.ErrorText.Render(clip(line, width)))
 		offset++
 	}
 
@@ -106,10 +106,15 @@ func (m *Model) renderStacked(width, height, yOffset int) string {
 	return lipgloss.JoinVertical(lipgloss.Left, listPane, detailPane)
 }
 
-// renderListPane sizes the list widget, records its geometry, and frames it.
+// renderListPane sizes the list widget, records its geometry, and frames it. The
+// pane is drawn focused (accent border, active selection cursor) when the list
+// holds keyboard focus, so the user can see where the arrow keys will land.
 func (m *Model) renderListPane(width, height, paneTop, paneLeft int) string {
 	innerW, innerH := components.PaneInner(width, height)
 	m.list.SetSize(innerW, innerH)
+
+	focused := m.focus == focusList
+	m.list.SetFocused(focused)
 
 	m.geom.listTop = paneTop + paneContentTop
 	m.geom.listLeft = paneLeft + paneBorderLeft
@@ -118,11 +123,12 @@ func (m *Model) renderListPane(width, height, paneTop, paneLeft int) string {
 
 	title := "entries (" + strconv.Itoa(m.list.Len()) + ")"
 
-	return components.Pane(m.styles, title, m.list.View(), width, height)
+	return framePane(m.styles, focused, title, m.list.View(), width, height)
 }
 
 // renderDetailPane sizes the detail widgets, records the history geometry, and
-// frames the detail.
+// frames the detail. The pane is drawn focused when the history holds keyboard
+// focus (the detail pane's only navigable widget), so the active pane is obvious.
 func (m *Model) renderDetailPane(width, height, paneTop, paneLeft int) string {
 	innerW, innerH := components.PaneInner(width, height)
 
@@ -139,7 +145,16 @@ func (m *Model) renderDetailPane(width, height, paneTop, paneLeft int) string {
 	m.geom.historyRight = m.geom.historyLeft + innerW
 	m.geom.historyRows = historyRows
 
-	return components.Pane(m.styles, title, body, width, height)
+	return framePane(m.styles, m.focus == focusHistory, title, body, width, height)
+}
+
+// framePane frames a pane with the focused border when focused, else the idle one.
+func framePane(st styles.Styles, focused bool, title, body string, width, height int) string {
+	if focused {
+		return components.PaneFocused(st, title, body, width, height)
+	}
+
+	return components.Pane(st, title, body, width, height)
 }
 
 // renderDetail builds the detail body and returns the line offset (within the
@@ -179,6 +194,7 @@ func (m *Model) renderDetail(innerW, innerH int) (string, int, int) {
 	historyLocalTop := len(lines)
 	historyH := max(innerH-historyLocalTop, 0)
 	m.history.SetSize(innerW, historyH)
+	m.history.SetFocused(m.focus == focusHistory)
 	lines = append(lines, strings.Split(m.history.View(), "\n")...)
 
 	return fitLines(lines, innerH), historyLocalTop, historyH
@@ -232,14 +248,29 @@ func (m *Model) tagLine(width int) string {
 	return fieldLine(m.styles, "Tags", tagsInline(m.detail.Tags), width)
 }
 
-// historyHeaderLine renders the "History  c: compare mode" row.
+// historyHeaderLine renders the "History  <hint>" row. The hint adapts to focus so
+// the enter→history / esc→list transitions are discoverable: from the list it
+// advertises `enter: history`; in the history it advertises `esc: list`; in
+// compare mode it advertises the pick/diff/exit keys.
 func (m *Model) historyHeaderLine(width int) string {
-	hint := "c: compare mode"
-	if m.history.Compare() {
+	title := m.styles.PaneTitle.Render("History")
+
+	var hint string
+
+	switch {
+	case m.history.Compare():
 		hint = "space: pick · enter: diff · esc: exit"
+	case m.history.Len() == 0:
+		// No versions: neither entering the history nor compare mode does anything,
+		// so advertise no (false) transition.
+		return clip(title, width)
+	case m.focus == focusHistory:
+		hint = "esc: list · c: compare mode"
+	default:
+		hint = "enter: history · c: compare mode"
 	}
 
-	return clip(m.styles.PaneTitle.Render("History")+"   "+m.styles.PageHint.Render(hint), width)
+	return clip(title+"   "+m.styles.PageHint.Render(hint), width)
 }
 
 // isSelectedStaged reports whether the selected entry has staged changes. It

--- a/internal/tui/styles/styles.go
+++ b/internal/tui/styles/styles.go
@@ -34,8 +34,17 @@ type Styles struct {
 
 	// Pane frames a titled content pane (the list and detail boxes).
 	Pane lipgloss.Style
+	// PaneFocused frames the pane that currently holds keyboard focus, with an
+	// accent border so the active pane reads as distinct from the idle one.
+	PaneFocused lipgloss.Style
 	// PaneTitle styles a pane's title line.
 	PaneTitle lipgloss.Style
+	// Selection styles the selected row in the pane that currently holds focus
+	// (the active cursor).
+	Selection lipgloss.Style
+	// SelectionInactive styles the selected row in a pane that does NOT hold focus,
+	// dimmed so the two panes never look equally selected at once.
+	SelectionInactive lipgloss.Style
 	// FieldLabel styles a metadata row label (e.g. "Version").
 	FieldLabel lipgloss.Style
 	// Banner styles the detail pane's staged-changes warning banner.
@@ -67,14 +76,19 @@ func New() Styles {
 			HelpBar:     lipgloss.NewStyle(),
 			Dialog:      lipgloss.NewStyle().Border(lipgloss.RoundedBorder()),
 			Pane:        lipgloss.NewStyle().Border(lipgloss.RoundedBorder()),
-			PaneTitle:   lipgloss.NewStyle().Bold(true),
-			FieldLabel:  lipgloss.NewStyle(),
-			Banner:      lipgloss.NewStyle(),
-			ErrorText:   lipgloss.NewStyle().Bold(true),
-			DiffHeader:  lipgloss.NewStyle().Bold(true),
-			DiffHunk:    lipgloss.NewStyle(),
-			DiffAdded:   lipgloss.NewStyle(),
-			DiffRemoved: lipgloss.NewStyle(),
+			// No color to distinguish the focused pane border under NO_COLOR; the
+			// selection marker and the adaptive hint carry the focus cue instead.
+			PaneFocused:       lipgloss.NewStyle().Border(lipgloss.RoundedBorder()),
+			PaneTitle:         lipgloss.NewStyle().Bold(true),
+			Selection:         lipgloss.NewStyle().Bold(true),
+			SelectionInactive: lipgloss.NewStyle(),
+			FieldLabel:        lipgloss.NewStyle(),
+			Banner:            lipgloss.NewStyle(),
+			ErrorText:         lipgloss.NewStyle().Bold(true),
+			DiffHeader:        lipgloss.NewStyle().Bold(true),
+			DiffHunk:          lipgloss.NewStyle(),
+			DiffAdded:         lipgloss.NewStyle(),
+			DiffRemoved:       lipgloss.NewStyle(),
 		}
 	}
 
@@ -89,23 +103,26 @@ func New() Styles {
 	)
 
 	return Styles{
-		StatusBar:   lipgloss.NewStyle().Bold(true).Foreground(fgBright),
-		StatusKey:   lipgloss.NewStyle().Foreground(muted),
-		StatusValue: lipgloss.NewStyle().Foreground(accent).Bold(true),
-		TabActive:   lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("0")).Background(accent).Padding(0, 1),
-		TabInactive: lipgloss.NewStyle().Foreground(subtle).Padding(0, 1),
-		Separator:   lipgloss.NewStyle().Foreground(muted),
-		PageHint:    lipgloss.NewStyle().Foreground(muted).Italic(true),
-		HelpBar:     lipgloss.NewStyle().Foreground(muted),
-		Dialog:      lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Foreground(fgBright).Padding(0, 1),
-		Pane:        lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(muted),
-		PaneTitle:   lipgloss.NewStyle().Bold(true).Foreground(accent),
-		FieldLabel:  lipgloss.NewStyle().Foreground(muted),
-		Banner:      lipgloss.NewStyle().Foreground(yellow),
-		ErrorText:   lipgloss.NewStyle().Bold(true).Foreground(red),
-		DiffHeader:  lipgloss.NewStyle().Bold(true).Foreground(accent),
-		DiffHunk:    lipgloss.NewStyle().Foreground(muted),
-		DiffAdded:   lipgloss.NewStyle().Foreground(green),
-		DiffRemoved: lipgloss.NewStyle().Foreground(red),
+		StatusBar:         lipgloss.NewStyle().Bold(true).Foreground(fgBright),
+		StatusKey:         lipgloss.NewStyle().Foreground(muted),
+		StatusValue:       lipgloss.NewStyle().Foreground(accent).Bold(true),
+		TabActive:         lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("0")).Background(accent).Padding(0, 1),
+		TabInactive:       lipgloss.NewStyle().Foreground(subtle).Padding(0, 1),
+		Separator:         lipgloss.NewStyle().Foreground(muted),
+		PageHint:          lipgloss.NewStyle().Foreground(muted).Italic(true),
+		HelpBar:           lipgloss.NewStyle().Foreground(muted),
+		Dialog:            lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Foreground(fgBright).Padding(0, 1),
+		Pane:              lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(muted),
+		PaneFocused:       lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(accent),
+		PaneTitle:         lipgloss.NewStyle().Bold(true).Foreground(accent),
+		Selection:         lipgloss.NewStyle().Foreground(accent).Bold(true),
+		SelectionInactive: lipgloss.NewStyle().Foreground(subtle),
+		FieldLabel:        lipgloss.NewStyle().Foreground(muted),
+		Banner:            lipgloss.NewStyle().Foreground(yellow),
+		ErrorText:         lipgloss.NewStyle().Bold(true).Foreground(red),
+		DiffHeader:        lipgloss.NewStyle().Bold(true).Foreground(accent),
+		DiffHunk:          lipgloss.NewStyle().Foreground(muted),
+		DiffAdded:         lipgloss.NewStyle().Foreground(green),
+		DiffRemoved:       lipgloss.NewStyle().Foreground(red),
 	}
 }

--- a/internal/tui/testdata/TestBrowser_AWSParamGolden.golden
+++ b/internal/tui/testdata/TestBrowser_AWSParamGolden.golden
@@ -14,8 +14,8 @@ prefix: —   filter: —   values:off  recursive:on  ⟳
 │                                            ││Modified    2026-07-01 09:30:00                                         │
 │                                            ││Tags        env=prod · team=api                                         │
 │                                            ││                                                                        │
-│                                            ││History   c: compare mode                                               │
-│                                            ││▸ #14  2026-07-01  current                                              │
+│                                            ││History   enter: history · c: compare mode                              │
+│                                            ││▹ #14  2026-07-01  current                                              │
 │                                            ││  #13  2026-06-24                                                       │
 │                                            ││  #12  2026-06-02                                                       │
 │                                            ││                                                                        │

--- a/internal/tui/testdata/TestBrowser_AWSParamHistoryFocusGolden.golden
+++ b/internal/tui/testdata/TestBrowser_AWSParamHistoryFocusGolden.golden
@@ -1,24 +1,24 @@
-suve  azure · vault:myvault
- Key Vault Staging
+suve  aws · profile:dev · account:123456789012 · region:ap-northeast-1
+ Param Secret Staging(1)
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-prefix: —   filter: —   values:off  ⟳
+prefix: —   filter: —   values:off  recursive:on  ⟳
 ╭────────────────────────────────────────────╮╭────────────────────────────────────────────────────────────────────────╮
-│entries (2)                                 ││api-token                                                               │
-│▸ api-token                                 ││Value   (x to reveal)                                                   │
-│  vault-secret                              ││•••••••••••••••                                                         │
+│entries (3)                                 ││/app/api/DATABASE_URL                                                   │
+│▹ /app/api/DATABASE_URL                     ││Value   (x to reveal)                                                   │
+│  /app/api/REDIS_URL                        ││••••••••••••••••••••••••                                                │
+│  /app/web/BASE_URL                 [staged]││                                                                        │
 │                                            ││                                                                        │
 │                                            ││                                                                        │
+│                                            ││Version     14 (current)                                                │
+│                                            ││Type        SecureString                                                │
+│                                            ││Modified    2026-07-01 09:30:00                                         │
+│                                            ││Tags        env=prod · team=api                                         │
 │                                            ││                                                                        │
-│                                            ││Version ID  9f8e7d6c5b4a                                                │
-│                                            ││Created     2026-07-01 09:30:00                                         │
-│                                            ││State       enabled                                                     │
-│                                            ││Tags        rotation=2026Q2                                             │
+│                                            ││History   esc: list · c: compare mode                                   │
+│                                            ││▸ #14  2026-07-01  current                                              │
+│                                            ││  #13  2026-06-24                                                       │
+│                                            ││  #12  2026-06-02                                                       │
 │                                            ││                                                                        │
-│                                            ││History   enter: history · c: compare mode                              │
-│                                            ││▹ 9f8e7d6c…  2026-07-01  current  [enabled]                             │
-│                                            ││     tags: rotation=2026Q2                                              │
-│                                            ││  4c3b2a19…  2026-06-24  [disabled]                                     │
-│                                            ││     tags: rotation=2026Q1                                              │
 │                                            ││                                                                        │
 │                                            ││                                                                        │
 │                                            ││                                                                        │

--- a/internal/tui/testdata/TestBrowser_AWSSecretGolden.golden
+++ b/internal/tui/testdata/TestBrowser_AWSSecretGolden.golden
@@ -15,8 +15,8 @@ prefix: —   filter: —   values:off  ⟳
 │                                            ││Labels      AWSCURRENT                                                  │
 │                                            ││Tags        (none)                                                      │
 │                                            ││                                                                        │
-│                                            ││History   c: compare mode                                               │
-│                                            ││▸ a1b2c3d4…  2026-07-01  current  [AWSCURRENT]                          │
+│                                            ││History   enter: history · c: compare mode                              │
+│                                            ││▹ a1b2c3d4…  2026-07-01  current  [AWSCURRENT]                          │
 │                                            ││  e5f6a7b8…  2026-06-24  [AWSPREVIOUS]                                  │
 │                                            ││                                                                        │
 │                                            ││                                                                        │

--- a/internal/tui/testdata/TestBrowser_GCloudSecretGolden.golden
+++ b/internal/tui/testdata/TestBrowser_GCloudSecretGolden.golden
@@ -14,8 +14,8 @@ prefix: —   filter: —   values:off  ⟳
 │                                            ││State       enabled                                                     │
 │                                            ││Tags        (none)                                                      │
 │                                            ││                                                                        │
-│                                            ││History   c: compare mode                                               │
-│                                            ││▸ 3  2026-07-01  current  [enabled]                                     │
+│                                            ││History   enter: history · c: compare mode                              │
+│                                            ││▹ 3  2026-07-01  current  [enabled]                                     │
 │                                            ││  2  2026-06-24  [disabled]                                             │
 │                                            ││  1  2026-06-02  [destroyed]                                            │
 │                                            ││                                                                        │


### PR DESCRIPTION
Closes #685
Closes #688

Two coupled display bugs in the TUI browser page (`internal/tui/pages/browser/`), fixed together so the page's rendering/state changes stay coherent.

## #685 — focused pane was invisible; enter→history undiscoverable

The list and history panes both drew their selected row with the same unconditional active highlight, so both looked selected at once and nothing told the user that `enter` moves focus into the history (or `esc` back).

Following the maintainer decision (dim the unfocused pane's selection, emphasize the focused pane, add `enter: history` / `esc: list` hints) and the GUI's focus model:

- Each widget (`EntryList`, `HistoryTable`) gains a `focused` flag. The focused pane draws the **active** cursor `▸` in the accent/bold style; the idle pane draws a **dimmed hollow** cursor `▹` — so the two panes never look equally selected.
- The focused pane gets an accent border (`Styles.PaneFocused`, via `components.PaneFocused`); under `NO_COLOR` this collapses to the plain border, so the marker + hint carry the cue in captured output.
- The History header hint is now adaptive: `enter: history` while the list is focused, `esc: list` while the history is focused, the pick/diff/exit keys in compare mode, and **no** hint for a version-less entry (where `onSelect` no-ops) — no false affordance.

## #688 — error line was sticky

The browser had a single shared `m.err`, cleared **only** by a successful list load. A transient detail/history error therefore lingered over a later entry whose loads all succeeded.

Mirroring the GUI's per-source error lifecycle (`selectParam` clears its error up front) and the staging page's per-section `err`:

- `m.err` is split into `listErr` / `detailErr` / `historyErr` / `stagedErr`; each is cleared the moment its own source next succeeds.
- `selectionCmd` (the single selection funnel) clears the transient detail/history errors up front, so a stale error never survives navigating to a new entry.
- The staging-store hard-fail (`stagedErr`, a launch-time key-loss) is a persistent condition and is deliberately **not** cleared by a selection change.

## Tests (TUI: Go unit + teatest golden)

This behavior lives only in the TUI render layer, so coverage is the two TUI layers:

- **Update-level unit tests** (`internal/tui/pages/browser/browser_test.go`): focus-marker swap across panes on `enter`; adaptive header hint (list vs history vs empty); stale history error cleared by a later successful load; detail error cleared on its own success; staged hard-fail surviving a selection change.
- **teatest golden**: new `TestBrowser_AWSParamHistoryFocusGolden` captures the history-focused frame (inverse highlights + `esc: list`); the existing browser goldens now capture the list-focused frame with the dimmed history selection.

## Verification

\`\`\`
$ go test ./internal/tui/pages/browser/... -run 'TestFocus|TestHistoryHeaderHint|TestStaleError|TestDetailErrorCleared|TestStagedErrorSurvives' -v
=== RUN   TestFocusHighlightDistinctBetweenPanes
=== RUN   TestHistoryHeaderHintAdaptsToFocus
=== RUN   TestHistoryHeaderHintSuppressedWhenEmpty
=== RUN   TestStaleErrorClearedByLaterSuccessfulLoad
=== RUN   TestDetailErrorClearedOnItsOwnSuccessfulLoad
=== RUN   TestStagedErrorSurvivesSelectionChange
--- PASS: TestStagedErrorSurvivesSelectionChange (0.00s)
--- PASS: TestStaleErrorClearedByLaterSuccessfulLoad (0.00s)
--- PASS: TestDetailErrorClearedOnItsOwnSuccessfulLoad (0.00s)
--- PASS: TestHistoryHeaderHintSuppressedWhenEmpty (0.00s)
--- PASS: TestHistoryHeaderHintAdaptsToFocus (0.00s)
--- PASS: TestFocusHighlightDistinctBetweenPanes (0.00s)
PASS
ok  	github.com/mpyw/suve/internal/tui/pages/browser	0.183s

$ go test -race ./internal/tui/...
ok  	github.com/mpyw/suve/internal/tui	3.694s
ok  	github.com/mpyw/suve/internal/tui/data	1.835s
ok  	github.com/mpyw/suve/internal/tui/dialogs	2.202s
ok  	github.com/mpyw/suve/internal/tui/pages/browser	2.413s
ok  	github.com/mpyw/suve/internal/tui/pages/diff	1.996s
ok  	github.com/mpyw/suve/internal/tui/pages/staging	1.532s

$ golangci-lint run --allow-parallel-runners --timeout=10m
0 issues.

$ mise build-gui
✓ built in 1.03s
Built bin/suve — run 'suve --gui'.
\`\`\`

### Golden: list-focused vs history-focused (the same frame, focus swapped)

List focused (`entries` pane) — active `▸` on the list, dimmed `▹` on history, `enter: history`:
\`\`\`
│▸ /app/api/DATABASE_URL                     ││History   enter: history · c: compare mode                              │
│  /app/api/REDIS_URL                        ││▹ #14  2026-07-01  current                                              │
\`\`\`

History focused (after `enter`) — dimmed `▹` on the list, active `▸` on history, `esc: list`:
\`\`\`
│▹ /app/api/DATABASE_URL                     ││History   esc: list · c: compare mode                                   │
│  /app/api/REDIS_URL                        ││▸ #14  2026-07-01  current                                              │
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)