### PR TITLE
fix(tui): scroll the staging apply-results view (#687)

### DIFF
--- a/internal/tui/dialogs/apply.go
+++ b/internal/tui/dialogs/apply.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"charm.land/bubbles/v2/key"
+	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
@@ -24,6 +25,14 @@ const dialogChrome = 4
 // minDialogContent floors the wrap width so a very narrow terminal still wraps
 // to something legible rather than one column.
 const minDialogContent = 24
+
+// resultsChrome is the vertical overhead the results view reserves around its
+// scrollable body so the box fits the screen: the shell's dialog border (top +
+// bottom = 2 rows), the pinned "Apply results" title plus its blank spacer
+// (2 rows), and the pinned blank spacer plus close hint (2 rows). The viewport
+// height is capped at screenHeight−resultsChrome so a long fan-out result list
+// scrolls inside the box while the title and close hint stay visible.
+const resultsChrome = 6
 
 // applyControl identifies a focusable row in the apply confirmation.
 type applyControl int
@@ -68,9 +77,18 @@ type applyDialog struct {
 	results         []data.StagingApplyResult
 	err             string
 	title           string
-	// width is the terminal width (from the last WindowSizeMsg); the results view
-	// wraps its lines to width−dialogChrome so the box never overflows the screen.
-	width int
+	// width / height are the terminal size (from the last WindowSizeMsg). The
+	// results view wraps its lines to width−dialogChrome so the box never overflows
+	// horizontally, and caps the scrollable body at height−resultsChrome so a long
+	// result list scrolls instead of clipping off-screen.
+	width  int
+	height int
+	// vp scrolls the results body when it is taller than the box can show; the
+	// title and close hint are rendered outside it so they stay pinned.
+	vp viewport.Model
+	// scrollable records whether the last synced body overflowed the viewport, so
+	// the close hint can advertise the scroll keys only when they do something.
+	scrollable bool
 }
 
 // ApplyInput configures an apply dialog.
@@ -99,6 +117,7 @@ func NewApply(in ApplyInput) Model {
 		tagCount:   in.TagCount,
 		styles:     in.Styles,
 		title:      in.Title,
+		vp:         viewport.New(),
 	}
 }
 
@@ -119,7 +138,8 @@ func (d *applyDialog) DismissCmd() tea.Cmd {
 func (d *applyDialog) Update(msg tea.Msg) (Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		d.width = msg.Width
+		d.width, d.height = msg.Width, msg.Height
+		d.syncViewport()
 
 		return d, nil
 	case applyResultsMsg:
@@ -130,7 +150,16 @@ func (d *applyDialog) Update(msg tea.Msg) (Model, tea.Cmd) {
 			d.err = msg.err.Error()
 		}
 
+		d.syncViewport()
+
 		return d, nil
+	case tea.MouseWheelMsg:
+		// Wheel scrolls the results body (the confirm phase has nothing to scroll).
+		var cmd tea.Cmd
+
+		d.vp, cmd = d.vp.Update(msg)
+
+		return d, cmd
 	case tea.KeyPressMsg:
 		return d.handleKey(msg)
 	}
@@ -171,7 +200,13 @@ func (d *applyDialog) handleKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 			return d, doneCmd("", d.summary(), true)
 		}
 
-		return d, nil
+		// Any other key scrolls the results body (↑↓/j/k, pgup/pgdn, etc.); Esc is
+		// intercepted by the shell before it reaches here, so it still closes.
+		var cmd tea.Cmd
+
+		d.vp, cmd = d.vp.Update(msg)
+
+		return d, cmd
 	}
 
 	return d.handleConfirmKey(msg)
@@ -279,11 +314,68 @@ func (d *applyDialog) changesLine() string {
 	return pluralize(d.entryCount, "entry", "entries") + " · " + pluralize(d.tagCount, "tag change", "tag changes")
 }
 
