### PR TITLE
refactor(tui): migrate mouse hit-testing to the lipgloss compositor (#663)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -23,6 +23,7 @@ import (
 	"github.com/mpyw/suve/internal/tui/components"
 	"github.com/mpyw/suve/internal/tui/data"
 	"github.com/mpyw/suve/internal/tui/dialogs"
+	"github.com/mpyw/suve/internal/tui/hit"
 	"github.com/mpyw/suve/internal/tui/keys"
 	"github.com/mpyw/suve/internal/tui/nav"
 	"github.com/mpyw/suve/internal/tui/styles"
@@ -126,6 +127,13 @@ type App struct {
 	// overlay stack; the top dialog captures input while any dialog is open.
 	pages   []page
 	dialogs []dialog
+
+	// dialogHits is the last-rendered overlay hit map: one region per dialog box at
+	// its centered screen position. A click while modal is resolved against it, and
+	// the hit region's bounds give the box origin the click is translated by — so a
+	// click reaching a dialog is un-offset via the compositor's layer origin rather
+	// than by re-deriving the centering math (the #663 dialog-offset fix).
+	dialogHits *hit.Map
 
 	keys   keys.Map
 	styles styles.Styles
@@ -582,20 +590,56 @@ func numberedTabJump(k keys.Map, msg tea.KeyPressMsg) (int, bool) {
 // jump keys perform), else to the active page.
 func (m *App) handleMouseClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
 	if len(m.dialogs) > 0 {
-		return m.updateTopDialog(msg)
+		return m.forwardDialogClick(msg)
 	}
 
 	// Below the minimum size the shell draws only the too-small notice — no tab
-	// bar — so a click at the tab-bar row must not hit-test (and switch) an
-	// invisible tab. Gate mouse tab selection on the same size the shell renders.
-	if m.width >= minWidth && m.height >= minHeight &&
-		msg.Button == tea.MouseLeft && msg.Y == m.tabBarRow() {
+	// bar or help bar — so a click on those rows must not hit-test invisible
+	// chrome. Gate mouse chrome selection on the same size the shell renders.
+	if m.width < minWidth || m.height < minHeight {
+		return m.updateActivePage(m.translateMouseClick(msg))
+	}
+
+	if msg.Button == tea.MouseLeft && msg.Y == m.tabBarRow() {
 		if i, ok := m.tabBar().TabAtX(msg.X); ok {
 			return m, m.jumpTab(i)
 		}
 	}
 
+	// A click on the help bar toggles the short/full help, the same as `?`.
+	if msg.Button == tea.MouseLeft && msg.Y >= m.helpBarTop() {
+		m.help.ShowAll = !m.help.ShowAll
+
+		return m, nil
+	}
+
 	return m.updateActivePage(m.translateMouseClick(msg))
+}
+
+// forwardDialogClick resolves a modal click against the overlay hit map and, when
+// it lands on the top dialog's box, forwards it translated into that dialog's
+// content-local coordinates (box origin from the hit region's bounds, plus the
+// frame inset). A click outside the top box is swallowed — a modal never leaks a
+// click to the page beneath it.
+func (m *App) forwardDialogClick(msg tea.MouseClickMsg) (tea.Model, tea.Cmd) {
+	top := len(m.dialogs) - 1
+
+	id, dx, dy, ok := m.dialogHits.At(msg.X, msg.Y)
+	if !ok || id != strconv.Itoa(top) {
+		return m, nil
+	}
+
+	left, topInset := m.dialogFrameOffset()
+	msg.X = dx - left
+	msg.Y = dy - topInset
+
+	return m.updateTopDialog(msg)
+}
+
+// helpBarTop is the first terminal row the (short or full) help bar occupies, so
+// a click at or below it is a help-toggle rather than a page-body click.
+func (m *App) helpBarTop() int {
+	return m.height - lipgloss.Height(m.helpView())
 }
 
 // translateMouseClick shifts a click's Y from screen coordinates into the active
@@ -1048,20 +1092,37 @@ func (m *App) helpView() string {
 	return m.styles.HelpBar.Render(" " + m.help.View(m.keys))
 }
 
-// overlayDialogs draws each dialog as a centered lipgloss v2 layer over the
-// page, later dialogs on top.
+// overlayDialogs draws each dialog as a centered lipgloss v2 layer over the page
+// (later dialogs on top) and rebuilds the overlay hit map: one region per dialog
+// box at the same centered position, so a modal click is resolved and un-offset
+// against the very layer that was drawn.
 func (m *App) overlayDialogs(base string) string {
 	canvas := lipgloss.NewCanvas(m.width, m.height)
 	canvas.Compose(lipgloss.NewLayer(base))
 
-	for _, d := range m.dialogs {
+	regions := make([]*lipgloss.Layer, 0, len(m.dialogs))
+
+	for i, d := range m.dialogs {
 		box := m.styles.Dialog.Render(d.View())
 		x := max((m.width-lipgloss.Width(box))/2, 0)   //nolint:mnd // centered horizontally
 		y := max((m.height-lipgloss.Height(box))/2, 0) //nolint:mnd // centered vertically
 		canvas.Compose(lipgloss.NewLayer(box).X(x).Y(y))
+		regions = append(regions,
+			hit.Region(strconv.Itoa(i), x, y, lipgloss.Width(box), lipgloss.Height(box)).Z(i))
 	}
 
+	m.dialogHits = hit.New(regions...)
+
 	return canvas.Render()
+}
+
+// dialogFrameOffset is the (left, top) content inset the shell's dialog frame
+// adds around a dialog's View content: the rounded border plus horizontal
+// padding. Subtracting it (plus the box origin) from a screen click yields the
+// dialog's content-local coordinate.
+func (m *App) dialogFrameOffset() (left, top int) {
+	return m.styles.Dialog.GetBorderLeftSize() + m.styles.Dialog.GetPaddingLeft(),
+		m.styles.Dialog.GetBorderTopSize() + m.styles.Dialog.GetPaddingTop()
 }
 
 // placeholderNotice is the muted text a tab's placeholder page shows, naming

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -291,6 +291,84 @@ func columnForTab(tb components.TabBar, target int) (int, bool) {
 	return 0, false
 }
 
+// TestUpdate_DialogClickTranslatedToContentLocal pins the #663 dialog-offset fix:
+// a click inside a centered dialog box reaches the dialog translated into its own
+// content-local coordinates — the box origin (from the overlay hit region) and
+// the frame inset subtracted — so a dialog hit-tests its controls without knowing
+// the shell's centering math. The screen coordinate is derived from the drawn
+// overlay region, never hard-coded.
+func TestUpdate_DialogClickTranslatedToContentLocal(t *testing.T) {
+	t.Parallel()
+
+	m := newApp(config{scope: provider.Scope{Provider: provider.ProviderAWS}, identity: awsIdentityFixture()})
+	m = updateApp(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	fd := &fakeDialog{}
+	m.dialogs = []dialog{fd}
+	_ = m.View() // composes the overlay and builds the dialog hit map
+
+	bx, by, ok := m.dialogHits.Origin("0")
+	require.True(t, ok, "the top dialog's box region is drawn")
+
+	left, top := m.dialogFrameOffset()
+
+	// Click a point 3 columns into the dialog content; the dialog must see (3, 0).
+	const dx, dy = 3, 0
+
+	_ = updateApp(t, m, tea.MouseClickMsg{X: bx + left + dx, Y: by + top + dy, Button: tea.MouseLeft})
+
+	var click *tea.MouseClickMsg
+
+	for _, msg := range fd.got {
+		if c, isClick := msg.(tea.MouseClickMsg); isClick {
+			c := c
+			click = &c
+		}
+	}
+
+	require.NotNil(t, click, "the click reached the dialog")
+	assert.Equal(t, dx, click.X, "X is translated to content-local (box origin + frame subtracted)")
+	assert.Equal(t, dy, click.Y, "Y is translated to content-local")
+}
+
+// TestUpdate_DialogClickOutsideBoxSwallowed pins that a modal click landing
+// outside the dialog box is swallowed — it never reaches the dialog and never
+// leaks to the page beneath (modality is preserved).
+func TestUpdate_DialogClickOutsideBoxSwallowed(t *testing.T) {
+	t.Parallel()
+
+	m := newApp(config{scope: provider.Scope{Provider: provider.ProviderAWS}, identity: awsIdentityFixture()})
+	m = updateApp(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	fd := &fakeDialog{}
+	m.dialogs = []dialog{fd}
+	_ = m.View()
+
+	// (0,0) is the top-left corner, well outside the centered box.
+	_ = updateApp(t, m, tea.MouseClickMsg{X: 0, Y: 0, Button: tea.MouseLeft})
+
+	for _, msg := range fd.got {
+		_, isClick := msg.(tea.MouseClickMsg)
+		assert.False(t, isClick, "a click outside the box is swallowed, not forwarded to the dialog")
+	}
+}
+
+// TestUpdate_HelpBarClickTogglesHelp pins that a click on the bottom help bar
+// toggles the short/full help, reducing to the same toggle `?` performs.
+func TestUpdate_HelpBarClickTogglesHelp(t *testing.T) {
+	t.Parallel()
+
+	m := newApp(config{scope: provider.Scope{Provider: provider.ProviderAWS}, identity: awsIdentityFixture()})
+	m = updateApp(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
+	require.False(t, m.help.ShowAll, "help starts collapsed")
+
+	m = updateApp(t, m, tea.MouseClickMsg{X: 1, Y: m.helpBarTop(), Button: tea.MouseLeft})
+	assert.True(t, m.help.ShowAll, "clicking the help bar expands the help (like ?)")
+
+	m = updateApp(t, m, tea.MouseClickMsg{X: 1, Y: m.helpBarTop(), Button: tea.MouseLeft})
+	assert.False(t, m.help.ShowAll, "clicking again collapses it")
+}
+
 // TestUpdate_CopyToClipboard pins that the `y` key routes a non-empty focused
 // value through the OSC52 clipboard seam (asserted via a stub, never real escape
 // bytes), and — the guard — that with no value it does NOT touch the clipboard:

--- a/internal/tui/dialogs/apply.go
+++ b/internal/tui/dialogs/apply.go
@@ -12,7 +12,15 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/mpyw/suve/internal/tui/data"
+	"github.com/mpyw/suve/internal/tui/hit"
 	"github.com/mpyw/suve/internal/tui/styles"
+)
+
+// Apply confirm-phase button region IDs (the results phase reuses regionClose).
+const (
+	applyRegionIgnore = "ignore"
+	applyRegionApply  = "apply"
+	applyRegionCancel = "apply-cancel"
 )
 
 // resultsChrome is the vertical overhead the results view reserves around its
@@ -78,6 +86,9 @@ type applyDialog struct {
 	// scrollable records whether the last synced body overflowed the viewport, so
 	// the close hint can advertise the scroll keys only when they do something.
 	scrollable bool
+	// hits maps a click on the confirm controls (ignore/apply/cancel) or the
+	// results close hint to the same action their key equivalents perform.
+	hits *hit.Map
 }
 
 // ApplyInput configures an apply dialog.
@@ -149,11 +160,49 @@ func (d *applyDialog) Update(msg tea.Msg) (Model, tea.Cmd) {
 		d.vp, cmd = d.vp.Update(msg)
 
 		return d, cmd
+	case tea.MouseClickMsg:
+		return d.handleClick(msg)
 	case tea.KeyPressMsg:
 		return d.handleKey(msg)
 	}
 
 	return d, nil
+}
+
+// handleClick reduces a click to the same action its key equivalent performs: in
+// the results phase the close hint closes (like enter); in the confirm phase the
+// ignore/apply/cancel controls each focus + activate. Busy swallows clicks (the
+// #568 double-fire guard).
+func (d *applyDialog) handleClick(msg tea.MouseClickMsg) (Model, tea.Cmd) {
+	if d.phase == phaseBusy {
+		return d, nil
+	}
+
+	id, _, _, ok := d.hits.At(msg.X, msg.Y)
+	if !ok {
+		return d, nil
+	}
+
+	if d.phase == phaseResults {
+		if id == regionClose {
+			return d, doneCmd("", d.summary(), true)
+		}
+
+		return d, nil
+	}
+
+	switch id {
+	case applyRegionIgnore:
+		d.focus = int(ctrlIgnore)
+	case applyRegionApply:
+		d.focus = int(ctrlApply)
+	case applyRegionCancel:
+		d.focus = int(ctrlApplyCancel)
+	default:
+		return d, nil
+	}
+
+	return d.activate()
 }
 
 func (d *applyDialog) handleKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
@@ -246,22 +295,42 @@ func (d *applyDialog) View() string {
 func (d *applyDialog) confirmView() string {
 	var b strings.Builder
 
-	b.WriteString(d.fit(d.styles.PaneTitle.Render(d.title)))
+	title := d.fit(d.styles.PaneTitle.Render(d.title))
+	target := d.fit(d.styles.FieldLabel.Render("Target  ") + " " + d.targetLine)
+	changes := d.fit(d.styles.FieldLabel.Render("Changes ") + " " + d.changesLine())
+
+	b.WriteString(title)
 	b.WriteString("\n\n")
-	b.WriteString(d.fit(d.styles.FieldLabel.Render("Target  ")+" "+d.targetLine) + "\n")
-	b.WriteString(d.fit(d.styles.FieldLabel.Render("Changes ")+" "+d.changesLine()) + "\n\n")
+	b.WriteString(target + "\n")
+	b.WriteString(changes + "\n\n")
 
 	if d.phase == phaseBusy {
+		d.hits = hit.New() // no controls while applying
 		b.WriteString(d.styles.PageHint.Render("applying…"))
 
 		return b.String()
 	}
 
-	b.WriteString(d.confirmRow(ctrlIgnore, checkbox(d.ignoreConflicts)+" Ignore conflicts"))
+	ignoreRow := d.confirmRow(ctrlIgnore, checkbox(d.ignoreConflicts)+" Ignore conflicts")
+	applyBtn := d.confirmRow(ctrlApply, "[ Apply ]")
+	cancelBtn := d.confirmRow(ctrlApplyCancel, "[ Cancel ]")
+
+	b.WriteString(ignoreRow)
 	b.WriteString("\n\n")
-	b.WriteString(d.confirmRow(ctrlApply, "[ Apply ]") + "    " + d.confirmRow(ctrlApplyCancel, "[ Cancel ]"))
+	b.WriteString(applyBtn + "    " + cancelBtn)
 	b.WriteString("\n\n")
 	b.WriteString(d.styles.PageHint.Render("↑↓: move · space/enter: toggle/confirm · esc: cancel"))
+
+	// The ignore row sits below the title, its blank line, the target/changes
+	// lines, and their blank line; the Apply/Cancel buttons one blank line below it.
+	ignoreY := lipgloss.Height(title) + 1 + lipgloss.Height(target) + lipgloss.Height(changes) + 1
+	buttonY := ignoreY + lipgloss.Height(ignoreRow) + 1
+	applyW := lipgloss.Width(applyBtn)
+	d.hits = hit.New(
+		hit.Region(applyRegionIgnore, 0, ignoreY, max(lipgloss.Width(ignoreRow), 1), 1),
+		hit.Region(applyRegionApply, 0, buttonY, applyW, 1),
+		hit.Region(applyRegionCancel, applyW+buttonGap, buttonY, lipgloss.Width(cancelBtn), 1),
+	)
 
 	return b.String()
 }
@@ -309,14 +378,21 @@ func (d *applyDialog) resultsView() string {
 	// Once sized, the body scrolls inside the viewport; before the first
 	// WindowSizeMsg it renders inline (uncapped) so a size-less unit render still
 	// shows every line.
+	body := d.resultsBody()
 	if d.sized() {
-		b.WriteString(d.vp.View())
-	} else {
-		b.WriteString(d.resultsBody())
+		body = d.vp.View()
 	}
 
+	b.WriteString(body)
 	b.WriteString("\n\n")
-	b.WriteString(d.styles.PageHint.Render(d.resultsHint()))
+
+	hint := d.styles.PageHint.Render(d.resultsHint())
+	b.WriteString(hint)
+
+	// The close hint sits below the pinned title, its blank line, the results body,
+	// and its blank line; a click on it closes like enter/esc.
+	closeY := 1 + 1 + lipgloss.Height(body) + 1
+	d.hits = hit.New(hit.Region(regionClose, 0, closeY, lipgloss.Width(hint), 1))
 
 	return b.String()
 }

--- a/internal/tui/dialogs/apply_test.go
+++ b/internal/tui/dialogs/apply_test.go
@@ -12,8 +12,20 @@ import (
 
 	"github.com/mpyw/suve/internal/capability"
 	"github.com/mpyw/suve/internal/tui/data"
+	"github.com/mpyw/suve/internal/tui/hit"
 	"github.com/mpyw/suve/internal/tui/styles"
 )
+
+// clickAt builds a left click at a hit region's drawn origin, so a dialog mouse
+// test derives its coordinate from the layout instead of hard-coding one.
+func clickAt(t *testing.T, hits *hit.Map, id string) tea.MouseClickMsg {
+	t.Helper()
+
+	x, y, ok := hits.Origin(id)
+	require.True(t, ok, "region %q was drawn", id)
+
+	return tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft}
+}
 
 // stubStaging is a controllable data.StagingService for the apply/reset dialog
 // tests: Apply returns a preset result (or a conflict result until conflicts are
@@ -395,6 +407,101 @@ func TestReset_FanOutAggregation(t *testing.T) {
 	require.True(t, ok, "reset emits a done message")
 	assert.Contains(t, done.Status, "5", "the aggregate voices the summed unstaged count (2+3)")
 	assert.False(t, next.Busy(), "the dialog clears busy once the reset finishes")
+}
+
+// TestApply_MouseClickConfirmControls pins #663's confirm-dialog coverage: a
+// click on the Ignore checkbox, Apply, and Cancel reduces to the same action the
+// key path performs (toggle, confirm, cancel), with coordinates from the drawn
+// control regions.
+func TestApply_MouseClickConfirmControls(t *testing.T) {
+	t.Parallel()
+
+	newDialog := func() *applyDialog {
+		svc := &stubStaging{service: "param", label: "Param", result: data.StagingApplyResult{ServiceLabel: "Param"}}
+		m := NewApply(ApplyInput{
+			Ctx: context.Background(), Targets: []data.StagingService{svc},
+			TargetLine: "aws", Title: "Apply staged changes — Param", EntryCount: 1, Styles: styles.New(),
+		})
+		m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+		_ = m.View()
+		d, ok := m.(*applyDialog)
+		require.True(t, ok)
+
+		return d
+	}
+
+	// Ignore checkbox click toggles ignoreConflicts (like enter on it).
+	d := newDialog()
+	require.False(t, d.ignoreConflicts)
+	_, _ = d.Update(clickAt(t, d.hits, applyRegionIgnore))
+	assert.True(t, d.ignoreConflicts, "clicking the Ignore checkbox toggles it")
+
+	// Apply button click confirms: busy + fan-out command (like focus Apply + enter).
+	d = newDialog()
+	_, cmd := d.Update(clickAt(t, d.hits, applyRegionApply))
+	assert.True(t, d.Busy(), "clicking Apply starts the fan-out")
+	require.NotNil(t, cmd, "clicking Apply dispatches the apply command")
+
+	// Cancel button click cancels.
+	d = newDialog()
+	_, cmd = d.Update(clickAt(t, d.hits, applyRegionCancel))
+	require.NotNil(t, cmd)
+	_, ok := cmd().(CanceledMsg)
+	assert.True(t, ok, "clicking Cancel cancels")
+}
+
+// TestApply_MouseClickResultsCloses pins that clicking the results close hint
+// closes with the same reload+voice enter performs.
+func TestApply_MouseClickResultsCloses(t *testing.T) {
+	t.Parallel()
+
+	d := appliedResults(t, data.StagingApplyResult{
+		ServiceLabel: "Param",
+		Entries:      []data.ApplyEntryResult{{Name: "a", Status: "updated"}},
+	})
+	_ = d.View() // build the results-phase close region
+
+	_, cmd := d.Update(clickAt(t, d.hits, regionClose))
+	require.NotNil(t, cmd, "clicking the close hint dispatches")
+	done, ok := cmd().(MutationDoneMsg)
+	require.True(t, ok, "clicking close emits MutationDoneMsg (like enter)")
+	assert.Contains(t, done.Status, "Applied", "the outcome is voiced")
+}
+
+// TestReset_MouseClickButtons pins that clicking the Reset/Cancel buttons reduces
+// to the same action the key path performs.
+func TestReset_MouseClickButtons(t *testing.T) {
+	t.Parallel()
+
+	newDialog := func() *resetDialog {
+		svc := &stubStaging{
+			service: "param", label: "Param",
+			resetResult: data.StagingResetResult{Type: data.StagingResetUnstagedAll, Count: 1},
+		}
+		m := NewReset(ResetInput{
+			Ctx: context.Background(), Targets: []data.StagingService{svc},
+			Title: "Reset staged changes — Param", Styles: styles.New(),
+		})
+		m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+		_ = m.View()
+		d, ok := m.(*resetDialog)
+		require.True(t, ok)
+
+		return d
+	}
+
+	// Cancel click cancels.
+	d := newDialog()
+	_, cmd := d.Update(clickAt(t, d.hits, resetRegionCancel))
+	require.NotNil(t, cmd)
+	_, ok := cmd().(CanceledMsg)
+	assert.True(t, ok, "clicking Cancel cancels")
+
+	// Reset click confirms: busy + reset command.
+	d = newDialog()
+	_, cmd = d.Update(clickAt(t, d.hits, resetRegionReset))
+	assert.True(t, d.Busy(), "clicking Reset starts the reset")
+	require.NotNil(t, cmd, "clicking Reset dispatches the reset command")
 }
 
 // TestReset_DefaultFocusCancels pins that the reset confirm opens focused on

--- a/internal/tui/dialogs/deleteconfirm.go
+++ b/internal/tui/dialogs/deleteconfirm.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mpyw/suve/internal/capability"
 	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/tui/data"
+	"github.com/mpyw/suve/internal/tui/hit"
 	"github.com/mpyw/suve/internal/tui/styles"
 )
 
@@ -66,6 +67,23 @@ type deleteConfirm struct {
 	focus int
 	busy  bool
 	err   string
+	// hits maps a click on a control row to focusing (and, for a toggle/button,
+	// activating) that control — the same reduction its keyboard navigation +
+	// enter performs.
+	hits *hit.Map
+}
+
+// deleteControlID / deleteControlFromID map a control to a stable region ID and
+// back, so a click resolves to the exact control it lands on.
+func deleteControlID(c deleteControl) string { return "ctrl-" + strconv.Itoa(int(c)) }
+
+func deleteControlFromID(id string) (deleteControl, bool) {
+	n, err := strconv.Atoi(strings.TrimPrefix(id, "ctrl-"))
+	if err != nil {
+		return 0, false
+	}
+
+	return deleteControl(n), true
 }
 
 // DeleteInput configures a delete dialog.
@@ -136,6 +154,12 @@ func (d *deleteConfirm) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return d, nil
 	case mutationResultMsg:
 		return d.onResult(msg)
+	case tea.MouseClickMsg:
+		if d.busy {
+			return d, nil // double-submit guard
+		}
+
+		return d.handleClick(msg)
 	case tea.KeyPressMsg:
 		if d.busy {
 			return d, nil // double-submit guard
@@ -145,6 +169,30 @@ func (d *deleteConfirm) Update(msg tea.Msg) (Model, tea.Cmd) {
 	}
 
 	return d, nil
+}
+
+// handleClick resolves a click against the control regions and reduces it to
+// focusing that control, then activating it when it is a toggle or button — the
+// same reduction as navigating to the control and pressing enter. The recovery
+// row only takes focus (its value adjusts with ←/→, not a click).
+func (d *deleteConfirm) handleClick(msg tea.MouseClickMsg) (Model, tea.Cmd) {
+	id, _, _, ok := d.hits.At(msg.X, msg.Y)
+	if !ok {
+		return d, nil
+	}
+
+	c, cok := deleteControlFromID(id)
+	if !cok {
+		return d, nil
+	}
+
+	d.focusControl(c)
+
+	if c == ctrlRecovery {
+		return d, nil
+	}
+
+	return d.activate()
 }
 
 func (d *deleteConfirm) handleKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
@@ -195,17 +243,30 @@ func (d *deleteConfirm) adjust(delta int) {
 }
 
 // activate acts on the focused control: toggles force/mode, submits, or cancels.
+//
+// Toggling force/mode adds or removes the recovery-window row, reshaping the
+// dialog's height. Bubble Tea would service that shrink/grow with a partial
+// cell-update optimization whose exact bytes depend on the terminal's
+// synchronized-output negotiation, so under CI (which negotiates differently
+// than a local run) a byte-stream assertion on the post-toggle frame can miss a
+// string split across the partial writes. Forcing a full repaint on the reshape
+// makes the toggle frame environment-independent — the same fix the staging
+// page's view toggle applies.
 func (d *deleteConfirm) activate() (Model, tea.Cmd) {
 	switch d.focused() {
 	case ctrlForce:
 		d.force = !d.force
 		// Toggling force changes the control set (hides/shows recovery); keep focus.
 		d.focusControl(ctrlForce)
+
+		return d, tea.ClearScreen
 	case ctrlMode:
 		d.staged = !d.staged
 		// Toggling mode changes the control set (staged shows the recovery row);
 		// keep focus on the mode row rather than letting the index drift.
 		d.focusControl(ctrlMode)
+
+		return d, tea.ClearScreen
 	case ctrlDelete:
 		d.busy = true
 
@@ -272,16 +333,35 @@ func (d *deleteConfirm) View() string {
 	b.WriteString("\n\n")
 
 	if d.busy {
+		d.hits = hit.New() // no controls while working
 		b.WriteString(d.styles.PageHint.Render("working…"))
 
 		return b.String()
 	}
 
-	var controls strings.Builder
+	// Controls begin below the header, its blank line, the name, and its blank
+	// line; each is one row except the recovery row (its "recoverable until" hint
+	// adds a second). Record a hit region per control at its drawn rows.
+	firstControl := lipgloss.Height(header) + 1 + lipgloss.Height(name) + 1
+	ctrlWidth := max(d.contentWidth(), 1)
+
+	var (
+		controls strings.Builder
+		regions  []*lipgloss.Layer
+		line     = firstControl
+	)
+
 	for _, c := range d.controls() {
-		controls.WriteString(d.renderControl(c))
+		rc := d.renderControl(c)
+		h := lipgloss.Height(rc)
+		regions = append(regions, hit.Region(deleteControlID(c), 0, line, ctrlWidth, h))
+		line += h
+
+		controls.WriteString(rc)
 		controls.WriteString("\n")
 	}
+
+	d.hits = hit.New(regions...)
 
 	// Wrap the hint too: it is the widest fixed line and would otherwise push the
 	// box past a 60-column terminal, clipping "esc: cancel" off the edge.

--- a/internal/tui/dialogs/dialogs_test.go
+++ b/internal/tui/dialogs/dialogs_test.go
@@ -735,6 +735,65 @@ func TestRestoreForm_Routing(t *testing.T) {
 	assert.True(t, mut.restoreCalled)
 }
 
+// TestDeleteConfirm_MouseClickControls pins #663's delete-dialog coverage: a
+// click on the force checkbox, the mode radio, the Delete button, and Cancel each
+// reduces to the same action navigating to the control and pressing enter/space
+// performs, with coordinates from the drawn control regions.
+func TestDeleteConfirm_MouseClickControls(t *testing.T) {
+	t.Parallel()
+
+	sized := func() *deleteConfirm {
+		d := newDelete(t, awsSecretCap())
+		_, _ = d.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+		_ = d.View()
+
+		return d
+	}
+
+	// Cancel click cancels.
+	d := sized()
+	_, cmd := d.Update(clickAt(t, d.hits, deleteControlID(ctrlCancel)))
+	require.NotNil(t, cmd)
+	_, ok := cmd().(CanceledMsg)
+	assert.True(t, ok, "clicking Cancel cancels")
+
+	// Force checkbox click toggles force (like space/enter on it).
+	d = sized()
+	require.False(t, d.force)
+	_, _ = d.Update(clickAt(t, d.hits, deleteControlID(ctrlForce)))
+	assert.True(t, d.force, "clicking the force checkbox toggles it")
+
+	// Mode radio click toggles the staged/immediate mode.
+	d = sized()
+	require.True(t, d.staged)
+	_, _ = d.Update(clickAt(t, d.hits, deleteControlID(ctrlMode)))
+	assert.False(t, d.staged, "clicking the mode radio toggles the mode")
+
+	// Delete button click submits: busy + mutation command.
+	d = sized()
+	_, cmd = d.Update(clickAt(t, d.hits, deleteControlID(ctrlDelete)))
+	assert.True(t, d.busy, "clicking Delete starts the mutation")
+	require.NotNil(t, cmd, "clicking Delete dispatches the delete command")
+}
+
+// TestErrorDialog_MouseClickCloses pins that clicking the error dialog's close
+// hint dismisses it, reducing to the same CanceledMsg enter/esc emit.
+func TestErrorDialog_MouseClickCloses(t *testing.T) {
+	t.Parallel()
+
+	m := NewError(styles.New(), "Cannot create here", "Select a single namespace before creating.")
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	_ = m.View()
+
+	d, ok := m.(*errorDialog)
+	require.True(t, ok)
+
+	_, cmd := d.Update(clickAt(t, d.hits, regionClose))
+	require.NotNil(t, cmd, "clicking the close hint dispatches")
+	_, isCancel := cmd().(CanceledMsg)
+	assert.True(t, isCancel, "clicking close dismisses (like enter/esc)")
+}
+
 func newDelete(t *testing.T, svcCap capability.ServiceCapability) *deleteConfirm {
 	t.Helper()
 

--- a/internal/tui/dialogs/errordialog.go
+++ b/internal/tui/dialogs/errordialog.go
@@ -8,12 +8,17 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 
+	"github.com/mpyw/suve/internal/tui/hit"
 	"github.com/mpyw/suve/internal/tui/styles"
 )
 
 // errorSpacerRows is the two blank lines the error dialog pins (one below the
 // title, one above the close hint) around the scrollable message body.
 const errorSpacerRows = 2
+
+// regionClose is the close-hint region ID (shared by the error dialog and any
+// confirm dialog whose close hint is clickable).
+const regionClose = "close"
 
 // errorDialog is a plain modal that surfaces a message the app could not handle
 // inline — a blocked operation (e.g. creating while viewing all namespaces) or a
@@ -33,6 +38,8 @@ type errorDialog struct {
 	// scrollable records whether the last synced body overflowed the viewport, so
 	// the close hint advertises the scroll keys only when they do something.
 	scrollable bool
+	// hits maps a click on the close hint to the same dismissal enter/esc perform.
+	hits *hit.Map
 }
 
 // NewError builds an error dialog with a title and message.
@@ -59,6 +66,12 @@ func (d *errorDialog) Update(msg tea.Msg) (Model, tea.Cmd) {
 		d.vp, cmd = d.vp.Update(msg)
 
 		return d, cmd
+	case tea.MouseClickMsg:
+		if id, _, _, ok := d.hits.At(msg.X, msg.Y); ok && id == regionClose {
+			return d, canceledCmd
+		}
+
+		return d, nil
 	case tea.KeyPressMsg:
 		if key.Matches(msg, navSelect) {
 			return d, canceledCmd
@@ -104,20 +117,28 @@ func (d *errorDialog) syncViewport() {
 func (d *errorDialog) View() string {
 	var b strings.Builder
 
-	b.WriteString(d.header())
+	header := d.header()
+	b.WriteString(header)
 	b.WriteString("\n\n")
 
 	// Once sized, the message scrolls inside the viewport; before the first
 	// WindowSizeMsg it renders inline (uncapped) so a size-less unit render still
 	// shows the whole message.
+	body := d.message
 	if d.sized() {
-		b.WriteString(d.vp.View())
-	} else {
-		b.WriteString(d.message)
+		body = d.vp.View()
 	}
 
+	b.WriteString(body)
 	b.WriteString("\n\n")
-	b.WriteString(d.hint())
+
+	hint := d.hint()
+	b.WriteString(hint)
+
+	// The close hint is clickable (the shell forwards a content-local click here),
+	// reducing to the same dismissal enter/esc perform.
+	hintY := lipgloss.Height(header) + 1 + lipgloss.Height(body) + 1
+	d.hits = hit.New(hit.Region(regionClose, 0, hintY, lipgloss.Width(hint), 1))
 
 	return b.String()
 }

--- a/internal/tui/dialogs/reset.go
+++ b/internal/tui/dialogs/reset.go
@@ -7,8 +7,10 @@ import (
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 
 	"github.com/mpyw/suve/internal/tui/data"
+	"github.com/mpyw/suve/internal/tui/hit"
 	"github.com/mpyw/suve/internal/tui/styles"
 )
 
@@ -18,6 +20,12 @@ type resetControl int
 const (
 	ctrlReset resetControl = iota
 	ctrlResetCancel
+)
+
+// Reset-button region IDs.
+const (
+	resetRegionReset  = "reset"
+	resetRegionCancel = "reset-cancel"
 )
 
 // resetResultsMsg carries the aggregated fan-out reset results back.
@@ -39,6 +47,9 @@ type resetDialog struct {
 
 	focus int
 	busy  bool
+	// hits maps a click on the Reset/Cancel button to focusing and activating it —
+	// the same reduction navigating to it and pressing enter performs.
+	hits *hit.Map
 }
 
 // ResetInput configures a reset dialog.
@@ -84,12 +95,40 @@ func (d *resetDialog) Update(msg tea.Msg) (Model, tea.Cmd) {
 		}
 
 		return d, doneCmd("", resetSummary(msg.results), true)
+	case tea.MouseClickMsg:
+		if d.busy {
+			return d, nil // double-submit guard
+		}
+
+		return d.handleClick(msg)
 	case tea.KeyPressMsg:
 		if d.busy {
 			return d, nil // double-submit guard
 		}
 
 		return d.handleKey(msg)
+	}
+
+	return d, nil
+}
+
+// handleClick reduces a click on the Reset/Cancel button to focusing then
+// activating it — the same as the arrow+enter key path.
+func (d *resetDialog) handleClick(msg tea.MouseClickMsg) (Model, tea.Cmd) {
+	id, _, _, ok := d.hits.At(msg.X, msg.Y)
+	if !ok {
+		return d, nil
+	}
+
+	switch id {
+	case resetRegionReset:
+		d.focus = int(ctrlReset)
+
+		return d.activate()
+	case resetRegionCancel:
+		d.focus = int(ctrlResetCancel)
+
+		return d.activate()
 	}
 
 	return d, nil
@@ -140,23 +179,42 @@ func (d *resetDialog) resetCmd() tea.Cmd {
 func (d *resetDialog) View() string {
 	var b strings.Builder
 
-	b.WriteString(d.fit(d.styles.PaneTitle.Render(d.title)))
+	title := d.fit(d.styles.PaneTitle.Render(d.title))
+	b.WriteString(title)
 	b.WriteString("\n\n")
 
 	if d.busy {
+		d.hits = hit.New() // no buttons while resetting
 		b.WriteString(d.styles.PageHint.Render("resetting…"))
 
 		return b.String()
 	}
 
-	b.WriteString(d.fit("Unstage every staged change for the target(s)?") + "\n\n")
-	b.WriteString(d.resetRow(ctrlReset, d.styles.ErrorText.Render("[ Reset ]")) + "    " +
-		d.resetRow(ctrlResetCancel, "[ Cancel ]"))
+	prompt := d.fit("Unstage every staged change for the target(s)?")
+	b.WriteString(prompt + "\n\n")
+
+	resetBtn := d.resetRow(ctrlReset, d.styles.ErrorText.Render("[ Reset ]"))
+	cancelBtn := d.resetRow(ctrlResetCancel, "[ Cancel ]")
+	b.WriteString(resetBtn + "    " + cancelBtn)
 	b.WriteString("\n\n")
 	b.WriteString(d.styles.PageHint.Render("↑↓: move · enter: confirm · esc: cancel"))
 
+	// The Reset/Cancel buttons sit on one line below the title, its blank line, the
+	// prompt, and its blank line. The 4-space gap separates the two button regions.
+	buttonRow := lipgloss.Height(title) + 1 + lipgloss.Height(prompt) + 1
+	resetW := lipgloss.Width(resetBtn)
+	cancelX := resetW + buttonGap
+	d.hits = hit.New(
+		hit.Region(resetRegionReset, 0, buttonRow, resetW, 1),
+		hit.Region(resetRegionCancel, cancelX, buttonRow, lipgloss.Width(cancelBtn), 1),
+	)
+
 	return b.String()
 }
+
+// buttonGap is the column gap between two side-by-side confirm buttons (the
+// "    " separator), used to place the second button's hit region.
+const buttonGap = 4
 
 func (d *resetDialog) resetRow(c resetControl, label string) string {
 	if resetControl(d.focus) == c {

--- a/internal/tui/hit/hit.go
+++ b/internal/tui/hit/hit.go
@@ -1,0 +1,95 @@
+// Package hit provides compositor-based mouse hit-testing for the TUI's pages
+// and dialogs. Each clickable region is a lipgloss v2 Layer with an ID placed at
+// its drawn location; lipgloss.Compositor.Hit resolves a point to the top-most
+// region and its bounds, from which a handler derives the in-region offset. This
+// replaces the hand-rolled point-in-rectangle geometry the pages used to keep in
+// sync with the renderer, so a mouse coordinate is hit-tested against the layers
+// once rather than double-managed.
+package hit
+
+import (
+	"strings"
+
+	"charm.land/lipgloss/v2"
+)
+
+// Map wraps a lipgloss.Compositor of ID'd region layers. A nil Map (or one built
+// with no regions) simply never hits, so callers need not guard for a page that
+// has not rendered yet.
+type Map struct {
+	comp *lipgloss.Compositor
+}
+
+// New builds a Map from region layers (typically produced by Region). Regions
+// may overlap: a higher Z region wins the hit, so a sub-region (e.g. a history
+// band inside a detail pane) is placed above the pane it sits in.
+func New(regions ...*lipgloss.Layer) *Map {
+	return &Map{comp: lipgloss.NewCompositor(regions...)}
+}
+
+// Region builds an ID'd layer sized w×h at (x, y). The content is a blank block
+// of exactly that size; only its bounds matter to Compositor.Hit. Width/height
+// below one are clamped to one so a degenerate region still has a hit cell.
+func Region(id string, x, y, w, h int) *lipgloss.Layer {
+	return lipgloss.NewLayer(block(w, h)).X(x).Y(y).ID(id)
+}
+
+// At hit-tests (x, y) against the map. It returns the ID of the top-most region
+// containing the point and the point's offset within that region (dx, dy from the
+// region's top-left), or ok=false when no region is hit.
+func (m *Map) At(x, y int) (id string, dx, dy int, ok bool) {
+	if m == nil || m.comp == nil {
+		return "", 0, 0, false
+	}
+
+	h := m.comp.Hit(x, y)
+	if h.Empty() {
+		return "", 0, 0, false
+	}
+
+	origin := h.Bounds().Min
+
+	return h.ID(), x - origin.X, y - origin.Y, true
+}
+
+// Origin returns the top-left (x, y) of the region with the given ID, or
+// ok=false when there is no such region. It lets a test derive a click
+// coordinate from the drawn layout instead of hard-coding one.
+func (m *Map) Origin(id string) (x, y int, ok bool) {
+	if m == nil || m.comp == nil {
+		return 0, 0, false
+	}
+
+	l := m.comp.GetLayer(id)
+	if l == nil {
+		return 0, 0, false
+	}
+
+	// Every region layer is a direct child of the compositor's root at (0,0), so
+	// its own X/Y are already absolute.
+	return l.GetX(), l.GetY(), true
+}
+
+// block builds an h-row, w-column blank string whose lipgloss width/height are
+// exactly w×h, so a layer built from it has those bounds.
+func block(w, h int) string {
+	if w < 1 {
+		w = 1
+	}
+
+	if h < 1 {
+		h = 1
+	}
+
+	row := strings.Repeat(" ", w)
+	if h == 1 {
+		return row
+	}
+
+	rows := make([]string, h)
+	for i := range rows {
+		rows[i] = row
+	}
+
+	return strings.Join(rows, "\n")
+}

--- a/internal/tui/hit/hit_test.go
+++ b/internal/tui/hit/hit_test.go
@@ -1,0 +1,81 @@
+package hit_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/tui/hit"
+)
+
+// TestAtResolvesRegionAndOffset pins that At returns the ID of the region under a
+// point and the point's offset from the region's top-left.
+func TestAtResolvesRegionAndOffset(t *testing.T) {
+	t.Parallel()
+
+	m := hit.New(
+		hit.Region("list", 1, 2, 10, 5),
+		hit.Region("history", 20, 8, 30, 4),
+	)
+
+	id, dx, dy, ok := m.At(3, 4)
+	assert.True(t, ok, "a point inside the list region hits")
+	assert.Equal(t, "list", id)
+	assert.Equal(t, 2, dx, "dx is the column offset from the region's left")
+	assert.Equal(t, 2, dy, "dy is the row offset from the region's top")
+
+	id, _, _, ok = m.At(0, 0)
+	assert.False(t, ok, "a point outside every region does not hit")
+	assert.Empty(t, id, "a miss returns no ID")
+}
+
+// TestAtPrefersHigherZ pins that an overlapping higher-Z region wins the hit, so
+// a sub-region placed above its container is resolved first.
+func TestAtPrefersHigherZ(t *testing.T) {
+	t.Parallel()
+
+	m := hit.New(
+		hit.Region("pane", 0, 0, 40, 20),
+		hit.Region("band", 0, 10, 40, 4).Z(1),
+	)
+
+	id, _, _, ok := m.At(5, 11)
+	require.True(t, ok)
+	assert.Equal(t, "band", id, "the higher-Z band wins over the pane it sits in")
+
+	id, _, _, ok = m.At(5, 3)
+	require.True(t, ok)
+	assert.Equal(t, "pane", id, "outside the band, the pane is hit")
+}
+
+// TestOriginReturnsLayoutCoordinate pins that Origin returns a region's drawn
+// top-left, so tests derive click coordinates from the layout.
+func TestOriginReturnsLayoutCoordinate(t *testing.T) {
+	t.Parallel()
+
+	m := hit.New(hit.Region("btn", 7, 9, 5, 1))
+
+	x, y, ok := m.Origin("btn")
+	assert.True(t, ok)
+	assert.Equal(t, 7, x)
+	assert.Equal(t, 9, y)
+
+	_, _, ok = m.Origin("missing")
+	assert.False(t, ok)
+}
+
+// TestNilMapNeverHits pins that a nil Map is safe: it hits nothing and has no
+// origins, so a page that has not rendered yet needs no guard.
+func TestNilMapNeverHits(t *testing.T) {
+	t.Parallel()
+
+	var m *hit.Map
+
+	id, _, _, ok := m.At(1, 1)
+	assert.False(t, ok)
+	assert.Empty(t, id)
+
+	_, _, ok = m.Origin("x")
+	assert.False(t, ok)
+}

--- a/internal/tui/pages/browser/browser.go
+++ b/internal/tui/pages/browser/browser.go
@@ -16,11 +16,13 @@ import (
 	"charm.land/bubbles/v2/spinner"
 	"charm.land/bubbles/v2/textinput"
 	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
 
 	"github.com/mpyw/suve/internal/capability"
 	"github.com/mpyw/suve/internal/provider/azure/appconfig/aznamespace"
 	"github.com/mpyw/suve/internal/tui/components"
 	"github.com/mpyw/suve/internal/tui/data"
+	"github.com/mpyw/suve/internal/tui/hit"
 	"github.com/mpyw/suve/internal/tui/keys"
 	"github.com/mpyw/suve/internal/tui/styles"
 )
@@ -160,27 +162,32 @@ type Model struct {
 	nsSeq       int
 	debounceSeq int
 
-	// geom is the last-rendered geometry, used to hit-test mouse clicks against
-	// what is actually on screen (never a hard-coded coordinate).
-	geom geom
+	// hits is the last-rendered hit map: one compositor region per clickable/
+	// scrollable area (header fields and toggles, the list, the detail pane, the
+	// value label, and the history band), rebuilt every View so a mouse coordinate
+	// is hit-tested against the layers rather than a hand-maintained geometry.
+	hits *hit.Map
+	// regions is the scratch slice View appends region layers to before building
+	// hits, reused across frames to avoid per-frame allocation churn.
+	regions []*lipgloss.Layer
 }
 
-// geom records where the list and history content sit in page-local coordinates
-// after the last View, so mouse handlers hit-test the drawn layout. Each region
-// is bounded on all four sides: left/right columns and top/rows. The right edge
-// matters because in the two-pane layout the list sits to the LEFT of the detail
-// pane and shares its vertical band with the value/meta/history content — without
-// a right edge the list would swallow every wheel/click aimed at the detail pane.
-type geom struct {
-	listTop      int
-	listLeft     int
-	listRight    int // exclusive right column of the list content
-	listRows     int
-	historyTop   int
-	historyLeft  int
-	historyRight int // exclusive right column of the history content
-	historyRows  int
-}
+// Clickable/scrollable region IDs for the browser hit map. The list and history
+// bands map a click to a row (via the in-region offset); the detail and value
+// regions route the wheel to the value pane; the header regions each reduce a
+// click to the same action their key equivalent performs.
+const (
+	regionList       = "list"
+	regionDetail     = "detail"
+	regionHistory    = "history"
+	regionValueLabel = "value-label"
+	regionNamespace  = "ns"
+	regionPrefix     = "prefix"
+	regionFilter     = "filter"
+	regionValues     = "values"
+	regionRecursive  = "recursive"
+	regionRefresh    = "refresh"
+)
 
 // New builds a browser page over a data source. ctx is the Run context threaded
 // through every fetch. staging may be nil when the service has no staging

--- a/internal/tui/pages/browser/browser_test.go
+++ b/internal/tui/pages/browser/browser_test.go
@@ -87,6 +87,18 @@ func newModel(t *testing.T, src *stubSource) *Model {
 
 func keyPress(r rune) tea.KeyPressMsg { return tea.KeyPressMsg{Code: r, Text: string(r)} }
 
+// regionOrigin returns the drawn top-left of a hit region, so a mouse test
+// derives its click coordinate from the rendered layout instead of hard-coding
+// one. It fails when the region was not drawn.
+func regionOrigin(t *testing.T, m *Model, id string) (int, int) {
+	t.Helper()
+
+	x, y, ok := m.hits.Origin(id)
+	require.True(t, ok, "region %q was drawn", id)
+
+	return x, y
+}
+
 func update(t *testing.T, m *Model, msg tea.Msg) (*Model, tea.Cmd) {
 	t.Helper()
 
@@ -484,9 +496,10 @@ func TestMouseClickSelectEqualsKeySelect(t *testing.T) {
 	// Mouse: click the row the geometry maps to index 2.
 	clicked := newModel(t, &stubSource{svcCap: awsParamCap()})
 	clicked, _ = update(t, clicked, listLoadedMsg{seq: clicked.listSeq, res: data.ListResult{Items: items}})
-	_ = clicked.View(clicked.width, clicked.height) // records geometry
+	_ = clicked.View(clicked.width, clicked.height) // rebuilds the hit map
 
-	x, y := clicked.geom.listLeft, clicked.geom.listTop+2 // row index 2
+	lx, ly := regionOrigin(t, clicked, regionList)
+	x, y := lx, ly+2 // row index 2
 	c, cmd := update(t, clicked, tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft})
 
 	assert.Equal(t, keyed.list.Selected(), c.list.Selected(), "click selects the same row as the key move")
@@ -1050,10 +1063,13 @@ func loadedWheelModel(t *testing.T) *Model {
 	m, _ = update(t, m, detailLoadedMsg{seq: m.detailSeq, d: data.Detail{Name: items[0].Name, Value: strings.Join(valueLines, "\n")}})
 	m, _ = update(t, m, historyLoadedMsg{seq: m.historySeq, rows: history})
 
-	_ = m.View(m.width, m.height) // records geometry, sizes the widgets and the value viewport
+	_ = m.View(m.width, m.height) // rebuilds the hit map, sizes the widgets and the value viewport
 
-	require.Positive(t, m.geom.listRows, "the list region is drawn")
-	require.Positive(t, m.geom.historyRows, "the history region is drawn")
+	_, _, listDrawn := m.hits.Origin(regionList)
+	require.True(t, listDrawn, "the list region is drawn")
+
+	_, _, historyDrawn := m.hits.Origin(regionHistory)
+	require.True(t, historyDrawn, "the history region is drawn")
 
 	return m
 }
@@ -1070,7 +1086,7 @@ func TestMouseWheelOverListScrollsList(t *testing.T) {
 	require.Zero(t, historyTopRow(t, m), "the history starts at the top")
 	valueBefore := m.valuePane.View()
 
-	x, y := m.geom.listLeft, m.geom.listTop
+	x, y := regionOrigin(t, m, regionList)
 
 	m, cmd := update(t, m, wheel(tea.MouseWheelDown, x, y))
 	assert.Nil(t, cmd, "a list wheel emits no command")
@@ -1089,7 +1105,7 @@ func TestMouseWheelDirectionOverList(t *testing.T) {
 	t.Parallel()
 
 	m := loadedWheelModel(t)
-	x, y := m.geom.listLeft, m.geom.listTop
+	x, y := regionOrigin(t, m, regionList)
 
 	m, _ = update(t, m, wheel(tea.MouseWheelDown, x, y))
 	m, _ = update(t, m, wheel(tea.MouseWheelDown, x, y))
@@ -1122,9 +1138,10 @@ func TestMouseWheelOverHistoryScrollsHistory(t *testing.T) {
 	require.Zero(t, historyTopRow(t, m), "the history starts at the top")
 	valueBefore := m.valuePane.View()
 
-	x, y := m.geom.historyLeft, m.geom.historyTop
-	require.True(t, m.geom.inHistory(x, y), "the point is inside the history region")
-	require.False(t, m.geom.inList(x, y), "the point is NOT inside the list region (bounded on the right)")
+	x, y := regionOrigin(t, m, regionHistory)
+	id, _, _, ok := m.hits.At(x, y)
+	require.True(t, ok, "the point is inside a region")
+	require.Equal(t, regionHistory, id, "the point resolves to the history region, not the list")
 
 	m, cmd := update(t, m, wheel(tea.MouseWheelDown, x, y))
 	assert.Nil(t, cmd, "a history wheel emits no command")
@@ -1150,11 +1167,12 @@ func TestMouseWheelOverValueRegionScrollsValuePane(t *testing.T) {
 	require.Zero(t, historyTopRow(t, m))
 	valueBefore := m.valuePane.View()
 
-	// Detail pane, value/meta region: right pane's left column, above the history.
-	x, y := m.geom.historyLeft, m.geom.listTop
-	require.Less(t, y, m.geom.historyTop, "the point is above the history band")
-	require.False(t, m.geom.inList(x, y), "the point is NOT in the list region")
-	require.False(t, m.geom.inHistory(x, y), "the point is NOT in the history region")
+	// Detail pane, value/meta region: the value-label row, above the history band.
+	x, y := regionOrigin(t, m, regionValueLabel)
+	id, _, _, ok := m.hits.At(x, y)
+	require.True(t, ok, "the point is inside a region")
+	require.Contains(t, []string{regionValueLabel, regionDetail}, id,
+		"the point is in the detail/value region, not the list or history")
 
 	m, _ = update(t, m, wheel(tea.MouseWheelDown, x, y))
 	assert.NotEqual(t, valueBefore, m.valuePane.View(), "a wheel over the value region scrolls the value pane")
@@ -1175,10 +1193,13 @@ func TestMouseClickInDetailRegionDoesNotSelectListRow(t *testing.T) {
 	m.list.SelectIndex(0)
 	require.Equal(t, 0, m.list.Selected())
 
-	// Value/meta region: detail pane, above the history band.
-	x, y := m.geom.historyLeft, m.geom.listTop
-	require.False(t, m.geom.inList(x, y), "the point is not in the list region")
-	require.False(t, m.geom.inHistory(x, y), "the point is not in the history region")
+	// Detail body region: a few rows below the value label (the value-pane area),
+	// which shares the list's vertical band in the two-pane layout.
+	dx, dy := regionOrigin(t, m, regionDetail)
+	x, y := dx, dy+3
+	id, _, _, ok := m.hits.At(x, y)
+	require.True(t, ok, "the point is inside a region")
+	require.Equal(t, regionDetail, id, "the point is in the detail body, not a list row")
 
 	m, cmd := update(t, m, tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft})
 	assert.Nil(t, cmd, "a detail-region click loads nothing (it is not a list row)")
@@ -1186,9 +1207,11 @@ func TestMouseClickInDetailRegionDoesNotSelectListRow(t *testing.T) {
 }
 
 // TestMouseClickHistoryRowInCompareSelectsRow pins that, in compare mode, a click
-// on a history row selects that row and marks it as a compare pick — the click
-// counterpart of the keyboard compare flow. The row coordinate is derived from
-// the history geometry, never hard-coded.
+// on a history row selects and picks that row — the click counterpart of the
+// keyboard compare flow — and that the click completing the second pick OPENS the
+// diff, reducing to the same nav.OpenDiff enter produces (#663 closes the "compare
+// can pick but not open via mouse" gap). Coordinates are derived from the history
+// region, never hard-coded.
 func TestMouseClickHistoryRowInCompareSelectsRow(t *testing.T) {
 	t.Parallel()
 
@@ -1199,19 +1222,117 @@ func TestMouseClickHistoryRowInCompareSelectsRow(t *testing.T) {
 	require.True(t, m.history.Compare())
 	require.Equal(t, focusHistory, m.focus)
 
-	// Click the history row the geometry maps to line 1 (index 1).
-	x, y := m.geom.historyLeft, m.geom.historyTop+1
-	line, ok := m.geom.historyLine(x, y)
+	// Click the history row the region maps to line 1 (index 1).
+	hx, hy := regionOrigin(t, m, regionHistory)
+	x, y := hx, hy+1
+	id, _, dy, ok := m.hits.At(x, y)
 	require.True(t, ok, "the point is inside the history region")
-	require.Equal(t, 1, line)
+	require.Equal(t, regionHistory, id)
+	require.Equal(t, 1, dy, "the in-region offset is the clicked line")
 
-	m, _ = update(t, m, tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft})
+	m, cmd := update(t, m, tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft})
 	assert.Equal(t, 1, m.history.Selected(), "a history-row click selects that row")
+	assert.Nil(t, cmd, "the first pick click does not open the diff yet")
 
-	// Click a second row so exactly two picks are marked, then confirm both.
-	x2, y2 := m.geom.historyLeft, m.geom.historyTop
-	m, _ = update(t, m, tea.MouseClickMsg{X: x2, Y: y2, Button: tea.MouseLeft})
+	// Click a second row so exactly two picks are marked: the completing click opens
+	// the diff, exactly as enter would after two keyboard picks.
+	x2, y2 := hx, hy
+	m, cmd = update(t, m, tea.MouseClickMsg{X: x2, Y: y2, Button: tea.MouseLeft})
 	i, j, picked := m.history.PickedVersions()
 	require.True(t, picked, "two history-row clicks mark two compare picks")
 	assert.ElementsMatch(t, []int{0, 1}, []int{i, j}, "the two clicked rows are the picks")
+
+	require.NotNil(t, cmd, "the click completing the second pick opens the diff")
+	_, isDiff := cmd().(nav.OpenDiff)
+	assert.True(t, isDiff, "a compare click that completes two picks opens the diff (like enter)")
+}
+
+// TestMouseClickHeaderRegionsMatchKeys pins #663's browser-header coverage: a
+// click on each header affordance reduces to the SAME action its key equivalent
+// performs — focusing the prefix/filter inputs (p, /), toggling values/recursive
+// (v, r), and refreshing (⟳). Coordinates come from the drawn header regions.
+func TestMouseClickHeaderRegionsMatchKeys(t *testing.T) {
+	t.Parallel()
+
+	m := newModel(t, &stubSource{svcCap: awsParamCap()})
+	m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{{Name: "/a"}}}})
+	_ = m.View(m.width, m.height)
+
+	// prefix field click focuses the prefix input (like `p`).
+	px, py := regionOrigin(t, m, regionPrefix)
+	m, _ = update(t, m, tea.MouseClickMsg{X: px, Y: py, Button: tea.MouseLeft})
+	assert.Equal(t, focusPrefix, m.focus, "clicking the prefix field focuses it (like p)")
+
+	// Commit (esc), then the filter field click focuses the filter (like `/`).
+	m, _ = update(t, m, tea.KeyPressMsg{Code: tea.KeyEscape})
+	_ = m.View(m.width, m.height)
+	fx, fy := regionOrigin(t, m, regionFilter)
+	m, _ = update(t, m, tea.MouseClickMsg{X: fx, Y: fy, Button: tea.MouseLeft})
+	assert.Equal(t, focusFilter, m.focus, "clicking the filter field focuses it (like /)")
+
+	m, _ = update(t, m, tea.KeyPressMsg{Code: tea.KeyEscape})
+	_ = m.View(m.width, m.height)
+
+	// values chip click toggles values-mode and reloads (like `v`).
+	vx, vy := regionOrigin(t, m, regionValues)
+	valSeq := m.listSeq
+	m, cmd := update(t, m, tea.MouseClickMsg{X: vx, Y: vy, Button: tea.MouseLeft})
+	assert.True(t, m.valuesOn, "clicking values toggles it on (like v)")
+	assert.NotNil(t, cmd, "the values toggle reloads")
+	assert.Greater(t, m.listSeq, valSeq)
+
+	_ = m.View(m.width, m.height)
+
+	// recursive chip click toggles recursive and reloads (like `r`).
+	rx, ry := regionOrigin(t, m, regionRecursive)
+	recBefore := m.recursive
+	m, cmd = update(t, m, tea.MouseClickMsg{X: rx, Y: ry, Button: tea.MouseLeft})
+	assert.Equal(t, !recBefore, m.recursive, "clicking recursive toggles it (like r)")
+	assert.NotNil(t, cmd, "the recursive toggle reloads")
+
+	_ = m.View(m.width, m.height)
+
+	// refresh (⟳) click reloads the list.
+	gx, gy := regionOrigin(t, m, regionRefresh)
+	refSeq := m.listSeq
+	_, cmd = update(t, m, tea.MouseClickMsg{X: gx, Y: gy, Button: tea.MouseLeft})
+	assert.NotNil(t, cmd, "clicking the refresh affordance reloads the list")
+	assert.Greater(t, m.listSeq, refSeq)
+}
+
+// TestMouseClickNamespaceBadgeCyclesFilter pins that clicking the App Config
+// namespace badge cycles the namespace filter, reducing to the same action space
+// performs there.
+func TestMouseClickNamespaceBadgeCyclesFilter(t *testing.T) {
+	t.Parallel()
+
+	m := newModel(t, &stubSource{svcCap: appConfigCap()})
+	m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{{Name: "app/x"}}}})
+	_ = m.View(m.width, m.height)
+	require.Equal(t, 0, m.nsIndex, "the namespace filter starts at the first option")
+
+	nx, ny := regionOrigin(t, m, regionNamespace)
+	m, cmd := update(t, m, tea.MouseClickMsg{X: nx, Y: ny, Button: tea.MouseLeft})
+	assert.Equal(t, 1, m.nsIndex, "clicking the ns badge cycles the namespace (like space)")
+	assert.NotNil(t, cmd, "cycling the namespace reloads the list")
+}
+
+// TestMouseClickValueLabelTogglesMask pins that clicking the "Value (x to reveal)"
+// label toggles the mask, reducing to the same action `x` performs.
+func TestMouseClickValueLabelTogglesMask(t *testing.T) {
+	t.Parallel()
+
+	m := newModel(t, &stubSource{svcCap: awsParamCap()})
+	m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{{Name: "/s"}}}})
+	m, _ = update(t, m, detailLoadedMsg{seq: m.detailSeq, d: data.Detail{Name: "/s", Value: "hunter2", Secret: true}})
+	_ = m.View(m.width, m.height)
+	require.True(t, m.valuePane.Masked(), "the secret value starts masked")
+
+	vx, vy := regionOrigin(t, m, regionValueLabel)
+	m, _ = update(t, m, tea.MouseClickMsg{X: vx, Y: vy, Button: tea.MouseLeft})
+	assert.False(t, m.valuePane.Masked(), "clicking the value label reveals (like x)")
+
+	_ = m.View(m.width, m.height)
+	m, _ = update(t, m, tea.MouseClickMsg{X: vx, Y: vy, Button: tea.MouseLeft})
+	assert.True(t, m.valuePane.Masked(), "clicking the value label again re-masks")
 }

--- a/internal/tui/pages/browser/mouse.go
+++ b/internal/tui/pages/browser/mouse.go
@@ -4,9 +4,13 @@ import (
 	tea "charm.land/bubbletea/v2"
 )
 
-// handleMouseClick maps a left click onto the drawn geometry: a list row click
-// selects that row and loads its detail (reducing to the same selection a key
-// move performs), and — in compare mode — a history row click picks it.
+// handleMouseClick resolves a left click against the last-rendered hit map and
+// reduces it to the SAME internal action its keyboard equivalent performs: a list
+// row click selects that row and loads its detail (like a key move); a history
+// row click focuses/selects it and, in compare mode, picks it (opening the diff
+// once two rows are picked, like enter); the value label toggles the mask (like
+// x); and each header region focuses a field or toggles/refreshes (like p / / /
+// v / r / ⟳).
 func (m *Model) handleMouseClick(msg tea.MouseClickMsg) (*Model, tea.Cmd) {
 	// A mouse interaction dismisses the transient invalid-action status, matching
 	// the key path and the staging page.
@@ -16,45 +20,83 @@ func (m *Model) handleMouseClick(msg tea.MouseClickMsg) (*Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if line, ok := m.geom.listLine(msg.X, msg.Y); ok {
-		if idx, rowOK := m.list.RowAtLine(line); rowOK {
+	id, _, dy, ok := m.hits.At(msg.X, msg.Y)
+	if !ok {
+		return m, nil
+	}
+
+	switch id {
+	case regionList:
+		if idx, rowOK := m.list.RowAtLine(dy); rowOK {
 			m.focus = focusList
 			m.list.SelectIndex(idx)
 
 			return m, m.selectionCmd()
 		}
-	}
-
-	if line, ok := m.geom.historyLine(msg.X, msg.Y); ok {
-		if idx, rowOK := m.history.RowAtLine(line); rowOK {
-			m.focus = focusHistory
-			m.history.SelectIndex(idx)
-
-			if m.history.Compare() {
-				m.history.TogglePick()
-			}
-
-			return m, nil
+	case regionHistory:
+		if idx, rowOK := m.history.RowAtLine(dy); rowOK {
+			return m, m.clickHistoryRow(idx)
 		}
+	case regionValueLabel:
+		m.valuePane.ToggleMask()
+	case regionNamespace:
+		return m, m.cycleNamespace()
+	case regionPrefix:
+		m.focusPrefix()
+	case regionFilter:
+		m.focusFilter()
+	case regionValues:
+		return m, m.toggleValues()
+	case regionRecursive:
+		return m, m.toggleRecursive()
+	case regionRefresh:
+		return m, m.refreshList()
 	}
 
 	return m, nil
 }
 
-// handleMouseWheel scrolls whichever pane the pointer is over: the list, the
-// history, or (when the pointer is elsewhere in the detail) the value pane.
+// clickHistoryRow focuses and selects a history row; in compare mode it picks the
+// row and, once two rows are picked, opens the diff — the click counterpart of the
+// keyboard space-pick / enter-diff flow, reducing to the same nav.OpenDiff.
+func (m *Model) clickHistoryRow(idx int) tea.Cmd {
+	m.focus = focusHistory
+	m.history.SelectIndex(idx)
+
+	if !m.history.Compare() {
+		return nil
+	}
+
+	m.history.TogglePick()
+
+	if _, _, ok := m.history.PickedVersions(); ok {
+		return m.openDiff()
+	}
+
+	return nil
+}
+
+// handleMouseWheel routes a wheel to the region under the pointer: the list, the
+// history, or the value pane (a wheel anywhere else in the detail also scrolls the
+// value pane). A wheel over the header or off the page is dropped — it never falls
+// through to the value pane.
 func (m *Model) handleMouseWheel(msg tea.MouseWheelMsg) (*Model, tea.Cmd) {
 	delta := wheelDelta(msg.Button)
 	if delta == 0 {
 		return m, nil
 	}
 
-	switch {
-	case m.geom.inList(msg.X, msg.Y):
+	id, _, _, ok := m.hits.At(msg.X, msg.Y)
+	if !ok {
+		return m, nil
+	}
+
+	switch id {
+	case regionList:
 		m.list.Scroll(delta)
-	case m.geom.inHistory(msg.X, msg.Y):
+	case regionHistory:
 		m.history.Scroll(delta)
-	default:
+	case regionDetail, regionValueLabel:
 		return m, m.valuePane.Update(msg)
 	}
 
@@ -71,40 +113,4 @@ func wheelDelta(button tea.MouseButton) int {
 	default:
 		return 0
 	}
-}
-
-// listLine maps a screen point to a 0-based list content line, or (0, false)
-// when the point is outside the list content region. The right-edge bound
-// (x < g.listRight) keeps the list from claiming the detail pane, which shares
-// its vertical band in the two-pane layout.
-func (g geom) listLine(x, y int) (int, bool) {
-	if x < g.listLeft || x >= g.listRight || y < g.listTop || y >= g.listTop+g.listRows {
-		return 0, false
-	}
-
-	return y - g.listTop, true
-}
-
-// historyLine maps a screen point to a 0-based history content line, bounded on
-// all four sides so a point outside the drawn history content never maps in.
-func (g geom) historyLine(x, y int) (int, bool) {
-	if x < g.historyLeft || x >= g.historyRight || y < g.historyTop || y >= g.historyTop+g.historyRows {
-		return 0, false
-	}
-
-	return y - g.historyTop, true
-}
-
-// inList reports whether a point is within the list content region.
-func (g geom) inList(x, y int) bool {
-	_, ok := g.listLine(x, y)
-
-	return ok
-}
-
-// inHistory reports whether a point is within the history content region.
-func (g geom) inHistory(x, y int) bool {
-	_, ok := g.historyLine(x, y)
-
-	return ok
 }

--- a/internal/tui/pages/browser/update.go
+++ b/internal/tui/pages/browser/update.go
@@ -285,26 +285,17 @@ func (m *Model) handleInputKey(msg tea.KeyPressMsg) (*Model, tea.Cmd) {
 func (m *Model) handleActionKey(msg tea.KeyPressMsg) (bool, tea.Cmd) {
 	switch {
 	case key.Matches(msg, prefixKey):
-		m.focus = focusPrefix
-		m.prefix.Focus()
+		m.focusPrefix()
 
 		return true, nil
 	case key.Matches(msg, filterKey):
-		m.focus = focusFilter
-		m.filter.Focus()
+		m.focusFilter()
 
 		return true, nil
 	case key.Matches(msg, valuesKey):
-		m.valuesOn = !m.valuesOn
-
-		return true, m.loadListCmd(false)
+		return true, m.toggleValues()
 	case key.Matches(msg, recursiveKey):
-		// Param supports recursive listing; elsewhere `r` is a plain refresh.
-		if m.svcCap.Service == "param" && !m.svcCap.HasNamespaces {
-			m.recursive = !m.recursive
-		}
-
-		return true, m.loadListCmd(false)
+		return true, m.toggleRecursive()
 	case key.Matches(msg, loadMoreKey):
 		return true, m.loadMore()
 	case key.Matches(msg, revealKey):
@@ -360,6 +351,43 @@ func (m *Model) handleActionKey(msg tea.KeyPressMsg) (bool, tea.Cmd) {
 	}
 
 	return false, nil
+}
+
+// focusPrefix / focusFilter move focus into the header prefix/filter input (the
+// `p` / `/` keys, and a click on that field). CapturesInput then routes raw
+// keystrokes to the input until it is committed.
+func (m *Model) focusPrefix() {
+	m.focus = focusPrefix
+	m.prefix.Focus()
+}
+
+func (m *Model) focusFilter() {
+	m.focus = focusFilter
+	m.filter.Focus()
+}
+
+// toggleValues flips values-mode and reloads the list (the `v` key and a click on
+// the values chip).
+func (m *Model) toggleValues() tea.Cmd {
+	m.valuesOn = !m.valuesOn
+
+	return m.loadListCmd(false)
+}
+
+// toggleRecursive flips recursive listing (param only; elsewhere `r`/⟳ is a plain
+// refresh) and reloads the list (the `r` key and a click on the recursive chip).
+func (m *Model) toggleRecursive() tea.Cmd {
+	// Param supports recursive listing; elsewhere `r` is a plain refresh.
+	if m.svcCap.Service == "param" && !m.svcCap.HasNamespaces {
+		m.recursive = !m.recursive
+	}
+
+	return m.loadListCmd(false)
+}
+
+// refreshList reloads the list (a click on the ⟳ refresh affordance).
+func (m *Model) refreshList() tea.Cmd {
+	return m.loadListCmd(false)
 }
 
 // selectedIsDeleteStaged reports whether the currently-selected entry is staged

--- a/internal/tui/pages/browser/view.go
+++ b/internal/tui/pages/browser/view.go
@@ -7,19 +7,37 @@ import (
 	"charm.land/lipgloss/v2"
 
 	"github.com/mpyw/suve/internal/tui/components"
+	"github.com/mpyw/suve/internal/tui/hit"
 	"github.com/mpyw/suve/internal/tui/styles"
 )
 
-// View renders the browser page into the content area and records the geometry
-// mouse handlers hit-test against.
+// headerSep is the three-space gap between header segments.
+const headerSep = "   "
+
+// headerSeg records a header segment's clickable column range in page-local
+// coordinates: the region ID and its [x, x+w) span on the header row.
+type headerSeg struct {
+	id string
+	x  int
+	w  int
+}
+
+// View renders the browser page into the content area and rebuilds the hit map
+// mouse handlers test against.
 func (m *Model) View(width, height int) string {
 	m.width, m.height = width, height
 	if width <= 0 || height <= 0 {
 		return ""
 	}
 
-	header := m.renderHeader(width)
+	m.regions = m.regions[:0]
+
+	header, segs := m.renderHeader(width)
 	headerH := lipgloss.Height(header)
+
+	for _, s := range segs {
+		m.regions = append(m.regions, hit.Region(s.id, s.x, 0, s.w, 1))
+	}
 
 	parts := []string{header}
 	offset := headerH
@@ -32,42 +50,71 @@ func (m *Model) View(width, height int) string {
 	bodyH := max(height-offset, 0)
 	parts = append(parts, m.renderBody(width, bodyH, offset))
 
+	m.hits = hit.New(m.regions...)
+
 	return strings.Join(parts, "\n")
 }
 
-// renderHeader renders the single prefix/filter/toggles line, plus the App
-// Config namespace filter and a spinner while loading.
-func (m *Model) renderHeader(width int) string {
-	var b strings.Builder
+// renderHeader renders the single prefix/filter/toggles line (plus the App Config
+// namespace filter and a spinner while loading) and returns each clickable
+// segment's column range, so a header click reduces to the same action its key
+// equivalent performs. Segment widths come from the rendered display width, so
+// styling never shifts a hit range (color-safe, like the section-button ranges).
+func (m *Model) renderHeader(width int) (string, []headerSeg) {
+	type piece struct {
+		s  string
+		id string // "" for an inert spacer
+	}
+
+	var pieces []piece
 
 	if m.svcCap.HasNamespaces {
-		b.WriteString(m.styles.FieldLabel.Render("ns: "))
-		b.WriteString(m.styles.StatusValue.Render(namespaceBadge(m.currentNamespace())))
-		b.WriteString("   ")
+		pieces = append(pieces,
+			piece{m.styles.FieldLabel.Render("ns: ") + m.styles.StatusValue.Render(namespaceBadge(m.currentNamespace())), regionNamespace},
+			piece{headerSep, ""},
+		)
 	}
 
-	b.WriteString(m.styles.FieldLabel.Render("prefix: "))
-	b.WriteString(fieldValue(m.prefix.Value(), m.focus == focusPrefix))
-	b.WriteString("   ")
-	b.WriteString(m.styles.FieldLabel.Render("filter: "))
-	b.WriteString(fieldValue(m.filter.Value(), m.focus == focusFilter))
-	b.WriteString("   ")
-	b.WriteString(toggle(m.styles, "values", m.valuesOn))
+	pieces = append(pieces,
+		piece{m.styles.FieldLabel.Render("prefix: ") + fieldValue(m.prefix.Value(), m.focus == focusPrefix), regionPrefix},
+		piece{headerSep, ""},
+		piece{m.styles.FieldLabel.Render("filter: ") + fieldValue(m.filter.Value(), m.focus == focusFilter), regionFilter},
+		piece{headerSep, ""},
+		piece{toggle(m.styles, "values", m.valuesOn), regionValues},
+	)
 
 	if m.svcCap.Service == "param" && !m.svcCap.HasNamespaces {
-		b.WriteString("  ")
-		b.WriteString(toggle(m.styles, "recursive", m.recursive))
+		pieces = append(pieces,
+			piece{"  ", ""},
+			piece{toggle(m.styles, "recursive", m.recursive), regionRecursive},
+		)
 	}
 
-	b.WriteString("  ")
-
+	refresh := "⟳"
 	if m.loading {
-		b.WriteString(m.spinner.View())
-	} else {
-		b.WriteString("⟳")
+		refresh = m.spinner.View()
 	}
 
-	return clip(b.String(), width)
+	pieces = append(pieces, piece{"  ", ""}, piece{refresh, regionRefresh})
+
+	var (
+		b    strings.Builder
+		segs []headerSeg
+		col  int
+	)
+
+	for _, p := range pieces {
+		w := lipgloss.Width(p.s)
+		if p.id != "" {
+			segs = append(segs, headerSeg{id: p.id, x: col, w: w})
+		}
+
+		b.WriteString(p.s)
+
+		col += w
+	}
+
+	return clip(b.String(), width), segs
 }
 
 // renderBody renders the list and detail panes (side by side or stacked) and
@@ -106,7 +153,7 @@ func (m *Model) renderStacked(width, height, yOffset int) string {
 	return lipgloss.JoinVertical(lipgloss.Left, listPane, detailPane)
 }
 
-// renderListPane sizes the list widget, records its geometry, and frames it. The
+// renderListPane sizes the list widget, records its hit region, and frames it. The
 // pane is drawn focused (accent border, active selection cursor) when the list
 // holds keyboard focus, so the user can see where the arrow keys will land.
 func (m *Model) renderListPane(width, height, paneTop, paneLeft int) string {
@@ -116,19 +163,22 @@ func (m *Model) renderListPane(width, height, paneTop, paneLeft int) string {
 	focused := m.focus == focusList
 	m.list.SetFocused(focused)
 
-	m.geom.listTop = paneTop + paneContentTop
-	m.geom.listLeft = paneLeft + paneBorderLeft
-	m.geom.listRight = m.geom.listLeft + innerW
-	m.geom.listRows = innerH
+	listTop := paneTop + paneContentTop
+	listLeft := paneLeft + paneBorderLeft
+	// The list region stops at its content's right edge so it never swallows a
+	// click/wheel aimed at the detail pane, which shares its vertical band in the
+	// two-pane layout.
+	m.regions = append(m.regions, hit.Region(regionList, listLeft, listTop, innerW, innerH))
 
 	title := "entries (" + strconv.Itoa(m.list.Len()) + ")"
 
 	return framePane(m.styles, focused, title, m.list.View(), width, height)
 }
 
-// renderDetailPane sizes the detail widgets, records the history geometry, and
-// frames the detail. The pane is drawn focused when the history holds keyboard
-// focus (the detail pane's only navigable widget), so the active pane is obvious.
+// renderDetailPane sizes the detail widgets, records the detail/value/history hit
+// regions, and frames the detail. The pane is drawn focused when the history holds
+// keyboard focus (the detail pane's only navigable widget), so the active pane is
+// obvious.
 func (m *Model) renderDetailPane(width, height, paneTop, paneLeft int) string {
 	innerW, innerH := components.PaneInner(width, height)
 
@@ -137,13 +187,25 @@ func (m *Model) renderDetailPane(width, height, paneTop, paneLeft int) string {
 		title = m.detail.Name
 	}
 
-	body, historyLocalTop, historyRows := m.renderDetail(innerW, innerH)
+	body, valueLabelLocalTop, historyLocalTop, historyRows := m.renderDetail(innerW, innerH)
 
-	// History content sits at: pane top + border + title + lines before history.
-	m.geom.historyTop = paneTop + paneContentTop + historyLocalTop
-	m.geom.historyLeft = paneLeft + paneBorderLeft
-	m.geom.historyRight = m.geom.historyLeft + innerW
-	m.geom.historyRows = historyRows
+	detailTop := paneTop + paneContentTop
+	detailLeft := paneLeft + paneBorderLeft
+
+	// The whole detail content is one region so a wheel anywhere in it scrolls the
+	// value pane; the value-label row and the history band sit above it (higher Z)
+	// so a click/wheel on them is resolved first.
+	m.regions = append(m.regions, hit.Region(regionDetail, detailLeft, detailTop, innerW, innerH))
+
+	if valueLabelLocalTop >= 0 {
+		m.regions = append(m.regions,
+			hit.Region(regionValueLabel, detailLeft, detailTop+valueLabelLocalTop, innerW, 1).Z(1))
+	}
+
+	if historyRows > 0 {
+		m.regions = append(m.regions,
+			hit.Region(regionHistory, detailLeft, detailTop+historyLocalTop, innerW, historyRows).Z(1))
+	}
 
 	return framePane(m.styles, m.focus == focusHistory, title, body, width, height)
 }
@@ -157,12 +219,13 @@ func framePane(st styles.Styles, focused bool, title, body string, width, height
 	return components.Pane(st, title, body, width, height)
 }
 
-// renderDetail builds the detail body and returns the line offset (within the
-// body) at which the history content begins and how many history rows are shown,
-// so the pane can record where clicks land.
-func (m *Model) renderDetail(innerW, innerH int) (string, int, int) {
+// renderDetail builds the detail body and returns the body-local line the value
+// label sits on (-1 when no detail is shown), the line the history content begins
+// on, and how many history rows are shown, so the pane can place the value-label
+// and history hit regions where they are drawn.
+func (m *Model) renderDetail(innerW, innerH int) (body string, valueLabelTop, historyTop, historyRows int) {
 	if !m.detailOK {
-		return m.styles.PageHint.Render("select an entry"), 0, 0
+		return m.styles.PageHint.Render("select an entry"), -1, 0, 0
 	}
 
 	var lines []string
@@ -172,6 +235,7 @@ func (m *Model) renderDetail(innerW, innerH int) (string, int, int) {
 		lines = append(lines, "")
 	}
 
+	valueLabelTop = len(lines)
 	lines = append(lines, m.valueLabelLine(innerW))
 	m.valuePane.SetSize(innerW, valuePaneHeight)
 	lines = append(lines, strings.Split(m.valuePane.View(), "\n")...)
@@ -185,19 +249,19 @@ func (m *Model) renderDetail(innerW, innerH int) (string, int, int) {
 	lines = append(lines, m.tagLine(innerW))
 
 	if !m.svcCap.HasVersionHistory {
-		return fitLines(lines, innerH), 0, 0
+		return fitLines(lines, innerH), valueLabelTop, 0, 0
 	}
 
 	lines = append(lines, "")
 	lines = append(lines, m.historyHeaderLine(innerW))
 
-	historyLocalTop := len(lines)
-	historyH := max(innerH-historyLocalTop, 0)
+	historyTop = len(lines)
+	historyH := max(innerH-historyTop, 0)
 	m.history.SetSize(innerW, historyH)
 	m.history.SetFocused(m.focus == focusHistory)
 	lines = append(lines, strings.Split(m.history.View(), "\n")...)
 
-	return fitLines(lines, innerH), historyLocalTop, historyH
+	return fitLines(lines, innerH), valueLabelTop, historyTop, historyH
 }
 
 // valueLabelLine renders the "Value  (x to reveal)" / "(J to format)" label row.

--- a/internal/tui/pages/staging/mouse.go
+++ b/internal/tui/pages/staging/mouse.go
@@ -1,16 +1,19 @@
 package staging
 
 import (
+	"strings"
+
 	tea "charm.land/bubbletea/v2"
 )
 
-// handleMouseClick maps a left click onto the last-rendered geometry, reducing
-// each click to the SAME internal action its keyboard equivalent performs: a
-// section's apply/reset button to apply/reset that section, an entry row to the
-// full-diff detail (like enter), a tag row to just selecting it (enter is a
-// no-op there — removal is `u`-only, never a click, #682), and the auto-unstaged
-// notice to dismiss. It follows the browser's hand-rolled geom hit-testing so
-// #663 can migrate both pages to the compositor uniformly.
+// handleMouseClick resolves a left click against the last-rendered hit map and
+// reduces it to the SAME internal action its keyboard equivalent performs: the
+// header toggle flips the diff/value view (like v); apply-all/reset-all/refresh
+// mirror A/R/ctrl+r; a section's apply/reset button applies/resets that section;
+// the notice dismisses (like esc); and a row click only SELECTS the row (never a
+// destructive cancel — removal is `u`-only, and enter's detail stays a key
+// action, resolving the browser/staging row-click divergence toward a single
+// "click selects" model).
 func (m *Model) handleMouseClick(msg tea.MouseClickMsg) (*Model, tea.Cmd) {
 	m.status = "" // a mouse interaction dismisses the transient invalid-action status
 
@@ -18,66 +21,60 @@ func (m *Model) handleMouseClick(msg tea.MouseClickMsg) (*Model, tea.Cmd) {
 		return m, nil
 	}
 
-	if m.geom.noticeRow >= 0 && msg.Y == m.geom.noticeRow {
+	id, _, _, ok := m.hits.At(msg.X, msg.Y)
+	if !ok {
+		return m, nil
+	}
+
+	switch {
+	case id == regionNotice:
 		m.noticeDismissed = true
-
-		return m, nil
-	}
-
-	line := msg.Y - m.geom.bodyTop
-	if line < 0 || line >= len(m.geom.lines) {
-		return m, nil
-	}
-
-	desc := m.geom.lines[line]
-
-	if desc.section >= 0 {
-		return m.clickSection(desc, msg.X)
-	}
-
-	if desc.row >= 0 {
-		return m.clickRow(desc.row)
+	case id == regionViewToggle:
+		return m, m.toggleView()
+	case id == regionApplyAll:
+		return m, m.apply(true)
+	case id == regionResetAll:
+		return m, m.reset(true)
+	case id == regionRefresh:
+		return m, m.reload()
+	case strings.HasPrefix(id, prefixSecApply):
+		return m, m.clickSection(id, prefixSecApply, m.applyServices)
+	case strings.HasPrefix(id, prefixSecReset):
+		return m, m.clickSection(id, prefixSecReset, m.resetServices)
+	case strings.HasPrefix(id, prefixRow):
+		return m.selectClickedRow(id)
 	}
 
 	return m, nil
 }
 
-// clickSection handles a click on a section header: apply/reset when the click
-// falls on the corresponding button columns.
-func (m *Model) clickSection(desc lineDesc, x int) (*Model, tea.Cmd) {
-	if desc.section >= len(m.sections) {
-		return m, nil
+// clickSection resolves a section-button region to its service and calls the
+// per-service apply/reset (the same reduction the header a/r keys perform).
+func (m *Model) clickSection(id, prefix string, action func([]string, bool) tea.Cmd) tea.Cmd {
+	i, ok := idIndex(id, prefix)
+	if !ok || i >= len(m.sections) {
+		return nil
 	}
 
-	service := m.sections[desc.section].service
-
-	switch {
-	case inRange(x, desc.apply):
-		return m, m.applyServices([]string{service}, false)
-	case inRange(x, desc.reset):
-		return m, m.resetServices([]string{service}, false)
-	default:
-		return m, nil
-	}
+	return action([]string{m.sections[i].service}, false)
 }
 
-// clickRow selects a row and performs its enter action (detail for an entry;
-// a no-op for a tag change, which is only selected), so a click reduces to the
-// key path.
-func (m *Model) clickRow(row int) (*Model, tea.Cmd) {
-	if row >= len(m.rows) {
+// selectClickedRow selects the clicked row (resetting the reveal like a key move,
+// #694) without performing any row action — a single click only navigates.
+func (m *Model) selectClickedRow(id string) (*Model, tea.Cmd) {
+	row, ok := idIndex(id, prefixRow)
+	if !ok || row >= len(m.rows) {
 		return m, nil
 	}
 
 	m.selected = row
-	// A selection move resets the reveal so a peek never persists onto another row
-	// (mirrors moveSelection; the reveal is scoped to the selected row — #694).
 	m.reveal = false
 
-	return m, m.onEnter()
+	return m, nil
 }
 
-// handleMouseWheel scrolls the section body.
+// handleMouseWheel scrolls the section body regardless of the pointer's column,
+// so there is no dead zone (the staging page has a single scrollable body).
 func (m *Model) handleMouseWheel(msg tea.MouseWheelMsg) (*Model, tea.Cmd) {
 	m.status = "" // a mouse interaction dismisses the transient invalid-action status
 
@@ -102,9 +99,4 @@ func wheelDelta(button tea.MouseButton) int {
 	default:
 		return 0
 	}
-}
-
-// inRange reports whether x is within the [start,end) column range.
-func inRange(x int, r [2]int) bool {
-	return x >= r[0] && x < r[1]
 }

--- a/internal/tui/pages/staging/staging.go
+++ b/internal/tui/pages/staging/staging.go
@@ -11,17 +11,35 @@ package staging
 
 import (
 	"context"
+	"strconv"
+	"strings"
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/mpyw/suve/internal/tui/data"
+	"github.com/mpyw/suve/internal/tui/hit"
 	"github.com/mpyw/suve/internal/tui/keys"
 	"github.com/mpyw/suve/internal/tui/styles"
 )
 
 // serviceSecret is the secret service key (the sections' masking axis).
 const serviceSecret = "secret"
+
+// Clickable region IDs for the staging hit map. The fixed-header affordances have
+// stable IDs; a section's apply/reset buttons and a selectable row carry their
+// index as a suffix (secApplyID / secResetID / rowID) so a click resolves to the
+// exact section or row it lands on.
+const (
+	regionNotice     = "notice"
+	regionViewToggle = "view-toggle"
+	regionApplyAll   = "apply-all"
+	regionResetAll   = "reset-all"
+	regionRefresh    = "refresh"
+	prefixSecApply   = "sec-apply-"
+	prefixSecReset   = "sec-reset-"
+	prefixRow        = "row-"
+)
 
 // Page-local key bindings not present in the global map.
 //
@@ -108,10 +126,31 @@ type Model struct {
 	// scroll the body so the selected row is visible.
 	scrollToSelection bool
 
-	// geom records the last-rendered line hit-map so mouse handlers hit-test what
-	// is actually on screen (never a hard-coded coordinate) — the browser geom
-	// pattern, kept consistent for the #663 compositor migration.
-	geom stagingGeom
+	// hits is the last-rendered hit map: one compositor region per clickable area
+	// (the header toggle/apply-all/reset-all/refresh, the dismissible notice, each
+	// section's apply/reset buttons, and each selectable row), rebuilt every View
+	// so a mouse coordinate is hit-tested against the layers rather than a
+	// hand-maintained geometry.
+	hits *hit.Map
+}
+
+// secApplyID / secResetID / rowID build the suffixed region IDs for a section's
+// apply/reset buttons and a selectable row.
+func secApplyID(section int) string { return prefixSecApply + strconv.Itoa(section) }
+func secResetID(section int) string { return prefixSecReset + strconv.Itoa(section) }
+func rowID(row int) string          { return prefixRow + strconv.Itoa(row) }
+
+// idIndex parses the integer suffix an ID carries after prefix (e.g. "row-3"→3),
+// reporting ok=false when id does not carry that prefix + integer.
+func idIndex(id, prefix string) (int, bool) {
+	rest, found := strings.CutPrefix(id, prefix)
+	if !found {
+		return 0, false
+	}
+
+	n, err := strconv.Atoi(rest)
+
+	return n, err == nil
 }
 
 // New builds the staging page over the offered services' staging seams (param

--- a/internal/tui/pages/staging/staging_test.go
+++ b/internal/tui/pages/staging/staging_test.go
@@ -475,11 +475,23 @@ func TestUpdate_BadgeCountAuthoritative(t *testing.T) {
 	assert.Equal(t, 2, msg.Count, "one entry + one tag change counts as two")
 }
 
+// regionOrigin returns the drawn top-left of a hit region, so a mouse test
+// derives its click coordinate from the rendered layout instead of hard-coding
+// one. It fails when the region was not drawn.
+func regionOrigin(t *testing.T, m *Model, id string) (int, int) {
+	t.Helper()
+
+	x, y, ok := m.hits.Origin(id)
+	require.True(t, ok, "region %q was drawn", id)
+
+	return x, y
+}
+
 // TestUpdate_MouseClickApplyResetSelectRow pins the mouse rule: a click on a
 // section's apply/reset button reduces to the SAME internal action its key
 // equivalent performs, and a click on a tag row only selects it (never the
 // destructive cancel — removal is `u`-only, #682), with coordinates read from
-// the rendered geometry (never hard-coded).
+// the drawn hit regions (never hard-coded).
 func TestUpdate_MouseClickApplyResetSelectRow(t *testing.T) {
 	t.Parallel()
 
@@ -496,11 +508,8 @@ func TestUpdate_MouseClickApplyResetSelectRow(t *testing.T) {
 	m := newModel(t, sec)
 
 	// Click the section header's apply button → apply confirmation for the section.
-	headerLine, header := findHeaderLine(m)
-	require.GreaterOrEqual(t, headerLine, 0, "a section header was rendered")
-
-	x := (header.apply[0] + header.apply[1]) / 2
-	_, cmd := m.Update(tea.MouseClickMsg{X: x, Y: m.geom.bodyTop + headerLine, Button: tea.MouseLeft})
+	ax, ay := regionOrigin(t, m, secApplyID(0))
+	_, cmd := m.Update(tea.MouseClickMsg{X: ax, Y: ay, Button: tea.MouseLeft})
 	require.NotNil(t, cmd)
 	applyMsg, ok := cmd().(nav.OpenApply)
 	require.True(t, ok, "clicking apply opens the apply confirmation")
@@ -508,42 +517,87 @@ func TestUpdate_MouseClickApplyResetSelectRow(t *testing.T) {
 	assert.False(t, applyMsg.Global)
 
 	// Click the reset button → reset confirmation.
-	x = (header.reset[0] + header.reset[1]) / 2
-	_, cmd = m.Update(tea.MouseClickMsg{X: x, Y: m.geom.bodyTop + headerLine, Button: tea.MouseLeft})
+	rx, ry := regionOrigin(t, m, secResetID(0))
+	_, cmd = m.Update(tea.MouseClickMsg{X: rx, Y: ry, Button: tea.MouseLeft})
 	require.NotNil(t, cmd)
 	_, ok = cmd().(nav.OpenReset)
 	assert.True(t, ok, "clicking reset opens the reset confirmation")
 
-	// Click the tag-add row → it only selects the row (no destructive cancel).
-	tagLine := findRowLine(m, 1) // row 1 is the tag add (row 0 is the entry)
-	require.GreaterOrEqual(t, tagLine, 0, "the tag row was rendered")
-
+	// Click the tag-add row (row 1; row 0 is the entry) → it only selects the row
+	// (no destructive cancel). The coordinate is the row region's origin.
+	tx, ty := regionOrigin(t, m, rowID(1))
 	m.selected = 0
-	_, cmd = m.Update(tea.MouseClickMsg{X: 4, Y: m.geom.bodyTop + tagLine, Button: tea.MouseLeft})
-	assert.Nil(t, cmd, "clicking a tag row dispatches nothing (enter is a no-op there)")
+	_, cmd = m.Update(tea.MouseClickMsg{X: tx, Y: ty, Button: tea.MouseLeft})
+	assert.Nil(t, cmd, "clicking a tag row dispatches nothing (it only selects)")
 	assert.Equal(t, 1, m.selected, "clicking the tag row selects it")
 	assert.Empty(t, sec.cancelAdds, "clicking a tag row never cancels its staged add")
 }
 
-// findHeaderLine returns the body-relative line index of the first section header
-// and its descriptor.
-func findHeaderLine(m *Model) (int, lineDesc) {
-	for i, d := range m.geom.lines {
-		if d.section >= 0 {
-			return i, d
-		}
-	}
+// TestUpdate_MouseClickEntryRowSelectsOnly pins the resolved row-click model: a
+// click on an entry row only SELECTS it — it does not open the detail page (enter
+// stays the key path), matching the browser's click-selects behavior.
+func TestUpdate_MouseClickEntryRowSelectsOnly(t *testing.T) {
+	t.Parallel()
 
-	return -1, lineDesc{}
+	sec := &stubService{
+		service: "param", label: "Param", svcCap: capFor("aws", "param"),
+		review: data.StagingReview{Entries: []data.StagedDiffRow{
+			{Name: "/app/one", Type: data.StagedDiffNormal, Operation: "update", StagedValue: "a"},
+			{Name: "/app/two", Type: data.StagedDiffNormal, Operation: "update", StagedValue: "b"},
+		}},
+	}
+	m := newModel(t, sec)
+	m.selected = 0
+
+	x, y := regionOrigin(t, m, rowID(1))
+	_, cmd := m.Update(tea.MouseClickMsg{X: x, Y: y, Button: tea.MouseLeft})
+	assert.Nil(t, cmd, "clicking an entry row only selects it (no detail-page open)")
+	assert.Equal(t, 1, m.selected, "clicking the entry row selects it")
 }
 
-// findRowLine returns the body-relative line index of the given selectable row.
-func findRowLine(m *Model, row int) int {
-	for i, d := range m.geom.lines {
-		if d.row == row {
-			return i
-		}
-	}
+// TestUpdate_MouseClickHeaderMatchesKeys pins #663's staging-header coverage: a
+// click on the view toggle, apply-all, reset-all, and refresh affordances reduces
+// to the same action v / A / R / ctrl+r perform, with coordinates from the drawn
+// header regions.
+func TestUpdate_MouseClickHeaderMatchesKeys(t *testing.T) {
+	t.Parallel()
 
-	return -1
+	param := &stubService{
+		service: "param", label: "Param", svcCap: capFor("aws", "param"),
+		review: data.StagingReview{Entries: []data.StagedDiffRow{{Name: "/p", Operation: "update", StagedValue: "v"}}},
+	}
+	secret := &stubService{
+		service: "secret", label: "Secret", svcCap: capFor("aws", "secret"),
+		review: data.StagingReview{Entries: []data.StagedDiffRow{{Name: "s", Operation: "create", StagedValue: "v"}}},
+	}
+	m := newModel(t, param, secret)
+
+	// View toggle click flips diff↔value (like v).
+	require.True(t, m.diffView)
+	vx, vy := regionOrigin(t, m, regionViewToggle)
+	m, _ = m.Update(tea.MouseClickMsg{X: vx, Y: vy, Button: tea.MouseLeft})
+	assert.False(t, m.diffView, "clicking the view toggle switches to value view (like v)")
+	_ = m.View(m.width, m.height)
+
+	// apply-all click requests the apply-all fan-out (like A).
+	aax, aay := regionOrigin(t, m, regionApplyAll)
+	_, cmd := m.Update(tea.MouseClickMsg{X: aax, Y: aay, Button: tea.MouseLeft})
+	require.NotNil(t, cmd, "clicking apply-all dispatches")
+	applyMsg, ok := cmd().(nav.OpenApply)
+	require.True(t, ok, "apply-all opens the apply-all confirmation")
+	assert.True(t, applyMsg.Global)
+	assert.ElementsMatch(t, []string{"param", "secret"}, applyMsg.Services)
+
+	// reset-all click requests the reset-all fan-out (like R).
+	rax, ray := regionOrigin(t, m, regionResetAll)
+	_, cmd = m.Update(tea.MouseClickMsg{X: rax, Y: ray, Button: tea.MouseLeft})
+	require.NotNil(t, cmd, "clicking reset-all dispatches")
+	resetMsg, ok := cmd().(nav.OpenReset)
+	require.True(t, ok, "reset-all opens the reset-all confirmation")
+	assert.True(t, resetMsg.Global)
+
+	// refresh click reloads every section (like ctrl+r).
+	fx, fy := regionOrigin(t, m, regionRefresh)
+	_, cmd = m.Update(tea.MouseClickMsg{X: fx, Y: fy, Button: tea.MouseLeft})
+	require.NotNil(t, cmd, "clicking refresh reloads the sections")
 }

--- a/internal/tui/pages/staging/update.go
+++ b/internal/tui/pages/staging/update.go
@@ -105,18 +105,7 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) (*Model, tea.Cmd) {
 
 		return m, nil
 	case key.Matches(msg, viewKey):
-		m.diffView = !m.diffView
-		m.reveal = false
-
-		// Toggling diff↔value rewrites every row's layout (diff spreads a value
-		// over ±lines; value packs it onto the header line). Bubble Tea's cell
-		// renderer would service that with a scroll-region optimization
-		// (ESC[…r + ESC[nS) whose result depends on the exact prior frame, so
-		// under a terminal that negotiates synchronized output differently (CI)
-		// the targeted cell writes land wrong and the staged values render
-		// empty. Force a full repaint so the toggle frame is
-		// environment-independent, exactly like the initial full paint.
-		return m, tea.ClearScreen
+		return m, m.toggleView()
 	case key.Matches(msg, m.keys.Select):
 		return m, m.onEnter()
 	case key.Matches(msg, revealKey):
@@ -150,6 +139,23 @@ func (m *Model) handleActionKey(msg tea.KeyPressMsg) (*Model, tea.Cmd) {
 	}
 
 	return m, nil
+}
+
+// toggleView flips the diff/value view (the `v` key and a click on the header
+// view toggle), resetting the reveal.
+//
+// Toggling diff↔value rewrites every row's layout (diff spreads a value over
+// ±lines; value packs it onto the header line). Bubble Tea's cell renderer would
+// service that with a scroll-region optimization (ESC[…r + ESC[nS) whose result
+// depends on the exact prior frame, so under a terminal that negotiates
+// synchronized output differently (CI) the targeted cell writes land wrong and
+// the staged values render empty. Force a full repaint so the toggle frame is
+// environment-independent, exactly like the initial full paint.
+func (m *Model) toggleView() tea.Cmd {
+	m.diffView = !m.diffView
+	m.reveal = false
+
+	return tea.ClearScreen
 }
 
 // moveSelection shifts the selection by delta (clamped) and keeps it visible.

--- a/internal/tui/pages/staging/view.go
+++ b/internal/tui/pages/staging/view.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mpyw/suve/internal/provider/azure/appconfig/aznamespace"
 	"github.com/mpyw/suve/internal/tui/data"
+	"github.com/mpyw/suve/internal/tui/hit"
 )
 
 // Operation keys (the neutral staging operation strings).
@@ -17,7 +18,9 @@ const (
 	operationDelete = "delete"
 )
 
-// lineDesc maps one rendered body line to what a mouse click on it acts on.
+// lineDesc maps one rendered body line to what a mouse click on it acts on. It
+// is intermediate layout state: View turns the visible descriptors into hit
+// regions once per frame.
 type lineDesc struct {
 	// row is the selectable row index this line belongs to, or -1.
 	row int
@@ -30,32 +33,29 @@ type lineDesc struct {
 	reset [2]int
 }
 
-// stagingGeom records the last-rendered hit-map so mouse handlers hit-test what
-// is on screen (the browser geom pattern; #663 migrates it to the compositor).
-type stagingGeom struct {
-	// bodyTop is the page-local screen row the scroll body starts on.
-	bodyTop int
-	// bodyRows is the visible body height.
-	bodyRows int
-	// lines maps a body-relative screen row to its descriptor.
-	lines []lineDesc
-	// noticeRow is the page-local row of the dismissible notice, or -1.
-	noticeRow int
+// headerRanges holds the fixed-header affordances' [start,end) column ranges,
+// computed from the plain layout so hit-testing is color-safe.
+type headerRanges struct {
+	view     [2]int
+	applyAll [2]int
+	resetAll [2]int
+	refresh  [2]int
 }
 
-// View renders the staging page into the content area and records the geometry.
+// View renders the staging page into the content area and rebuilds the hit map.
 func (m *Model) View(width, height int) string {
 	m.width, m.height = width, height
 	if width <= 0 || height <= 0 {
 		return ""
 	}
 
-	m.geom = stagingGeom{noticeRow: -1}
+	header, hRanges := m.headerLine(width)
+	head := []string{header}
 
-	head := []string{m.headerLine(width)}
+	noticeRow := -1
 
 	if m.noticeVisible() {
-		m.geom.noticeRow = len(head)
+		noticeRow = len(head)
 		head = append(head, m.noticeLine(width))
 	}
 
@@ -67,19 +67,67 @@ func (m *Model) View(width, height int) string {
 
 	bodyTop := len(head)
 	bodyH := max(height-bodyTop-1, 0)
-	m.geom.bodyTop = bodyTop
-	m.geom.bodyRows = bodyH
 
 	lines, descs, rowFirst := m.bodyLines(width)
 	m.clampScroll(len(lines), bodyH, rowFirst)
 
 	visible, visDescs := window(lines, descs, m.scroll, bodyH)
-	m.geom.lines = visDescs
+
+	m.hits = m.buildHits(width, bodyTop, noticeRow, hRanges, visDescs)
 
 	out := append(head, visible...) //nolint:gocritic // head is a fresh slice; appending body then footer is intentional
 	out = append(out, footer)
 
 	return strings.Join(out, "\n")
+}
+
+// buildHits assembles the frame's hit regions in page-local coordinates: the
+// fixed-header affordances at row 0, the dismissible notice (when shown), and —
+// from the VISIBLE body descriptors — each section's apply/reset buttons and each
+// selectable row (spanning its consecutive lines). Rows fill the full width so a
+// click anywhere on a row selects it; the section buttons sit above (higher Z) on
+// their header line.
+func (m *Model) buildHits(width, bodyTop, noticeRow int, h headerRanges, visDescs []lineDesc) *hit.Map {
+	regions := []*lipgloss.Layer{
+		rangeRegion(regionViewToggle, h.view, 0),
+		rangeRegion(regionApplyAll, h.applyAll, 0),
+		rangeRegion(regionResetAll, h.resetAll, 0),
+		rangeRegion(regionRefresh, h.refresh, 0),
+	}
+
+	if noticeRow >= 0 {
+		regions = append(regions, hit.Region(regionNotice, 0, noticeRow, width, 1))
+	}
+
+	for i := 0; i < len(visDescs); {
+		d := visDescs[i]
+		y := bodyTop + i
+
+		switch {
+		case d.section >= 0:
+			regions = append(regions,
+				rangeRegion(secApplyID(d.section), d.apply, y).Z(1),
+				rangeRegion(secResetID(d.section), d.reset, y).Z(1),
+			)
+			i++
+		case d.row >= 0:
+			start := i
+			for i < len(visDescs) && visDescs[i].row == d.row {
+				i++
+			}
+
+			regions = append(regions, hit.Region(rowID(d.row), 0, bodyTop+start, width, i-start))
+		default:
+			i++
+		}
+	}
+
+	return hit.New(regions...)
+}
+
+// rangeRegion builds a 1-row region for a [start,end) column range at row y.
+func rangeRegion(id string, r [2]int, y int) *lipgloss.Layer {
+	return hit.Region(id, r[0], y, r[1]-r[0], 1)
 }
 
 // footerLine renders the reserved bottom row: a pending invalid-action status
@@ -101,13 +149,43 @@ func (m *Model) hintLine(width int) string {
 	return m.styles.PageHint.Render(clip(hint, width))
 }
 
-// headerLine renders the fixed top line: the view toggle and the global
-// apply-all / reset-all / refresh affordances.
-func (m *Model) headerLine(width int) string {
-	toggle := "view: " + m.styles.PaneTitle.Render(bracket("diff", m.diffView)) + " " + bracket("value", !m.diffView)
-	actions := m.styles.PageHint.Render("A apply-all · R reset-all · ctrl+r refresh")
+// headerLine renders the fixed top line — the view toggle and the global
+// apply-all / reset-all / refresh affordances — and returns each affordance's
+// clickable column range, so a header click reduces to the same action its key
+// equivalent performs. The ranges come from the plain layout (byte == column for
+// this ASCII line), so styling never shifts a hit range (color-safe).
+func (m *Model) headerLine(width int) (string, headerRanges) {
+	const (
+		applyText   = "A apply-all"
+		resetText   = "R reset-all"
+		refreshText = "ctrl+r refresh"
+	)
 
-	return clip(toggle+"   "+actions, width)
+	toggleText := "view: " + bracket("diff", m.diffView) + " " + bracket("value", !m.diffView)
+	actionsText := applyText + " · " + resetText + " · " + refreshText
+	plain := toggleText + "   " + actionsText
+
+	ranges := headerRanges{
+		view:     [2]int{0, lipgloss.Width(toggleText)},
+		applyAll: indexSpan(plain, applyText),
+		resetAll: indexSpan(plain, resetText),
+		refresh:  indexSpan(plain, refreshText),
+	}
+
+	toggle := "view: " + m.styles.PaneTitle.Render(bracket("diff", m.diffView)) + " " + bracket("value", !m.diffView)
+	actions := m.styles.PageHint.Render(actionsText)
+
+	return clip(toggle+"   "+actions, width), ranges
+}
+
+// indexSpan finds sub in plain and returns its [start,end) column range.
+func indexSpan(plain, sub string) [2]int {
+	start := strings.Index(plain, sub)
+	if start < 0 {
+		return [2]int{0, 0}
+	}
+
+	return [2]int{start, start + len(sub)}
 }
 
 // noticeLine renders the dismissible auto-unstaged notice.


### PR DESCRIPTION
Closes #663.

Retires the TUI's hand-rolled `geom`/`stagingGeom` point-in-rectangle hit-testing and replaces it with a shared `internal/tui/hit` package built on lipgloss v2's `Compositor.Hit(x,y) LayerHit`. Every clickable/scrollable area is now an ID'd region layer placed where it is drawn; a mouse coordinate is resolved against the layers once (and un-offset via the hit region's `Bounds().Min`) instead of being double-managed.

## Acceptance-checklist coverage (from #663's comment)

Dead-to-mouse, now clickable — each click reduces to the SAME internal action its key equivalent performs, verified at the `Update` layer:

- [x] **Confirmation dialogs** — delete/apply/reset buttons, `Ignore conflicts`/`Force delete` checkboxes, Stage/Apply-immediately radios, and the error-dialog close hint. The shell un-offsets a modal click through the overlay compositor's layer origin (box origin + border/padding inset, read from the `Dialog` style so it is correct in both color and `NO_COLOR` modes) before forwarding it content-local — fixing the raw-screen-coordinate dialog bug.
- [x] **Browser header** — `prefix:`/`filter:` fields, `values`/`recursive` toggles, App Config `ns:` badge, `⟳` refresh, and the `Value (x to reveal)` label.
- [x] **Staging header** — `view: [diff] value` toggle, `A apply-all`, `R reset-all`, `ctrl+r refresh`.
- [x] **Help bar** — a click toggles short/full help (like `?`); gated on the min terminal size like the tab bar.
- [ ] **Load-more footer row** — latent (the footer never renders today, #700); out of scope, no behavior to hit-test.

Behavioral divergences resolved:

- [x] **Compare mode** — a history-row click that completes the second pick now opens the diff (same `nav.OpenDiff` as `enter`) instead of dead-ending.
- [x] **Row-click model unified** — click *selects* on both pages. Staging no longer opens the detail page (`enter` still does) or cancels a tag on a single click (`u` only) — this also removes a mis-click footgun.
- [x] **Wheel routing** — the browser routes the wheel per region (list / history / value pane) and no longer falls through to the value pane over the header/chrome.
- [x] **Apply/reset results wheel** — scrolls the #687 results viewport (kept working).

Latent traps:

- [x] **Un-offset dialog coordinates** — fixed via the compositor layer origin (see above).
- [x] **Hard-coded test coordinate** — the `staging_test.go` `X: 4` literal is gone; every mouse test derives its coordinate from the drawn region (`hits.Origin`).

huh-form dialogs (entry/tag/restore) stay keyboard-only per the maintainer decision (huh v2 has no upstream mouse support).

`geom`/`stagingGeom` are fully removed; no new `.github/deadcode-allow.txt` entries. Goldens are unchanged (visible output is byte-identical; only ANSI grouping differs).

## Verification

All commands run in the worktree at `ab2cf4b` (based on `origin/epic/tui`).

\`\`\`
$ go test ./... 2>&1 | grep -v '^ok\|no test files'
   (no output — all packages pass)

$ go test -race ./internal/tui/...
ok  github.com/mpyw/suve/internal/tui               5.659s
ok  github.com/mpyw/suve/internal/tui/data          2.064s
ok  github.com/mpyw/suve/internal/tui/dialogs       1.839s
ok  github.com/mpyw/suve/internal/tui/hit           1.235s
ok  github.com/mpyw/suve/internal/tui/pages/browser 2.589s
ok  github.com/mpyw/suve/internal/tui/pages/diff    2.331s
ok  github.com/mpyw/suve/internal/tui/pages/staging 2.112s

$ golangci-lint run --allow-parallel-runners --timeout=10m
0 issues.

$ sh .github/scripts/check-deadcode.sh
Dead code gate OK: no unreachable funcs outside .github/deadcode-allow.txt.

$ mise build-gui
Built bin/suve — run 'suve --gui'.
\`\`\`

New/changed `Update`-level tests prove each newly-clickable region dispatches the same action as its key equivalent, that a compare-completing history click opens the diff, that browser wheel routing targets the right region (and drops over chrome), and that a modal click is translated to the dialog's content-local coordinates (and swallowed outside the box). A context-isolated review of the region math, dialog translation (incl. `NO_COLOR` vs color padding), and z-ordering found no material correctness issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)