### PR TITLE
fix(gui): mask secret-service values in version diff and staging review (#714, #715)

### DIFF
--- a/internal/gui/frontend/src/lib/SecretView.svelte
+++ b/internal/gui/frontend/src/lib/SecretView.svelte
@@ -830,6 +830,7 @@
     <DiffDisplay
       oldValue={formatJsonValue(diffResult.oldValue)}
       newValue={formatJsonValue(diffResult.newValue)}
+      secret={true}
       oldLabel="Old"
       newLabel="New"
       oldSubLabel={diffResult.oldVersionId}

--- a/internal/gui/frontend/src/lib/StagingSection.svelte
+++ b/internal/gui/frontend/src/lib/StagingSection.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { gui } from '../../wailsjs/go/models';
   import DiffDisplay from './DiffDisplay.svelte';
+  import { maskValue } from './viewUtils';
   import './common.css';
 
   interface Props {
@@ -16,6 +17,12 @@
     // Whether to show each entry's namespace as a badge (Azure App Configuration
     // only). "(NULL)" is the null/default namespace.
     showNamespace?: boolean;
+    // Whether this whole section renders secret material (the Secret service).
+    // OR'd with each entry's own value-type flag so both a secret-service entry
+    // and a SecureString param are masked. Mirrors the TUI's `sec.secret ||
+    // e.Secret` (staging/view.go) — the section flag also covers a secret-service
+    // create, whose per-entry flag the usecase leaves unset (#715).
+    secret?: boolean;
     onapply: () => void;
     onreset: () => void;
     onedit: (entry: gui.StagingDiffEntry) => void;
@@ -37,6 +44,7 @@
     viewMode,
     hasTags = true,
     showNamespace = false,
+    secret = false,
     onapply,
     onreset,
     onedit,
@@ -119,6 +127,7 @@
     <ul class="entry-list">
       {#each entries as entry}
         {@const tagEntry = findTagEntry(entry.name)}
+        {@const rowSecret = secret || entry.secret}
         <li class="entry-item">
           <div class="entry-header">
             <span class="operation-badge" style="background: {getOperationColor(entry.operation || '')}">
@@ -167,8 +176,11 @@
           {#if entry.operation === 'delete'}
             {#if viewMode === 'diff'}
               <div class="entry-diff">
+                <!-- The staged side is the literal "(deleted)" sentinel (not
+                     secret), so mask only the remote value here rather than
+                     passing `secret` (which would mask both sides). -->
                 <DiffDisplay
-                  oldValue={entry.remoteValue || ''}
+                  oldValue={rowSecret ? maskValue(entry.remoteValue || '') : (entry.remoteValue || '')}
                   newValue="(deleted)"
                   oldLabel="Remote"
                   newLabel="Staged"
@@ -184,13 +196,14 @@
                 <DiffDisplay
                   oldValue={entry.remoteValue || ''}
                   newValue={entry.stagedValue}
+                  secret={rowSecret}
                   oldLabel="Remote"
                   newLabel="Staged"
                   oldSubLabel={entry.remoteIdentifier || ''}
                 />
               </div>
             {:else}
-              <pre class="entry-value">{entry.stagedValue}</pre>
+              <pre class="entry-value">{rowSecret ? maskValue(entry.stagedValue) : entry.stagedValue}</pre>
             {/if}
           {/if}
         </li>

--- a/internal/gui/frontend/src/lib/StagingView.svelte
+++ b/internal/gui/frontend/src/lib/StagingView.svelte
@@ -584,6 +584,7 @@
         entries={secretEntries}
         tagEntries={secretTagEntries}
         hasTags={secretSvc?.hasTags ?? true}
+        secret={true}
         {viewMode}
         onapply={() => openApplyModal('secret')}
         onreset={() => openResetModal('secret')}

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -48,6 +48,10 @@ export interface StagedEntry {
   // per-service envelope round-trips back into the same service regardless of
   // the name shape (Google Cloud/Azure names carry no leading '/').
   service?: Service;
+  // Optional value-type secret flag. When set, StagingDiff stamps it onto the
+  // entry's DTO (mirroring the backend's DiffEntry.Secret) so the staging review
+  // masks a SecureString param even in the non-secret Param section.
+  secret?: boolean;
 }
 
 export interface StagedTagEntry {
@@ -1210,6 +1214,11 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
             stagedValue: s.value || '',
             description: '',
             warning: '',
+            // Mirror the backend's value-type secret flag: secret-service
+            // entries are secret material (the create path leaves it unset —
+            // the section-level flag masks those). A per-entry override wins so
+            // a SecureString param can be flagged too.
+            secret: s.secret ?? (service === 'secret' && s.operation !== 'create'),
           })),
           tagEntries: tagStaged.map((t: any) => ({
             name: t.name,

--- a/internal/gui/frontend/tests/secret-service-mask.spec.ts
+++ b/internal/gui/frontend/tests/secret-service-mask.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupWailsMocks,
+  createSecretStagedState,
+  createParamStagedState,
+  createStagedValue,
+  navigateTo,
+  waitForItemList,
+  clickItemByName,
+} from './fixtures/wails-mock';
+
+// ============================================================================
+// GUI secret-service masking leaks (#714, #715)
+//
+// Pre-existing GUI leaks surfaced during the #704 audit while fixing #677/#702
+// (PR #711 fixed the value-type SecureString-param diff + the TUI staging
+// review, but left these two GUI secret-SERVICE surfaces unmasked):
+//
+//   #714 — SecretView "Version Comparison" rendered both secret values in
+//          cleartext (the detail pane already masks by default).
+//   #715 — the GUI staging review rendered secret-service staged/remote values
+//          in cleartext, in both diff and value view modes.
+//
+// The reference behavior is the GUI's own masked-by-default secret handling
+// (detail pane / Version History). These tests assert no plaintext secret value
+// reaches either surface and that masking bullets/asterisks are present.
+// ============================================================================
+
+test.describe('Secret-service version diff masking (#714)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Default mock state ships my-secret with three versions carrying
+    // distinctive cleartext values.
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await navigateTo(page, 'Secret');
+    await waitForItemList(page);
+  });
+
+  test('masks both sides of a secret version comparison', async ({ page }) => {
+    await clickItemByName(page, 'my-secret');
+
+    await page.getByRole('button', { name: /Compare/i }).click();
+    await page.locator('.diff-checkbox input').first().check();
+    await page.locator('.diff-checkbox input').nth(1).check();
+    await page.getByRole('button', { name: 'Show Diff' }).click();
+
+    await expect(page.getByText('Version Comparison')).toBeVisible();
+
+    const oldSide = (await page.locator('.diff-value.diff-old').textContent()) ?? '';
+    const newSide = (await page.locator('.diff-value.diff-new').textContent()) ?? '';
+
+    // No cleartext version value may appear on either side.
+    for (const side of [oldSide, newSide]) {
+      expect(side).not.toContain('secret-value-1');
+      expect(side).not.toContain('secret-value-old');
+      expect(side).not.toContain('secret-value-initial');
+      expect(side).not.toContain('secret-value');
+    }
+
+    // Both sides are masked (a change still shows as differing asterisk runs).
+    expect(oldSide).toMatch(/\*/);
+    expect(newSide).toMatch(/\*/);
+  });
+});
+
+test.describe('Secret-service staging review masking (#715)', () => {
+  // Distinctive cleartext that must never reach the staging review.
+  const UPDATE_VALUE = 'super-secret-staged-update';
+  const CREATE_VALUE = 'super-secret-staged-create';
+  const REMOTE_VALUE = 'remote-value'; // the mock's remote value for non-create entries
+
+  async function gotoSecretStaging(page: import('@playwright/test').Page) {
+    await setupWailsMocks(
+      page,
+      createSecretStagedState([
+        createStagedValue('my-secret', 'update', UPDATE_VALUE),
+        createStagedValue('new-secret', 'create', CREATE_VALUE),
+        createStagedValue('old-secret', 'delete'),
+      ]),
+    );
+    await page.goto('/');
+    await navigateTo(page, 'Staging');
+    // Wait until the secret section's staged rows are rendered.
+    await expect(page.locator('.entry-item').first()).toBeVisible();
+  }
+
+  test('masks staged/remote values in diff view', async ({ page }) => {
+    await gotoSecretStaging(page);
+    // Default view mode is Diff.
+    await expect(page.getByRole('button', { name: 'Diff' })).toHaveClass(/active/);
+
+    const body = (await page.locator('.staging-content').textContent()) ?? '';
+    expect(body).not.toContain(UPDATE_VALUE);
+    expect(body).not.toContain(CREATE_VALUE);
+    expect(body).not.toContain(REMOTE_VALUE);
+    // Something is still rendered as masked bullets/asterisks.
+    expect(body).toMatch(/\*/);
+    // The delete sentinel stays readable (it is not secret material).
+    expect(body).toContain('(deleted)');
+  });
+
+  test('masks staged values in value view', async ({ page }) => {
+    await gotoSecretStaging(page);
+    await page.getByRole('button', { name: 'Value' }).click();
+    await expect(page.getByRole('button', { name: 'Value' })).toHaveClass(/active/);
+
+    const body = (await page.locator('.staging-content').textContent()) ?? '';
+    expect(body).not.toContain(UPDATE_VALUE);
+    expect(body).not.toContain(CREATE_VALUE);
+    expect(body).toMatch(/\*/);
+  });
+});
+
+test.describe('SecureString-param staging review masking (per-entry flag, #715)', () => {
+  // A SecureString param lives in the non-secret Param section, so only the
+  // per-entry DiffEntry.Secret flag can mask it — this isolates that path from
+  // the secret section's service-axis flag.
+  const SECURE_VALUE = 'securestring-staged-plaintext';
+
+  test('masks a SecureString param staged value in the Param section', async ({ page }) => {
+    await setupWailsMocks(page, {
+      ...createParamStagedState([
+        { name: '/app/secure/token', operation: 'update', value: SECURE_VALUE, secret: true },
+      ]),
+    });
+    await page.goto('/');
+    await navigateTo(page, 'Staging');
+    await expect(page.locator('.entry-item').first()).toBeVisible();
+
+    // Value view renders the staged value directly.
+    await page.getByRole('button', { name: 'Value' }).click();
+    const body = (await page.locator('.staging-content').textContent()) ?? '';
+    expect(body).not.toContain(SECURE_VALUE);
+    expect(body).toMatch(/\*/);
+  });
+});

--- a/internal/gui/frontend/wailsjs/go/models.ts
+++ b/internal/gui/frontend/wailsjs/go/models.ts
@@ -800,11 +800,12 @@ export namespace gui {
 	    stagedValue?: string;
 	    description?: string;
 	    warning?: string;
-	
+	    secret: boolean;
+
 	    static createFrom(source: any = {}) {
 	        return new StagingDiffEntry(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.name = source["name"];
@@ -816,6 +817,7 @@ export namespace gui {
 	        this.stagedValue = source["stagedValue"];
 	        this.description = source["description"];
 	        this.warning = source["warning"];
+	        this.secret = source["secret"];
 	    }
 	}
 	export class StagingDiffTagEntry {

--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -167,6 +167,11 @@ type StagingDiffEntry struct {
 	StagedValue      string  `json:"stagedValue,omitempty"`
 	Description      *string `json:"description,omitempty"`
 	Warning          string  `json:"warning,omitempty"`
+	// Secret reports whether this entry's values are secret material (a
+	// SecureString param, or any secret-service entry) so the staging review
+	// masks them instead of rendering cleartext. Mirrors the TUI's per-row flag
+	// (staging/view.go); threaded from stagingusecase.DiffEntry.Secret (#715).
+	Secret bool `json:"secret"`
 }
 
 // StagingDiffTagEntry represents a single diff tag entry.
@@ -829,6 +834,7 @@ func (a *App) StagingDiff(service string, name string) (*StagingDiffResult, erro
 			StagedValue:      e.StagedValue,
 			Description:      e.Description,
 			Warning:          e.Warning,
+			Secret:           e.Secret,
 		}
 	})
 


### PR DESCRIPTION
Closes #714
Closes #715

## Problem

Two pre-existing **GUI secret-SERVICE masking leaks**, surfaced during the #704 TUI bug-audit epic in the context-isolated review of PR #711 (#677/#702). #711 masked the value-type SecureString-**param** diff and the **TUI** staging review, but explicitly left these two GUI secret-service surfaces untouched (its "Out of scope" note):

1. **#714 — secret version diff.** `SecretView.svelte`'s "Version Comparison" modal passed the raw values to `DiffDisplay` with no `secret` flag, so both secret values rendered in **cleartext** — even though the detail "Current Value" pane and Version History mask the same value by default.
2. **#715 — staging review.** `StagingSection.svelte` rendered secret-service staged/remote values in **cleartext** (both diff and value view), and the usecase `DiffEntry.Secret` flag added by #711 was never surfaced on the GUI binding `gui.StagingDiffEntry`.

## Fix

Mirrors #711 and the GUI's own masked-by-default secret handling.

- **#714** — pass `secret={true}` to the `DiffDisplay` in SecretView's version-comparison modal. The secret service is always secret material, so this is unconditional (mask-only, matching #711's diff decision — no reveal toggle in a diff). `DiffDisplay` masks both sides before diffing, so a change still shows as differing asterisk runs.
- **#715** —
  - thread `Secret` through the Go DTO `gui.StagingDiffEntry` (populated from `stagingusecase.DiffEntry.Secret`) and hand-edit `wailsjs/go/models.ts` to match (the file is hand-maintained/pruned per #711; verified by the `TestDTOContract` gate rather than a full `mise generate-gui-bindings`);
  - add a **section-level** `secret` prop to `StagingSection`, OR'd per-row with each entry's own flag (`rowSecret = secret || entry.secret`) — mirroring the TUI's `sec.secret || e.Secret`. `StagingView` sets `secret={true}` on the Secret section. The section flag is essential because the usecase leaves `DiffEntry.Secret` unset on a **create** (no remote to fetch), so the per-entry flag alone would leak a secret-service create;
  - mask all three render spots: the update diff (both sides via `secret={rowSecret}`), the plain/create value `<pre>` (`maskValue` when `rowSecret`), and the delete diff's **remote value only** — the staged side is the literal `(deleted)` sentinel (not secret), so it stays readable instead of being masked to meaningless asterisks.

The Param section keeps no section flag, so a SecureString param is masked there purely via the now-threaded per-entry `entry.secret` (the value-type axis).

## Tests (GUI Playwright, three-layer rule)

The leak lives in the GUI (the Go DTO change is inert without a consumer), so the regression coverage is Playwright — `internal/gui/frontend/tests/secret-service-mask.spec.ts`:

- **#714** — open a secret version comparison; assert neither side contains any cleartext version value and both are masked (`*`).
- **#715** — stage secret-service create + update + delete; assert no cleartext staged/remote value appears in **diff** view or **value** view, `*` is present, and the `(deleted)` sentinel stays readable. The create entry is flagged non-secret in the mock, so it genuinely exercises the section-level flag.
- **per-entry flag** — a SecureString-param staged update in the (non-secret) Param section is masked, isolating the threaded `DiffEntry.Secret` path.

The Go `StagingDiffEntry.Secret` field is guarded by the existing `TestDTOContract` gate.

## Out of scope (follow-up)

The review surfaced one residual, value-type-axis leak filed as **#719**: a SecureString-**param** **create** staged via the CLI still renders unmasked in both the TUI and GUI staging review, because `diff.go`'s create branch never sets `DiffEntry.Secret`. It affects the usecase/TUI/GUI uniformly (a gap in the #677/#711 family, not a secret-service issue), so it belongs in its own PR.

## Verification

```
$ mise test
ok  github.com/mpyw/suve/internal/usecase/staging  0.852s
ok  github.com/mpyw/suve/internal/tui/pages/staging 0.555s
(all packages ok)

$ golangci-lint run --allow-parallel-runners --timeout=10m
0 issues.

$ go test -tags production ./internal/gui/ -run TestDTOContract
ok  github.com/mpyw/suve/internal/gui  0.315s

$ mise build-gui
✓ built in 2.44s
Built bin/suve — run 'suve --gui'.

$ (cd internal/gui/frontend && npx playwright test secret-service-mask.spec.ts)
  12 passed (11.8s)          # chromium, firefox, webkit × 4 tests
```

Full GUI Playwright suite: **1468 passed, 2 failed**. Both failures are pre-existing flakes unrelated to the masking paths: `keyboard-focus.spec.ts › Tab navigation through item list` on webkit (the exact flake #711 documented, fails identically on the clean base) and `edge-cases.spec.ts › add tag without key` on firefox (passed on isolated re-run). The 444-test staging/secret/version-history/securestring suites all pass — no masking regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