+// sized reports whether a WindowSizeMsg has arrived, so the results view knows
+// whether it may cap the body to the screen (a viewport with a zero width/height
+// renders nothing).
+func (d *applyDialog) sized() bool { return d.width > 0 && d.height > 0 }
+
+// syncViewport (re)builds the scrollable results body and sizes the viewport to
+// min(needed, screenHeight−resultsChrome), so a long fan-out result list scrolls
+// inside the box while the title and close hint stay pinned. It is a no-op until
+// a WindowSizeMsg arrives (before that the results view renders inline, uncapped).
+func (d *applyDialog) syncViewport() {
+	if !d.sized() {
+		return
+	}
+
+	body := d.resultsBody()
+	lines := max(lipgloss.Height(body), 1)
+	avail := max(d.height-resultsChrome, 1)
+	height := min(lines, avail)
+
+	d.scrollable = lines > height
+	d.vp.SetWidth(d.contentWidth())
+	d.vp.SetHeight(height)
+	d.vp.SetContent(body)
+}
+
 func (d *applyDialog) resultsView() string {
 	var b strings.Builder
 
 	b.WriteString(d.styles.PaneTitle.Render("Apply results"))
 	b.WriteString("\n\n")
+
+	// Once sized, the body scrolls inside the viewport; before the first
+	// WindowSizeMsg it renders inline (uncapped) so a size-less unit render still
+	// shows every line.
+	if d.sized() {
+		b.WriteString(d.vp.View())
+	} else {
+		b.WriteString(d.resultsBody())
+	}
+
+	b.WriteString("\n\n")
+	b.WriteString(d.styles.PageHint.Render(d.resultsHint()))
+
+	return b.String()
+}
+
+// resultsHint pins the close hint, advertising the scroll keys only when the body
+// actually overflows the viewport.
+func (d *applyDialog) resultsHint() string {
+	if d.scrollable {
+		return "↑↓/pgup/pgdn: scroll · enter/esc: close"
+	}
+
+	return "enter/esc: close"
+}
+
+// resultsBody renders the scrollable results content: the hard-failure banner (if
+// any) followed by every service's entry/tag statuses, conflicts, and unstage
+// warnings. The trailing blank each service block leaves is trimmed so the pinned
+// close hint sits one blank line below the body.
+func (d *applyDialog) resultsBody() string {
+	var b strings.Builder
 
 	if d.err != "" {
 		b.WriteString(d.fit(d.styles.ErrorText.Render(d.err)) + "\n\n")
@@ -293,9 +385,7 @@ func (d *applyDialog) resultsView() string {
 		d.writeServiceResults(&b, res)
 	}
 
-	b.WriteString(d.styles.PageHint.Render("enter/esc: close"))
-
-	return b.String()
+	return strings.TrimRight(b.String(), "\n")
 }
 
 // writeServiceResults appends one service's entry/tag statuses, conflicts, and

--- a/internal/tui/dialogs/apply_test.go
+++ b/internal/tui/dialogs/apply_test.go
@@ -3,6 +3,7 @@ package dialogs
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
@@ -122,6 +123,156 @@ func TestApply_FanOutAggregation(t *testing.T) {
 	assert.Contains(t, view, "s1", "the secret result is shown")
 	assert.Contains(t, view, "Param", "results are grouped by service")
 	assert.Contains(t, view, "Secret")
+}
+
+// pressPgDown sends a page-down key press (viewport scrolling).
+func pressPgDown() tea.KeyPressMsg { return tea.KeyPressMsg{Code: tea.KeyPgDown} }
+
+// manyEntries builds n distinct applied-entry results, named entry-000…entry-NNN
+// so a test can locate the first vs last in the rendered viewport.
+func manyEntries(n int) []data.ApplyEntryResult {
+	entries := make([]data.ApplyEntryResult, n)
+	for i := range entries {
+		entries[i] = data.ApplyEntryResult{Name: fmt.Sprintf("entry-%03d", i), Status: "updated"}
+	}
+
+	return entries
+}
+
+// appliedResults builds an apply dialog, sizes it to a fixed 100×24 terminal, and
+// drives it through the confirm → apply → results transition with the given
+// single-service result, returning the concrete dialog in its results phase. The
+// 24-row height is short enough that a many-entry body must scroll.
+func appliedResults(t *testing.T, result data.StagingApplyResult) *applyDialog {
+	t.Helper()
+
+	const (
+		width  = 100
+		height = 24
+	)
+
+	svc := &stubStaging{service: "param", label: "Param", result: result}
+
+	m := NewApply(ApplyInput{
+		Ctx: context.Background(), Targets: []data.StagingService{svc},
+		TargetLine: "aws", Title: "Apply staged changes — Param", EntryCount: len(result.Entries), Styles: styles.New(),
+	})
+
+	m, _ = m.Update(tea.WindowSizeMsg{Width: width, Height: height})
+	m, _ = m.Update(pressDown()) // focus Apply
+	m, cmd := m.Update(pressEnter())
+	m = drive(t, m, cmd) // run the fan-out command and fold in the results
+
+	d, ok := m.(*applyDialog)
+	require.True(t, ok, "the apply dialog is an *applyDialog")
+	require.Equal(t, phaseResults, d.phase, "the dialog reached the results phase")
+
+	return d
+}
+
+// TestApply_ResultsScrollable pins the #687 fix: a result set taller than the box
+// is capped into a scrollable viewport, the close hint stays pinned (never clipped
+// off-screen), and paging down reaches the tail that was hidden at the top.
+func TestApply_ResultsScrollable(t *testing.T) {
+	t.Parallel()
+
+	const entries = 50
+
+	// A short terminal: the 50-line body cannot fit, so it must scroll.
+	d := appliedResults(t, data.StagingApplyResult{
+		ServiceLabel: "Param", Entries: manyEntries(entries),
+	})
+
+	assert.True(t, d.scrollable, "a body taller than the box scrolls")
+	assert.Equal(t, entries, d.vp.TotalLineCount(), "every result line is in the viewport")
+	assert.Less(t, d.vp.Height(), entries, "the viewport is capped below the full body height")
+	assert.True(t, d.vp.AtTop(), "the results open scrolled to the top")
+
+	top := d.View()
+	assert.Contains(t, top, "enter/esc: close", "the close hint is pinned even with a long body")
+	assert.Contains(t, top, "scroll", "the hint advertises the scroll keys when the body overflows")
+	assert.Contains(t, top, "entry-000", "the first result is visible at the top")
+	assert.NotContains(t, top, "entry-049", "the last result is below the fold at the top")
+
+	// Page down until the tail is reached (a bounded loop: each page advances by
+	// the viewport height, so the body is exhausted well within `entries` presses).
+	// Update mutates the pointer receiver in place, so d reflects each scroll.
+	for range entries {
+		if d.vp.AtBottom() {
+			break
+		}
+
+		_, _ = d.Update(pressPgDown())
+	}
+
+	assert.True(t, d.vp.AtBottom(), "paging down reaches the bottom of the results")
+
+	bottom := d.View()
+	assert.Contains(t, bottom, "entry-049", "the previously-hidden last result is reachable by scrolling")
+	assert.Contains(t, bottom, "enter/esc: close", "the close hint stays pinned after scrolling")
+}
+
+// TestApply_ResultsMouseWheelScrolls pins that the mouse wheel scrolls the results
+// body (the #687 report noted the wheel was dropped): a wheel-down event advances
+// the viewport off the top.
+func TestApply_ResultsMouseWheelScrolls(t *testing.T) {
+	t.Parallel()
+
+	d := appliedResults(t, data.StagingApplyResult{
+		ServiceLabel: "Param", Entries: manyEntries(50),
+	})
+	require.True(t, d.vp.AtTop(), "the results open at the top")
+
+	_, _ = d.Update(tea.MouseWheelMsg{Button: tea.MouseWheelDown})
+
+	assert.False(t, d.vp.AtTop(), "a wheel-down event scrolls the results body")
+}
+
+// TestApply_ResultsShortNoScroll pins that a body that fits renders inline (no
+// scroll): the viewport is sized to the exact body height, nothing is clipped,
+// and the hint does not advertise scroll keys that would do nothing.
+func TestApply_ResultsShortNoScroll(t *testing.T) {
+	t.Parallel()
+
+	d := appliedResults(t, data.StagingApplyResult{
+		ServiceLabel: "Param",
+		Entries: []data.ApplyEntryResult{
+			{Name: "entry-000", Status: "updated"},
+			{Name: "entry-001", Status: "created"},
+		},
+	})
+
+	assert.False(t, d.scrollable, "a body that fits does not scroll")
+	assert.Equal(t, 2, d.vp.TotalLineCount(), "both result lines are present")
+
+	view := d.View()
+	assert.Contains(t, view, "entry-000", "the first result renders")
+	assert.Contains(t, view, "entry-001", "the second result renders")
+	assert.Contains(t, view, "enter/esc: close", "the close hint renders")
+	assert.NotContains(t, view, "scroll", "no scroll keys are advertised when the body fits")
+}
+
+// TestApply_ScrollThenDismissReloads pins that the #669 Esc-reload behavior
+// survives scrolling: after paging through a long results list, dismissing with
+// Back (DismissCmd) still emits the pop+reload+voice MutationDoneMsg.
+func TestApply_ScrollThenDismissReloads(t *testing.T) {
+	t.Parallel()
+
+	d := appliedResults(t, data.StagingApplyResult{
+		ServiceLabel: "Param", Entries: manyEntries(50),
+	})
+
+	// Scroll down; Esc (routed by the shell to DismissCmd) must still reload.
+	m, _ := d.Update(pressPgDown())
+	dr, ok := m.(DismissReloader)
+	require.True(t, ok, "the apply dialog is a DismissReloader after scrolling")
+
+	reload := dr.DismissCmd()
+	require.NotNil(t, reload, "results phase: Back still reloads after scrolling")
+
+	done, ok := reload().(MutationDoneMsg)
+	require.True(t, ok, "Back after scrolling emits MutationDoneMsg (pop+reload+voice)")
+	assert.Contains(t, done.Status, "Applied", "the outcome is still voiced")
 }
 
 // TestApply_ConflictThenIgnoreReapply pins the conflict → re-apply path: the

--- a/internal/tui/staging_golden_test.go
+++ b/internal/tui/staging_golden_test.go
@@ -4,6 +4,7 @@ package tui
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"testing"
 	"time"
@@ -266,6 +267,37 @@ func TestStaging_ApplyResultsGolden(t *testing.T) { //nolint:paralleltest // gol
 
 	// Focus Apply (row 1) and confirm to reach the results view.
 	raw := captureDialogWithKeys(t, newDialogHost(d, nil), "Apply results",
+		keyDownMsg(), keyEnterMsg())
+	golden.RequireEqual(t, renderVisibleScreen(t, raw))
+}
+
+// TestStaging_ApplyResultsScrollableGolden pins the #687 fix: an apply result set
+// taller than the terminal is capped into a scrollable viewport with the title and
+// close hint pinned — so the tail and the hint are never clipped off-screen. The
+// 40-entry body cannot fit the 30-row golden terminal, so the frame shows the
+// viewport-capped head plus the pinned "scroll · enter/esc: close" hint.
+func TestStaging_ApplyResultsScrollableGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
+	goldenEnv(t)
+
+	entries := make([]data.ApplyEntryResult, 40)
+	for i := range entries {
+		entries[i] = data.ApplyEntryResult{Name: fmt.Sprintf("/app/web/PARAM_%02d", i), Status: "updated"}
+	}
+
+	svc := &goldenStaging{
+		service: "param", label: "Param",
+		applyResult: data.StagingApplyResult{ServiceLabel: "Param", Entries: entries},
+	}
+
+	// TargetLine is omitted: it appears only on the confirm view, and this golden
+	// captures the results view.
+	d := dialogs.NewApply(dialogs.ApplyInput{
+		Ctx: context.Background(), Targets: []data.StagingService{svc},
+		Title: "Apply staged changes — Param", EntryCount: len(entries), Styles: styles.New(),
+	})
+
+	// Focus Apply (row 1) and confirm to reach the results view.
+	raw := captureDialogWithKeys(t, newDialogHost(d, nil), "enter/esc: close",
 		keyDownMsg(), keyEnterMsg())
 	golden.RequireEqual(t, renderVisibleScreen(t, raw))
 }

