### PR TITLE
fix(tui): distinguish value/tag/both in the browser staged banner (#701)

### DIFF
--- a/internal/tui/browser_fixtures_test.go
+++ b/internal/tui/browser_fixtures_test.go
@@ -32,12 +32,16 @@ func capFor(prov, service string) capability.ServiceCapability {
 
 // staticProbe is a test staging probe returning a fixed staged snapshot, so a
 // golden can exercise the [staged] badge, the staged-changes banner, and the
-// delete-staged affordance gate without a keychain. deleteKeys/entryCount/tagCount
-// are optional; when both counts are left zero they default to one staged entry
-// per key, so an existing golden that sets only keys keeps its Staging(n) badge.
+// delete-staged affordance gate without a keychain. deleteKeys/entryKeys/tagKeys
+// and entryCount/tagCount are optional; when both counts are left zero they
+// default to one staged entry per key, and when neither entryKeys nor tagKeys is
+// set every key defaults to an entry (value) change — so an existing golden that
+// sets only keys keeps its Staging(n) badge and its value-change banner.
 type staticProbe struct {
 	keys       map[data.StagedKey]struct{}
 	deleteKeys map[data.StagedKey]struct{}
+	entryKeys  map[data.StagedKey]struct{}
+	tagKeys    map[data.StagedKey]struct{}
 	entryCount int
 	tagCount   int
 }
@@ -48,9 +52,16 @@ func (p staticProbe) Staged(context.Context) (data.StagingSnapshot, error) {
 		entryCount = len(p.keys)
 	}
 
+	entryKeys, tagKeys := p.entryKeys, p.tagKeys
+	if entryKeys == nil && tagKeys == nil {
+		entryKeys = p.keys
+	}
+
 	return data.StagingSnapshot{
 		Keys:       p.keys,
 		DeleteKeys: p.deleteKeys,
+		EntryKeys:  entryKeys,
+		TagKeys:    tagKeys,
 		EntryCount: entryCount,
 		TagCount:   tagCount,
 	}, nil

--- a/internal/tui/browser_golden_test.go
+++ b/internal/tui/browser_golden_test.go
@@ -136,6 +136,72 @@ func TestBrowser_DeleteStagedGateStatusGolden(t *testing.T) { //nolint:parallelt
 	golden.RequireEqual(t, screen)
 }
 
+// The default selection is index 0 (/app/api/DATABASE_URL); staging that entry
+// makes its detail-pane banner render, so the three staged-kind goldens below
+// pin the value-only / tag-only / both wording (#701).
+//
+//nolint:gochecknoglobals // immutable test fixture
+var stagedSelectedKey = data.StagedKey{Name: "/app/api/DATABASE_URL"}
+
+// awsParamStagedBannerApp builds the AWS param browser with the default-selected
+// entry staged for the given change kinds.
+func awsParamStagedBannerApp(entry, tags bool) *App {
+	keySet := map[data.StagedKey]struct{}{stagedSelectedKey: {}}
+	probe := staticProbe{keys: keySet}
+
+	if entry {
+		probe.entryKeys = keySet
+	}
+
+	if tags {
+		probe.tagKeys = keySet
+	}
+
+	return newApp(config{
+		scope:     provider.Scope{Provider: provider.ProviderAWS},
+		identity:  awsIdentityFixture(),
+		sourceFor: sourceForShape("param", awsParamSource(), probe),
+	})
+}
+
+// TestBrowser_StagedValueBannerGolden pins the value-only staged banner: the
+// selected entry has a staged value change and no tag change.
+func TestBrowser_StagedValueBannerGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
+	goldenEnv(t)
+
+	raw := captureUntil(t, awsParamStagedBannerApp(true, false), "staged value changes", browserTermWidth, browserTermHeight)
+	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+
+	require.Contains(t, screen, "⚠ staged value changes — S: staging", "value-only shows the value-change banner")
+	require.NotContains(t, screen, "tag changes", "value-only must not mention tag changes")
+	golden.RequireEqual(t, screen)
+}
+
+// TestBrowser_StagedTagBannerGolden pins the tag-only staged banner: the selected
+// entry has a staged tag change and no value change.
+func TestBrowser_StagedTagBannerGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
+	goldenEnv(t)
+
+	raw := captureUntil(t, awsParamStagedBannerApp(false, true), "staged tag changes", browserTermWidth, browserTermHeight)
+	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+
+	require.Contains(t, screen, "⚠ staged tag changes — S: staging", "tag-only shows the tag-change banner")
+	require.NotContains(t, screen, "value and tag", "tag-only must not use the combined wording")
+	golden.RequireEqual(t, screen)
+}
+
+// TestBrowser_StagedValueAndTagBannerGolden pins the combined staged banner: the
+// selected entry has both a staged value change and a staged tag change.
+func TestBrowser_StagedValueAndTagBannerGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
+	goldenEnv(t)
+
+	raw := captureUntil(t, awsParamStagedBannerApp(true, true), "staged value and tag changes", browserTermWidth, browserTermHeight)
+	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+
+	require.Contains(t, screen, "⚠ staged value and tag changes — S: staging", "both shows the combined banner")
+	golden.RequireEqual(t, screen)
+}
+
 // TestBrowser_AWSSecretGolden renders the AWS secret browser (staging labels +
 // ARN, masked value).
 func TestBrowser_AWSSecretGolden(t *testing.T) { //nolint:paralleltest // goldenEnv calls t.Setenv (NO_COLOR/TZ), which forbids t.Parallel

--- a/internal/tui/data/staging.go
+++ b/internal/tui/data/staging.go
@@ -19,13 +19,19 @@ type StagedKey struct {
 // StagingSnapshot is the browser's read-only view of a service's staged state.
 // Keys drives the [staged] badge and the detail banner; DeleteKeys is the subset
 // staged for deletion, so the browser can gate the edit/delete/tag affordances
-// that the reducer would reject as dead-end transitions (#692). EntryCount and
+// that the reducer would reject as dead-end transitions (#692). EntryKeys and
+// TagKeys split Keys by change kind — a value/entry change and a tag change —
+// so the detail banner can distinguish value-only / tag-only / both, mirroring
+// the GUI's StagingStatus {hasEntry, hasTags} pair
+// (internal/gui/frontend/src/lib/StagingBanner.svelte) (#701). EntryCount and
 // TagCount are the staged entry-row and tag-change totals whose sum feeds the
 // Staging tab badge — the same entries+tags definition the staging page uses, so
 // the badge no longer oscillates between two counts (#693).
 type StagingSnapshot struct {
 	Keys       map[StagedKey]struct{}
 	DeleteKeys map[StagedKey]struct{}
+	EntryKeys  map[StagedKey]struct{}
+	TagKeys    map[StagedKey]struct{}
 	EntryCount int
 	TagCount   int
 }
@@ -77,6 +83,8 @@ func (p *stagingProbe) Staged(ctx context.Context) (StagingSnapshot, error) {
 	snap := StagingSnapshot{
 		Keys:       make(map[StagedKey]struct{}, len(out.Entries)+len(out.TagEntries)),
 		DeleteKeys: map[StagedKey]struct{}{},
+		EntryKeys:  make(map[StagedKey]struct{}, len(out.Entries)),
+		TagKeys:    make(map[StagedKey]struct{}, len(out.TagEntries)),
 		EntryCount: len(out.Entries),
 		TagCount:   len(out.TagEntries),
 	}
@@ -84,6 +92,7 @@ func (p *stagingProbe) Staged(ctx context.Context) (StagingSnapshot, error) {
 	for _, e := range out.Entries {
 		key := StagedKey{Name: e.Name, Namespace: e.Namespace}
 		snap.Keys[key] = struct{}{}
+		snap.EntryKeys[key] = struct{}{}
 
 		if e.Operation == staging.OperationDelete {
 			snap.DeleteKeys[key] = struct{}{}
@@ -91,7 +100,9 @@ func (p *stagingProbe) Staged(ctx context.Context) (StagingSnapshot, error) {
 	}
 
 	for _, t := range out.TagEntries {
-		snap.Keys[StagedKey{Name: t.Name, Namespace: t.Namespace}] = struct{}{}
+		key := StagedKey{Name: t.Name, Namespace: t.Namespace}
+		snap.Keys[key] = struct{}{}
+		snap.TagKeys[key] = struct{}{}
 	}
 
 	return snap, nil

--- a/internal/tui/pages/browser/browser.go
+++ b/internal/tui/pages/browser/browser.go
@@ -119,8 +119,13 @@ type Model struct {
 	// edit/delete/tag affordances are dead-end transitions on such an entry (the
 	// reducer rejects them), so they are gated on this set (#692).
 	deleteStagedKeys map[data.StagedKey]struct{}
-	loading          bool
-	spinner          spinner.Model
+	// entryStagedKeys and tagStagedKeys split stagedKeys by change kind (value/entry
+	// vs tag), so the detail banner distinguishes value-only / tag-only / both,
+	// matching the GUI's StagingBanner (#701).
+	entryStagedKeys map[data.StagedKey]struct{}
+	tagStagedKeys   map[data.StagedKey]struct{}
+	loading         bool
+	spinner         spinner.Model
 
 	// Detail state.
 	valuePane       components.ValuePane
@@ -203,6 +208,8 @@ func New(ctx context.Context, source data.Source, staging data.StagingProbe, st 
 		valuePane:        components.NewValuePane(),
 		stagedKeys:       map[data.StagedKey]struct{}{},
 		deleteStagedKeys: map[data.StagedKey]struct{}{},
+		entryStagedKeys:  map[data.StagedKey]struct{}{},
+		tagStagedKeys:    map[data.StagedKey]struct{}{},
 		// Recursive listing defaults on (GUI parity): a param browser shows the whole
 		// subtree under a prefix by default. The toggle is only shown/effective for a
 		// non-namespaced param service; elsewhere the field is inert.

--- a/internal/tui/pages/browser/browser_test.go
+++ b/internal/tui/pages/browser/browser_test.go
@@ -757,6 +757,60 @@ func TestOpenNewCarriesDeleteStagedKeys(t *testing.T) {
 	assert.True(t, carried, "the create request carries the delete-staged keys for client-side validation")
 }
 
+// TestStagedBannerDistinguishesKind pins #701: the detail-pane staged banner
+// distinguishes a staged value change, a staged tag change, and both — matching
+// the GUI's StagingBanner — rather than collapsing every staged kind into one
+// message. Each case stages the default-selected entry with a different change
+// kind and asserts the rendered banner wording.
+func TestStagedBannerDistinguishesKind(t *testing.T) {
+	t.Parallel()
+
+	const name = "/app/x"
+
+	key := data.StagedKey{Name: name}
+	keySet := map[data.StagedKey]struct{}{key: {}}
+
+	cases := []struct {
+		label   string
+		entry   bool
+		tags    bool
+		want    string
+		notWant string
+	}{
+		{"value-only", true, false, "⚠ staged value changes — S: staging", "tag changes"},
+		{"tag-only", false, true, "⚠ staged tag changes — S: staging", "value and tag"},
+		{"both", true, true, "⚠ staged value and tag changes — S: staging", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			t.Parallel()
+
+			m := newModel(t, &stubSource{svcCap: awsParamCap()})
+			m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{{Name: name}}}})
+			m, _ = update(t, m, detailLoadedMsg{seq: m.detailSeq, d: data.Detail{Name: name}})
+
+			snap := data.StagingSnapshot{Keys: keySet}
+			if tc.entry {
+				snap.EntryKeys = keySet
+			}
+
+			if tc.tags {
+				snap.TagKeys = keySet
+			}
+
+			m, _ = update(t, m, stagedLoadedMsg{seq: m.stagedSeq, snap: snap})
+
+			out := m.View(m.width, m.height)
+			assert.Contains(t, out, tc.want, "banner reflects the staged change kind")
+
+			if tc.notWant != "" {
+				assert.NotContains(t, out, tc.notWant, "banner must not use another kind's wording")
+			}
+		})
+	}
+}
+
 // TestOpenNewBlocksAllNamespaces pins the App Configuration create-block: a write
 // targets one concrete namespace, so requesting the create dialog while the
 // header filter is on `*` (all namespaces) emits an OpenError rather than the

--- a/internal/tui/pages/browser/update.go
+++ b/internal/tui/pages/browser/update.go
@@ -172,6 +172,8 @@ func (m *Model) onStagedLoaded(msg stagedLoadedMsg) tea.Cmd {
 	m.stagedErr = ""
 	m.stagedKeys = msg.snap.Keys
 	m.deleteStagedKeys = msg.snap.DeleteKeys
+	m.entryStagedKeys = msg.snap.EntryKeys
+	m.tagStagedKeys = msg.snap.TagKeys
 	m.rebuildRows()
 
 	service := m.svcCap.Service

--- a/internal/tui/pages/browser/view.go
+++ b/internal/tui/pages/browser/view.go
@@ -167,8 +167,8 @@ func (m *Model) renderDetail(innerW, innerH int) (string, int, int) {
 
 	var lines []string
 
-	if m.isSelectedStaged() {
-		lines = append(lines, m.styles.Banner.Render(clip("⚠ staged changes — S: staging", innerW)))
+	if text, staged := m.selectedStagedBanner(); staged {
+		lines = append(lines, m.styles.Banner.Render(clip(text, innerW)))
 		lines = append(lines, "")
 	}
 
@@ -273,18 +273,38 @@ func (m *Model) historyHeaderLine(width int) string {
 	return clip(title+"   "+m.styles.PageHint.Render(hint), width)
 }
 
-// isSelectedStaged reports whether the selected entry has staged changes. It
-// resolves the item by index (see selectedItem) so a namespaced duplicate keys
-// the banner off the correct (name, namespace) pair.
-func (m *Model) isSelectedStaged() bool {
+// selectedStagedBanner returns the detail-pane banner text for the selected
+// entry and whether it is staged at all. The text distinguishes a staged value
+// change, a staged tag change, and both — mirroring the GUI's StagingBanner
+// (internal/gui/frontend/src/lib/StagingBanner.svelte) so the affordance no
+// longer collapses every staged kind into one message (#701). It resolves the
+// item by index (see selectedItem) so a namespaced duplicate keys the banner off
+// the correct (name, namespace) pair.
+func (m *Model) selectedStagedBanner() (string, bool) {
 	item, ok := m.selectedItem()
 	if !ok {
-		return false
+		return "", false
 	}
 
-	_, staged := m.stagedKeys[dataStagedKey(item)]
+	key := dataStagedKey(item)
+	if _, staged := m.stagedKeys[key]; !staged {
+		return "", false
+	}
 
-	return staged
+	_, hasEntry := m.entryStagedKeys[key]
+	_, hasTags := m.tagStagedKeys[key]
+
+	switch {
+	case hasEntry && hasTags:
+		return "⚠ staged value and tag changes — S: staging", true
+	case hasTags:
+		return "⚠ staged tag changes — S: staging", true
+	default:
+		// A staged key with no tag change is a value/entry change (create, edit, or
+		// delete); the value wording also covers the defensive case of a staged key
+		// absent from both split sets.
+		return "⚠ staged value changes — S: staging", true
+	}
 }
 
 // fieldLine renders a "Label  value" metadata row, clipped to width.

--- a/internal/tui/testdata/TestBrowser_StagedTagBannerGolden.golden
+++ b/internal/tui/testdata/TestBrowser_StagedTagBannerGolden.golden
@@ -1,26 +1,26 @@
 suve  aws · profile:dev · account:123456789012 · region:ap-northeast-1
  Param Secret Staging(1)
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-prefix: —   filter: —   values:off  ⟳
-cannot tag: staged for deletion — reset first
+prefix: —   filter: —   values:off  recursive:on  ⟳
 ╭────────────────────────────────────────────╮╭────────────────────────────────────────────────────────────────────────╮
-│entries (2)                                 ││prod/api/key                                                            │
-│▸ prod/api/key                      [staged]││⚠ staged value changes — S: staging                                     │
-│  prod/web/session                          ││                                                                        │
-│                                            ││Value   (x to reveal)                                                   │
-│                                            ││••••••••••••                                                            │
+│entries (3)                                 ││/app/api/DATABASE_URL                                                   │
+│▸ /app/api/DATABASE_URL             [staged]││⚠ staged tag changes — S: staging                                       │
+│  /app/api/REDIS_URL                        ││                                                                        │
+│  /app/web/BASE_URL                         ││Value   (x to reveal)                                                   │
+│                                            ││••••••••••••••••••••••••                                                │
 │                                            ││                                                                        │
 │                                            ││                                                                        │
 │                                            ││                                                                        │
-│                                            ││Version ID  a1b2c3d4-1111-2222-3333-444455556666                        │
-│                                            ││Created     2026-07-01 09:30:00                                         │
-│                                            ││ARN         arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:pr│
-│                                            ││Labels      AWSCURRENT                                                  │
-│                                            ││Tags        (none)                                                      │
+│                                            ││Version     14 (current)                                                │
+│                                            ││Type        SecureString                                                │
+│                                            ││Modified    2026-07-01 09:30:00                                         │
+│                                            ││Tags        env=prod · team=api                                         │
 │                                            ││                                                                        │
 │                                            ││History   enter: history · c: compare mode                              │
-│                                            ││▹ a1b2c3d4…  2026-07-01  current  [AWSCURRENT]                          │
-│                                            ││  e5f6a7b8…  2026-06-24  [AWSPREVIOUS]                                  │
+│                                            ││▹ #14  2026-07-01  current                                              │
+│                                            ││  #13  2026-06-24                                                       │
+│                                            ││  #12  2026-06-02                                                       │
+│                                            ││                                                                        │
 │                                            ││                                                                        │
 │                                            ││                                                                        │
 │                                            ││                                                                        │

--- a/internal/tui/testdata/TestBrowser_StagedValueAndTagBannerGolden.golden
+++ b/internal/tui/testdata/TestBrowser_StagedValueAndTagBannerGolden.golden
@@ -1,26 +1,26 @@
 suve  aws · profile:dev · account:123456789012 · region:ap-northeast-1
  Param Secret Staging(1)
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-prefix: —   filter: —   values:off  ⟳
-cannot tag: staged for deletion — reset first
+prefix: —   filter: —   values:off  recursive:on  ⟳
 ╭────────────────────────────────────────────╮╭────────────────────────────────────────────────────────────────────────╮
-│entries (2)                                 ││prod/api/key                                                            │
-│▸ prod/api/key                      [staged]││⚠ staged value changes — S: staging                                     │
-│  prod/web/session                          ││                                                                        │
-│                                            ││Value   (x to reveal)                                                   │
-│                                            ││••••••••••••                                                            │
+│entries (3)                                 ││/app/api/DATABASE_URL                                                   │
+│▸ /app/api/DATABASE_URL             [staged]││⚠ staged value and tag changes — S: staging                             │
+│  /app/api/REDIS_URL                        ││                                                                        │
+│  /app/web/BASE_URL                         ││Value   (x to reveal)                                                   │
+│                                            ││••••••••••••••••••••••••                                                │
 │                                            ││                                                                        │
 │                                            ││                                                                        │
 │                                            ││                                                                        │
-│                                            ││Version ID  a1b2c3d4-1111-2222-3333-444455556666                        │
-│                                            ││Created     2026-07-01 09:30:00                                         │
-│                                            ││ARN         arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:pr│
-│                                            ││Labels      AWSCURRENT                                                  │
-│                                            ││Tags        (none)                                                      │
+│                                            ││Version     14 (current)                                                │
+│                                            ││Type        SecureString                                                │
+│                                            ││Modified    2026-07-01 09:30:00                                         │
+│                                            ││Tags        env=prod · team=api                                         │
 │                                            ││                                                                        │
 │                                            ││History   enter: history · c: compare mode                              │
-│                                            ││▹ a1b2c3d4…  2026-07-01  current  [AWSCURRENT]                          │
-│                                            ││  e5f6a7b8…  2026-06-24  [AWSPREVIOUS]                                  │
+│                                            ││▹ #14  2026-07-01  current                                              │
+│                                            ││  #13  2026-06-24                                                       │
+│                                            ││  #12  2026-06-02                                                       │
+│                                            ││                                                                        │
 │                                            ││                                                                        │
 │                                            ││                                                                        │
 │                                            ││                                                                        │

--- a/internal/tui/testdata/TestBrowser_StagedValueBannerGolden.golden
+++ b/internal/tui/testdata/TestBrowser_StagedValueBannerGolden.golden
@@ -1,26 +1,26 @@
 suve  aws · profile:dev · account:123456789012 · region:ap-northeast-1
  Param Secret Staging(1)
 ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
-prefix: —   filter: —   values:off  ⟳
-cannot tag: staged for deletion — reset first
+prefix: —   filter: —   values:off  recursive:on  ⟳
 ╭────────────────────────────────────────────╮╭────────────────────────────────────────────────────────────────────────╮
-│entries (2)                                 ││prod/api/key                                                            │
-│▸ prod/api/key                      [staged]││⚠ staged value changes — S: staging                                     │
-│  prod/web/session                          ││                                                                        │
-│                                            ││Value   (x to reveal)                                                   │
-│                                            ││••••••••••••                                                            │
+│entries (3)                                 ││/app/api/DATABASE_URL                                                   │
+│▸ /app/api/DATABASE_URL             [staged]││⚠ staged value changes — S: staging                                     │
+│  /app/api/REDIS_URL                        ││                                                                        │
+│  /app/web/BASE_URL                         ││Value   (x to reveal)                                                   │
+│                                            ││••••••••••••••••••••••••                                                │
 │                                            ││                                                                        │
 │                                            ││                                                                        │
 │                                            ││                                                                        │
-│                                            ││Version ID  a1b2c3d4-1111-2222-3333-444455556666                        │
-│                                            ││Created     2026-07-01 09:30:00                                         │
-│                                            ││ARN         arn:aws:secretsmanager:ap-northeast-1:123456789012:secret:pr│
-│                                            ││Labels      AWSCURRENT                                                  │
-│                                            ││Tags        (none)                                                      │
+│                                            ││Version     14 (current)                                                │
+│                                            ││Type        SecureString                                                │
+│                                            ││Modified    2026-07-01 09:30:00                                         │
+│                                            ││Tags        env=prod · team=api                                         │
 │                                            ││                                                                        │
 │                                            ││History   enter: history · c: compare mode                              │
-│                                            ││▹ a1b2c3d4…  2026-07-01  current  [AWSCURRENT]                          │
-│                                            ││  e5f6a7b8…  2026-06-24  [AWSPREVIOUS]                                  │
+│                                            ││▹ #14  2026-07-01  current                                              │
+│                                            ││  #13  2026-06-24                                                       │
+│                                            ││  #12  2026-06-02                                                       │
+│                                            ││                                                                        │
 │                                            ││                                                                        │
 │                                            ││                                                                        │
 │                                            ││                                                                        │


### PR DESCRIPTION
Closes #701

## Problem

The browser detail-pane staged banner was a single fixed string
(`⚠ staged changes — S: staging`) for any staged entry, so an entry whose only
staged change is a tag add looked identical to one with a staged value edit —
the user couldn't tell what kind of change was pending without opening the
Staging tab. The GUI already distinguishes these
(`internal/gui/frontend/src/lib/StagingBanner.svelte`: value / tag / both, off
its `StagingStatus {hasEntry, hasTags}` pair).

## Fix

Cited site: `internal/tui/pages/browser/view.go`.

Builds on the #721 probe snapshot rather than re-deriving staged state:

- `data.StagingSnapshot` (`internal/tui/data/staging.go`) now carries `EntryKeys`
  (keys with a value/entry change — create, edit, or delete) and `TagKeys` (keys
  with a tag change), split from the existing union `Keys`. The `[staged]` badge,
  `DeleteKeys` gate, and the entries+tags tab-badge count are untouched.
- The browser records both sets and `selectedStagedBanner` varies the wording off
  per-key membership, mirroring the GUI's three-way message priority
  (both → value → tag):
  - value-only → `⚠ staged value changes — S: staging`
  - tag-only → `⚠ staged tag changes — S: staging`
  - both → `⚠ staged value and tag changes — S: staging`

A delete-staged entry reads "staged value changes" (a delete is an entry change),
matching the GUI's `hasEntry`.

## Tests (TUI, where the bug lives)

- Update-level `TestStagedBannerDistinguishesKind` (`internal/tui/pages/browser/browser_test.go`):
  stages the selected entry value-only / tag-only / both and asserts each banner
  wording (plus negative assertions against the other kinds' wording).
- Three teatest goldens (`internal/tui/browser_golden_test.go`):
  `TestBrowser_StagedValue{,AndTag}BannerGolden` / `TestBrowser_StagedTagBannerGolden`
  render three distinct banner lines.

This is a TUI-only presentation fix (the GUI is the reference and already has this
distinction + Playwright coverage), so no new CLI e2e / Playwright layer applies.

## Verification

```
$ go test -race ./internal/tui/...
ok  	github.com/mpyw/suve/internal/tui	4.718s
ok  	github.com/mpyw/suve/internal/tui/data	2.291s
ok  	github.com/mpyw/suve/internal/tui/dialogs	1.848s
ok  	github.com/mpyw/suve/internal/tui/pages/browser	1.279s
ok  	github.com/mpyw/suve/internal/tui/pages/diff	1.952s
ok  	github.com/mpyw/suve/internal/tui/pages/staging	2.460s

$ golangci-lint run --allow-parallel-runners --timeout=10m
0 issues.

$ mise build-gui
✓ built in 1.46s
Built bin/suve — run 'suve --gui'.
```

Three distinct banner lines from the generated goldens:

```
TestBrowser_StagedValueBannerGolden.golden:       ⚠ staged value changes — S: staging
TestBrowser_StagedTagBannerGolden.golden:         ⚠ staged tag changes — S: staging
TestBrowser_StagedValueAndTagBannerGolden.golden: ⚠ staged value and tag changes — S: staging
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
