### PR TITLE
fix(tui): constrain tag Remove to the entry's existing tags (#705)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -370,7 +370,7 @@ func (m *App) openTag(req nav.OpenTag) tea.Cmd {
 
 	d, cmd := dialogs.NewTagForm(dialogs.TagInput{
 		Ctx: m.runCtx, Mutator: mut, Service: req.Service, Styles: m.styles,
-		Name: req.Name, Namespace: req.Namespace, StagedOnly: req.StagedOnly,
+		Name: req.Name, Namespace: req.Namespace, Tags: req.Tags, StagedOnly: req.StagedOnly,
 	})
 
 	return m.pushDialog(d, cmd)

--- a/internal/tui/dialog_golden_test.go
+++ b/internal/tui/dialog_golden_test.go
@@ -207,6 +207,10 @@ func captureDialogWithKeys(t *testing.T, host *dialogHost, marker string, keys .
 func keyDownMsg() tea.KeyPressMsg  { return tea.KeyPressMsg{Code: tea.KeyDown} }
 func keyEnterMsg() tea.KeyPressMsg { return tea.KeyPressMsg{Code: tea.KeyEnter} }
 
+// keyRightMsg toggles an inline huh select (e.g. the tag dialog's Add/Remove
+// action) to its next option.
+func keyRightMsg() tea.KeyPressMsg { return tea.KeyPressMsg{Code: tea.KeyRight} }
+
 func goldenCap(prov, service string) capability.ServiceCapability {
 	sc, _ := capabilityFor(provider.Provider(prov), service)
 
@@ -321,6 +325,41 @@ func TestDialog_TagAWSParamGolden(t *testing.T) { //nolint:paralleltest // golde
 	})
 
 	dialogGolden(t, newDialogHost(m, cmd), "Action")
+}
+
+// TestDialog_TagRemoveSelectGolden renders the tag form after toggling to the
+// Remove action on an entry that has tags: the key field is a select of the
+// entry's CURRENT tags (env=prod / team=api), not a blind free-text key, so an
+// untag can only target a tag that is actually present (#705).
+func TestDialog_TagRemoveSelectGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
+	goldenEnv(t)
+
+	m, cmd := dialogs.NewTagForm(dialogs.TagInput{
+		Ctx: context.Background(), Mutator: capMutator{cap: goldenCap("aws", "param")},
+		Service: "param", Styles: styles.New(), Name: "/app/api/DATABASE_URL",
+		Tags: []data.Tag{{Key: "env", Value: "prod"}, {Key: "team", Value: "api"}},
+	})
+
+	// Right toggles the inline action select from Add to Remove; the form rebuilds
+	// onto the Remove branch and shows the existing-tags select.
+	raw := captureDialogWithKeys(t, newDialogHost(m, cmd), "env=prod", keyRightMsg())
+	golden.RequireEqual(t, renderVisibleScreen(t, raw))
+}
+
+// TestDialog_TagRemoveEmptyGolden renders the tag form after toggling to Remove
+// on an entry with NO tags: instead of a free-text key, Remove shows a
+// "(no tags to remove)" note, the empty state that keeps an untag from being
+// invited when there is nothing to remove (#705).
+func TestDialog_TagRemoveEmptyGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
+	goldenEnv(t)
+
+	m, cmd := dialogs.NewTagForm(dialogs.TagInput{
+		Ctx: context.Background(), Mutator: capMutator{cap: goldenCap("aws", "param")},
+		Service: "param", Styles: styles.New(), Name: "/app/api/DATABASE_URL",
+	})
+
+	raw := captureDialogWithKeys(t, newDialogHost(m, cmd), "(no tags to remove)", keyRightMsg())
+	golden.RequireEqual(t, renderVisibleScreen(t, raw))
 }
 
 // TestDialog_EntryFormStagedOnlyGolden renders the edit form as launched from the