--- a/internal/tui/testdata/TestStaging_ApplyResultsScrollableGolden.golden
+++ b/internal/tui/testdata/TestStaging_ApplyResultsScrollableGolden.golden
@@ -1,0 +1,30 @@
+╭────────────────────────────────────────────────────────────────────────────────────────────────╮
+│Apply results                                                                                   │
+│                                                                                                │
+│✓ updated  /app/web/PARAM_00                                                                    │
+│✓ updated  /app/web/PARAM_01                                                                    │
+│✓ updated  /app/web/PARAM_02                                                                    │
+│✓ updated  /app/web/PARAM_03                                                                    │
+│✓ updated  /app/web/PARAM_04                                                                    │
+│✓ updated  /app/web/PARAM_05                                                                    │
+│✓ updated  /app/web/PARAM_06                                                                    │
+│✓ updated  /app/web/PARAM_07                                                                    │
+│✓ updated  /app/web/PARAM_08                                                                    │
+│✓ updated  /app/web/PARAM_09                                                                    │
+│✓ updated  /app/web/PARAM_10                                                                    │
+│✓ updated  /app/web/PARAM_11                                                                    │
+│✓ updated  /app/web/PARAM_12                                                                    │
+│✓ updated  /app/web/PARAM_13                                                                    │
+│✓ updated  /app/web/PARAM_14                                                                    │
+│✓ updated  /app/web/PARAM_15                                                                    │
+│✓ updated  /app/web/PARAM_16                                                                    │
+│✓ updated  /app/web/PARAM_17                                                                    │
+│✓ updated  /app/web/PARAM_18                                                                    │
+│✓ updated  /app/web/PARAM_19                                                                    │
+│✓ updated  /app/web/PARAM_20                                                                    │
+│✓ updated  /app/web/PARAM_21                                                                    │
+│✓ updated  /app/web/PARAM_22                                                                    │
+│✓ updated  /app/web/PARAM_23                                                                    │
+│                                                                                                │
+│↑↓/pgup/pgdn: scroll · enter/esc: close                                                         │
+╰────────────────────────────────────────────────────────────────────────────────────────────────╯


