### PR TITLE
fix(tui,gui): reveal explicit diff/compare surfaces by default (#735, #702)

### DIFF
--- a/internal/gui/frontend/src/lib/DiffDisplay.svelte
+++ b/internal/gui/frontend/src/lib/DiffDisplay.svelte
@@ -9,17 +9,50 @@
     newLabel?: string;
     oldSubLabel?: string;
     newSubLabel?: string;
-    // secret masks both sides before diffing, so a SecureString value never
-    // renders in cleartext (mask-only, matching the TUI's secret diff — #702).
+    // secret marks BOTH sides as secret material. A Compare/diff view is a
+    // surface the user explicitly opened to inspect the change, so a secret diff
+    // is REVEALED by default (#702/#735); the Hide/Show toggle masks it. Use
+    // oldSecret/newSecret to mark only one side (e.g. a delete whose staged side
+    // is the literal "(deleted)" sentinel, not secret material).
     secret?: boolean;
+    oldSecret?: boolean;
+    newSecret?: boolean;
   }
 
-  let { oldValue, newValue, oldLabel = 'Old', newLabel = 'New', oldSubLabel = '', newSubLabel = '', secret = false }: Props = $props();
+  let {
+    oldValue,
+    newValue,
+    oldLabel = 'Old',
+    newLabel = 'New',
+    oldSubLabel = '',
+    newSubLabel = '',
+    secret = false,
+    oldSecret = secret,
+    newSecret = secret,
+  }: Props = $props();
 
-  let displayOld = $derived(secret ? maskValue(oldValue) : oldValue);
-  let displayNew = $derived(secret ? maskValue(newValue) : newValue);
+  // Explicit diff surfaces reveal by default; the toggle hides again.
+  let revealed = $state(true);
+  let anySecret = $derived(oldSecret || newSecret);
+
+  let displayOld = $derived(oldSecret && !revealed ? maskValue(oldValue) : oldValue);
+  let displayNew = $derived(newSecret && !revealed ? maskValue(newValue) : newValue);
   let diff = $derived(computeInlineDiff(displayOld, displayNew));
 </script>
