### PR TITLE
fix(staging): mask create-staged SecureString param in the staging review (#719)

### DIFF
--- a/internal/gui/frontend/tests/secret-service-mask.spec.ts
+++ b/internal/gui/frontend/tests/secret-service-mask.spec.ts
@@ -134,3 +134,42 @@ test.describe('SecureString-param staging review masking (per-entry flag, #715)'
     expect(body).toMatch(/\*/);
   });
 });
+
+test.describe('SecureString-param staging review CREATE masking (#719)', () => {
+  // A create has no remote to fetch, so the diff usecase used to leave its
+  // Secret flag false — the create-staged value rendered in cleartext. The flag
+  // now derives from the staged value type (SecureString ⇒ secret), so a
+  // create-staged SecureString param is masked like every other secret value.
+  const SECURE_CREATE_VALUE = 'securestring-created-plaintext';
+
+  async function gotoParamCreateStaging(page: import('@playwright/test').Page) {
+    await setupWailsMocks(page, {
+      ...createParamStagedState([
+        { name: '/app/secure/new-token', operation: 'create', value: SECURE_CREATE_VALUE, secret: true },
+      ]),
+    });
+    await page.goto('/');
+    await navigateTo(page, 'Staging');
+    await expect(page.locator('.entry-item').first()).toBeVisible();
+  }
+
+  test('masks a create-staged SecureString param value in diff view', async ({ page }) => {
+    await gotoParamCreateStaging(page);
+    // Default view mode is Diff; a create renders its staged value directly.
+    await expect(page.getByRole('button', { name: 'Diff' })).toHaveClass(/active/);
+
+    const body = (await page.locator('.staging-content').textContent()) ?? '';
+    expect(body).not.toContain(SECURE_CREATE_VALUE);
+    expect(body).toMatch(/\*/);
+  });
+
+  test('masks a create-staged SecureString param value in value view', async ({ page }) => {
+    await gotoParamCreateStaging(page);
+    await page.getByRole('button', { name: 'Value' }).click();
+    await expect(page.getByRole('button', { name: 'Value' })).toHaveClass(/active/);
+
+    const body = (await page.locator('.staging-content').textContent()) ?? '';
+    expect(body).not.toContain(SECURE_CREATE_VALUE);
+    expect(body).toMatch(/\*/);
+  });
+});

--- a/internal/tui/staging_golden_test.go
+++ b/internal/tui/staging_golden_test.go
@@ -36,6 +36,11 @@ const secretStagedValue = "super-secret-token-value"
 // type, not the section's service axis (#677); it must never render revealed.
 const secureStringParamValue = "securestring-db-password-value"
 
+// secureStringCreateValue is a SecureString PARAM staged CREATE value. A create
+// has no remote to fetch, so its Secret flag is derived from the staged value
+// type (#719); it must never render revealed.
+const secureStringCreateValue = "securestring-created-api-key-value"
+
 // goldenStaging is a golden-only data.StagingService returning a fixed review
 // and (for the results golden) a fixed apply result. It never touches a store.
 type goldenStaging struct {
@@ -162,6 +167,77 @@ func secureStringStagingApp() *App {
 		identity:   awsIdentityFixture(),
 		stagingFor: secureStringStagingFixture(),
 	})
+}
+
+// secureStringCreateStagingFixture wires a param section holding a single
+// SecureString param staged CREATE (Secret=true) alongside a plaintext param
+// create, so a golden can prove the SecureString create value is masked in the
+// PARAM (non-secret) section while the plaintext one is not — a create has no
+// remote, so its Secret flag comes from the staged value type (#719).
+func secureStringCreateStagingFixture() func(string) data.StagingService {
+	param := &goldenStaging{
+		service: "param", label: "Param", svcCap: goldenCap("aws", "param"),
+		review: data.StagingReview{
+			Entries: []data.StagedDiffRow{
+				{
+					Name: "/app/api/SECURE_CREATE", Type: data.StagedDiffCreate, Operation: "create", Secret: true,
+					StagedValue: secureStringCreateValue,
+				},
+				{
+					Name: "/app/web/NEW_CDN_URL", Type: data.StagedDiffCreate, Operation: "create",
+					StagedValue: "https://cdn-new.example.com",
+				},
+			},
+		},
+	}
+
+	return func(service string) data.StagingService {
+		if service == "param" {
+			return param
+		}
+
+		return nil
+	}
+}
+
+// secureStringCreateStagingApp lands on the Staging tab with only the
+// SecureString param create fixture wired.
+func secureStringCreateStagingApp() *App {
+	return newApp(config{
+		scope:      provider.Scope{Provider: provider.ProviderAWS},
+		service:    "staging",
+		identity:   awsIdentityFixture(),
+		stagingFor: secureStringCreateStagingFixture(),
+	})
+}
+
+// TestStaging_SecureStringParamCreateDiffViewGolden pins that a SecureString
+// param staged CREATE is masked in the PARAM section, while a plaintext param
+// create is shown verbatim — a create derives its Secret flag from the staged
+// value type (#719).
+func TestStaging_SecureStringParamCreateDiffViewGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
+	goldenEnv(t)
+
+	raw := captureStaging(t, secureStringCreateStagingApp(), "SECURE_CREATE", false)
+	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+
+	assert.NotContains(t, screen, secureStringCreateValue, "no revealed SecureString param create value in the diff-view golden")
+	assert.Contains(t, screen, "•", "the SecureString param create row is masked with bullets, proving it renders (not just absent)")
+	assert.Contains(t, screen, "https://cdn-new.example.com", "a plaintext param create row is NOT masked")
+	golden.RequireEqual(t, screen)
+}
+
+// TestStaging_SecureStringParamCreateValueViewGolden pins the same masking after
+// toggling to value view.
+func TestStaging_SecureStringParamCreateValueViewGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
+	goldenEnv(t)
+
+	raw := captureStaging(t, secureStringCreateStagingApp(), "SECURE_CREATE", true)
+	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+
+	assert.NotContains(t, screen, secureStringCreateValue, "no revealed SecureString param create value in the value-view golden")
+	assert.Contains(t, screen, "•", "the SecureString param create row is masked with bullets, proving it renders (not just absent)")
+	golden.RequireEqual(t, screen)
 }
 
 // TestStaging_SecureStringParamDiffViewGolden pins that a SecureString param