### PR DESCRIPTION
Closes #687

## Problem

The staging apply-results view concatenated one line per applied entry, tag, conflict, and unstage warning across all fan-out services into a single non-scrolling string. A result set taller than the terminal was clipped at the bottom — later services' outcomes, unstage warnings, and the `enter/esc: close` hint — with no way to scroll (the wheel was dropped). Apply outcomes, including errors, were silently hidden exactly when the batch was large.

## Fix

`internal/tui/dialogs/apply.go` now routes the results body through a bubbles `viewport.Model` (the same pattern the diff page uses):

- The viewport is sized to `min(neededLines, screenHeight − resultsChrome)`, where `resultsChrome = 6` accounts for the dialog border (2), the pinned title + spacer (2), and the pinned spacer + close hint (2). The box therefore always fits the screen.
- The `Apply results` title and the close hint are rendered **outside** the viewport, so they stay pinned and are never clipped.
- Scroll keys (`↑↓`/`j`/`k`, `pgup`/`pgdn`, …) and the mouse wheel are forwarded to the viewport. The hint advertises the scroll keys only when the body actually overflows.
- Before the first `WindowSizeMsg` the body renders inline (uncapped), so a size-less render still shows everything.

`enter`/`space` still close (matched before the scroll forward), and **Esc is intercepted by the shell** before it reaches the dialog, so the #669 `DismissReloader` reload-on-close behavior is untouched. A short result set that fits renders byte-for-byte as before (the existing `TestStaging_ApplyResultsGolden` golden is unchanged).