+
+{#if anySecret}
+  <div class="diff-mask-toggle">
+    <button
+      type="button"
+      class="btn-mask-toggle"
+      class:active={!revealed}
+      title={revealed ? 'Hide secret values' : 'Show secret values'}
+      onclick={() => (revealed = !revealed)}
+    >
+      {revealed ? 'Hide' : 'Show'}
+    </button>
+  </div>
+{/if}
 
 <div class="diff-container">
   <div class="diff-side">
@@ -43,6 +76,31 @@
 </div>
 
 <style>
+  .diff-mask-toggle {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 8px;
+  }
+
+  .btn-mask-toggle {
+    padding: 4px 10px;
+    font-size: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 4px;
+    background: transparent;
+    color: #ccc;
+    cursor: pointer;
+  }
+
+  .btn-mask-toggle:hover {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  .btn-mask-toggle.active {
+    border-color: #4a9eff;
+    color: #4a9eff;
+  }
+
   .diff-container {
     display: flex;
     gap: 16px;

--- a/internal/gui/frontend/src/lib/StagingSection.svelte
+++ b/internal/gui/frontend/src/lib/StagingSection.svelte
@@ -176,12 +176,15 @@
           {#if entry.operation === 'delete'}
             {#if viewMode === 'diff'}
               <div class="entry-diff">
-                <!-- The staged side is the literal "(deleted)" sentinel (not
-                     secret), so mask only the remote value here rather than
-                     passing `secret` (which would mask both sides). -->
+                <!-- The remote-vs-staged comparison is revealed by default (the
+                     user explicitly opened this diff, #735); the DiffDisplay
+                     Hide/Show toggle can mask it. Only the remote side is secret
+                     — the staged side is the literal "(deleted)" sentinel — so
+                     pass oldSecret rather than secret (which would mask both). -->
                 <DiffDisplay
-                  oldValue={rowSecret ? maskValue(entry.remoteValue || '') : (entry.remoteValue || '')}
+                  oldValue={entry.remoteValue || ''}
                   newValue="(deleted)"
+                  oldSecret={rowSecret}
                   oldLabel="Remote"
                   newLabel="Staged"
                   oldSubLabel={entry.remoteIdentifier || ''}

--- a/internal/gui/frontend/tests/secret-service-mask.spec.ts
+++ b/internal/gui/frontend/tests/secret-service-mask.spec.ts
@@ -10,23 +10,21 @@ import {
 } from './fixtures/wails-mock';
 
 // ============================================================================
-// GUI secret-service masking leaks (#714, #715)
+// GUI secret-service diff reveal vs passive masking (#714, #715, #735)
 //
-// Pre-existing GUI leaks surfaced during the #704 audit while fixing #677/#702
-// (PR #711 fixed the value-type SecureString-param diff + the TUI staging
-// review, but left these two GUI secret-SERVICE surfaces unmasked):
+// Per the confirmed policy, an EXPLICIT diff surface — the "Version Comparison"
+// modal and the staging DIFF view's remote-vs-staged ± comparison — is REVEALED
+// by default (the user opened it to inspect the change), with a Hide/Show toggle
+// (#735). PASSIVE surfaces stay masked by default:
 //
-//   #714 — SecretView "Version Comparison" rendered both secret values in
-//          cleartext (the detail pane already masks by default).
-//   #715 — the GUI staging review rendered secret-service staged/remote values
-//          in cleartext, in both diff and value view modes.
+//   - the staging VALUE view (plain staged-value listing),
+//   - a staged CREATE (a lone new value, not a remote-vs-staged comparison).
 //
-// The reference behavior is the GUI's own masked-by-default secret handling
-// (detail pane / Version History). These tests assert no plaintext secret value
-// reaches either surface and that masking bullets/asterisks are present.
+// These tests assert the diff comparison reveals and the toggle hides, while the
+// passive value view and create values remain masked with bullets/asterisks.
 // ============================================================================
 
-test.describe('Secret-service version diff masking (#714)', () => {
+test.describe('Secret-service version diff reveal + hide toggle (#714/#735)', () => {
   test.beforeEach(async ({ page }) => {
     // Default mock state ships my-secret with three versions carrying
     // distinctive cleartext values.
@@ -36,7 +34,7 @@ test.describe('Secret-service version diff masking (#714)', () => {
     await waitForItemList(page);
   });
 
-  test('masks both sides of a secret version comparison', async ({ page }) => {
+  test('reveals both sides of a secret version comparison by default, hides on toggle', async ({ page }) => {
     await clickItemByName(page, 'my-secret');
 
     await page.getByRole('button', { name: /Compare/i }).click();
@@ -46,18 +44,22 @@ test.describe('Secret-service version diff masking (#714)', () => {
 
     await expect(page.getByText('Version Comparison')).toBeVisible();
 
-    const oldSide = (await page.locator('.diff-value.diff-old').textContent()) ?? '';
-    const newSide = (await page.locator('.diff-value.diff-new').textContent()) ?? '';
+    // Revealed by default: the explicit comparison shows real values so the diff
+    // is meaningful (#735).
+    let oldSide = (await page.locator('.diff-value.diff-old').textContent()) ?? '';
+    let newSide = (await page.locator('.diff-value.diff-new').textContent()) ?? '';
+    expect(oldSide + newSide).toContain('secret-value');
 
-    // No cleartext version value may appear on either side.
+    // The Hide toggle masks both sides — no cleartext version value remains.
+    await page.locator('.btn-mask-toggle').click();
+    oldSide = (await page.locator('.diff-value.diff-old').textContent()) ?? '';
+    newSide = (await page.locator('.diff-value.diff-new').textContent()) ?? '';
     for (const side of [oldSide, newSide]) {
       expect(side).not.toContain('secret-value-1');
       expect(side).not.toContain('secret-value-old');
       expect(side).not.toContain('secret-value-initial');
       expect(side).not.toContain('secret-value');
     }
-
-    // Both sides are masked (a change still shows as differing asterisk runs).
     expect(oldSide).toMatch(/\*/);
     expect(newSide).toMatch(/\*/);
   });
@@ -84,19 +86,32 @@ test.describe('Secret-service staging review masking (#715)', () => {
     await expect(page.locator('.entry-item').first()).toBeVisible();
   }
 
-  test('masks staged/remote values in diff view', async ({ page }) => {
+  test('reveals staged/remote comparison values in diff view (create stays masked), hides on toggle', async ({ page }) => {
     await gotoSecretStaging(page);
     // Default view mode is Diff.
     await expect(page.getByRole('button', { name: 'Diff' })).toHaveClass(/active/);
 
-    const body = (await page.locator('.staging-content').textContent()) ?? '';
-    expect(body).not.toContain(UPDATE_VALUE);
+    let body = (await page.locator('.staging-content').textContent()) ?? '';
+    // An update/delete is a real remote-vs-staged comparison → revealed by
+    // default so the change is meaningful (#735).
+    expect(body).toContain(UPDATE_VALUE);
+    expect(body).toContain(REMOTE_VALUE);
+    // A create is a lone new value (no comparison) → stays masked (#719).
     expect(body).not.toContain(CREATE_VALUE);
-    expect(body).not.toContain(REMOTE_VALUE);
-    // Something is still rendered as masked bullets/asterisks.
     expect(body).toMatch(/\*/);
     // The delete sentinel stays readable (it is not secret material).
     expect(body).toContain('(deleted)');
+
+    // Hiding every comparison (each toggle clicked once) masks the revealed values.
+    const toggles = page.locator('.btn-mask-toggle');
+    const count = await toggles.count();
+    for (let i = 0; i < count; i++) {
+      await toggles.nth(i).click();
+    }
+    body = (await page.locator('.staging-content').textContent()) ?? '';
+    expect(body).not.toContain(UPDATE_VALUE);
+    expect(body).not.toContain(REMOTE_VALUE);
+    expect(body).toMatch(/\*/);
   });
 
   test('masks staged values in value view', async ({ page }) => {

--- a/internal/gui/frontend/tests/securestring-diff.spec.ts
+++ b/internal/gui/frontend/tests/securestring-diff.spec.ts
@@ -8,12 +8,12 @@ import {
 } from './fixtures/wails-mock';
 
 // ============================================================================
-// SecureString param diff masking (GUI counterpart of #677 — see #702)
+// SecureString param diff reveal + hide toggle (GUI counterpart of #677 — #702)
 //
-// A SecureString param is masked in the detail pane, but its version diff used
-// to render both plaintext values. The diff DTO now carries a value-type secret
-// flag (SecureString ⇒ true) that DiffDisplay masks on, so neither cleartext
-// value reaches the diff modal.
+// A SecureString param's Version Comparison is a surface the user explicitly
+// opened to inspect the change, so its values are REVEALED by default (#702/
+// #735). The DiffDisplay Hide/Show toggle can still mask both sides, matching
+// the detail pane's masked-by-default behavior on demand.
 // ============================================================================
 
 // Distinctive cleartext values that must NEVER appear in the diff modal.
@@ -39,7 +39,7 @@ test.describe('SecureString param diff masking', () => {
     await waitForItemList(page);
   });
 
-  test('masks both sides of a SecureString version diff', async ({ page }) => {
+  test('reveals both sides of a SecureString version diff by default, and hides on toggle', async ({ page }) => {
     await clickItemByName(page, '/app/secure/token');
 
     await page.getByRole('button', { name: /Compare/i }).click();
@@ -49,17 +49,26 @@ test.describe('SecureString param diff masking', () => {
 
     await expect(page.getByText('Version Comparison')).toBeVisible();
 
-    // Neither cleartext value may appear anywhere in the diff modal.
-    const oldSide = (await page.locator('.diff-value.diff-old').textContent()) ?? '';
-    const newSide = (await page.locator('.diff-value.diff-new').textContent()) ?? '';
+    // Revealed by default: both cleartext values are shown so the diff is useful.
+    let oldSide = (await page.locator('.diff-value.diff-old').textContent()) ?? '';
+    let newSide = (await page.locator('.diff-value.diff-new').textContent()) ?? '';
+    expect(oldSide).toContain(OLD_SECRET);
+    expect(newSide).toContain(NEW_SECRET);
 
+    // The Hide toggle masks both sides (bullets/asterisks), so a change still
+    // shows without disclosing content.
+    await page.locator('.btn-mask-toggle').click();
+    oldSide = (await page.locator('.diff-value.diff-old').textContent()) ?? '';
+    newSide = (await page.locator('.diff-value.diff-new').textContent()) ?? '';
     expect(oldSide).not.toContain(OLD_SECRET);
     expect(oldSide).not.toContain('plaintext-old');
     expect(newSide).not.toContain(NEW_SECRET);
     expect(newSide).not.toContain('plaintext-new');
-
-    // Both sides are masked with bullets/asterisks, so a change still shows.
     expect(oldSide).toMatch(/\*/);
     expect(newSide).toMatch(/\*/);
+
+    // Show again brings the values back.
+    await page.locator('.btn-mask-toggle').click();
+    expect((await page.locator('.diff-value.diff-new').textContent()) ?? '').toContain(NEW_SECRET);
   });
 });

--- a/internal/tui/browser_golden_test.go
+++ b/internal/tui/browser_golden_test.go
@@ -362,12 +362,11 @@ func TestDiff_AWSParamGolden(t *testing.T) { //nolint:paralleltest // goldenEnv 
 	diffGolden(t, host, "@@")
 }
 
-// TestDiff_AWSParamSecureStringGolden pins a SecureString PARAM diff: the two
-// versions differ, so the diff renders +/- lines — every one a run of mask
-// bullets, never a revealed value. A SecureString is a secret on the value-type
-// axis even though it lives on the param service, so its diff must mask exactly
-// like a secret-service diff (#677). The fixture's cleartext value must NOT
-// appear in the golden.
+// TestDiff_AWSParamSecureStringGolden pins a SecureString PARAM diff: the
+// Compare/diff view is a surface the user explicitly opened to inspect the
+// change, so its values are REVEALED by default (#702/#735) — a SecureString is
+// a secret on the value-type axis, so `x` can still hide it, but the default
+// shows the real +/- change. The fixture's cleartext values appear in the golden.
 func TestDiff_AWSParamSecureStringGolden(t *testing.T) { //nolint:paralleltest // goldenEnv calls t.Setenv (NO_COLOR/TZ), which forbids t.Parallel
 	goldenEnv(t)
 
@@ -376,9 +375,8 @@ func TestDiff_AWSParamSecureStringGolden(t *testing.T) { //nolint:paralleltest /
 	raw := captureUntil(t, host, "diff:", goldenTermWidth, goldenTermHeight)
 	screen := renderVisibleScreenSize(t, raw, goldenTermWidth, goldenTermHeight)
 
-	require.NotContains(t, screen, secureStringDiffValue, "no revealed SecureString value in the diff golden")
-	require.NotContains(t, screen, secureStringDiffOldValue, "no revealed SecureString value in the diff golden")
-	require.Contains(t, screen, "•", "the SecureString diff is masked with bullets, proving it renders (not just absent)")
+	require.Contains(t, screen, secureStringDiffValue, "the SecureString diff is revealed by default (#702/#735)")
+	require.Contains(t, screen, secureStringDiffOldValue, "both SecureString versions are shown")
 	golden.RequireEqual(t, screen)
 }
 
@@ -390,10 +388,10 @@ func TestDiff_AWSSecretGolden(t *testing.T) { //nolint:paralleltest // goldenEnv
 	diffGolden(t, host, "diff:")
 }
 
-// TestDiff_GCloudSecretGolden pins a SECRET diff: the two versions differ, so the
-// diff renders +/- lines — and every one is a run of mask bullets, never a
-// revealed secret value (the fixture values, e.g. "googlecloud-secret-value-…",
-// must not appear in the golden).
+// TestDiff_GCloudSecretGolden pins a SECRET diff: the Compare/diff view is
+// explicitly opened to inspect the change, so the two differing versions are
+// REVEALED by default (#735) — the real +/- content shows (the `x` toggle can
+// still hide it).
 func TestDiff_GCloudSecretGolden(t *testing.T) { //nolint:paralleltest // goldenEnv calls t.Setenv (NO_COLOR/TZ), which forbids t.Parallel
 	goldenEnv(t)
 

--- a/internal/tui/pages/diff/diff.go
+++ b/internal/tui/pages/diff/diff.go
@@ -28,6 +28,14 @@ import (
 //nolint:gochecknoglobals // immutable page-local binding
 var parseJSONKey = key.NewBinding(key.WithKeys("J"), key.WithHelp("J", "parse-json"))
 
+// maskKey toggles masking of a secret diff. The Compare/diff view is a surface
+// the user explicitly opened to inspect the change, so its values are REVEALED
+// by default (#702/#735); `x` hides them again. It is a no-op on a non-secret
+// diff (whose values are never masked).
+//
+//nolint:gochecknoglobals // immutable page-local binding
+var maskKey = key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "hide/show"))
+
 // loadedMsg carries the fetched two-version contents back to the model.
 type loadedMsg struct {
 	content data.DiffContent
@@ -55,7 +63,11 @@ type Model struct {
 	content   data.DiffContent
 	loaded    bool
 	parseJSON bool
-	err       string
+	// masked hides a secret diff's values. It defaults to false: an explicitly
+	// opened Compare/diff view reveals values so the diff is meaningful
+	// (#702/#735); `x` toggles it to mask both sides.
+	masked bool
+	err    string
 }
 
 // New builds a diff page from a navigation request. ctx is the Run context
@@ -158,6 +170,11 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) (*Model, tea.Cmd) {
 		m.render()
 
 		return m, nil
+	case key.Matches(msg, maskKey):
+		m.masked = !m.masked
+		m.render()
+
+		return m, nil
 	}
 
 	var cmd tea.Cmd
@@ -185,13 +202,14 @@ func (m *Model) render() {
 
 	oldVal, newVal := m.content.OldValue, m.content.NewValue
 
-	// A secret diff is masked on BOTH sides before diffing, so a revealed value
-	// never reaches the viewport (or a golden). Masking is per-line and length-
-	// capped, so a change still shows as differing bullet runs without disclosing
-	// content. Parse-json is skipped for a secret: the masked bullets are not JSON,
-	// and normalizing the raw secret first could leak its structure.
+	// A Compare/diff view is a surface the user explicitly opened to inspect the
+	// change, so a secret's values are shown by default (#702/#735). Pressing `x`
+	// masks BOTH sides before diffing (per-line, length-capped bullets), so a
+	// change still shows as differing runs without disclosing content — and while
+	// masked, parse-json is skipped: the bullets are not JSON, and normalizing the
+	// raw secret first could leak its structure.
 	switch {
-	case m.content.Secret:
+	case m.content.Secret && m.masked:
 		oldVal = components.MaskValue(oldVal)
 		newVal = components.MaskValue(newVal)
 	case m.parseJSON:
@@ -250,6 +268,15 @@ func (m *Model) View(width, height int) string {
 	title := "diff: " + m.name
 	if m.loaded {
 		title = "diff: " + m.content.OldLabel + " → " + m.content.NewLabel
+	}
+
+	// Surface the mask toggle so hiding a revealed secret diff is discoverable.
+	if m.loaded && m.content.Secret {
+		if m.masked {
+			title += "  ·  x: show"
+		} else {
+			title += "  ·  x: hide"
+		}
 	}
 
 	body := m.vp.View()

--- a/internal/tui/pages/diff/diff_test.go
+++ b/internal/tui/pages/diff/diff_test.go
@@ -29,11 +29,12 @@ func newDiff(t *testing.T) *Model {
 // keyPress builds a printable key press.
 func keyPress(r rune) tea.KeyPressMsg { return tea.KeyPressMsg{Code: r, Text: string(r)} }
 
-// TestSecretDiffMasksBothSides pins the leak guard: a SECRET diff whose two
-// versions differ renders +/- lines, but every line is a run of mask bullets —
-// no revealed secret value reaches the viewport. The two values differ in length
-// so the masked runs differ, proving a change is still visible without content.
-func TestSecretDiffMasksBothSides(t *testing.T) {
+// TestSecretDiffRevealedByDefaultAndHideToggle pins the relaxed policy: the
+// Compare/diff view is a surface the user explicitly opened to inspect the
+// change, so a secret's values are SHOWN by default (#702/#735) — and `x` hides
+// them again, masking both sides into differing bullet runs that still show a
+// change without disclosing content.
+func TestSecretDiffRevealedByDefaultAndHideToggle(t *testing.T) {
 	t.Setenv("NO_COLOR", "1")
 
 	const (
@@ -50,24 +51,37 @@ func TestSecretDiffMasksBothSides(t *testing.T) {
 		Secret:   true,
 	}})
 
-	out := m.View(100, 40)
+	// Revealed by default: both cleartext values are shown so the diff is useful.
+	shown := m.View(100, 40)
+	assert.Contains(t, shown, oldSecret, "the old secret value is shown by default")
+	assert.Contains(t, shown, newSecret, "the new secret value is shown by default")
+	assert.NotContains(t, shown, "•", "a revealed secret diff has no mask bullets")
 
-	// No revealed secret anywhere in the output.
-	assert.NotContains(t, out, oldSecret, "the old secret value must never be rendered")
-	assert.NotContains(t, out, newSecret, "the new secret value must never be rendered")
-	assert.NotContains(t, out, "secret", "no fragment of a secret value leaks")
+	// `x` hides it: neither cleartext value reaches the viewport, and a masked
+	// difference still renders (differing bullet runs).
+	m, _ = m.Update(keyPress('x'))
+	require.True(t, m.masked, "x masks the secret diff")
 
-	// A real, masked difference: both a removed and an added bullet line.
-	assert.Contains(t, out, "•", "the masked diff renders bullet runs")
-	assert.Contains(t, out, "-•", "a removed masked line is shown")
-	assert.Contains(t, out, "+•", "an added masked line is shown")
-	assert.NotContains(t, out, "(no differences)", "the differing versions produce a diff")
+	hidden := m.View(100, 40)
+	assert.NotContains(t, hidden, oldSecret, "the old secret value must never be rendered while masked")
+	assert.NotContains(t, hidden, newSecret, "the new secret value must never be rendered while masked")
+	assert.NotContains(t, hidden, "secret", "no fragment of a secret value leaks while masked")
+	assert.Contains(t, hidden, "•", "the masked diff renders bullet runs")
+	assert.Contains(t, hidden, "-•", "a removed masked line is shown")
+	assert.Contains(t, hidden, "+•", "an added masked line is shown")
+	assert.NotContains(t, hidden, "(no differences)", "the differing versions produce a masked diff")
+
+	// `x` again reveals: back to cleartext.
+	m, _ = m.Update(keyPress('x'))
+	require.False(t, m.masked, "x toggles back to revealed")
+	assert.Contains(t, m.View(100, 40), newSecret, "toggling back shows the value again")
 }
 
-// TestSecretDiffEqualLengthsMaskToNoDifference pins that when two secret values
-// mask to the same run (equal length), the diff collapses to "(no differences)"
-// rather than leaking that they in fact differ — masking is length-only.
-func TestSecretDiffEqualLengthsMaskToNoDifference(t *testing.T) {
+// TestSecretDiffHiddenEqualLengthsMaskToNoDifference pins that once hidden, two
+// secret values that mask to the same run (equal length) collapse to
+// "(no differences)" rather than leaking that they in fact differ — masking is
+// length-only.
+func TestSecretDiffHiddenEqualLengthsMaskToNoDifference(t *testing.T) {
 	t.Setenv("NO_COLOR", "1")
 
 	m := newDiff(t)
@@ -75,9 +89,12 @@ func TestSecretDiffEqualLengthsMaskToNoDifference(t *testing.T) {
 		OldLabel: "s#1",
 		NewLabel: "s#2",
 		OldValue: "aaaaaaaa", // 8 runes
-		NewValue: "bbbbbbbb", // 8 runes → same 8 bullets
+		NewValue: "bbbbbbbb", // 8 runes → same 8 bullets when masked
 		Secret:   true,
 	}})
+
+	// Hide first, then the equal-length masked runs are indistinguishable.
+	m, _ = m.Update(keyPress('x'))
 
 	out := m.View(100, 40)
 

--- a/internal/tui/pages/staging/staging.go
+++ b/internal/tui/pages/staging/staging.go
@@ -100,9 +100,14 @@ type Model struct {
 
 	// diffView selects diff (Remote vs Staged) vs value (raw staged) rendering.
 	diffView bool
-	// reveal unmasks the SELECTED row's secret staged value (never page-global);
-	// reset on a selection move, a view toggle, and reload (#694).
+	// reveal unmasks the SELECTED row's secret staged value in VALUE view (never
+	// page-global); reset on a selection move, a view toggle, and reload (#694).
 	reveal bool
+	// diffHidden masks the DIFF view's remote-vs-staged secret values. The diff
+	// view is a surface the user explicitly opened to inspect the change, so it is
+	// revealed by default (diffHidden=false, #735); `x` in diff view toggles it to
+	// hide. Reset on a view toggle and reload.
+	diffHidden bool
 	// noticeDismissed hides the auto-unstaged notice until the next load.
 	noticeDismissed bool
 	// status is a transient one-line message shown in the footer for an invalid
@@ -189,6 +194,7 @@ func (m *Model) CapturesInput() bool { return false }
 func (m *Model) reload() tea.Cmd {
 	m.noticeDismissed = false
 	m.reveal = false
+	m.diffHidden = false
 
 	cmds := make([]tea.Cmd, 0, len(m.sections))
 	for i := range m.sections {

--- a/internal/tui/pages/staging/staging_test.go
+++ b/internal/tui/pages/staging/staging_test.go
@@ -226,6 +226,54 @@ func TestUpdate_RevealIsPerSelectedRow(t *testing.T) {
 	assert.NotContains(t, screen, valueRow0, "the earlier row stays masked")
 }
 
+// TestUpdate_DiffViewRevealedByDefault pins #735: in the DEFAULT diff view a
+// secret entry's remote-vs-staged comparison is SHOWN (both sides), so the diff
+// is meaningful — the whole diff view reveals together (not per-row), and `x`
+// toggles a page-level hide that masks every secret comparison at once.
+func TestUpdate_DiffViewRevealedByDefault(t *testing.T) {
+	t.Parallel()
+
+	const (
+		remote0 = "REMOTE-ROW-ZERO"
+		staged0 = "STAGED-ROW-ZERO"
+		remote1 = "REMOTE-ROW-ONE"
+		staged1 = "STAGED-ROW-ONE"
+	)
+
+	sec := &stubService{
+		service: "secret", label: "Secret", svcCap: capFor("aws", "secret"),
+		review: data.StagingReview{Entries: []data.StagedDiffRow{
+			{Name: "prod/api/one", Type: data.StagedDiffNormal, Operation: "update", RemoteValue: remote0, StagedValue: staged0},
+			{Name: "prod/api/two", Type: data.StagedDiffNormal, Operation: "update", RemoteValue: remote1, StagedValue: staged1},
+		}},
+	}
+	m := newModel(t, sec)
+	require.True(t, m.diffView, "diff is the default view")
+
+	// Revealed by default: every row's remote and staged values are shown.
+	screen := m.View(100, 30)
+	for _, v := range []string{remote0, staged0, remote1, staged1} {
+		assert.Contains(t, screen, v, "diff view reveals %q by default", v)
+	}
+
+	// `x` hides the whole diff view (page-level, not per-selected-row): no secret
+	// value remains, but bullets prove the rows still render.
+	m, _ = m.Update(keyPress('x'))
+	require.True(t, m.diffHidden, "x hides the diff view")
+
+	screen = m.View(100, 30)
+	for _, v := range []string{remote0, staged0, remote1, staged1} {
+		assert.NotContains(t, screen, v, "x masks %q across the whole diff view", v)
+	}
+
+	assert.Contains(t, screen, "•", "masked diff rows still render as bullets")
+
+	// `x` again reveals everything.
+	m, _ = m.Update(keyPress('x'))
+	require.False(t, m.diffHidden, "x toggles back to revealed")
+	assert.Contains(t, m.View(100, 30), staged1, "toggling back shows the values again")
+}
+
 // tagOpsReview is a param section with one staged tag add and one staged tag
 // removal (no entry rows), used to exercise the tag-row key handling.
 func tagOpsReview() data.StagingReview {
@@ -289,11 +337,12 @@ func TestUpdate_TagRowRevealAndEnterNonDestructive(t *testing.T) {
 	for _, row := range []int{0, 1} {
 		m.selected = row
 
-		// `x` reveals only: it flips reveal and dispatches nothing.
-		before := m.reveal
+		// `x` only toggles masking (here the diff-view page-level hide, the default
+		// view) and dispatches nothing — it never cancels a staged tag change.
+		before := m.diffHidden
 		m, cmd := m.Update(keyPress('x'))
 		assert.Nil(t, cmd, "x dispatches no command on a tag row")
-		assert.Equal(t, !before, m.reveal, "x toggles reveal on a tag row")
+		assert.Equal(t, !before, m.diffHidden, "x toggles the diff-view mask on a tag row")
 
 		// enter is a no-op: no command, no cancel.
 		_, cmd = m.Update(tea.KeyPressMsg{Code: tea.KeyEnter})

--- a/internal/tui/pages/staging/update.go
+++ b/internal/tui/pages/staging/update.go
@@ -154,6 +154,7 @@ func (m *Model) handleActionKey(msg tea.KeyPressMsg) (*Model, tea.Cmd) {
 func (m *Model) toggleView() tea.Cmd {
 	m.diffView = !m.diffView
 	m.reveal = false
+	m.diffHidden = false
 
 	return tea.ClearScreen
 }
@@ -172,12 +173,25 @@ func (m *Model) moveSelection(delta int) {
 	m.reveal = false
 }
 
-// onReveal toggles the reveal for the SELECTED row's value only (never
-// page-global): pressing `x` unmasks just the selected secret, and moving the
-// selection resets it (#694). It is reveal-only on every row kind (including tag
-// rows): removing a staged change — entry or tag — is `u`'s job, never `x`, so a
-// user who learned `x` = reveal never destroys a staged change by peeking (#682).
+// onReveal toggles secret masking with `x`, view-aware:
+//
+//   - In DIFF view the remote-vs-staged comparison is revealed by default (the
+//     surface the user explicitly opened to inspect the change, #735); `x`
+//     toggles a page-level HIDE so the diff can still be masked.
+//   - In VALUE view the raw staged value is masked by default; `x` unmasks only
+//     the SELECTED row's value (never page-global), and moving the selection
+//     resets it (#694).
+//
+// It never removes a staged change — that is `u`'s job on every row kind
+// (including tag rows) — so a user who learned `x` never destroys a staged
+// change by peeking (#682).
 func (m *Model) onReveal() {
+	if m.diffView {
+		m.diffHidden = !m.diffHidden
+
+		return
+	}
+
 	m.reveal = !m.reveal
 }
 
@@ -367,6 +381,19 @@ func (m *Model) noticeVisible() bool {
 func (m *Model) maskValue(value string, secret bool, rowIdx int) string {
 	revealed := m.reveal && rowIdx == m.selected
 	if secret && !revealed {
+		return components.MaskValue(value)
+	}
+
+	return value
+}
+
+// maskDiffValue masks a secret value for the DIFF view. The diff view is shown
+// revealed by default so the remote-vs-staged change is meaningful (#735); it is
+// masked only while the page-level hide is on (`x` in diff view). Unlike
+// maskValue this is page-level, not per-selected-row: the whole diff view masks
+// or reveals together.
+func (m *Model) maskDiffValue(value string, secret bool) string {
+	if secret && m.diffHidden {
 		return components.MaskValue(value)
 	}
 

--- a/internal/tui/pages/staging/view.go
+++ b/internal/tui/pages/staging/view.go
@@ -144,7 +144,14 @@ func (m *Model) footerLine(width int) string {
 // apply/reset. These are page-local (not in keys.Map), so the global help bar
 // never lists them; this line makes them discoverable (#655).
 func (m *Model) hintLine(width int) string {
-	const hint = "e edit · u unstage · t tags · x reveal · enter detail · v view · a apply · r reset"
+	// `x` is view-aware: it hides the revealed diff comparison in diff view, and
+	// reveals the selected masked value in value view (see onReveal).
+	xHint := "x reveal"
+	if m.diffView {
+		xHint = "x hide"
+	}
+
+	hint := "e edit · u unstage · t tags · " + xHint + " · enter detail · v view · a apply · r reset"
 
 	return m.styles.PageHint.Render(clip(hint, width))
 }
@@ -322,23 +329,29 @@ func (m *Model) entryLines(sec *section, e data.StagedDiffRow, rowIdx int) []str
 	return append([]string{head}, m.diffLines(sec, e, rowIdx)...)
 }
 
-// diffLines renders an entry's Remote-vs-Staged ± lines (masked for secrets,
-// revealed only when rowIdx is the selected row — see maskValue).
+// diffLines renders an entry's Remote-vs-Staged ± lines. An update/delete is a
+// real remote-vs-staged comparison, revealed by default so the change is
+// meaningful (#735); `x` in diff view hides it (see maskDiffValue). A create has
+// no remote to compare against — it is a lone new value, not a comparison — so
+// it stays masked as a plain value (peekable per-row in value view), never
+// revealed as part of the diff (#719).
 func (m *Model) diffLines(sec *section, e data.StagedDiffRow, rowIdx int) []string {
-	var lines []string
-
 	// A SecureString param row is secret even in a non-secret (param) section, so
 	// OR the row's own flag into the section's (#677).
 	secret := sec.secret || e.Secret
-	remote := m.maskValue(e.RemoteValue, secret, rowIdx)
-	staged := m.maskValue(e.StagedValue, secret, rowIdx)
 
-	if e.Operation != operationCreate {
-		lines = append(lines, "    "+m.styles.DiffRemoved.Render("- "+firstLine(remote)))
+	if e.Operation == operationCreate {
+		staged := firstLine(m.maskValue(e.StagedValue, secret, rowIdx))
+
+		return []string{"    " + m.styles.DiffAdded.Render("+ "+staged)}
 	}
 
+	remote := firstLine(m.maskDiffValue(e.RemoteValue, secret))
+	lines := []string{"    " + m.styles.DiffRemoved.Render("- "+remote)}
+
 	if e.Operation != operationDelete {
-		lines = append(lines, "    "+m.styles.DiffAdded.Render("+ "+firstLine(staged)))
+		staged := firstLine(m.maskDiffValue(e.StagedValue, secret))
+		lines = append(lines, "    "+m.styles.DiffAdded.Render("+ "+staged))
 	}
 
 	return lines

--- a/internal/tui/staging_golden_test.go
+++ b/internal/tui/staging_golden_test.go
@@ -250,9 +250,8 @@ func TestStaging_SecureStringParamDiffViewGolden(t *testing.T) { //nolint:parall
 	raw := captureStaging(t, secureStringStagingApp(), "SECURE_TOKEN", false)
 	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
 
-	assert.NotContains(t, screen, secureStringParamValue, "no revealed SecureString param value in the diff-view golden")
-	assert.Contains(t, screen, "•", "the SecureString param row is masked with bullets, proving it renders (not just absent)")
-	assert.Contains(t, screen, "https://cdn-new.example.com", "a plaintext param row is NOT masked")
+	assert.Contains(t, screen, secureStringParamValue, "the SecureString param diff is revealed by default (#677/#735)")
+	assert.Contains(t, screen, "https://cdn-new.example.com", "a plaintext param row is shown too")
 	golden.RequireEqual(t, screen)
 }
 
@@ -270,14 +269,29 @@ func TestStaging_SecureStringParamValueViewGolden(t *testing.T) { //nolint:paral
 }
 
 // TestStaging_DiffViewGolden renders the staging page in the default diff view.
-// Secret values are masked on both diff sides, so the secret value never appears.
+// The remote-vs-staged comparison is a surface the user explicitly opened to
+// inspect the change, so secret values are REVEALED by default (#735).
 func TestStaging_DiffViewGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
 	goldenEnv(t)
 
 	raw := captureStaging(t, stagingApp(), "prod/api/session", false)
 	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
 
-	assert.NotContains(t, screen, secretStagedValue, "no revealed secret value in the diff-view golden")
+	assert.Contains(t, screen, secretStagedValue, "the secret remote-vs-staged diff is revealed by default (#735)")
+	golden.RequireEqual(t, screen)
+}
+
+// TestStaging_DiffViewHiddenGolden pins the diff-view mask toggle: pressing `x`
+// in diff view hides every secret comparison (page-level), so no secret value
+// appears while the rows still render as masked bullet runs.
+func TestStaging_DiffViewHiddenGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
+	goldenEnv(t)
+
+	raw := captureStagingKeys(t, stagingApp(), "prod/api/session", keyPress('x'))
+	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+
+	assert.NotContains(t, screen, secretStagedValue, "x hides the revealed secret diff")
+	assert.Contains(t, screen, "•", "the hidden diff still renders as masked bullets")
 	golden.RequireEqual(t, screen)
 }
 

--- a/internal/tui/testdata/TestDiff_AWSParamSecureStringGolden.golden
+++ b/internal/tui/testdata/TestDiff_AWSParamSecureStringGolden.golden
@@ -1,11 +1,11 @@
 ╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
-│diff: /app/api/DATABASE_URL#13 → /app/api/DATABASE_URL#14                                         │
+│diff: /app/api/DATABASE_URL#13 → /app/api/DATABASE_URL#14  ·  x: hide                             │
 │--- /app/api/DATABASE_URL#13                                                                      │
 │+++ /app/api/DATABASE_URL#14                                                                      │
 │@@ -1 +1 @@                                                                                       │
-│-•••••••••••                                                                                      │
+│-db-pass-old                                                                                      │
 │\ No newline at end of file                                                                       │
-│+•••••••••••••••••••••                                                                            │
+│+db-secret-password-v2                                                                            │
 │\ No newline at end of file                                                                       │
 │                                                                                                  │
 │                                                                                                  │

--- a/internal/tui/testdata/TestDiff_AWSSecretGolden.golden
+++ b/internal/tui/testdata/TestDiff_AWSSecretGolden.golden
@@ -1,5 +1,5 @@
 ╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
-│diff: prod/api/key#e5f6a7b8… → prod/api/key#a1b2c3d4…                                             │
+│diff: prod/api/key#e5f6a7b8… → prod/api/key#a1b2c3d4…  ·  x: hide                                 │
 │(no differences)                                                                                  │
 │                                                                                                  │
 │                                                                                                  │

--- a/internal/tui/testdata/TestDiff_AzureKVGolden.golden
+++ b/internal/tui/testdata/TestDiff_AzureKVGolden.golden
@@ -1,5 +1,5 @@
 ╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
-│diff: vault-secret#4c3b2a19… → vault-secret#9f8e7d6c…                                             │
+│diff: vault-secret#4c3b2a19… → vault-secret#9f8e7d6c…  ·  x: hide                                 │
 │(no differences)                                                                                  │
 │                                                                                                  │
 │                                                                                                  │

--- a/internal/tui/testdata/TestDiff_GCloudSecretGolden.golden
+++ b/internal/tui/testdata/TestDiff_GCloudSecretGolden.golden
@@ -1,11 +1,11 @@
 ╭──────────────────────────────────────────────────────────────────────────────────────────────────╮
-│diff: api-key#2 → api-key#3                                                                       │
+│diff: api-key#2 → api-key#3  ·  x: hide                                                           │
 │--- api-key#2                                                                                     │
 │+++ api-key#3                                                                                     │
 │@@ -1 +1 @@                                                                                       │
-│-••••••••••••••••••••                                                                             │
+│-googlecloud-secret-2                                                                             │
 │\ No newline at end of file                                                                       │
-│+••••••••••••••••••••••••                                                                         │
+│+googlecloud-secret-value-three                                                                   │
 │\ No newline at end of file                                                                       │
 │                                                                                                  │
 │                                                                                                  │

--- a/internal/tui/testdata/TestStaging_DiffViewGolden.golden
+++ b/internal/tui/testdata/TestStaging_DiffViewGolden.golden
@@ -14,10 +14,10 @@ Param (3)                                                                       
 
 Secret (2)                                                                                            a apply · r reset
   delete  prod/api/old-key
-    - ••••••••••••••••••••••••
+    - super-secret-token-value
   update  prod/api/session
-    - ••••••••••••••••••••••••
-    + ••••••••••••••••••••••••
+    - old-super-secret-token-value
+    + super-secret-token-value
 
 
 
@@ -30,5 +30,5 @@ Secret (2)                                                                      
 
 
 
-e edit · u unstage · t tags · x reveal · enter detail · v view · a apply · r reset
+e edit · u unstage · t tags · x hide · enter detail · v view · a apply · r reset
  tab next tab • 1/2/3 jump to tab • ? help • q quit

--- a/internal/tui/testdata/TestStaging_DiffViewHiddenGolden.golden
+++ b/internal/tui/testdata/TestStaging_DiffViewHiddenGolden.golden
@@ -4,7 +4,7 @@ suve  aws · profile:dev · account:123456789012 · region:ap-northeast-1
 view: [diff] value   A apply-all · R reset-all · ctrl+r refresh
 ⚠ auto-unstaged: /app/web/OLD_FLAG (staged value now equals remote)  esc: dismiss
 Param (3)                                                                                             a apply · r reset
-  update  /app/web/CDN_URL
+▸ update  /app/web/CDN_URL
     - https://cdn-old.example.com
     + https://cdn-new.example.com
   create  /app/web/NEW_FLAG
@@ -13,11 +13,11 @@ Param (3)                                                                       
   tags  /app/api/DATABASE_URL  −env (was prod)   u unstage
 
 Secret (2)                                                                                            a apply · r reset
-▸ delete  prod/api/old-key
-    - super-secret-token-value
+  delete  prod/api/old-key
+    - ••••••••••••••••••••••••
   update  prod/api/session
-    - old-super-secret-token-value
-    + super-secret-token-value
+    - ••••••••••••••••••••••••
+    + ••••••••••••••••••••••••
 
 
 
@@ -30,5 +30,5 @@ Secret (2)                                                                      
 
 
 
-cannot tag: staged for deletion — reset first
+e edit · u unstage · t tags · x hide · enter detail · v view · a apply · r reset
  tab next tab • 1/2/3 jump to tab • ? help • q quit

--- a/internal/tui/testdata/TestStaging_SecureStringParamCreateDiffViewGolden.golden
+++ b/internal/tui/testdata/TestStaging_SecureStringParamCreateDiffViewGolden.golden
@@ -30,5 +30,5 @@ Param (2)                                                                       
 
 
 
-e edit · u unstage · t tags · x reveal · enter detail · v view · a apply · r reset
+e edit · u unstage · t tags · x hide · enter detail · v view · a apply · r reset
  tab next tab • 1/2/3 jump to tab • ? help • q quit

--- a/internal/tui/testdata/TestStaging_SecureStringParamDiffViewGolden.golden
+++ b/internal/tui/testdata/TestStaging_SecureStringParamDiffViewGolden.golden
@@ -4,8 +4,8 @@ suve  aws · profile:dev · account:123456789012 · region:ap-northeast-1
 view: [diff] value   A apply-all · R reset-all · ctrl+r refresh
 Param (2)                                                                                             a apply · r reset
 ▸ update  /app/api/SECURE_TOKEN
-    - ••••••••••••••••••••••••
-    + ••••••••••••••••••••••••
+    - old-securestring-db-password-value
+    + securestring-db-password-value
   update  /app/web/CDN_URL
     - https://cdn-old.example.com
     + https://cdn-new.example.com
@@ -30,5 +30,5 @@ Param (2)                                                                       
 
 
 
-e edit · u unstage · t tags · x reveal · enter detail · v view · a apply · r reset
+e edit · u unstage · t tags · x hide · enter detail · v view · a apply · r reset
  tab next tab • 1/2/3 jump to tab • ? help • q quit


### PR DESCRIPTION
Relaxes the explicit-diff over-masking per the confirmed product policy: **mask passive secret surfaces, but reveal (shown by default) the surfaces the user explicitly opens to inspect values — the version Compare/diff view and the staging DIFF view** — while keeping a mask/Show toggle so hiding is still possible.

Addresses #735 (TUI staging diff view masked → useless) and #702 (GUI SecureString param diff rendered masked). Complements the already-closed #731/#714/#739. The earlier masking work (#677/#711/#720) over-masked these explicit diff surfaces; this narrows that policy to passive surfaces only.

## What changed

**TUI**
- **Diff page** (`internal/tui/pages/diff`) — backs the browser version Compare and the staging remote-vs-staged detail: a secret diff is **revealed by default**; `x` toggles hide/show and the pane title surfaces the toggle. Parse-json now works on a revealed secret.
- **Staging DIFF view** (`internal/tui/pages/staging`) — an update/delete remote-vs-staged comparison is **revealed by default**; `x` in diff view toggles a page-level hide. A staged **create** (a lone new value, not a comparison) stays masked (#719); the **VALUE view** keeps its per-row masked-by-default reveal (#694).

**GUI**
- **`DiffDisplay.svelte`** — reveals by default and owns a **Hide/Show toggle** when either side is secret (adds per-side `oldSecret`/`newSecret`). Drives the ParamView + SecretView "Version Comparison" modals and the StagingSection diff mode.
- **`StagingSection.svelte`** — the delete diff reveals the remote by default; the value view and staged-create plain value stay masked.

## Surfaces: revealed vs kept-masked

| Surface | Frontend | Before | After |
|---|---|---|---|
| Version Compare / Show-Diff (secret + SecureString param) | TUI diff page / GUI ParamView + SecretView modals | masked | **revealed + toggle** |
| Staging DIFF view — update/delete ± comparison | TUI + GUI | masked | **revealed + toggle** |
| Staging DIFF view — staged **create** (lone value, no comparison) | TUI + GUI | masked | masked (unchanged, #719) |
| Staging **VALUE** view (plain staged value) | TUI + GUI | masked (per-row reveal) | masked (unchanged, #694) |
| Single-value detail pane | TUI + GUI | masked | masked (unchanged) |
| Version history value rows | TUI + GUI | masked | masked (unchanged) |
| List value previews | GUI | (handled by #734) | untouched |

## Verification (real output, epic/tui @ ddbf7a9)

```
$ go test -race ./internal/tui/...
ok  github.com/mpyw/suve/internal/tui                  6.863s
ok  github.com/mpyw/suve/internal/tui/pages/diff       (cached)
ok  github.com/mpyw/suve/internal/tui/pages/staging    1.341s
(all packages ok)

$ go test ./internal/...          # mise test
(all ok / no test files)

$ golangci-lint run --allow-parallel-runners --timeout=10m
0 issues.

$ mise build-gui
✓ built in 518ms
Built bin/suve — run 'suve --gui'.

$ (cd internal/gui/frontend && npx playwright test)
1481 passed  (1 pre-existing webkit-only flake: keyboard-focus "Tab navigation
through item list" — fails identically on origin/epic/tui, unrelated to diffs)
```

Regenerated TUI goldens: the explicit DIFF goldens now legitimately contain values (`TestStaging_DiffViewGolden`, `TestStaging_SecureStringParamDiffViewGolden`, `TestDiff_*SecretGolden`, `TestDiff_AWSParamSecureStringGolden`); a new `TestStaging_DiffViewHiddenGolden` pins the hide toggle. Passive-surface goldens (value view, single value, create) stay masked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
