### PR TITLE
fix(tui): rework staged probe — gate dead-end e/d/t, one badge count, surface probe errors (#692, #693, #695)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -332,7 +332,7 @@ func (m *App) openEntryForm(req nav.OpenEntryForm) tea.Cmd {
 		Ctx: m.runCtx, Mutator: mut, Service: req.Service, Styles: m.styles,
 		Edit: req.Edit, Name: req.Name, Namespace: req.Namespace,
 		Value: req.Value, TypeLabel: req.TypeLabel, Description: req.Description,
-		StagedOnly: req.StagedOnly,
+		StagedOnly: req.StagedOnly, DeleteStagedKeys: req.DeleteStagedKeys,
 	})
 
 	return m.pushDialog(d, cmd)

--- a/internal/tui/browser_fixtures_test.go
+++ b/internal/tui/browser_fixtures_test.go
@@ -30,13 +30,30 @@ func capFor(prov, service string) capability.ServiceCapability {
 	return sc
 }
 
-// staticProbe is a test staging probe returning a fixed staged-key set, so a
-// golden can exercise the [staged] badge and the staged-changes banner without a
-// keychain.
-type staticProbe struct{ keys map[data.StagedKey]struct{} }
+// staticProbe is a test staging probe returning a fixed staged snapshot, so a
+// golden can exercise the [staged] badge, the staged-changes banner, and the
+// delete-staged affordance gate without a keychain. deleteKeys/entryCount/tagCount
+// are optional; when both counts are left zero they default to one staged entry
+// per key, so an existing golden that sets only keys keeps its Staging(n) badge.
+type staticProbe struct {
+	keys       map[data.StagedKey]struct{}
+	deleteKeys map[data.StagedKey]struct{}
+	entryCount int
+	tagCount   int
+}
 
-func (p staticProbe) StagedKeys(context.Context) (map[data.StagedKey]struct{}, error) {
-	return p.keys, nil
+func (p staticProbe) Staged(context.Context) (data.StagingSnapshot, error) {
+	entryCount, tagCount := p.entryCount, p.tagCount
+	if entryCount == 0 && tagCount == 0 {
+		entryCount = len(p.keys)
+	}
+
+	return data.StagingSnapshot{
+		Keys:       p.keys,
+		DeleteKeys: p.deleteKeys,
+		EntryCount: entryCount,
+		TagCount:   tagCount,
+	}, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tui/browser_golden_test.go
+++ b/internal/tui/browser_golden_test.go
@@ -107,6 +107,35 @@ func TestBrowser_AWSParamHistoryFocusGolden(t *testing.T) { //nolint:paralleltes
 	golden.RequireEqual(t, renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight))
 }
 
+// TestBrowser_DeleteStagedGateStatusGolden pins #692: on an entry staged for
+// deletion, pressing `t` (edit/delete/tag are all dead-end transitions there)
+// does not open the tag dialog but surfaces a one-line status message instead —
+// matching the GUI, which hides those controls. The delete-staged entry is the
+// default selection (index 0), so the gate fires on the first `t`.
+func TestBrowser_DeleteStagedGateStatusGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
+	goldenEnv(t)
+
+	doomed := data.StagedKey{Name: "prod/api/key"}
+	probe := staticProbe{
+		keys:       map[data.StagedKey]struct{}{doomed: {}},
+		deleteKeys: map[data.StagedKey]struct{}{doomed: {}},
+		entryCount: 1,
+	}
+
+	m := newApp(config{
+		scope:     provider.Scope{Provider: provider.ProviderAWS},
+		service:   "secret",
+		identity:  awsIdentityFixture(),
+		sourceFor: sourceForShape("secret", awsSecretSource(), probe),
+	})
+
+	raw := captureBrowserAfterKeys(t, m, "Version ID", keyPress('t'))
+	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+
+	require.Contains(t, screen, "cannot tag: staged for deletion", "the gate surfaces a status message rather than the tag dialog")
+	golden.RequireEqual(t, screen)
+}
+
 // TestBrowser_AWSSecretGolden renders the AWS secret browser (staging labels +
 // ARN, masked value).
 func TestBrowser_AWSSecretGolden(t *testing.T) { //nolint:paralleltest // goldenEnv calls t.Setenv (NO_COLOR/TZ), which forbids t.Parallel

--- a/internal/tui/data/staging.go
+++ b/internal/tui/data/staging.go
@@ -16,13 +16,28 @@ type StagedKey struct {
 	Namespace string
 }
 
+// StagingSnapshot is the browser's read-only view of a service's staged state.
+// Keys drives the [staged] badge and the detail banner; DeleteKeys is the subset
+// staged for deletion, so the browser can gate the edit/delete/tag affordances
+// that the reducer would reject as dead-end transitions (#692). EntryCount and
+// TagCount are the staged entry-row and tag-change totals whose sum feeds the
+// Staging tab badge — the same entries+tags definition the staging page uses, so
+// the badge no longer oscillates between two counts (#693).
+type StagingSnapshot struct {
+	Keys       map[StagedKey]struct{}
+	DeleteKeys map[StagedKey]struct{}
+	EntryCount int
+	TagCount   int
+}
+
 // StagingProbe reports which items in the current service have staged changes
 // (an entry or a tag change), so the browser can show a [staged] badge and the
 // detail pane a staged-changes banner. It is read-only — the parity of the
 // GUI's StagingCheckStatus/StagingStatus reads (the staging page owns the mutations).
 type StagingProbe interface {
-	// StagedKeys returns the set of staged (name, namespace) keys for the service.
-	StagedKeys(ctx context.Context) (map[StagedKey]struct{}, error)
+	// Staged returns the staged snapshot (badge keys, delete-staged subset, and
+	// entry/tag counts) for the service.
+	Staged(ctx context.Context) (StagingSnapshot, error)
 }
 
 // StoreUnavailableError marks a StagingProbe failure that comes from CONSTRUCTING
@@ -51,23 +66,33 @@ func NewStagingProbe(strategy staging.ServiceStrategy, store store.ReadOperator)
 	return &stagingProbe{strategy: strategy, store: store}
 }
 