## Tests

Update-level (`internal/tui/dialogs/apply_test.go`):
- `TestApply_ResultsScrollable` — a 50-line body on a 24-row terminal is capped into a scrollable viewport (`TotalLineCount==50`, `Height<50`), opens at the top with the first result visible and the last below the fold, the close hint is pinned and advertises scroll keys, and paging down reaches the previously-hidden tail.
- `TestApply_ResultsShortNoScroll` — a body that fits renders inline with the hint but no scroll-key advertisement.
- `TestApply_ResultsMouseWheelScrolls` — a wheel-down event scrolls the body (the report's dropped-wheel case).
- `TestApply_ScrollThenDismissReloads` — Esc-reload (#669) still emits `MutationDoneMsg` after scrolling.

teatest golden (`internal/tui/staging_golden_test.go`):
- `TestStaging_ApplyResultsScrollableGolden` — a 40-line result set at a 30-row terminal renders as a viewport-capped box with the pinned `scroll · enter/esc: close` hint (the capture waits on the hint marker, so a clipped hint would fail the test rather than golden a wrong frame).

## Verification

\`\`\`
$ go test ./internal/tui/dialogs/... -run TestApply -v | grep -E "PASS|ok"
--- PASS: TestApply_FanOutAggregation (0.00s)
--- PASS: TestApply_DismissReloadsOnResults (0.00s)
--- PASS: TestApply_ResultsMouseWheelScrolls (0.00s)
--- PASS: TestApply_ScrollThenDismissReloads (0.00s)
--- PASS: TestApply_ResultsShortNoScroll (0.00s)
--- PASS: TestApply_ConflictThenIgnoreReapply (0.00s)
--- PASS: TestApply_ResultsScrollable (0.00s)
ok  	github.com/mpyw/suve/internal/tui/dialogs

$ go test -race ./internal/tui/...
ok  	github.com/mpyw/suve/internal/tui	3.578s
ok  	github.com/mpyw/suve/internal/tui/data
ok  	github.com/mpyw/suve/internal/tui/dialogs	1.663s
ok  	github.com/mpyw/suve/internal/tui/pages/browser
ok  	github.com/mpyw/suve/internal/tui/pages/diff
ok  	github.com/mpyw/suve/internal/tui/pages/staging

$ golangci-lint run --allow-parallel-runners --timeout=10m
0 issues.

$ mise build-gui
...
Built bin/suve — run 'suve --gui'.
\`\`\`

Generated golden (`TestStaging_ApplyResultsScrollableGolden.golden`) — the box fits the 30-row terminal, the tail (PARAM_24..PARAM_39) is below the fold and scrollable, and the hint is pinned:

\`\`\`
╭────────────────────────────────────────────────────────────────────────────────────────────────╮
│Apply results                                                                                   │
│                                                                                                │
│✓ updated  /app/web/PARAM_00                                                                    │
│ ... (PARAM_01 … PARAM_23) ...                                                                  │
│✓ updated  /app/web/PARAM_23                                                                    │
│                                                                                                │
│↑↓/pgup/pgdn: scroll · enter/esc: close                                                         │
╰────────────────────────────────────────────────────────────────────────────────────────────────╯
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)