### PR TITLE
fix(tui): guard against stacking duplicate dialogs on rapid key press (#697)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -395,7 +395,21 @@ func (m *App) mutatorForService(service string) data.Mutator {
 // pushDialog appends a dialog to the modal stack, seeds it with the current size
 // (so its embedded form lays out before the first render), clears any transient
 // status, and returns the dialog's Init command.
+//
+// Dialog-open requests arrive as async commands (a page emits
+// func() tea.Msg { return nav.Open*{...} }), so a rapid double-press of a
+// dialog-open key (e/n/d/t/a) can emit two Open* commands before the first
+// dialog lands, and both would otherwise push an identical dialog — Esc then
+// reveals the duplicate underneath. Guard against that here, the single choke
+// point every dialog push flows through: a dialog is modal (once one is on the
+// stack it captures all input, so the page can no longer emit Open*), so any
+// Open* arriving while a dialog is already open is a stale in-flight duplicate.
+// Drop it rather than stack a second dialog.
 func (m *App) pushDialog(d dialogs.Model, initCmd tea.Cmd) tea.Cmd {
+	if len(m.dialogs) > 0 {
+		return nil
+	}
+
 	m.status = ""
 	m.dialogs = append(m.dialogs, dialogAdapter{m: d})
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/tui/components"
+	"github.com/mpyw/suve/internal/tui/data"
 	"github.com/mpyw/suve/internal/tui/dialogs"
 	"github.com/mpyw/suve/internal/tui/nav"
 )
@@ -198,6 +199,30 @@ func TestUpdate_MutationDoneClosesDialog(t *testing.T) {
 	m = updateApp(t, m, dialogs.MutationDoneMsg{Service: "param", Status: "Staged create."})
 	assert.Empty(t, m.dialogs, "a completed mutation closes the dialog")
 	assert.Equal(t, "Staged create.", m.status, "the outcome is voiced in the status line")
+}
+
+// TestUpdate_DialogOpenGuardPreventsStacking pins #697: dialog-open requests
+// arrive as async commands, so a rapid double-press of a dialog-open key can
+// emit two Open* commands before the first dialog lands. The app must push
+// exactly one dialog — the second (stale, in-flight) Open* is dropped rather
+// than stacking an identical duplicate that Esc would reveal underneath.
+func TestUpdate_DialogOpenGuardPreventsStacking(t *testing.T) {
+	t.Parallel()
+
+	mut := capMutator{cap: goldenCap("aws", "param")}
+	m := newApp(config{
+		scope:      provider.Scope{Provider: provider.ProviderAWS},
+		identity:   awsIdentityFixture(),
+		mutatorFor: func(string) data.Mutator { return mut },
+	})
+
+	open := nav.OpenEntryForm{Service: "param"}
+
+	m = updateApp(t, m, open)
+	require.Len(t, m.dialogs, 1, "the first open pushes the dialog")
+
+	m = updateApp(t, m, open)
+	assert.Len(t, m.dialogs, 1, "a second open while a dialog is already on the stack is dropped, not stacked")
 }
 
 // stagingTabTitle returns the current Staging tab title.


### PR DESCRIPTION
Closes #697

## Problem

Dialog-open requests are emitted as async tea commands (a page emits `func() tea.Msg { return nav.Open*{...} }`), and the app pushed them unconditionally. A rapid double-press of a dialog-open key (`e`/`n`/`d`/`t`/`a`) can be handled twice by the still-active page before the first Open message lands, so both commands land and **two identical dialogs stack** — Esc reveals the duplicate underneath. No data risk (submit is busy-guarded), but confusing.

## Fix

Guard at `internal/tui/app.go` `pushDialog`, the single choke point every dialog push flows through (`openEntryForm`/`openDelete`/`openTag`/`openRestore`/`openApply`/`openReset` and the inline `OpenError` case all route through it):

```go
if len(m.dialogs) > 0 {
    return nil
}
```

A dialog is modal — once one is on the stack it captures all input, so the page can no longer emit `Open*`. Therefore any `Open*` arriving while a dialog is already open is a stale in-flight duplicate and is dropped. Dialog internals are untouched. `pushDiff`/`pushStagingDetail` push *pages* (a separate stack) and are correctly unaffected.

A context-isolated review confirmed no legitimate dialog-over-dialog flow exists (no dialog emits `Open*`; the apply-results view replaces content in-place, not via a second push), so the guard breaks nothing.

## Test

Added an `Update`-level regression test `TestUpdate_DialogOpenGuardPreventsStacking` (`internal/tui/app_test.go`): two consecutive `nav.OpenEntryForm` messages result in exactly one dialog on the stack. Confirmed it fails without the guard (2 dialogs) and passes with it.

## Verification

Test catches the bug (guard temporarily reverted):

```
    app_test.go:225:
        	Error:      	"[{0x14000320008} {0x14000323008}]" should have 1 item(s), but has 2
        	Test:       	TestUpdate_DialogOpenGuardPreventsStacking
        	Messages:   	a second open while a dialog is already on the stack is dropped, not stacked
FAIL	github.com/mpyw/suve/internal/tui	0.422s
```

`mise test` (tail):

```
ok  	github.com/mpyw/suve/internal/tui	3.778s
ok  	github.com/mpyw/suve/internal/tui/dialogs	2.632s
ok  	github.com/mpyw/suve/internal/tui/pages/browser	2.508s
ok  	github.com/mpyw/suve/internal/tui/pages/staging	2.621s
...
```

`go test -race ./internal/tui/...`:

```
ok  	github.com/mpyw/suve/internal/tui	3.743s
ok  	github.com/mpyw/suve/internal/tui/dialogs	2.193s
ok  	github.com/mpyw/suve/internal/tui/pages/browser	2.329s
ok  	github.com/mpyw/suve/internal/tui/pages/staging	1.533s
```

`golangci-lint run --allow-parallel-runners --timeout=10m`:

```
0 issues.
```

`mise build-gui`:

```
✓ built in 1.03s
Built bin/suve — run 'suve --gui'.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
