### PR TITLE
fix(tui): make param immediate-create an upsert (#691)

### DIFF
--- a/internal/tui/data/mutate.go
+++ b/internal/tui/data/mutate.go
@@ -2,6 +2,7 @@ package data
 
 import (
 	"context"
+	"errors"
 
 	"github.com/mpyw/suve/internal/capability"
 	"github.com/mpyw/suve/internal/cli/commands/aws/param/paramtype"
@@ -19,10 +20,14 @@ import (
 // WriteOutcome carries the semantic result of a mutation the UI must voice.
 // Skipped is set when a staged edit equalled the live value (nothing staged);
 // Unstaged when an edit-back-to-base or a delete-of-staged-create auto-unstaged
-// the entry (EditOutput.Skipped/Unstaged, DeleteOutput.Unstaged).
+// the entry (EditOutput.Skipped/Unstaged, DeleteOutput.Unstaged); Updated when
+// an immediate create fell back to update because the entry already existed
+// (the create-or-update/upsert branch), so the status voices an update rather
+// than a create — matching the GUI (ParamSet) and CLI (`param set`).
 type WriteOutcome struct {
 	Skipped  bool
 	Unstaged bool
+	Updated  bool
 }
 
 // Mutator is the write-path seam the mutation dialogs depend on. Every method is
@@ -140,13 +145,35 @@ func (m *paramMutator) Create(
 		return WriteOutcome{}, err
 	}
 
-	uc := &param.CreateUseCase{Writer: store}
+	valueType := paramtype.Parse(typeLabel)
 
-	_, err = uc.Execute(ctx, param.CreateInput{
-		Name: key.Name, Value: value, Type: paramtype.Parse(typeLabel), Description: description,
+	// Immediate create is a create-or-update (upsert), matching the GUI (ParamSet)
+	// and the CLI (`param set`): try create first, and if the parameter already
+	// exists fall back to update instead of surfacing the raw ErrAlreadyExists.
+	// The staged branch above is untouched — stage-time add validation is unchanged.
+	createUC := &param.CreateUseCase{Writer: store}
+
+	_, err = createUC.Execute(ctx, param.CreateInput{
+		Name: key.Name, Value: value, Type: valueType, Description: description,
 	})
+	if err == nil {
+		return WriteOutcome{}, nil
+	}
 
-	return WriteOutcome{}, err
+	if !errors.Is(err, provider.ErrAlreadyExists) {
+		return WriteOutcome{}, err
+	}
+
+	updateUC := &param.UpdateUseCase{Store: store}
+
+	_, err = updateUC.Execute(ctx, param.UpdateInput{
+		Name: key.Name, Value: value, Type: valueType, Description: description,
+	})
+	if err != nil {
+		return WriteOutcome{}, err
+	}
+
+	return WriteOutcome{Updated: true}, nil
 }
 
 func (m *paramMutator) Update(

--- a/internal/tui/data/mutate_test.go
+++ b/internal/tui/data/mutate_test.go
@@ -359,3 +359,59 @@ func TestParamMutator_ImmediateRouting(t *testing.T) {
 	_, err = st.GetEntry(ctx, staging.ServiceParam, staging.EntryKey{Name: "/app/NEW"})
 	require.ErrorIs(t, err, staging.ErrNotStaged)
 }
+
+// TestParamMutator_ImmediateCreateUpserts pins the #691 fix: an immediate param
+// create is a create-or-update (upsert), matching the GUI (ParamSet) and the CLI
+// (`param set`). Creating over an EXISTING param no longer surfaces the raw
+// provider.ErrAlreadyExists — it falls back to update and reports the outcome as
+// an update so the dialog voices it. A create error that is NOT already-exists is
+// still surfaced unchanged (never silently swallowed as an upsert).
+//
+//nolint:paralleltest // sets HOME / SUVE_STAGING_KEY via t.Setenv (newParamMutator)
+func TestParamMutator_ImmediateCreateUpserts(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("create over an existing param falls back to update", func(t *testing.T) {
+		var createTried, put bool
+
+		provStore := &providermock.Store{
+			CreateFunc: func(context.Context, string, string, domain.ValueType, string, ...provider.WriteOption) (domain.Version, error) {
+				createTried = true
+
+				return domain.Version{}, provider.ErrAlreadyExists
+			},
+			// UpdateUseCase reads the entry before writing; report it as present.
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) {
+				return &domain.Entry{Name: existingParamName, Value: "old", Type: domain.ValueTypePlaintext}, nil
+			},
+			PutFunc: func(context.Context, string, string, domain.ValueType, string, ...provider.WriteOption) (domain.Version, error) {
+				put = true
+
+				return domain.Version{ID: "2"}, nil
+			},
+		}
+
+		mut, _ := newParamMutator(t, provStore)
+
+		out, err := mut.Create(ctx, data.StagedKey{Name: existingParamName}, "new", "String", "", false)
+		require.NoError(t, err, "immediate create over an existing param upserts instead of raising already-exists")
+		assert.True(t, createTried, "create is attempted first")
+		assert.True(t, put, "the already-exists create falls back to update (Put)")
+		assert.True(t, out.Updated, "the outcome reports an update so the dialog voices it")
+	})
+
+	t.Run("a non-already-exists create error is surfaced unchanged", func(t *testing.T) {
+		sentinel := errors.New("provider exploded")
+
+		provStore := &providermock.Store{
+			CreateFunc: func(context.Context, string, string, domain.ValueType, string, ...provider.WriteOption) (domain.Version, error) {
+				return domain.Version{}, sentinel
+			},
+		}
+
+		mut, _ := newParamMutator(t, provStore)
+
+		_, err := mut.Create(ctx, data.StagedKey{Name: "/app/NEW"}, "v", "String", "", false)
+		require.ErrorIs(t, err, sentinel, "a non-already-exists error is returned, not treated as an upsert")
+	})
+}

--- a/internal/tui/dialogs/dialogs_test.go
+++ b/internal/tui/dialogs/dialogs_test.go
@@ -475,6 +475,40 @@ func TestEntryForm_ResultVoicing(t *testing.T) {
 	assert.Contains(t, entryStatus(true, true, data.WriteOutcome{Unstaged: true}), "auto-unstaged")
 	assert.Equal(t, "Staged update.", entryStatus(true, true, data.WriteOutcome{}))
 	assert.Equal(t, "Applied create.", entryStatus(false, false, data.WriteOutcome{}))
+	// #691: an immediate create that upserted onto an existing entry voices an
+	// update, matching the GUI/CLI create-or-update semantics.
+	assert.Equal(t, "Applied update.", entryStatus(false, false, data.WriteOutcome{Updated: true}))
+}
+
+// TestEntryForm_ImmediateCreateUpsertVoicesUpdate pins the #691 fix at the dialog
+// layer: when an immediate param create upserts onto an existing entry, the
+// mutator reports WriteOutcome{Updated: true}; the dialog must voice "Applied
+// update." (never surface the raw already-exists error) and emit MutationDoneMsg.
+func TestEntryForm_ImmediateCreateUpsertVoicesUpdate(t *testing.T) {
+	t.Parallel()
+
+	d, mut := newEntry(t, awsParamCap(), false)
+	d.name = "/app/EXISTS"
+	d.value = "new"
+	d.staged = false
+	// The data layer upserted onto an existing param: create fell back to update.
+	mut.outcome = data.WriteOutcome{Updated: true}
+
+	// Run the create submit and feed its result back through Update (the real loop).
+	cmd := d.submit()
+	require.NotNil(t, cmd)
+
+	m, done := d.Update(cmd())
+
+	dd, ok := m.(*entryForm)
+	require.True(t, ok)
+	assert.True(t, mut.createCalled, "an immediate create routes through Create")
+	assert.False(t, mut.staged, "the write is immediate")
+	assert.Empty(t, dd.err, "no raw already-exists error is surfaced")
+
+	msg, ok := done().(MutationDoneMsg)
+	require.True(t, ok, "a successful upsert emits MutationDoneMsg")
+	assert.Equal(t, "Applied update.", msg.Status, "an upsert voices an update, not a create")
 }
 
 // TestDeleteConfirm_ForceRecoveryGating pins that force/recovery rows appear only

--- a/internal/tui/dialogs/entryform.go
+++ b/internal/tui/dialogs/entryform.go
@@ -466,8 +466,12 @@ func entryStatus(edit, staged bool, o data.WriteOutcome) string {
 		return "Reverted to the base value — change auto-unstaged."
 	}
 
+	// An immediate create that upserted onto an existing entry (o.Updated) reports
+	// as an update, so the status matches what actually happened (create-or-update
+	// parity with the GUI/CLI). Staged creates never upsert, so o.Updated is only
+	// ever set on the immediate path.
 	verb := "create"
-	if edit {
+	if edit || o.Updated {
 		verb = "update"
 	}
 


### PR DESCRIPTION
Closes #691

## Problem

The TUI's param immediate-create ran only `param.CreateUseCase` and surfaced `provider.ErrAlreadyExists` verbatim, while the GUI (`ParamSet`, `internal/gui/param.go`) and CLI (`param set`) perform a create-or-update. Same "New" button, different semantics across frontends — and creating over an existing param leaked a raw "already exists" provider error.

Maintainer decision (#691, 2026-07-13): align the TUI immediate branch with the GUI/CLI upsert; on `errors.Is(err, provider.ErrAlreadyExists)` fall back to `param.UpdateUseCase` (mirror `ParamSet`). Staged branch stays as-is. Voice created-vs-updated in the result status line.

## Fix

- `internal/tui/data/mutate.go` — `paramMutator.Create` immediate branch is now a create-or-update: try create, and on `ErrAlreadyExists` fall back to `param.UpdateUseCase`, mirroring the GUI. A non-already-exists error is returned unchanged (never swallowed as an upsert). The staged branch is untouched — stage-time add validation is unchanged.
- `WriteOutcome` gains an `Updated` flag (set only on the immediate upsert path); `internal/tui/dialogs/entryform.go` `entryStatus` voices "Applied update." when a create upserted onto an existing entry, so the status matches what actually happened.

## Tests (three-layer rule)

The GUI/CLI already cover upsert. Added TUI coverage at the two layers this bug lives in:

- Data layer (`internal/tui/data/mutate_test.go`, `TestParamMutator_ImmediateCreateUpserts`): immediate create over an existing param upserts (`Updated=true`, no raw already-exists error); a non-already-exists create error is surfaced unchanged.
- Dialog layer (`internal/tui/dialogs/dialogs_test.go`, `TestEntryForm_ImmediateCreateUpsertVoicesUpdate` + `entryStatus` assertion): an immediate-create upsert voices "Applied update." and emits `MutationDoneMsg` with no error.

## Verification

\`\`\`
$ go test -race ./internal/tui/...
ok  	github.com/mpyw/suve/internal/tui	4.499s
ok  	github.com/mpyw/suve/internal/tui/data	1.393s
ok  	github.com/mpyw/suve/internal/tui/dialogs	1.755s
ok  	github.com/mpyw/suve/internal/tui/pages/browser	1.497s
ok  	github.com/mpyw/suve/internal/tui/pages/diff	2.183s
ok  	github.com/mpyw/suve/internal/tui/pages/staging	2.375s

$ mise test
ok  	.../internal/tui/dialogs	2.273s
ok  	.../internal/usecase/param	1.654s
... (all packages ok)

$ golangci-lint run --allow-parallel-runners --timeout=10m
0 issues.

$ mise build-gui
✓ built in 1.23s
Built bin/suve — run 'suve --gui'.
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)