### PR TITLE
fix(seed): keep database-password a SecureString on update

### DIFF
--- a/scripts/seed.sh
+++ b/scripts/seed.sh
@@ -88,7 +88,7 @@ seed_aws_param() {
   run aws param tag /suve-demo/app/database-url env=production team=payments managed-by=suve
 
   run aws param create /suve-demo/app/database-password "correct-horse-battery-staple" --secure --description "DB password (rotated quarterly)"
-  run aws param update --yes /suve-demo/app/database-password "Tr0ub4dour-and-3-more"
+  run aws param update --yes /suve-demo/app/database-password "Tr0ub4dour-and-3-more" --secure
   run aws param tag /suve-demo/app/database-password rotation=90d env=production
 
   run aws param create /suve-demo/app/feature-flags "beta,dark-mode" --type StringList --description "Enabled feature flags"


### PR DESCRIPTION
Fixes #730

The demo seed (`scripts/seed.sh`) creates `/suve-demo/app/database-password` as a SecureString (`--secure`), then updates it **without** `--secure`. Because `suve aws param update` defaults an unspecified `--type` to `String` (`paramtype.Parse("")` -> `Plaintext`), the update silently downgraded the parameter from SecureString to String — which made it look like suve was dropping the SecureString type in the demo/GUI/TUI (the misunderstanding filed as #730).

Fix: re-specify `--secure` on the update so the parameter stays a SecureString across versions.

Note (out of scope here): this surfaced that `param update` with neither `--secure` nor `--type` silently downgrades an existing SecureString to String. Whether `update` should instead preserve the existing type is worth a separate discussion.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>