--- a/internal/tui/testdata/TestStaging_SecureStringParamCreateDiffViewGolden.golden
+++ b/internal/tui/testdata/TestStaging_SecureStringParamCreateDiffViewGolden.golden
@@ -1,0 +1,34 @@
+suve  aws · profile:dev · account:123456789012 · region:ap-northeast-1
+ Param Secret Staging(2)
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+view: [diff] value   A apply-all · R reset-all · ctrl+r refresh
+Param (2)                                                                                             a apply · r reset
+▸ create  /app/api/SECURE_CREATE
+    + ••••••••••••••••••••••••
+  create  /app/web/NEW_CDN_URL
+    + https://cdn-new.example.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+e edit · u unstage · t tags · x reveal · enter detail · v view · a apply · r reset
+ tab next tab • 1/2/3 jump to tab • ? help • q quit

--- a/internal/tui/testdata/TestStaging_SecureStringParamCreateValueViewGolden.golden
+++ b/internal/tui/testdata/TestStaging_SecureStringParamCreateValueViewGolden.golden
@@ -1,0 +1,34 @@
+suve  aws · profile:dev · account:123456789012 · region:ap-northeast-1
+ Param Secret Staging(2)
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+view: diff [value]   A apply-all · R reset-all · ctrl+r refresh
+Param (2)                                                                                             a apply · r reset
+▸ create  /app/api/SECURE_CREATE   ••••••••••••••••••••••••
+  create  /app/web/NEW_CDN_URL   https://cdn-new.example.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+e edit · u unstage · t tags · x reveal · enter detail · v view · a apply · r reset
+ tab next tab • 1/2/3 jump to tab • ? help • q quit

--- a/internal/usecase/staging/diff.go
+++ b/internal/usecase/staging/diff.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/parallel"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/staging"
@@ -293,6 +294,10 @@ func (u *DiffUseCase) handleFetchError(ctx context.Context, key staging.EntryKey
 			Operation:   entry.Operation,
 			StagedValue: lo.FromPtr(entry.Value),
 			Description: entry.Description,
+			// A create has no remote to fetch, so derive Secret from the staged
+			// value type: a SecureString param (or any secret-typed staged value)
+			// is masked in the review like every other secret value (#719).
+			Secret: entry.ValueType == domain.ValueTypeSecret,
 		}, nil
 
 	case staging.OperationUpdate:

--- a/internal/usecase/staging/diff_test.go
+++ b/internal/usecase/staging/diff_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store/testutil"
@@ -158,6 +159,37 @@ func TestDiffUseCase_Execute_CreateDiff(t *testing.T) {
 	assert.Equal(t, usecasestaging.DiffEntryCreate, entry.Type)
 	assert.Equal(t, "new-value", entry.StagedValue)
 	assert.Equal(t, "new param", *entry.Description)
+	assert.False(t, entry.Secret, "a plaintext param create staged diff is not secret")
+}
+
+// TestDiffUseCase_Execute_CreateDiff_SecretFromValueType pins that a staged
+// SecureString-param CREATE flags the diff entry secret from its staged value
+// type — a create has no remote to fetch, so the Secret flag must come from the
+// staged ValueType rather than a fetch result (#719).
+func TestDiffUseCase_Execute_CreateDiff_SecretFromValueType(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/secret"}, staging.Entry{
+		Operation: staging.OperationCreate,
+		Value:     lo.ToPtr("new-secret"),
+		ValueType: domain.ValueTypeSecret,
+		StagedAt:  time.Now(),
+	}))
+
+	strategy := newMockDiffStrategy()
+	strategy.fetchErrors["/app/secret"] = provider.ErrNotFound
+
+	uc := &usecasestaging.DiffUseCase{Strategy: strategy, Store: store}
+
+	output, err := uc.Execute(t.Context(), usecasestaging.DiffInput{})
+	require.NoError(t, err)
+	require.Len(t, output.Entries, 1)
+
+	entry := output.Entries[0]
+	assert.Equal(t, usecasestaging.DiffEntryCreate, entry.Type)
+	assert.Equal(t, "new-secret", entry.StagedValue)
+	assert.True(t, entry.Secret, "a SecureString param create flags the diff entry secret from its staged value type")
 }
 
 func TestDiffUseCase_Execute_DeleteDiff(t *testing.T) {


### PR DESCRIPTION
Closes #719

## Problem

A create-staged SecureString param rendered its value in **cleartext** in the staging review (both TUI and GUI). PR #711/#720 masked SecureString-param **updates** (which carry a remote value the fetch path flags secret) and secret-**service** entries — but a **create** has no remote to fetch, so the diff usecase's `OperationCreate` branch left `DiffEntry.Secret` false, and neither frontend's param section masks an unflagged row.

## Fix

Root-cause fix at the cited site — `internal/usecase/staging/diff.go`, `handleFetchError` `OperationCreate` branch:

```go
Secret: entry.ValueType == domain.ValueTypeSecret,
```

The create-staged entry already carries its `ValueType` (the #664/#680 plumbing), so deriving `Secret` from it closes the gap uniformly at the usecase layer and flows to **both** frontends through the existing per-row masking path they already had:

- TUI `internal/tui/pages/staging/view.go`: `sec.secret || e.Secret` (mapped via `internal/tui/data/stagingservice.go`).
- GUI `internal/gui/frontend/src/lib/StagingSection.svelte`: `rowSecret = secret || entry.secret` (threaded via `internal/gui/staging.go`).

**No bindings change.** The `StagingDiffEntry` DTO and `wailsjs/go/models.ts` already carry the `secret` field from #715; `TestDTOContract` still passes.

The already-fixed update/remote path (`processDiffResult` → `Secret: fetchResult.Secret`) is untouched, so #711/#720 masking is not regressed.

## Scope note

Creates staged **through the GUI itself** still record no value type (`App.StagingAdd` sends none) — a known, separate limitation explicitly called out in #719. The GUI reproduction for #719 is a CLI-staged SecureString create against the shared staging store; that entry records `ValueType=Secret`, and the GUI review now masks it. Threading the value type through `App.StagingAdd` (and the related apply-time type loss) is a distinct follow-up, not part of #719's prescribed fix.

## Regression tests (three layers)

- **Go unit** (`internal/usecase/staging/diff_test.go`): `TestDiffUseCase_Execute_CreateDiff_SecretFromValueType` — a create + `ValueTypeSecret` yields `DiffEntry.Secret=true`; the existing plaintext-create test now asserts `Secret=false`.
- **TUI teatest goldens** (`internal/tui/staging_golden_test.go`): `TestStaging_SecureStringParamCreate{DiffView,ValueView}Golden` — the create-staged SecureString value is masked with bullets (no plaintext) while a plaintext param create renders verbatim.
- **GUI Playwright** (`internal/gui/frontend/tests/secret-service-mask.spec.ts`): `SecureString-param staging review CREATE masking (#719)` — masked in both diff and value view.

## Verification

`mise test`:
```
ok  github.com/mpyw/suve/internal/usecase/staging  0.217s
ok  github.com/mpyw/suve/internal/tui              (cached)
ok  github.com/mpyw/suve/internal/tui/data         2.505s
... (all packages ok)
```

`go test -race ./internal/tui/...`:
```
ok  github.com/mpyw/suve/internal/tui              4.263s
ok  github.com/mpyw/suve/internal/tui/data         1.796s
ok  github.com/mpyw/suve/internal/tui/pages/staging 1.813s
```

`golangci-lint run --allow-parallel-runners --timeout=10m`:
```
0 issues.
```

`mise build-gui`:
```
✓ built in 1.01s
Built bin/suve — run 'suve --gui'.
```
`go test -tags dev ./internal/gui/... -run TestDTOContract` → `ok github.com/mpyw/suve/internal/gui`.

GUI Playwright (`cd internal/gui/frontend && npm run test`):
```
1475 passed (3.9m)
1 failed  [webkit] tests/keyboard-focus.spec.ts:54 › should allow Tab navigation through item list
```
The single failure is a pre-existing webkit Tab-focus flake, unrelated to this change — it reproduces on the clean `epic/tui` base with the working tree stashed. The four masking specs (including the two new create cases) pass on webkit in isolation.

New TUI diff-view golden (SecureString create masked, plaintext create verbatim):
```
▸ create  /app/api/SECURE_CREATE
    + ••••••••••••••••••••••••
  create  /app/web/NEW_CDN_URL
    + https://cdn-new.example.com
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)