--- a/internal/tui/dialogs/dialogs_test.go
+++ b/internal/tui/dialogs/dialogs_test.go
@@ -687,20 +687,150 @@ func TestTagForm_Routing(t *testing.T) {
 	mut := &fakeMutator{svcCap: awsParamCap()}
 	m, _ := NewTagForm(TagInput{
 		Ctx: context.Background(), Mutator: mut, Service: "param", Styles: styles.New(), Name: "/app/X",
+		Tags: []data.Tag{{Key: "owner", Value: "team"}},
 	})
 	d, ok := m.(*tagForm)
 	require.True(t, ok)
 
-	d.tagKey, d.tagValue, d.staged = "owner", "team", true
+	d.tagKey, d.tagValue, d.staged = "env", "prod", true
 
 	d.remove = false
 	execCmd(t, d.submit())
-	assert.True(t, mut.addTagCalled, "add action routes to AddTag")
+	assert.True(t, mut.addTagCalled, "add action routes to AddTag with the free-text key")
+	assert.Equal(t, "env", mut.tagKey)
 	assert.True(t, mut.staged)
 
+	// Remove routes the key chosen from the existing-tags select (removeKey), never
+	// the free-text Add key.
 	d.remove = true
+	d.removeKey = "owner"
 	execCmd(t, d.submit())
-	assert.Equal(t, "owner", mut.tagKey, "remove action routes to RemoveTag with the key")
+	assert.Equal(t, "owner", mut.tagKey, "remove action routes to RemoveTag with the selected key")
+}
+
+// TestTagForm_RemoveConstrainedToExistingTags pins the #705 fix: the Remove
+// action is a select of the entry's CURRENT tags (labelled key=value, valued by
+// key so it routes straight to RemoveTag), never a blind free-text key. The
+// select seeds a present key by default, so a Remove always has a valid target,
+// and choosing a present tag stages the untag with that key. Add stays a
+// free-text key + value (adding a new tag is legitimately open-ended).
+func TestTagForm_RemoveConstrainedToExistingTags(t *testing.T) {
+	t.Parallel()
+
+	mut := &fakeMutator{svcCap: awsParamCap()}
+	m, _ := NewTagForm(TagInput{
+		Ctx: context.Background(), Mutator: mut, Service: "param", Styles: styles.New(), Name: "/app/X",
+		Tags: []data.Tag{{Key: "env", Value: "prod"}, {Key: "team", Value: "api"}},
+	})
+	d, ok := m.(*tagForm)
+	require.True(t, ok)
+
+	// Add (the default) is a free-text key input, unchanged.
+	assert.Contains(t, stripANSI(d.View()), "Key", "Add offers a free-text key input")
+	assert.Contains(t, stripANSI(d.View()), "(add only)", "Add offers the value input")
+
+	// Remove offers a select of the existing tags, not a free-text key.
+	_, isSelect := d.removeField().(*huh.Select[string])
+	assert.True(t, isSelect, "Remove offers a select of existing tags, not a free-text key")
+
+	d.remove = true
+	require.NotNil(t, d.rebuildForm())
+	assert.Equal(t, "env", d.removeKey, "the select seeds the first existing tag as the default target")
+
+	view := stripANSI(d.View())
+	assert.Contains(t, view, "env=prod", "the select lists the existing tags as key=value options")
+	assert.Contains(t, view, "team=api")
+	assert.NotContains(t, view, "(add only)", "the Add-only value input is gone in Remove mode")
+
+	// Selecting a present tag stages the untag with that key.
+	d.removeKey = "team"
+	execCmd(t, d.submit())
+	assert.Equal(t, "team", mut.tagKey, "the chosen present key is the untag target")
+}
+
+// TestTagForm_StagedOnlyIsAddOnly pins the staged-only surface (the staging
+// review page) is Add-only: it never has the remote tag set to constrain a
+// Remove, so it offers no Remove action rather than a guaranteed empty-state
+// dead-end. Removing a remote tag is done from the browser.
+func TestTagForm_StagedOnlyIsAddOnly(t *testing.T) {
+	t.Parallel()
+
+	mut := &fakeMutator{svcCap: awsParamCap()}
+	m, _ := NewTagForm(TagInput{
+		Ctx: context.Background(), Mutator: mut, Service: "param", Styles: styles.New(),
+		Name: "/app/X", StagedOnly: true,
+	})
+	d, ok := m.(*tagForm)
+	require.True(t, ok)
+
+	view := stripANSI(d.View())
+	assert.Contains(t, view, "Add tag", "the staged-only tag form offers Add")
+	assert.NotContains(t, view, "Remove tag", "the staged-only tag form offers no Remove action")
+
+	// A browser launch (not staged-only) still offers Remove.
+	bm, _ := NewTagForm(TagInput{
+		Ctx: context.Background(), Mutator: mut, Service: "param", Styles: styles.New(), Name: "/app/X",
+	})
+	b, ok := bm.(*tagForm)
+	require.True(t, ok)
+
+	_, _ = b.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	assert.True(t, b.remove, "a browser launch can toggle to Remove")
+}
+
+// TestTagForm_RemoveEmptyState pins the #705 empty state: an entry with no tags
+// has nothing to untag, so Remove shows a "(no tags to remove)" note instead of a
+// free-text key, and completing the Remove action is blocked — the guard reopens
+// with the note rather than dead-ending on a guaranteed-failing untag, and no
+// untag is ever submitted.
+func TestTagForm_RemoveEmptyState(t *testing.T) {
+	t.Parallel()
+
+	mut := &fakeMutator{svcCap: awsParamCap()}
+	m, _ := NewTagForm(TagInput{
+		Ctx: context.Background(), Mutator: mut, Service: "param", Styles: styles.New(), Name: "/app/X",
+	})
+	d, ok := m.(*tagForm)
+	require.True(t, ok)
+
+	_, isNote := d.removeField().(*huh.Note)
+	assert.True(t, isNote, "with no tags, Remove shows a note, not a free-text key")
+
+	d.remove = true
+	require.NotNil(t, d.rebuildForm())
+	assert.Contains(t, stripANSI(d.View()), "(no tags to remove)", "the empty state names why nothing can be removed")
+
+	// The empty Remove has no key to route, and the completion guard blocks it (see
+	// the teatest TestTUI_TagRemoveEmptyBlocksSubmit for the end-to-end proof that
+	// no untag is submitted). Here we pin that nothing has been routed yet.
+	assert.Empty(t, mut.tagKey, "no untag key is set for an entry with no tags")
+	assert.False(t, d.busy)
+}
+
+// TestTagForm_ActionToggleMorphsKeyField pins that toggling the action select
+// rebuilds the form so the key field morphs between the free-text Add input and
+// the Remove select — the mechanism behind the #705 constraint.
+func TestTagForm_ActionToggleMorphsKeyField(t *testing.T) {
+	t.Parallel()
+
+	mut := &fakeMutator{svcCap: awsParamCap()}
+	m, _ := NewTagForm(TagInput{
+		Ctx: context.Background(), Mutator: mut, Service: "param", Styles: styles.New(), Name: "/app/X",
+		Tags: []data.Tag{{Key: "env", Value: "prod"}},
+	})
+	d, ok := m.(*tagForm)
+	require.True(t, ok)
+
+	_, _ = d.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+
+	require.False(t, d.builtRemove, "the form starts on the Add branch")
+
+	// Right arrow toggles the inline action select to Remove; the next Update pass
+	// rebuilds the form onto the Remove branch.
+	_, _ = d.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	assert.True(t, d.remove, "right toggles the action to Remove")
+	assert.True(t, d.builtRemove, "the form rebuilt onto the Remove branch")
+	assert.Contains(t, stripANSI(d.View()), "env=prod", "the Remove select is now shown")
 }
 
 // TestDeleteConfirm_ResultVoicing pins the delete status voicing, including the

