### PR TITLE
fix(param): preserve existing type on aws param update when unspecified (#738)

### DIFF
--- a/e2e/aws_param_test.go
+++ b/e2e/aws_param_test.go
@@ -1483,6 +1483,48 @@ func TestAWSParam_UpdateWithType(t *testing.T) {
 	})
 }
 
+// TestAWSParam_UpdatePreservesTypeWhenUnspecified verifies that a value-only
+// update (no --type/--secure) keeps the parameter's existing type instead of
+// silently downgrading a SecureString to String (see #738).
+func TestAWSParam_UpdatePreservesTypeWhenUnspecified(t *testing.T) {
+	setupEnv(t)
+
+	paramName := "/suve-e2e-update/preserve-type-test"
+
+	// Cleanup
+	_, _, _ = runCommand(t, paramdelete.Command(), "--yes", paramName)
+	t.Cleanup(func() {
+		_, _, _ = runCommand(t, paramdelete.Command(), "--yes", paramName)
+	})
+
+	// Create as SecureString.
+	t.Run("create-secure", func(t *testing.T) {
+		_, _, err := runCommand(t, paramcreate.Command(), "--secure", paramName, "secret-v1")
+		require.NoError(t, err)
+	})
+
+	t.Run("verify-created-secure", func(t *testing.T) {
+		stdout, _, err := runCommand(t, cmdparam.ShowCommand(), paramName)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "SecureString")
+	})
+
+	// Update the value only, with neither --secure nor --type.
+	t.Run("update-value-only", func(t *testing.T) {
+		stdout, _, err := runCommand(t, paramupdate.Command(), "--yes", paramName, "secret-v2")
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "Updated")
+	})
+
+	// The type must still be SecureString across the new version.
+	t.Run("verify-still-secure", func(t *testing.T) {
+		stdout, _, err := runCommand(t, cmdparam.ShowCommand(), paramName)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "SecureString")
+		assert.NotContains(t, stdout, "Type: String")
+	})
+}
+
 // TestAWSParam_UpdateConflictingFlags tests error handling for conflicting flags.
 func TestAWSParam_UpdateConflictingFlags(t *testing.T) {
 	setupEnv(t)

--- a/internal/cli/commands/aws/param/update/update.go
+++ b/internal/cli/commands/aws/param/update/update.go
@@ -30,6 +30,10 @@ type Options struct {
 	Value       string
 	Type        string
 	Description string
+	// PreserveType keeps the parameter's existing type when neither --type nor
+	// --secure was given, so a value-only update never downgrades a
+	// SecureString/StringList to String. When true, Type is ignored.
+	PreserveType bool
 	// ParamOpts holds the raw AWS-specific option flag values (tier, data
 	// type, allowed pattern, policies). Empty fields contribute no option.
 	ParamOpts paramopts.Values
@@ -49,9 +53,13 @@ Use 'suve param create' to create a new parameter.
 To manage tags, use 'suve param tag' and 'suve param untag' commands.
 
 PARAMETER TYPES:
-   String        Plain text value (default)
+   String        Plain text value
    StringList    Comma-separated list of values
    SecureString  Encrypted value using AWS KMS
+
+When neither --type nor --secure is given, the parameter's existing type is
+preserved, so a value-only update never downgrades a SecureString or StringList
+to String. Pass --type/--secure to change the type intentionally.
 
 The --secure flag is a shorthand for --type SecureString.
 You cannot use both --secure and --type together.
@@ -69,8 +77,7 @@ EXAMPLES:
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:  "type",
-				Value: "String",
-				Usage: "Parameter type (String, StringList, SecureString)",
+				Usage: "Parameter type (String, StringList, SecureString); omit to preserve the existing type",
 			},
 			&cli.BoolFlag{
 				Name:  "secure",
@@ -123,6 +130,11 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	if secure {
 		paramType = "SecureString"
 	}
+
+	// With neither --type nor --secure, preserve the parameter's existing type
+	// instead of defaulting to String, so a value-only update never downgrades a
+	// SecureString (dropping KMS encryption) or StringList.
+	preserveType := !secure && !cmd.IsSet("type")
 
 	if err := paramtype.Validate(paramType); err != nil {
 		return err
@@ -200,10 +212,11 @@ func action(ctx context.Context, cmd *cli.Command) error {
 	}
 
 	return r.Run(ctx, Options{
-		Name:        name,
-		Value:       newValue,
-		Type:        paramType,
-		Description: cmd.String("description"),
+		Name:         name,
+		Value:        newValue,
+		Type:         paramType,
+		PreserveType: preserveType,
+		Description:  cmd.String("description"),
 		ParamOpts: paramopts.Values{
 			Tier:           cmd.String("tier"),
 			DataType:       cmd.String("data-type"),
@@ -216,11 +229,12 @@ func action(ctx context.Context, cmd *cli.Command) error {
 // Run executes the update command.
 func (r *Runner) Run(ctx context.Context, opts Options) error {
 	result, err := r.UseCase.Execute(ctx, param.UpdateInput{
-		Name:        opts.Name,
-		Value:       opts.Value,
-		Type:        paramtype.Parse(opts.Type),
-		Description: opts.Description,
-		Options:     paramopts.Build(opts.ParamOpts),
+		Name:         opts.Name,
+		Value:        opts.Value,
+		Type:         paramtype.Parse(opts.Type),
+		PreserveType: opts.PreserveType,
+		Description:  opts.Description,
+		Options:      paramopts.Build(opts.ParamOpts),
 	})
 	if err != nil {
 		return err

--- a/internal/cli/commands/aws/param/update/update_test.go
+++ b/internal/cli/commands/aws/param/update/update_test.go
@@ -136,6 +136,33 @@ func TestRun_WriteOptions(t *testing.T) {
 	})
 }
 
+// TestRun_PreserveType verifies that a value-only update (PreserveType, no
+// --type/--secure) reuses the existing parameter's type, so an existing
+// SecureString is not silently rewritten as String.
+func TestRun_PreserveType(t *testing.T) {
+	t.Parallel()
+
+	var gotType domain.ValueType
+
+	store := &providermock.Store{
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{Name: name, Value: "old-value", Type: domain.ValueTypeSecret}, nil
+		},
+		PutFunc: func(_ context.Context, _, _ string, vt domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
+			gotType = vt
+
+			return domain.Version{ID: "2"}, nil
+		},
+	}
+
+	var buf, errBuf bytes.Buffer
+
+	r := &update.Runner{UseCase: &param.UpdateUseCase{Store: store}, Stdout: &buf, Stderr: &errBuf}
+	err := r.Run(t.Context(), update.Options{Name: "/app/secret", Value: "v", PreserveType: true})
+	require.NoError(t, err)
+	assert.Equal(t, domain.ValueTypeSecret, gotType)
+}
+
 func TestRun(t *testing.T) {
 	t.Parallel()
 

--- a/internal/usecase/param/update.go
+++ b/internal/usecase/param/update.go
@@ -15,6 +15,12 @@ type UpdateInput struct {
 	Value       string
 	Type        domain.ValueType
 	Description string
+	// PreserveType, when true, keeps the existing parameter's type instead of
+	// applying Type. `aws param update` sets it when neither --type nor --secure
+	// is given, so a value-only update never downgrades an existing SecureString
+	// (dropping KMS encryption) or StringList to String. Callers that pass an
+	// explicit type (GUI, TUI) leave it false and Type is applied as-is.
+	PreserveType bool
 	// Options carries provider-specific write options (e.g. AWS param Tier,
 	// DataType). They are passed through to the provider unchanged.
 	Options []provider.WriteOption
@@ -51,7 +57,7 @@ func (u *UpdateUseCase) GetCurrentValue(ctx context.Context, name string) (strin
 // parameter doesn't exist it returns ErrParameterNotFound. A read failure other
 // than not-found is propagated unchanged (never treated as "does not exist").
 func (u *UpdateUseCase) Execute(ctx context.Context, input UpdateInput) (*UpdateOutput, error) {
-	_, err := u.Store.Get(ctx, input.Name, provider.VersionRef{})
+	entry, err := u.Store.Get(ctx, input.Name, provider.VersionRef{})
 
 	switch {
 	case errors.Is(err, provider.ErrNotFound):
@@ -60,7 +66,15 @@ func (u *UpdateUseCase) Execute(ctx context.Context, input UpdateInput) (*Update
 		return nil, err
 	}
 
-	version, err := u.Store.Put(ctx, input.Name, input.Value, input.Type, input.Description, input.Options...)
+	// A value-only update must not change the type. When the caller did not
+	// specify one, reuse the existing entry's type (already fetched above) so a
+	// SecureString/StringList is never silently rewritten as String.
+	valueType := input.Type
+	if input.PreserveType {
+		valueType = entry.Type
+	}
+
+	version, err := u.Store.Put(ctx, input.Name, input.Value, valueType, input.Description, input.Options...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update parameter: %w", err)
 	}

--- a/internal/usecase/param/update_test.go
+++ b/internal/usecase/param/update_test.go
@@ -92,6 +92,96 @@ func TestUpdateUseCase_Execute(t *testing.T) {
 	assert.Equal(t, int64(5), output.Version)
 }
 
+// TestUpdateUseCase_Execute_PreserveType verifies that a value-only update
+// (PreserveType) reuses the existing parameter's type, so a SecureString is not
+// silently downgraded to String even when Type is left at its zero value.
+func TestUpdateUseCase_Execute_PreserveType(t *testing.T) {
+	t.Parallel()
+
+	var gotType domain.ValueType
+
+	store := &providermock.Store{
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{Name: name, Type: domain.ValueTypeSecret}, nil
+		},
+		PutFunc: func(_ context.Context, _, _ string, vt domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
+			gotType = vt
+
+			return domain.Version{ID: "2"}, nil
+		},
+	}
+
+	uc := &param.UpdateUseCase{Store: store}
+
+	_, err := uc.Execute(t.Context(), param.UpdateInput{
+		Name:         "/app/secret",
+		Value:        "new-value",
+		PreserveType: true,
+		// Type deliberately left unset to prove PreserveType wins over it.
+	})
+	require.NoError(t, err)
+	assert.Equal(t, domain.ValueTypeSecret, gotType)
+}
+
+// TestUpdateUseCase_Execute_PreserveType_StringList verifies preservation also
+// covers StringList (the issue names it alongside SecureString).
+func TestUpdateUseCase_Execute_PreserveType_StringList(t *testing.T) {
+	t.Parallel()
+
+	var gotType domain.ValueType
+
+	store := &providermock.Store{
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{Name: name, Type: domain.ValueTypeList}, nil
+		},
+		PutFunc: func(_ context.Context, _, _ string, vt domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
+			gotType = vt
+
+			return domain.Version{ID: "2"}, nil
+		},
+	}
+
+	uc := &param.UpdateUseCase{Store: store}
+
+	_, err := uc.Execute(t.Context(), param.UpdateInput{
+		Name:         "/app/list",
+		Value:        "a,b,c",
+		PreserveType: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, domain.ValueTypeList, gotType)
+}
+
+// TestUpdateUseCase_Execute_ExplicitTypeOverridesPreserve verifies an explicit
+// Type is applied verbatim (PreserveType false) even when it differs from the
+// existing entry's type — an intentional type change must go through.
+func TestUpdateUseCase_Execute_ExplicitTypeOverridesPreserve(t *testing.T) {
+	t.Parallel()
+
+	var gotType domain.ValueType
+
+	store := &providermock.Store{
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{Name: name, Type: domain.ValueTypeSecret}, nil
+		},
+		PutFunc: func(_ context.Context, _, _ string, vt domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
+			gotType = vt
+
+			return domain.Version{ID: "3"}, nil
+		},
+	}
+
+	uc := &param.UpdateUseCase{Store: store}
+
+	_, err := uc.Execute(t.Context(), param.UpdateInput{
+		Name:  "/app/secret",
+		Value: "new-value",
+		Type:  domain.ValueTypePlaintext,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, domain.ValueTypePlaintext, gotType)
+}
+
 // TestUpdateUseCase_Execute_NotFound verifies a missing parameter is reported
 // as not-found (only provider.ErrNotFound triggers this path).
 func TestUpdateUseCase_Execute_NotFound(t *testing.T) {


### PR DESCRIPTION
Closes #738

## Problem
`suve aws param update <name> <value>` with neither `--secure` nor `--type` silently rewrote the parameter as `String`, downgrading an existing `SecureString` (dropping KMS encryption) or a `StringList`. Updating only the value should never change the type. The GUI/TUI already preserve the type on edit (they pass the current type through); only the CLI lacked this.

## Mechanism
- `internal/cli/commands/aws/param/update/update.go`: with `--type`/`--secure` unset, `paramType` was `""`.
- `paramtype.Parse("")` defaults to `domain.ValueTypePlaintext`.
- `internal/usecase/param/update.go`: that type was passed to `Store.Put`.
- `internal/provider/aws/param/param.go` `Put`: always sends `Type` with `Overwrite:true`, so `Plaintext` -> `ParameterTypeString`, overwriting the stored type.

## Fix — implementation option (a)
I took **option (a)** (reuse the existing type), not (b) (omit `Type` on the `Overwrite=true` `PutParameter`). Reasons:
- **Deterministic and portable**: reading the current type and passing it back explicitly behaves identically on real SSM and on localstack. Option (b) relies on SSM's "omit Type on overwrite retains existing type" semantics, which localstack does not reliably emulate — making the e2e flaky.
- **No provider-seam change**: the AWS adapter still always receives a concrete type; `domain`, `provider` interfaces, and version refs are untouched.

Concretely, a `PreserveType bool` is threaded from the CLI (set when neither `--type` nor `--secure` is given) into `param.UpdateInput`. `UpdateUseCase.Execute` already fetches the entry for its existence check, so it reuses that entry's `Type` when `PreserveType` is set — **no extra read**. An explicit `--type`/`--secure` still overrides (intentional type change). The field defaults to `false`, so `create` (still defaults `String`) and the GUI/TUI (pass an explicit type) are unaffected.

## Scope
- AWS param only (the type axis is AWS-specific; gcloud/azure param unaffected).
- `create` semantics unchanged.
- GUI/TUI untouched (confirmed on #738 they already preserve).

## Tests (three-layer)
- **Go unit** (`internal/usecase/param/update_test.go`): a no-type update over an existing `SecureString` keeps `SecureString`; same for `StringList`; an explicit type still applies over a differing existing type.
- **Go unit** (`internal/cli/commands/aws/param/update/update_test.go`): `Runner.Run` with `PreserveType` reuses the fetched type.
- **CLI e2e** (`e2e/aws_param_test.go` `TestAWSParam_UpdatePreservesTypeWhenUnspecified`): `param create --secure` then a value-only `param update` (no `--secure`) keeps `SecureString` across versions. Runs on CI against localstack.

## Verification

Unit tests (local):
\`\`\`
$ go test -v -run 'PreserveType|ExplicitTypeOverrides' ./internal/usecase/param/... ./internal/cli/commands/aws/param/update/...
=== RUN   TestUpdateUseCase_Execute_PreserveType
--- PASS: TestUpdateUseCase_Execute_PreserveType (0.00s)
=== RUN   TestUpdateUseCase_Execute_PreserveType_StringList
--- PASS: TestUpdateUseCase_Execute_PreserveType_StringList (0.00s)
=== RUN   TestUpdateUseCase_Execute_ExplicitTypeOverridesPreserve
--- PASS: TestUpdateUseCase_Execute_ExplicitTypeOverridesPreserve (0.00s)
ok  	github.com/mpyw/suve/internal/usecase/param
=== RUN   TestRun_PreserveType
--- PASS: TestRun_PreserveType (0.00s)
ok  	github.com/mpyw/suve/internal/cli/commands/aws/param/update
\`\`\`

Full unit suite (\`mise test\`) and \`go build ./...\` pass; \`golangci-lint run --allow-parallel-runners --timeout=10m\` over the changed packages reports 0 issues. The e2e case runs on CI (localstack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)