-func (p *stagingProbe) StagedKeys(ctx context.Context) (map[StagedKey]struct{}, error) {
+func (p *stagingProbe) Staged(ctx context.Context) (StagingSnapshot, error) {
 	uc := &stagingusecase.StatusUseCase{Strategy: p.strategy, Store: p.store}
 
 	out, err := uc.Execute(ctx, stagingusecase.StatusInput{})
 	if err != nil {
-		return nil, err
+		return StagingSnapshot{}, err
 	}
 
-	keys := make(map[StagedKey]struct{}, len(out.Entries)+len(out.TagEntries))
+	snap := StagingSnapshot{
+		Keys:       make(map[StagedKey]struct{}, len(out.Entries)+len(out.TagEntries)),
+		DeleteKeys: map[StagedKey]struct{}{},
+		EntryCount: len(out.Entries),
+		TagCount:   len(out.TagEntries),
+	}
 
 	for _, e := range out.Entries {
-		keys[StagedKey{Name: e.Name, Namespace: e.Namespace}] = struct{}{}
+		key := StagedKey{Name: e.Name, Namespace: e.Namespace}
+		snap.Keys[key] = struct{}{}
+
+		if e.Operation == staging.OperationDelete {
+			snap.DeleteKeys[key] = struct{}{}
+		}
 	}
 
 	for _, t := range out.TagEntries {
-		keys[StagedKey{Name: t.Name, Namespace: t.Namespace}] = struct{}{}
+		snap.Keys[StagedKey{Name: t.Name, Namespace: t.Namespace}] = struct{}{}
 	}
 
-	return keys, nil
+	return snap, nil
 }

--- a/internal/tui/dialogs/dialogs_test.go
+++ b/internal/tui/dialogs/dialogs_test.go
@@ -224,6 +224,40 @@ func TestTagForm_StagedOnlyHidesModeToggle(t *testing.T) {
 	assert.True(t, mut.staged, "a staged-only submit writes staged, never immediate")
 }
 
+// TestEntryForm_CreateNameRejectsDeleteStaged pins the create-name client-side
+// validation half of #692: the name field's validator rejects a name that is
+// already staged for deletion with an inline friendly message, so the write never
+// reaches the reducer's raw post-submit "cannot add to delete-staged" error. The
+// key is (name, namespace), so a same-name entry under a different namespace does
+// not collide, and a required-name error still fires for an empty name.
+func TestEntryForm_CreateNameRejectsDeleteStaged(t *testing.T) {
+	t.Parallel()
+
+	mut := &fakeMutator{svcCap: awsParamCap()}
+
+	m, _ := NewEntryForm(EntryFormInput{
+		Ctx: context.Background(), Mutator: mut, Service: "param", Styles: styles.New(),
+		DeleteStagedKeys: map[data.StagedKey]struct{}{{Name: "/app/doomed"}: {}},
+	})
+	d, ok := m.(*entryForm)
+	require.True(t, ok)
+
+	validate := d.nameValidator()
+
+	err := validate("/app/doomed")
+	require.Error(t, err, "a delete-staged name is rejected client-side")
+	assert.Contains(t, err.Error(), "staged for deletion", "the message names the reason")
+
+	require.NoError(t, validate("/app/fresh"), "a name that is not delete-staged is accepted")
+	require.Error(t, validate(""), "the required-name check still fires")
+
+	// The key is (name, namespace): the same name under a different namespace is
+	// not the delete-staged (empty-namespace) key, so it is accepted.
+	d.namespace = "other"
+
+	require.NoError(t, validate("/app/doomed"), "a same-name entry under a different namespace does not collide")
+}
+
 // newAppConfigEntry builds an App Configuration (namespaced) create/edit form
 // seeded with a namespace, for the namespace read-only assertions.
 func newAppConfigEntry(t *testing.T, edit bool, namespace string) *entryForm {

--- a/internal/tui/dialogs/entryform.go
+++ b/internal/tui/dialogs/entryform.go
@@ -58,6 +58,11 @@ type entryForm struct {
 	// review page's edit path); the browser leaves it false and keeps the toggle.
 	stagedOnly bool
 
+	// deleteStagedKeys is the set of (name, namespace) keys staged for deletion,
+	// used by the create name validator to reject a delete-staged name inline
+	// rather than dead-ending on the reducer's post-submit error (#692).
+	deleteStagedKeys map[data.StagedKey]struct{}
+
 	// Bound form values.
 	name        string
 	namespace   string
@@ -92,6 +97,9 @@ type EntryFormInput struct {
 	// review can never launch an immediate write that bypasses the staging store.
 	StagedOnly  bool
 	Description string
+	// DeleteStagedKeys lets a create dialog reject a name already staged for
+	// deletion with an inline validation error (#692). Unset for an edit.
+	DeleteStagedKeys map[data.StagedKey]struct{}
 }
 
 // NewEntryForm builds a create/edit dialog. It returns the dialog and its Init
@@ -100,18 +108,19 @@ func NewEntryForm(in EntryFormInput) (Model, tea.Cmd) {
 	svcCap := in.Mutator.Capability()
 
 	d := &entryForm{
-		ctx:         in.Ctx,
-		mutator:     in.Mutator,
-		svcCap:      svcCap,
-		service:     in.Service,
-		styles:      in.Styles,
-		edit:        in.Edit,
-		name:        in.Name,
-		namespace:   in.Namespace,
-		valueType:   defaultTypeLabel(svcCap, in.TypeLabel),
-		value:       in.Value,
-		description: in.Description,
-		stagedOnly:  in.StagedOnly,
+		ctx:              in.Ctx,
+		mutator:          in.Mutator,
+		svcCap:           svcCap,
+		service:          in.Service,
+		styles:           in.Styles,
+		edit:             in.Edit,
+		name:             in.Name,
+		namespace:        in.Namespace,
+		valueType:        defaultTypeLabel(svcCap, in.TypeLabel),
+		value:            in.Value,
+		description:      in.Description,
+		stagedOnly:       in.StagedOnly,
+		deleteStagedKeys: in.DeleteStagedKeys,
 		// Staged by default when the service supports staging; otherwise always
 		// immediate (the mode toggle is hidden). A staged-only surface forces
 		// staged regardless (its toggle is hidden too).
@@ -159,7 +168,7 @@ func (d *entryForm) rebuildForm() tea.Cmd {
 
 	if !d.edit {
 		fields = append(fields, huh.NewInput().Key("name").Title("Name").
-			Value(&d.name).Validate(requiredField("name")))
+			Value(&d.name).Validate(d.nameValidator()))
 	}
 
 	if d.svcCap.HasNamespaces {
@@ -476,6 +485,32 @@ func entryStatus(edit, staged bool, o data.WriteOutcome) string {
 	}
 
 	return "Applied " + verb + "."
+}
+
+// nameValidator builds the create name field's validator: the name is required,
+// and it must not already be staged for deletion. Validating client-side against
+// the delete-staged key set the browser already holds turns what would otherwise
+// be a raw post-submit reducer error ("cannot add to delete-staged") into an
+// inline, friendly message before the write is ever attempted (#692). The key is
+// (typed name, current namespace) read from the live namespace pointer; for the
+// common create (a concrete seeded namespace — an all-namespaces create is
+// blocked upstream) the namespace is fixed, so the check is exact. Should a later
+// namespace edit slip a delete-staged name past this, the reducer still refuses
+// the write — this only upgrades the common case to a friendlier message.
+func (d *entryForm) nameValidator() func(string) error {
+	required := requiredField("name")
+
+	return func(s string) error {
+		if err := required(s); err != nil {
+			return err
+		}
+
+		if _, ok := d.deleteStagedKeys[data.StagedKey{Name: s, Namespace: d.namespace}]; ok {
+			return stringError(s + " is staged for deletion — reset it first")
+		}
+
+		return nil
+	}
 }
 
 // requiredField builds a huh validator that rejects an empty/whitespace value.

--- a/internal/tui/nav/nav.go
+++ b/internal/tui/nav/nav.go
@@ -69,6 +69,12 @@ type OpenEntryForm struct {
 	// GUI's dedicated StagingEdit/StagingAddTag calls, which offer no immediate mode.
 	StagedOnly  bool
 	Description string
+	// DeleteStagedKeys is the set of (name, namespace) keys currently staged for
+	// deletion, carried into a create dialog so the name field can reject a name
+	// that is delete-staged client-side (an inline friendly message) instead of
+	// letting the write dead-end on the reducer's post-submit error (#692). It is
+	// unset for an edit (the name is fixed).
+	DeleteStagedKeys map[data.StagedKey]struct{}
 }
 
 // OpenDelete asks the app to open the delete-confirm dialog for the selected

--- a/internal/tui/pages/browser/browser.go
+++ b/internal/tui/pages/browser/browser.go
@@ -115,8 +115,12 @@ type Model struct {
 	items      []data.Item
 	nextToken  string
 	stagedKeys map[data.StagedKey]struct{}
-	loading    bool
-	spinner    spinner.Model
+	// deleteStagedKeys is the subset of stagedKeys staged for deletion; the
+	// edit/delete/tag affordances are dead-end transitions on such an entry (the
+	// reducer rejects them), so they are gated on this set (#692).
+	deleteStagedKeys map[data.StagedKey]struct{}
+	loading          bool
+	spinner          spinner.Model
 
 	// Detail state.
 	valuePane       components.ValuePane
@@ -135,6 +139,11 @@ type Model struct {
 	detailErr  string
 	historyErr string
 	stagedErr  string
+	// actionStatus is a transient one-line message shown when a key is pressed on
+	// a row where its transition is a dead-end (e.g. edit/delete/tag on a
+	// delete-staged entry) — the browser's parity with the staging page's #684
+	// invalid-action status. It is cleared on the next key press.
+	actionStatus string
 
 	// Monotonic sequence guards (GUI loadSeq pattern): a response is applied only
 	// when its seq still matches the latest issued one.
@@ -180,19 +189,20 @@ func New(ctx context.Context, source data.Source, staging data.StagingProbe, st 
 	sp := spinner.New(spinner.WithSpinner(spinner.Dot))
 
 	m := &Model{
-		ctx:        ctx,
-		source:     source,
-		staging:    staging,
-		svcCap:     source.Capability(),
-		styles:     st,
-		keys:       km,
-		prefix:     prefix,
-		filter:     filter,
-		spinner:    sp,
-		list:       components.NewEntryList(st),
-		history:    components.NewHistoryTable(st),
-		valuePane:  components.NewValuePane(),
-		stagedKeys: map[data.StagedKey]struct{}{},
+		ctx:              ctx,
+		source:           source,
+		staging:          staging,
+		svcCap:           source.Capability(),
+		styles:           st,
+		keys:             km,
+		prefix:           prefix,
+		filter:           filter,
+		spinner:          sp,
+		list:             components.NewEntryList(st),
+		history:          components.NewHistoryTable(st),
+		valuePane:        components.NewValuePane(),
+		stagedKeys:       map[data.StagedKey]struct{}{},
+		deleteStagedKeys: map[data.StagedKey]struct{}{},
 		// Recursive listing defaults on (GUI parity): a param browser shows the whole
 		// subtree under a prefix by default. The toggle is only shown/effective for a
 		// non-namespaced param service; elsewhere the field is inert.

--- a/internal/tui/pages/browser/browser_test.go
+++ b/internal/tui/pages/browser/browser_test.go
@@ -638,24 +638,123 @@ func TestStagingJump(t *testing.T) {
 	assert.True(t, ok, "S emits nav.OpenStaging")
 }
 
-// TestOnStagedLoadedSurfacesStoreHardFail pins the read-path key-loss surfacing:
-// a staging store-construction hard-fail (a key-loss while encrypted state exists)
-// is shown on the browser error line, while an ordinary transient probe read error
-// stays quiet (badges just do not show — no error-line spam).
-func TestOnStagedLoadedSurfacesStoreHardFail(t *testing.T) {
+// TestOnStagedLoadedSurfacesProbeErrors pins the read-path error surfacing (#695):
+// a transient probe read error shows a short "staged status unavailable" note
+// rather than being swallowed (silent swallowing would hide every [staged] badge,
+// making a staged entry look un-staged), and a store-construction hard-fail
+// (a key-loss while encrypted state exists) shows its own actionable message.
+func TestOnStagedLoadedSurfacesProbeErrors(t *testing.T) {
 	t.Parallel()
 
 	m := newModel(t, &stubSource{svcCap: awsParamCap()})
 	_ = m.loadStagedCmd() // advance stagedSeq so the messages are current
 
-	// A transient probe read error is swallowed.
+	// A transient probe read error is surfaced as a non-fatal note, not swallowed.
 	m, _ = update(t, m, stagedLoadedMsg{seq: m.stagedSeq, err: errors.New("probe timeout")})
-	assert.Empty(t, m.stagedErr, "a transient probe error does not spam the error line")
+	assert.Equal(t, "staged status unavailable", m.stagedErr, "a transient probe error is surfaced, not silently dropped")
+	assert.Contains(t, m.errLines(), "staged status unavailable", "the note reaches the rendered error region")
 
-	// A store-construction hard-fail (key-loss) is surfaced.
+	// A store-construction hard-fail (key-loss) is surfaced with its own message.
 	hard := &data.StoreUnavailableError{Err: errors.New("cannot access the staging encryption key")}
 	m, _ = update(t, m, stagedLoadedMsg{seq: m.stagedSeq, err: hard})
 	assert.Contains(t, m.stagedErr, "staging encryption key", "a key-loss hard-fail is surfaced on the read path")
+}
+
+// TestStagedCountUsesEntriesPlusTags pins #693: the browser reports the Staging
+// tab badge count as entries + tag changes (the staging page's definition), so an
+// item with both an entry change and a tag change counts as 2 — never the
+// deduplicated key count (1) the browser used before, which made the badge
+// oscillate between the two surfaces.
+func TestStagedCountUsesEntriesPlusTags(t *testing.T) {
+	t.Parallel()
+
+	m := newModel(t, &stubSource{svcCap: awsSecretCap()})
+	_ = m.loadStagedCmd()
+
+	key := data.StagedKey{Name: "prod/api/key"}
+	// One item carries BOTH a staged entry change and a staged tag change: one
+	// deduplicated key, but two changes.
+	snap := data.StagingSnapshot{
+		Keys:       map[data.StagedKey]struct{}{key: {}},
+		DeleteKeys: map[data.StagedKey]struct{}{},
+		EntryCount: 1,
+		TagCount:   1,
+	}
+
+	_, cmd := update(t, m, stagedLoadedMsg{seq: m.stagedSeq, snap: snap})
+	require.NotNil(t, cmd, "a fresh staged load reports the tab count")
+
+	count, ok := cmd().(nav.StagedCount)
+	require.True(t, ok, "onStagedLoaded emits nav.StagedCount")
+	assert.Equal(t, 2, count.Count, "the badge counts entries + tags (2), not the deduplicated key (1)")
+}
+
+// TestEditDeleteTagGatedOnDeleteStaged pins #692: on an entry staged for deletion,
+// e/d/t do not open their (dead-end) dialogs but set a one-line status message
+// instead — matching the GUI, which hides those controls. A non-delete-staged
+// entry keeps the affordances.
+func TestEditDeleteTagGatedOnDeleteStaged(t *testing.T) {
+	t.Parallel()
+
+	m := newModel(t, &stubSource{svcCap: awsSecretCap()}) // has tags
+	m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{
+		{Name: "prod/live"}, {Name: "prod/doomed"},
+	}}})
+	m, _ = update(t, m, detailLoadedMsg{seq: m.detailSeq, d: data.Detail{Name: "prod/live", Value: "v"}})
+
+	// prod/doomed (index 1) is staged for deletion.
+	doomed := data.StagedKey{Name: "prod/doomed"}
+	snap := data.StagingSnapshot{
+		Keys:       map[data.StagedKey]struct{}{doomed: {}},
+		DeleteKeys: map[data.StagedKey]struct{}{doomed: {}},
+		EntryCount: 1,
+	}
+	m, _ = update(t, m, stagedLoadedMsg{seq: m.stagedSeq, snap: snap})
+
+	m.list.SelectIndex(1) // select the delete-staged entry
+	require.True(t, m.selectedIsDeleteStaged(), "prod/doomed is delete-staged")
+
+	for _, tc := range []struct {
+		key  rune
+		want string
+	}{
+		{'e', "cannot edit: staged for deletion"},
+		{'d', "already staged for deletion"},
+		{'t', "cannot tag: staged for deletion"},
+	} {
+		m, cmd := update(t, m, keyPress(tc.key))
+		assert.Nil(t, cmd, "%c on a delete-staged entry opens no dialog", tc.key)
+		assert.Contains(t, m.actionStatus, tc.want, "%c surfaces the gate status", tc.key)
+		assert.Contains(t, m.errLines(), m.actionStatus, "the gate status renders in the error region")
+	}
+
+	// A non-delete-staged entry keeps the affordances: e opens the edit form.
+	m.list.SelectIndex(0)
+	require.False(t, m.selectedIsDeleteStaged(), "prod/live is not delete-staged")
+	m, cmd := update(t, m, keyPress('e'))
+	require.NotNil(t, cmd, "edit is offered on a non-delete-staged entry")
+	_, ok := cmd().(nav.OpenEntryForm)
+	assert.True(t, ok, "e opens the entry form when the entry is not delete-staged")
+	assert.Empty(t, m.actionStatus, "no gate status on a valid action")
+}
+
+// TestOpenNewCarriesDeleteStagedKeys pins that the create dialog request carries
+// the delete-staged key set, so the entry form can reject a delete-staged name
+// client-side (#692) instead of dead-ending on the reducer.
+func TestOpenNewCarriesDeleteStagedKeys(t *testing.T) {
+	t.Parallel()
+
+	m := newModel(t, &stubSource{svcCap: awsParamCap()})
+	doomed := data.StagedKey{Name: "/app/doomed"}
+	m.deleteStagedKeys = map[data.StagedKey]struct{}{doomed: {}}
+
+	cmd := m.openNew()
+	require.NotNil(t, cmd)
+	form, ok := cmd().(nav.OpenEntryForm)
+	require.True(t, ok, "openNew emits nav.OpenEntryForm")
+	assert.False(t, form.Edit)
+	_, carried := form.DeleteStagedKeys[doomed]
+	assert.True(t, carried, "the create request carries the delete-staged keys for client-side validation")
 }
 
 // TestOpenNewBlocksAllNamespaces pins the App Configuration create-block: a write

--- a/internal/tui/pages/browser/cmds.go
+++ b/internal/tui/pages/browser/cmds.go
@@ -27,7 +27,7 @@ type (
 	}
 	stagedLoadedMsg struct {
 		seq  int
-		keys map[data.StagedKey]struct{}
+		snap data.StagingSnapshot
 		err  error
 	}
 	namespacesLoadedMsg struct {
@@ -105,9 +105,9 @@ func (m *Model) loadStagedCmd() tea.Cmd {
 	probe := m.staging
 
 	return func() tea.Msg {
-		keys, err := probe.StagedKeys(ctx)
+		snap, err := probe.Staged(ctx)
 
-		return stagedLoadedMsg{seq: seq, keys: keys, err: err}
+		return stagedLoadedMsg{seq: seq, snap: snap, err: err}
 	}
 }
 

--- a/internal/tui/pages/browser/mouse.go
+++ b/internal/tui/pages/browser/mouse.go
@@ -8,6 +8,10 @@ import (
 // selects that row and loads its detail (reducing to the same selection a key
 // move performs), and — in compare mode — a history row click picks it.
 func (m *Model) handleMouseClick(msg tea.MouseClickMsg) (*Model, tea.Cmd) {
+	// A mouse interaction dismisses the transient invalid-action status, matching
+	// the key path and the staging page.
+	m.actionStatus = ""
+
 	if msg.Button != tea.MouseLeft {
 		return m, nil
 	}

--- a/internal/tui/pages/browser/update.go
+++ b/internal/tui/pages/browser/update.go
@@ -143,12 +143,16 @@ func (m *Model) onHistoryLoaded(msg historyLoadedMsg) {
 	m.historyVersions = versionIDs(msg.rows)
 }
 
-// onStagedLoaded records the staged-key set, rebuilds the rows so badges appear,
-// and reports the staged count to the app for the Staging tab badge. An ordinary
-// probe read error is non-fatal (badges simply do not show), but a
+// onStagedLoaded records the staged snapshot, rebuilds the rows so badges appear,
+// and reports the staged count to the app for the Staging tab badge. Any probe
+// read error is surfaced on the error line rather than swallowed: a
 // store-construction hard-fail (a staging key-loss while encrypted state exists)
-// is surfaced on the error line so a launch-time key-loss is visible on the read
-// path, not only when the user attempts a write.
+// shows its actionable message, and an ordinary transient read error shows a
+// short "staged status unavailable" note — never full silence, which would hide
+// every [staged] badge and make a staged entry look un-staged (#695). The tab
+// badge counts entries + tag changes — the same definition the staging page uses
+// — so the two surfaces share one count rather than oscillating between a
+// deduplicated-key count and entries+tags (#693).
 func (m *Model) onStagedLoaded(msg stagedLoadedMsg) tea.Cmd {
 	if msg.seq != m.stagedSeq {
 		return nil
@@ -158,29 +162,32 @@ func (m *Model) onStagedLoaded(msg stagedLoadedMsg) tea.Cmd {
 		var storeErr *data.StoreUnavailableError
 		if errors.As(msg.err, &storeErr) {
 			m.stagedErr = storeErr.Error()
+		} else {
+			m.stagedErr = "staged status unavailable"
 		}
 
 		return nil
 	}
 
 	m.stagedErr = ""
-	m.stagedKeys = msg.keys
+	m.stagedKeys = msg.snap.Keys
+	m.deleteStagedKeys = msg.snap.DeleteKeys
 	m.rebuildRows()
 
 	service := m.svcCap.Service
-	count := len(msg.keys)
+	count := msg.snap.EntryCount + msg.snap.TagCount
 
 	return func() tea.Msg { return nav.StagedCount{Service: service, Count: count} }
 }
 
 // errLines returns the active error lines in a stable order — list, detail,
-// history, then the staging-store hard-fail — each owned by its own source so a
-// transient failure clears when that source next succeeds without masking or
-// lingering over another source's state.
+// history, the staging-store/probe note, then the transient invalid-action
+// status — each owned by its own source so a transient failure clears when that
+// source next succeeds without masking or lingering over another source's state.
 func (m *Model) errLines() []string {
-	lines := make([]string, 0, 4) //nolint:mnd // the four error sources
+	lines := make([]string, 0, 5) //nolint:mnd // the four error sources plus the action status
 
-	for _, e := range []string{m.listErr, m.detailErr, m.historyErr, m.stagedErr} {
+	for _, e := range []string{m.listErr, m.detailErr, m.historyErr, m.stagedErr, m.actionStatus} {
 		if e != "" {
 			lines = append(lines, e)
 		}
@@ -235,6 +242,11 @@ func (m *Model) CapturesInput() bool {
 // handleKey routes a key: to a focused text input when editing, else to the
 // page-local bindings, else to the focused list/history widget.
 func (m *Model) handleKey(msg tea.KeyPressMsg) (*Model, tea.Cmd) {
+	// Clear the transient invalid-action status on any key; a dead-end action
+	// below re-sets it when the pressed key is itself invalid for the selection
+	// (mirrors the staging page's #684 status handling).
+	m.actionStatus = ""
+
 	if m.focus == focusPrefix || m.focus == focusFilter {
 		return m.handleInputKey(msg)
 	}
@@ -308,16 +320,52 @@ func (m *Model) handleActionKey(msg tea.KeyPressMsg) (bool, tea.Cmd) {
 	case key.Matches(msg, newKey):
 		return true, m.openNew()
 	case key.Matches(msg, editKey):
+		if m.selectedIsDeleteStaged() {
+			m.actionStatus = "cannot edit: staged for deletion — reset first"
+
+			return true, nil
+		}
+
 		return true, m.openEdit()
 	case key.Matches(msg, deleteKey):
+		if m.selectedIsDeleteStaged() {
+			m.actionStatus = "already staged for deletion — reset first"
+
+			return true, nil
+		}
+
 		return true, m.openDelete()
 	case key.Matches(msg, tagKey):
+		// A no-tags service ignores `t` entirely (openTag is a no-op there), so it
+		// must not surface a delete-staged status that implies tagging is otherwise
+		// possible.
+		if m.svcCap.HasTags && m.selectedIsDeleteStaged() {
+			m.actionStatus = "cannot tag: staged for deletion — reset first"
+
+			return true, nil
+		}
+
 		return true, m.openTag()
 	case key.Matches(msg, restoreKey):
 		return true, m.openRestore()
 	}
 
 	return false, nil
+}
+
+// selectedIsDeleteStaged reports whether the currently-selected entry is staged
+// for deletion. Editing, deleting, or tagging such an entry is a dead-end the
+// reducer rejects post-submit, so the affordance is gated with a friendly status
+// instead (#692), matching the GUI's staging tab, which hides those controls.
+func (m *Model) selectedIsDeleteStaged() bool {
+	item, ok := m.selectedItem()
+	if !ok {
+		return false
+	}
+
+	_, deleteStaged := m.deleteStagedKeys[dataStagedKey(item)]
+
+	return deleteStaged
 }
 
 // openNew requests the create dialog. Creating while viewing all/multiple App
@@ -334,7 +382,11 @@ func (m *Model) openNew() tea.Cmd {
 	}
 
 	return func() tea.Msg {
-		return nav.OpenEntryForm{Service: m.svcCap.Service, Namespace: m.currentNamespace()}
+		return nav.OpenEntryForm{
+			Service:          m.svcCap.Service,
+			Namespace:        m.currentNamespace(),
+			DeleteStagedKeys: m.deleteStagedKeys,
+		}
 	}
 }
 

--- a/internal/tui/pages/staging/update.go
+++ b/internal/tui/pages/staging/update.go
@@ -35,10 +35,9 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 }
 
 // onReviewLoaded applies a staged-review response when fresh, rebuilds the rows,
-// and reports the section's authoritative staged count (entries + tag changes,
-// counted separately) so the Staging tab badge is exact — fixing the browser's
-// best-effort undercount, which deduplicates an item that has both an entry and
-// a tag change into one.
+// and reports the section's staged count as entries + tag changes (counted
+// separately). The browser's staged probe reports the same entries+tags total,
+// so the Staging tab badge reads one consistent count from either surface (#693).
 func (m *Model) onReviewLoaded(msg reviewLoadedMsg) tea.Cmd {
 	if msg.section >= len(m.sections) {
 		return nil

--- a/internal/tui/sources.go
+++ b/internal/tui/sources.go
@@ -332,22 +332,21 @@ func (f *sourceFactory) resolveAWSStagingScope() (provider.Scope, error) {
 }
 
 // lazyStagingProbe defers building the real probe (and thus the on-disk store)
-// to the first StagedKeys call, so page construction never blocks on the
-// keychain.
+// to the first Staged call, so page construction never blocks on the keychain.
 type lazyStagingProbe struct {
 	build func() (data.StagingProbe, error)
 }
 
-func (p *lazyStagingProbe) StagedKeys(ctx context.Context) (map[data.StagedKey]struct{}, error) {
+func (p *lazyStagingProbe) Staged(ctx context.Context) (data.StagingSnapshot, error) {
 	probe, err := p.build()
 	if err != nil {
 		// A build failure is a store-construction hard-fail (e.g. a keychain
 		// key-loss while encrypted state exists). Mark it so the browser surfaces it
 		// on the error line instead of silently dropping the staging badges.
-		return nil, &data.StoreUnavailableError{Err: err}
+		return data.StagingSnapshot{}, &data.StoreUnavailableError{Err: err}
 	}
 
-	return probe.StagedKeys(ctx)
+	return probe.Staged(ctx)
 }
 
 // capabilityFor looks up the ServiceCapability for a provider+service in the

--- a/internal/tui/testdata/TestBrowser_DeleteStagedGateStatusGolden.golden
+++ b/internal/tui/testdata/TestBrowser_DeleteStagedGateStatusGolden.golden
@@ -1,0 +1,34 @@
+suve  aws · profile:dev · account:123456789012 · region:ap-northeast-1
+ Param Secret Staging(1)
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+prefix: —   filter: —   values:off  ⟳
+cannot tag: staged for deletion — reset first
+╭────────────────────────────────────────────╮╭────────────────────────────────────────────────────────────────────────╮
+│entries (2)                                 ││prod/api/key                                                            │
+│▸ prod/api/key                      [staged]││⚠ staged changes — S: staging                                           │
+│  prod/web/session                          ││                                                                        │
+│                                            ││Value   (x to reveal)                                                   │
+│                                            ││••••••••••••                                                            │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+│                                            ││Version ID  a1b2c3d4-1111-2222-3333-444455556666                        │
+│                                            ││Created     2026-07-01 09:30:00                                         │
+│                                            ││ARN         arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:pr│
+│                                            ││Labels      AWSCURRENT                                                  │
+│                                            ││Tags        (none)                                                      │
+│                                            ││                                                                        │
+│                                            ││History   enter: history · c: compare mode                              │
+│                                            ││▹ a1b2c3d4…  2026-07-01  current  [AWSCURRENT]                          │
+│                                            ││  e5f6a7b8…  2026-06-24  [AWSPREVIOUS]                                  │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+╰────────────────────────────────────────────╯╰────────────────────────────────────────────────────────────────────────╯
+ tab next tab • 1/2/3 jump to tab • ? help • q quit


### PR DESCRIPTION
Closes #692
Closes #693
Closes #695

These three bugs all live in the browser page's staged-probe result and badge logic, so they are fixed together. The probe (`internal/tui/data/staging.go`) now returns a `StagingSnapshot` — badge keys, the delete-staged subset, and separate entry/tag counts — which each fix consumes.

## #692 — e/d/t no longer dead-end on delete-staged entries (Medium)

On an entry staged for deletion, `e`/`d`/`t` used to open their dialogs and then fail post-submit with a raw reducer string (`cannot edit: staged for deletion, reset first`). They are now gated on the selected item's delete-staged state (`internal/tui/pages/browser/update.go`) with a friendly one-line transient status — the browser's parity with the staging page's #684 status handling — matching the GUI, which hides those controls. The `t` gate is guarded by `HasTags` so a no-tags service does not imply tagging is otherwise possible.

Per the affordance sweep, the `n` create form (whose name is typed before its staged state is knowable) now validates the typed name against the delete-staged key set client-side (`internal/tui/dialogs/entryform.go`), turning the reducer's post-submit `cannot add to delete-staged` into an inline message before the write is attempted.

## #693 — one Staging tab badge count (Low)

The badge oscillated between the browser's deduplicated-key count (entry+tag change on one item = 1) and the staging page's entries+tags count (= 2). **Chosen definition: entries + tags** (the staging page's definition, per the maintainer). The probe now reports entry and tag counts separately, and the browser feeds the badge `EntryCount + TagCount`, so both surfaces report the same total.

## #695 — transient probe read errors no longer hide all badges (Low)

A transient probe *read* error was swallowed (only a store-construction hard-fail was surfaced), so every `[staged]` badge silently vanished and a staged entry looked un-staged. Any probe read error is now surfaced: a store hard-fail keeps its actionable message; a transient read error shows a short `staged status unavailable` note.

## Tests (TUI regression, all layers this change touches)

- `internal/tui/pages/browser/browser_test.go`: `TestEditDeleteTagGatedOnDeleteStaged` (e/d/t gated + valid entry still offered), `TestStagedCountUsesEntriesPlusTags` (badge = entries+tags), `TestOnStagedLoadedSurfacesProbeErrors` (probe error surfaced, not swallowed), `TestOpenNewCarriesDeleteStagedKeys`.
- `internal/tui/dialogs/dialogs_test.go`: `TestEntryForm_CreateNameRejectsDeleteStaged` (create-name validator).
- `internal/tui/browser_golden_test.go` + golden: `TestBrowser_DeleteStagedGateStatusGolden` (the gate status line rendered on screen).

## Verification

```
$ go test -race ./internal/tui/...
ok  github.com/mpyw/suve/internal/tui         4.822s
ok  github.com/mpyw/suve/internal/tui/data    1.353s
ok  github.com/mpyw/suve/internal/tui/dialogs 1.956s
ok  github.com/mpyw/suve/internal/tui/pages/browser 1.658s
ok  github.com/mpyw/suve/internal/tui/pages/diff    2.325s
ok  github.com/mpyw/suve/internal/tui/pages/staging 1.446s

$ mise test
ok  github.com/mpyw/suve/internal/tui ...  (full suite green)

$ golangci-lint run --allow-parallel-runners --timeout=10m
0 issues.

$ mise build-gui
✓ built in 916ms
Built bin/suve — run 'suve --gui'.
```

The rendered gate status (from `TestBrowser_DeleteStagedGateStatusGolden`):

```
 Param Secret Staging(1)
────────────────────────────────────────────────────────────────────
prefix: —   filter: —   values:off  ⟳
cannot tag: staged for deletion — reset first
╭──────────────────────╮╭─────────────────────────────────╮
│entries (2)           ││prod/api/key                     │
│▸ prod/api/key [staged]││⚠ staged changes — S: staging   │
│  prod/web/session    ││ ...                             │
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