--- a/internal/tui/dialogs/tagform.go
+++ b/internal/tui/dialogs/tagform.go
@@ -7,6 +7,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	huh "charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/samber/lo"
 
 	"github.com/mpyw/suve/internal/capability"
 	"github.com/mpyw/suve/internal/tui/data"
@@ -26,14 +27,27 @@ type tagForm struct {
 
 	name      string
 	namespace string
+	// tags is the entry's current tag set, seeding the Remove action's choices so
+	// an untag can only target a tag that is actually present (#705). Empty when the
+	// caller has none to offer (e.g. the staging review page), in which case Remove
+	// shows an empty state rather than a blind free-text key.
+	tags []data.Tag
 
 	remove   bool
-	tagKey   string
-	tagValue string
-	staged   bool
+	tagKey   string // Add: the free-text key to add
+	tagValue string // Add: the value to add
+	// removeKey is the key chosen for removal, bound to the Remove action's select
+	// (seeded from tags). It is distinct from the Add key so a typed Add key never
+	// masquerades as a removable one, keeping the empty-tags guard honest.
+	removeKey string
+	staged    bool
 	// stagedOnly hides the mode toggle and forces a staged tag write (the staging
 	// review page's tag path); the browser leaves it false and keeps the toggle.
 	stagedOnly bool
+	// builtRemove records the action the current form was built for, so Update can
+	// rebuild the form when the action toggles — morphing the key field between the
+	// free-text Add input and the Remove select of existing tags.
+	builtRemove bool
 
 	form *huh.Form
 	busy bool
@@ -48,6 +62,9 @@ type TagInput struct {
 	Styles    styles.Styles
 	Name      string
 	Namespace string
+	// Tags is the entry's current tag set, offered as the Remove action's choices
+	// (#705). Empty when the caller has none to offer.
+	Tags []data.Tag
 	// StagedOnly opens the dialog from a staged-only surface (the staging review
 	// page): the mode toggle is hidden and the tag write is forced staged.
 	StagedOnly bool
@@ -65,6 +82,7 @@ func NewTagForm(in TagInput) (Model, tea.Cmd) {
 		styles:     in.Styles,
 		name:       in.Name,
 		namespace:  in.Namespace,
+		tags:       in.Tags,
 		stagedOnly: in.StagedOnly,
 		// Staged by default when the service supports staging; a staged-only surface
 		// forces staged regardless (its toggle is hidden too).
@@ -77,13 +95,37 @@ func NewTagForm(in TagInput) (Model, tea.Cmd) {
 }
 
 func (d *tagForm) rebuildForm() tea.Cmd {
+	// Remove is offered only on a surface that can supply the entry's current tag
+	// set to constrain it (the browser). A staged-only surface (the staging review
+	// page) knows only the staged deltas, never the remote tag set, so it offers
+	// Add only — removing a remote tag is done from the browser, where the tag set
+	// is visible; this keeps Remove from becoming a guaranteed empty-state dead-end
+	// there (#705), mirroring how the mode toggle is hidden on that surface.
+	actionOpts := []huh.Option[bool]{huh.NewOption("Add tag", false)}
+	if !d.stagedOnly {
+		actionOpts = append(actionOpts, huh.NewOption("Remove tag", true))
+	}
+
 	fields := []huh.Field{
 		huh.NewSelect[bool]().Key("action").Title("Action").Inline(true).
-			Options(huh.NewOption("Add tag", false), huh.NewOption("Remove tag", true)).
-			Value(&d.remove),
-		huh.NewInput().Key("tagkey").Title("Key").Value(&d.tagKey).Validate(requiredField("key")),
-		huh.NewInput().Key("tagvalue").Title("Value").Placeholder("(add only)").Value(&d.tagValue),
+			Options(actionOpts...).Value(&d.remove),
 	}
+
+	// The key field morphs with the action: Add takes a free-text key + value (a
+	// new tag is legitimately open-ended); Remove is constrained to the entry's
+	// CURRENT tags so an untag can only target a tag that is actually present —
+	// mirroring the GUI's per-chip remove — instead of a blind free-text key that
+	// would invite a guaranteed stage-time/provider failure (#705).
+	if d.remove {
+		fields = append(fields, d.removeField())
+	} else {
+		fields = append(fields,
+			huh.NewInput().Key("tagkey").Title("Key").Value(&d.tagKey).Validate(requiredField("key")),
+			huh.NewInput().Key("tagvalue").Title("Value").Placeholder("(add only)").Value(&d.tagValue),
+		)
+	}
+
+	d.builtRemove = d.remove
 
 	// The mode toggle is offered only when staging is supported AND the dialog was
 	// not launched from a staged-only surface (the staging review page), which has
@@ -100,6 +142,24 @@ func (d *tagForm) rebuildForm() tea.Cmd {
 	// Init the (re)built form, then cap its body to the known terminal size so a
 	// retry after an error never renders at full natural height off-screen.
 	return tea.Batch(d.form.Init(), d.syncFormSize())
+}
+
+// removeField builds the Remove action's key field: a select of the entry's
+// current tags (labelled "key=value", valued by key so it routes straight to
+// RemoveTag), or a read-only note when the entry has no tags. The select binds
+// removeKey, which huh seeds to the first tag on build, so a Remove always has a
+// valid target; the note path is blocked from submitting by the empty-tags guard
+// in Update.
+func (d *tagForm) removeField() huh.Field {
+	if len(d.tags) == 0 {
+		return huh.NewNote().Title("Tag").Description("(no tags to remove)")
+	}
+
+	opts := lo.Map(d.tags, func(t data.Tag, _ int) huh.Option[string] {
+		return huh.NewOption(t.Key+"="+t.Value, t.Key)
+	})
+
+	return huh.NewSelect[string]().Key("removekey").Title("Tag").Options(opts...).Value(&d.removeKey)
 }
 
 // syncFormSize re-caps the embedded form's scrollable body to the current
@@ -153,8 +213,24 @@ func (d *tagForm) Update(msg tea.Msg) (Model, tea.Cmd) {
 		d.form = f
 	}
 
+	// The action toggled: rebuild so the key field morphs between the free-text Add
+	// input and the Remove select of existing tags. Clear any stale error first.
+	if d.remove != d.builtRemove {
+		d.err = ""
+
+		return d, d.rebuildForm()
+	}
+
 	switch d.form.State {
 	case huh.StateCompleted:
+		// A Remove on an entry with no tags has nothing to target: reopen with a
+		// note rather than dead-ending on a guaranteed-failing untag (#705).
+		if d.remove && len(d.tags) == 0 {
+			d.err = "no tags to remove"
+
+			return d, d.rebuildForm()
+		}
+
 		d.busy = true
 
 		return d, d.submit()
@@ -169,13 +245,16 @@ func (d *tagForm) Update(msg tea.Msg) (Model, tea.Cmd) {
 func (d *tagForm) submit() tea.Cmd {
 	key := data.StagedKey{Name: d.name, Namespace: d.namespace}
 	remove := d.remove
+	// Remove routes the key chosen from the existing-tags select; Add routes the
+	// free-text key + value.
+	removeKey := d.removeKey
 	tagKey, tagValue := d.tagKey, d.tagValue
 	staged := d.staged
 	mut, ctx := d.mutator, d.ctx
 
 	return runMutation(func() (data.WriteOutcome, error) {
 		if remove {
-			return mut.RemoveTag(ctx, key, tagKey, staged)
+			return mut.RemoveTag(ctx, key, removeKey, staged)
 		}
 
 		return mut.AddTag(ctx, key, tagKey, tagValue, staged)

--- a/internal/tui/nav/nav.go
+++ b/internal/tui/nav/nav.go
@@ -90,6 +90,12 @@ type OpenTag struct {
 	Service   string
 	Name      string
 	Namespace string
+	// Tags is the entry's current tag set, seeding the Remove action's choices so
+	// an untag can only target a tag that is actually present (a blind free-text
+	// key would invite a guaranteed stage-time/provider failure — #705). Empty when
+	// the caller has no tag set to offer (e.g. the staging review page, which knows
+	// only the staged deltas), in which case Remove shows an empty state.
+	Tags []data.Tag
 	// StagedOnly launches the tag dialog in a staged-only context (the staging
 	// review page): the mode toggle is hidden and the tag write is forced staged.
 	// An immediate tag write from a staged surface can silently revert on a later

--- a/internal/tui/pages/browser/browser_test.go
+++ b/internal/tui/pages/browser/browser_test.go
@@ -969,11 +969,20 @@ func TestOpenTagHasTagsGate(t *testing.T) {
 
 	tagging := newModel(t, &stubSource{svcCap: awsParamCap()})
 	tagging, _ = update(t, tagging, listLoadedMsg{seq: tagging.listSeq, res: data.ListResult{Items: []data.Item{{Name: "/x"}}}})
+
+	// The tag dialog seeds from the loaded detail, so it is a no-op until one loads.
+	assert.Nil(t, tagging.openTag(), "tag is a no-op until a detail is loaded")
+
+	tagging, _ = update(t, tagging, detailLoadedMsg{seq: tagging.detailSeq, d: data.Detail{
+		Name: "/x", Tags: []data.Tag{{Key: "env", Value: "prod"}},
+	}})
 	cmd := tagging.openTag()
-	require.NotNil(t, cmd, "a tagging service with a selection opens the tag dialog")
+	require.NotNil(t, cmd, "a tagging service with a loaded detail opens the tag dialog")
 	open, ok := cmd().(nav.OpenTag)
 	require.True(t, ok, "tag emits nav.OpenTag")
 	assert.Equal(t, "/x", open.Name)
+	assert.Equal(t, []data.Tag{{Key: "env", Value: "prod"}}, open.Tags,
+		"the entry's current tags seed the Remove action's choices (#705)")
 	assert.False(t, open.StagedOnly, "a browser tag keeps the immediate-mode toggle (not a staged-only surface)")
 }
 

--- a/internal/tui/pages/browser/update.go
+++ b/internal/tui/pages/browser/update.go
@@ -460,20 +460,23 @@ func (m *Model) openDelete() tea.Cmd {
 }
 
 // openTag requests the tag add/remove dialog for the selected entry (only when
-// the service supports tags).
+// the service supports tags). It is seeded from the loaded detail — like openEdit
+// — so the Remove action can offer the entry's CURRENT tags (m.detail.Tags)
+// rather than a blind free-text key (#705); it is therefore a no-op until a
+// detail is loaded, and the seeded tags always match the seeded name.
 func (m *Model) openTag() tea.Cmd {
-	if !m.svcCap.HasTags {
+	if !m.svcCap.HasTags || !m.detailOK {
 		return nil
 	}
 
-	item, ok := m.selectedItem()
-	if !ok {
-		return nil
+	req := nav.OpenTag{
+		Service:   m.svcCap.Service,
+		Name:      m.detail.Name,
+		Namespace: m.detail.Namespace,
+		Tags:      m.detail.Tags,
 	}
 
-	return func() tea.Msg {
-		return nav.OpenTag{Service: m.svcCap.Service, Name: item.Name, Namespace: item.Namespace}
-	}
+	return func() tea.Msg { return req }
 }
 
 // openRestore requests the restore dialog (name input), only when the service

--- a/internal/tui/tagform_interaction_test.go
+++ b/internal/tui/tagform_interaction_test.go
@@ -1,0 +1,155 @@
+//nolint:testpackage // white-box: drives the tag dialog through the shared teatest host
+package tui
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	teatest "github.com/charmbracelet/x/exp/teatest/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mpyw/suve/internal/capability"
+	"github.com/mpyw/suve/internal/tui/data"
+	"github.com/mpyw/suve/internal/tui/dialogs"
+	"github.com/mpyw/suve/internal/tui/styles"
+)
+
+// recordingMutator is a data.Mutator that records the tag call the tag dialog
+// routes, so an interaction test can assert whether (and with what key) a submit
+// reached the mutator. It is concurrency-safe: the tea program calls it from its
+// own goroutine while the test polls from another.
+type recordingMutator struct {
+	cap capability.ServiceCapability
+
+	mu           sync.Mutex
+	removeCalled bool
+	addCalled    bool
+	tagKey       string
+	staged       bool
+}
+
+func (m *recordingMutator) Capability() capability.ServiceCapability { return m.cap }
+
+func (*recordingMutator) Create(context.Context, data.StagedKey, string, string, string, bool) (data.WriteOutcome, error) {
+	return data.WriteOutcome{}, nil
+}
+
+func (*recordingMutator) Update(context.Context, data.StagedKey, string, string, string, bool) (data.WriteOutcome, error) {
+	return data.WriteOutcome{}, nil
+}
+
+func (*recordingMutator) Delete(context.Context, data.StagedKey, bool, int, bool) (data.WriteOutcome, error) {
+	return data.WriteOutcome{}, nil
+}
+
+func (m *recordingMutator) AddTag(_ context.Context, _ data.StagedKey, tagKey, _ string, staged bool) (data.WriteOutcome, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.addCalled, m.tagKey, m.staged = true, tagKey, staged
+
+	return data.WriteOutcome{}, nil
+}
+
+func (m *recordingMutator) RemoveTag(_ context.Context, _ data.StagedKey, tagKey string, staged bool) (data.WriteOutcome, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.removeCalled, m.tagKey, m.staged = true, tagKey, staged
+
+	return data.WriteOutcome{}, nil
+}
+
+func (*recordingMutator) Restore(context.Context, string) (data.WriteOutcome, error) {
+	return data.WriteOutcome{}, nil
+}
+
+func (m *recordingMutator) snapshot() (remove bool, add bool, tagKey string, staged bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.removeCalled, m.addCalled, m.tagKey, m.staged
+}
+
+// TestTUI_TagRemoveRoutesSelectedKey drives a non-empty Remove through the real
+// event loop: toggling to Remove and completing the form routes the tag key the
+// select seeded (the first existing tag), never the free-text Add key, to
+// RemoveTag with the staged mode (#705).
+func TestTUI_TagRemoveRoutesSelectedKey(t *testing.T) {
+	t.Parallel()
+
+	mut := &recordingMutator{cap: capability.ServiceCapability{Service: "param", HasTags: true, HasStaging: true}}
+	m, cmd := dialogs.NewTagForm(dialogs.TagInput{
+		Ctx: context.Background(), Mutator: mut, Service: "param", Styles: styles.New(), Name: "/app/X",
+		Tags: []data.Tag{{Key: "env", Value: "prod"}, {Key: "team", Value: "api"}},
+	})
+
+	tm := teatest.NewTestModel(t, newDialogHost(m, cmd), teatest.WithInitialTermSize(goldenTermWidth, goldenTermHeight))
+
+	tm.Send(keyRightMsg()) // Add -> Remove
+
+	for range 4 {
+		tm.Send(keyEnterMsg()) // advance action -> select -> mode -> complete
+	}
+
+	// Wait for the submit to reach the mutator.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if remove, _, _, _ := mut.snapshot(); remove {
+			break
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	remove, add, tagKey, staged := mut.snapshot()
+	assert.True(t, remove, "a completed Remove routes to RemoveTag")
+	assert.False(t, add, "a Remove never routes to AddTag")
+	assert.Equal(t, "env", tagKey, "the select-seeded key (not a free-text key) is the untag target")
+	assert.True(t, staged, "the untag routes staged by default")
+
+	tm.Send(hostQuitMsg{})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
+}
+
+// TestTUI_TagRemoveEmptyBlocksSubmit drives a Remove on an entry with NO tags
+// through the real event loop: completing the form never submits an untag — the
+// empty-tags guard reopens the "(no tags to remove)" note instead of routing a
+// guaranteed-failing empty untag to the mutator (#705).
+func TestTUI_TagRemoveEmptyBlocksSubmit(t *testing.T) {
+	t.Parallel()
+
+	mut := &recordingMutator{cap: capability.ServiceCapability{Service: "param", HasTags: true, HasStaging: true}}
+	m, cmd := dialogs.NewTagForm(dialogs.TagInput{
+		Ctx: context.Background(), Mutator: mut, Service: "param", Styles: styles.New(), Name: "/app/X",
+	})
+
+	host := newDialogHost(m, cmd)
+	tm := teatest.NewTestModel(t, host, teatest.WithInitialTermSize(goldenTermWidth, goldenTermHeight))
+
+	tm.Send(keyRightMsg()) // Add -> Remove
+
+	for range 6 {
+		tm.Send(keyEnterMsg()) // try to complete; the guard must catch every completion
+	}
+
+	// Give the loop time to process every enter (and any guarded rebuild).
+	time.Sleep(300 * time.Millisecond)
+
+	remove, add, _, _ := mut.snapshot()
+	assert.False(t, remove, "no untag is submitted when the entry has no tags")
+	assert.False(t, add, "no tag write is submitted at all")
+
+	// The empty state is still on screen (never dead-ended into a submit).
+	var buf bytes.Buffer
+
+	_, _ = io.Copy(&buf, tm.Output())
+	assert.Contains(t, buf.String(), "(no tags to remove)", "the empty state persists")
+
+	tm.Send(hostQuitMsg{})
+	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
+}

--- a/internal/tui/testdata/TestDialog_TagRemoveEmptyGolden.golden
+++ b/internal/tui/testdata/TestDialog_TagRemoveEmptyGolden.golden
@@ -1,0 +1,15 @@
+╭──────────────────────────────────────────────────────╮
+│Tag — /app/api/DATABASE_URL                           │
+│                                                      │
+│┃ Action                                              │
+│┃ ← Remove tag →                                      │
+│                                                      │
+│  Tag                                                 │
+│                                                      │
+│  (no tags to remove)                                 │
+│                                                      │
+│                                                      │
+│  Mode                                                │
+│  (•) Stage    ( ) Apply immediately                  │
+│tab/↑↓: fields · enter: submit · esc: cancel          │
+╰──────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_TagRemoveSelectGolden.golden
+++ b/internal/tui/testdata/TestDialog_TagRemoveSelectGolden.golden
@@ -1,0 +1,14 @@
+╭──────────────────────────────────────────────────────╮
+│Tag — /app/api/DATABASE_URL                           │
+│                                                      │
+│┃ Action                                              │
+│┃ ← Remove tag →                                      │
+│                                                      │
+│  Tag                                                 │
+│  > env=prod                                          │
+│    team=api                                          │
+│                                                      │
+│  Mode                                                │
+│  (•) Stage    ( ) Apply immediately                  │
+│tab/↑↓: fields · enter: submit · esc: cancel          │
+╰──────────────────────────────────────────────────────╯


### PR DESCRIPTION
Fixes #705: TUI tag Remove was a blind free-text input, inviting invalid untags. Tag Remove is now constrained to the entry's existing tags (select-from-known-set, mirroring the GUI); tag Add stays free-text.

Regression tests added at the TUI Update + golden layers. Local gates were run in the agent worktree prior to push; CI is the authoritative gate.

Closes #705

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>