### PR TITLE
feat(gcloud,staging): GCloud secret --description + capability-gated staging --description (#666)

### DIFF
--- a/docs/gcloud.md
+++ b/docs/gcloud.md
@@ -12,7 +12,7 @@ Primary command: `gcloud secret`
 > [!NOTE]
 > Google Cloud secrets are integer-versioned (`1`, `2`, `3`, ... or `latest`) and have **no staging labels**.
 
-Google Cloud also supports the local **staging workflow** via `suve gcloud stage` (or the bare `suve stage` alias when Google Cloud is the only active staging backend). Because Google Cloud is secret-only, `gcloud stage` operates on secrets directly: `add`, `edit`, `delete`, `status`, `diff`, `apply`, `reset`, `tag`, `untag`, `export`, and `import`. Since Secret Manager versions are immutable, a staged `edit` applies as a new version, and there are no force / recovery-window delete options. See the [staging workflow](../README.md#staging-workflow) overview for the general flow.
+Google Cloud also supports the local **staging workflow** via `suve gcloud stage` (or the bare `suve stage` alias when Google Cloud is the only active staging backend). Because Google Cloud is secret-only, `gcloud stage` operates on secrets directly: `add`, `edit`, `delete`, `status`, `diff`, `apply`, `reset`, `tag`, `untag`, `export`, and `import`. Since Secret Manager versions are immutable, a staged `edit` applies as a new version, and there are no force / recovery-window delete options. `stage add` / `stage edit` accept `--description` (stored as the `description` annotation, applied on `stage apply`). See the [staging workflow](../README.md#staging-workflow) overview for the general flow.
 
 ## Authentication and Configuration
 
@@ -36,6 +36,10 @@ suve gcloud --project my-project secret list
 export GOOGLE_CLOUD_PROJECT=my-project
 suve gcloud secret list
 ```
+
+## TUI
+
+Launch the terminal UI with `suve gcloud --tui` (or bare `suve --tui` when Google Cloud is the only active provider). It consumes the same project scope as the CLI — `--project` or `GOOGLE_CLOUD_PROJECT` — and offers the Secret tab (Google Cloud has no param service). See [TUI mode](../README.md#tui-mode) for the keymap.
 
 ## Version Specification
 
@@ -276,9 +280,13 @@ suve gcloud secret create [options] <name> [<value>]
 | Option | Alias | Default | Description |
 |--------|-------|---------|-------------|
 | `--value-stdin` | - | `false` | Read the value from stdin instead of the positional argument (keeps it out of argv/ps and shell history) |
+| `--description` | - | - | Description for the secret (stored as the `description` annotation) |
 
 > [!NOTE]
 > The value can be provided as a positional argument, piped in with `--value-stdin` (so it never appears in `ps`/argv or shell history), or typed into `$EDITOR` when omitted.
+
+> [!NOTE]
+> Google Cloud secrets have no native description field. suve stores `--description` as the secret's `description` annotation, which is distinct from the labels that back the tag axis, so it never collides with a tag.
 
 **Examples:**
 
@@ -288,6 +296,9 @@ suve gcloud secret create my-api-key "sk-12345"
 
 # Create a JSON secret
 suve gcloud secret create my-config '{"host":"db"}'
+
+# Create with a description
+suve gcloud secret create --description "app credentials" my-api-key "sk-12345"
 ```
 
 > [!NOTE]
@@ -316,6 +327,7 @@ suve gcloud secret update [options] <name> [<value>]
 |--------|-------|---------|-------------|
 | `--yes` | - | `false` | Skip confirmation prompt |
 | `--value-stdin` | - | `false` | Read the value from stdin instead of the positional argument (keeps it out of argv/ps and shell history) |
+| `--description` | - | - | Description for the secret (updates the `description` annotation) |
 
 > [!NOTE]
 > The value can be provided as a positional argument, piped in with `--value-stdin` (so it never appears in `ps`/argv or shell history), or typed into `$EDITOR` when omitted.
@@ -328,6 +340,9 @@ suve gcloud secret update my-api-key "new-value"
 
 # Update without confirmation
 suve gcloud secret update --yes my-api-key "new-value"
+
+# Update the description
+suve gcloud secret update --description "rotated key" my-api-key "new-value"
 ```
 
 > [!NOTE]

--- a/e2e/gcloud_secret_test.go
+++ b/e2e/gcloud_secret_test.go
@@ -151,3 +151,40 @@ func TestGoogleCloudSecret_FullWorkflow(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// TestGoogleCloudSecret_Description exercises the --description flag (stored as
+// the secret's "description" annotation) across immediate create/update and the
+// read view. This is #666's Google Cloud description support: the flag was
+// previously absent on gcloud, and staged descriptions were silently dropped.
+func TestGoogleCloudSecret_Description(t *testing.T) {
+	setupGoogleCloud(t)
+
+	const name = "suve-e2e-gcloud-secret-desc"
+
+	// Best-effort cleanup from a previous run.
+	_, _ = runGcloud(t, "secret", "delete", "--yes", name)
+
+	t.Run("create with --description", func(t *testing.T) {
+		_, err := runGcloud(t, "secret", "create", name, "initial-value", "--description", "app credentials")
+		require.NoError(t, err)
+
+		stdout, err := runGcloud(t, "secret", "show", name)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "Description")
+		assert.Contains(t, stdout, "app credentials")
+	})
+
+	t.Run("update --description changes the annotation", func(t *testing.T) {
+		_, err := runGcloud(t, "secret", "update", "--yes", name, "next-value", "--description", "rotated key")
+		require.NoError(t, err)
+
+		stdout, err := runGcloud(t, "secret", "show", name)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "rotated key")
+	})
+
+	t.Run("cleanup", func(t *testing.T) {
+		_, err := runGcloud(t, "secret", "delete", "--yes", name)
+		require.NoError(t, err)
+	})
+}

--- a/e2e/gcloud_stage_test.go
+++ b/e2e/gcloud_stage_test.go
@@ -129,6 +129,41 @@ func TestGoogleCloudStage_Workflow(t *testing.T) {
 	})
 }
 
+// TestGoogleCloudStage_DescriptionApplied confirms that a staged description is
+// carried through apply to the "description" annotation and shown in the read
+// view — #666's fix for the previously silent no-op (the value was accepted and
+// shown in status/diff, then dropped on apply for non-AWS providers).
+func TestGoogleCloudStage_DescriptionApplied(t *testing.T) {
+	setupGoogleCloud(t)
+	setupTempHome(t)
+
+	const (
+		project = "suve-e2e"
+		name    = "suve-e2e-gcloud-stage-desc/create"
+	)
+
+	cleanup := func() { _, _ = runGcloud(t, "secret", "delete", "--yes", name) }
+	cleanup()
+	t.Cleanup(cleanup)
+
+	store := newGoogleCloudStore(project)
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceSecret, staging.EntryKey{Name: name}, staging.Entry{
+		Operation:   staging.OperationCreate,
+		Value:       lo.ToPtr("created-value"),
+		Description: lo.ToPtr("staged description"),
+		StagedAt:    time.Now(),
+	}))
+
+	_, err := runGcloud(t, "stage", "apply", "--yes")
+	require.NoError(t, err)
+
+	stdout, err := runGcloud(t, "secret", "show", name)
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "created-value")
+	assert.Contains(t, stdout, "Description")
+	assert.Contains(t, stdout, "staged description")
+}
+
 // TestGoogleCloudStage_FlatAliasReachesEmulator confirms the flat `suve stage`
 // alias, when forced to Google Cloud, resolves the project and drives the same
 // emulator-backed staging store.

--- a/internal/cli/commands/aws/stage/param/command.go
+++ b/internal/cli/commands/aws/stage/param/command.go
@@ -19,6 +19,7 @@ var config = stgcli.CommandConfig{
 	ItemName:         "parameter",
 	Factory:          cliinternal.AWSParamStrategyFactory,
 	ParserFactory:    staging.AWSParamParserFactory,
+	HasDescription:   true,
 	ValueTypeFlags:   valueTypeFlags(),
 	ValueTypeFromCmd: resolveValueType,
 }

--- a/internal/cli/commands/aws/stage/secret/command.go
+++ b/internal/cli/commands/aws/stage/secret/command.go
@@ -14,10 +14,11 @@ const nounSecret = "secret"
 
 //nolint:gochecknoglobals // package-level config for command factory
 var config = stgcli.CommandConfig{
-	CommandName:   nounSecret,
-	ItemName:      nounSecret,
-	Factory:       cliinternal.AWSSecretStrategyFactory,
-	ParserFactory: staging.AWSSecretParserFactory,
+	CommandName:    nounSecret,
+	ItemName:       nounSecret,
+	Factory:        cliinternal.AWSSecretStrategyFactory,
+	ParserFactory:  staging.AWSSecretParserFactory,
+	HasDescription: true,
 }
 
 // Config returns the AWS Secrets Manager staging command config. It is used by

--- a/internal/cli/commands/gcloud/create.go
+++ b/internal/cli/commands/gcloud/create.go
@@ -21,8 +21,9 @@ type CreateRunner struct {
 
 // CreateOptions holds the options for the create command.
 type CreateOptions struct {
-	Name  string
-	Value string
+	Name        string
+	Value       string
+	Description string
 }
 
 // CreateCommand returns the Google Cloud Secret Manager create command.
@@ -39,6 +40,10 @@ secret, use 'suve gcloud secret update' instead.
 The secret is created with automatic replication, and the given value becomes
 its first version. To add labels after creation, use 'suve gcloud secret tag'.
 
+A --description is stored as the secret's "description" annotation (Google Cloud
+secrets have no native description field; the annotation axis is distinct from
+the labels that back tags).
+
 The value may be given as a positional argument, read from stdin with
 --value-stdin (so it never appears in argv/ps or shell history), or, when
 omitted, typed into $EDITOR.
@@ -50,6 +55,10 @@ EXAMPLES:
    suve gcloud secret create my-key                            Type value into $EDITOR`,
 		Flags: []cli.Flag{
 			cliinternal.ValueStdinFlag(),
+			&cli.StringFlag{
+				Name:  "description",
+				Usage: "Description for the secret (stored as the \"description\" annotation)",
+			},
 		},
 		Action: createAction,
 	}
@@ -88,12 +97,12 @@ func createAction(ctx context.Context, cmd *cli.Command) error {
 		Stderr:  cmd.Root().ErrWriter,
 	}
 
-	return r.Run(ctx, CreateOptions{Name: args.Get(0), Value: value})
+	return r.Run(ctx, CreateOptions{Name: args.Get(0), Value: value, Description: cmd.String("description")})
 }
 
 // Run executes the create command.
 func (r *CreateRunner) Run(ctx context.Context, opts CreateOptions) error {
-	result, err := r.UseCase.Execute(ctx, gcloud.CreateInput{Name: opts.Name, Value: opts.Value})
+	result, err := r.UseCase.Execute(ctx, gcloud.CreateInput{Name: opts.Name, Value: opts.Value, Description: opts.Description})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/commands/gcloud/gcloud_test.go
+++ b/internal/cli/commands/gcloud/gcloud_test.go
@@ -79,13 +79,17 @@ func TestCommandValidation(t *testing.T) {
 func TestCreateRunner(t *testing.T) {
 	t.Parallel()
 
+	var gotDescription string
+
 	store := &providermock.Store{
 		CreateFunc: func(
-			_ context.Context, name, value string, vt domain.ValueType, _ string, _ ...provider.WriteOption,
+			_ context.Context, name, value string, vt domain.ValueType, description string, _ ...provider.WriteOption,
 		) (domain.Version, error) {
 			assert.Equal(t, "my-secret", name)
 			assert.Equal(t, "value", value)
 			assert.Equal(t, domain.ValueTypeSecret, vt)
+
+			gotDescription = description
 
 			return domain.Version{ID: "1"}, nil
 		},
@@ -98,22 +102,27 @@ func TestCreateRunner(t *testing.T) {
 		Stdout:  &buf,
 		Stderr:  &errBuf,
 	}
-	require.NoError(t, r.Run(t.Context(), gcloud.CreateOptions{Name: "my-secret", Value: "value"}))
+	require.NoError(t, r.Run(t.Context(), gcloud.CreateOptions{Name: "my-secret", Value: "value", Description: "app credentials"}))
 	assert.Contains(t, buf.String(), "Created secret my-secret")
 	assert.Contains(t, buf.String(), "version: 1")
+	assert.Equal(t, "app credentials", gotDescription, "the --description value reaches the writer")
 }
 
 func TestUpdateRunner(t *testing.T) {
 	t.Parallel()
+
+	var gotDescription string
 
 	store := &providermock.Store{
 		GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) {
 			return &domain.Entry{Name: "my-secret", Value: "old"}, nil
 		},
 		PutFunc: func(
-			_ context.Context, _, value string, _ domain.ValueType, _ string, _ ...provider.WriteOption,
+			_ context.Context, _, value string, _ domain.ValueType, description string, _ ...provider.WriteOption,
 		) (domain.Version, error) {
 			assert.Equal(t, "new", value)
+
+			gotDescription = description
 
 			return domain.Version{ID: "2"}, nil
 		},
@@ -126,9 +135,10 @@ func TestUpdateRunner(t *testing.T) {
 		Stdout:  &buf,
 		Stderr:  &errBuf,
 	}
-	require.NoError(t, r.Run(t.Context(), gcloud.UpdateOptions{Name: "my-secret", Value: "new"}))
+	require.NoError(t, r.Run(t.Context(), gcloud.UpdateOptions{Name: "my-secret", Value: "new", Description: "rotated key"}))
 	assert.Contains(t, buf.String(), "Updated secret my-secret")
 	assert.Contains(t, buf.String(), "version: 2")
+	assert.Equal(t, "rotated key", gotDescription, "the --description value reaches the writer")
 }
 
 func TestUpdateRunner_NotFound(t *testing.T) {
@@ -189,11 +199,12 @@ func TestShowPresenter(t *testing.T) {
 		},
 		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
 			return &domain.Entry{
-				Name:    name,
-				Value:   "s3cr3t",
-				Type:    domain.ValueTypeSecret,
-				Version: domain.Version{ID: "3", State: "enabled", Created: &created},
-				Tags:    []domain.Tag{{Key: "env", Value: "prod"}},
+				Name:        name,
+				Value:       "s3cr3t",
+				Type:        domain.ValueTypeSecret,
+				Version:     domain.Version{ID: "3", State: "enabled", Created: &created},
+				Description: "app credentials",
+				Tags:        []domain.Tag{{Key: "env", Value: "prod"}},
 			}, nil
 		},
 	}
@@ -215,6 +226,9 @@ func TestShowPresenter(t *testing.T) {
 	assert.Contains(t, out, "3")
 	assert.Contains(t, out, "s3cr3t")
 	assert.Contains(t, out, "env")
+	// The "description" annotation surfaces as a Description field in the read view.
+	assert.Contains(t, out, "Description")
+	assert.Contains(t, out, "app credentials")
 	// No ARN or Stages fields for Google Cloud.
 	assert.NotContains(t, out, "ARN")
 	assert.NotContains(t, out, "Stages")

--- a/internal/cli/commands/gcloud/show.go
+++ b/internal/cli/commands/gcloud/show.go
@@ -19,12 +19,13 @@ import (
 
 // showJSONOutput represents the JSON output structure for the show command.
 type showJSONOutput struct {
-	Name    string            `json:"name"`
-	Version string            `json:"version,omitempty"`
-	State   string            `json:"state,omitempty"`
-	Created string            `json:"created,omitempty"`
-	Labels  map[string]string `json:"labels"`
-	Value   string            `json:"value"`
+	Name        string            `json:"name"`
+	Version     string            `json:"version,omitempty"`
+	State       string            `json:"state,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Created     string            `json:"created,omitempty"`
+	Labels      map[string]string `json:"labels"`
+	Value       string            `json:"value"`
 }
 
 // showPresenter renders Google Cloud Secret Manager show output.
@@ -73,6 +74,10 @@ func (p *showPresenter) RenderText(stdout io.Writer, value string) {
 		out.Field("State", result.State)
 	}
 
+	if result.Description != "" {
+		out.Field("Description", result.Description)
+	}
+
 	if result.CreatedDate != nil {
 		out.Field("Created", timeutil.FormatRFC3339(*result.CreatedDate))
 	}
@@ -93,10 +98,11 @@ func (p *showPresenter) RenderJSON(stdout io.Writer, value string) error {
 	result := p.result
 
 	jsonOut := showJSONOutput{
-		Name:    result.Name,
-		Version: result.Version,
-		State:   result.State,
-		Value:   value,
+		Name:        result.Name,
+		Version:     result.Version,
+		State:       result.State,
+		Description: result.Description,
+		Value:       value,
 	}
 
 	if result.CreatedDate != nil {

--- a/internal/cli/commands/gcloud/stage.go
+++ b/internal/cli/commands/gcloud/stage.go
@@ -14,11 +14,12 @@ import (
 // on-disk staging state by the resolved project.
 func gcloudStageConfig() stgcli.CommandConfig {
 	return stgcli.CommandConfig{
-		CommandName:   nounSecret,
-		ItemName:      nounSecret,
-		Factory:       cliinternal.GoogleCloudSecretStrategyFactory,
-		ParserFactory: staging.GoogleCloudSecretParserFactory,
-		ScopeResolver: cliinternal.GoogleCloudStagingScopeResolver,
+		CommandName:    nounSecret,
+		ItemName:       nounSecret,
+		Factory:        cliinternal.GoogleCloudSecretStrategyFactory,
+		ParserFactory:  staging.GoogleCloudSecretParserFactory,
+		ScopeResolver:  cliinternal.GoogleCloudStagingScopeResolver,
+		HasDescription: true,
 	}
 }
 

--- a/internal/cli/commands/gcloud/update.go
+++ b/internal/cli/commands/gcloud/update.go
@@ -22,8 +22,9 @@ type UpdateRunner struct {
 
 // UpdateOptions holds the options for the update command.
 type UpdateOptions struct {
-	Name  string
-	Value string
+	Name        string
+	Value       string
+	Description string
 }
 
 // UpdateCommand returns the Google Cloud Secret Manager update command.
@@ -36,6 +37,9 @@ func UpdateCommand() *cli.Command {
 
 The new version becomes the latest; prior versions remain accessible by number.
 Use 'suve gcloud secret create' to create a new secret.
+
+A --description updates the secret's "description" annotation (Google Cloud
+secrets have no native description field).
 
 The value may be given as a positional argument, read from stdin with
 --value-stdin (so it never appears in argv/ps or shell history), or, when
@@ -52,6 +56,10 @@ EXAMPLES:
 				Usage: "Skip confirmation prompt",
 			},
 			cliinternal.ValueStdinFlag(),
+			&cli.StringFlag{
+				Name:  "description",
+				Usage: "Description for the secret (stored as the \"description\" annotation)",
+			},
 		},
 		Action: updateAction,
 	}
@@ -123,12 +131,12 @@ func updateAction(ctx context.Context, cmd *cli.Command) error {
 		Stderr:  cmd.Root().ErrWriter,
 	}
 
-	return r.Run(ctx, UpdateOptions{Name: name, Value: newValue})
+	return r.Run(ctx, UpdateOptions{Name: name, Value: newValue, Description: cmd.String("description")})
 }
 
 // Run executes the update command.
 func (r *UpdateRunner) Run(ctx context.Context, opts UpdateOptions) error {
-	result, err := r.UseCase.Execute(ctx, gcloud.UpdateInput{Name: opts.Name, Value: opts.Value})
+	result, err := r.UseCase.Execute(ctx, gcloud.UpdateInput{Name: opts.Name, Value: opts.Value, Description: opts.Description})
 	if err != nil {
 		return err
 	}

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -48,6 +48,10 @@ export interface StagedEntry {
   // per-service envelope round-trips back into the same service regardless of
   // the name shape (Google Cloud/Azure names carry no leading '/').
   service?: Service;
+  // Optional value-type secret flag. When set, StagingDiff stamps it onto the
+  // entry's DTO (mirroring the backend's DiffEntry.Secret) so the staging review
+  // masks a SecureString param even in the non-secret Param section.
+  secret?: boolean;
 }
 
 export interface StagedTagEntry {
@@ -625,7 +629,9 @@ export function createGoogleCloudState(overrides: Partial<MockState> = {}): Part
     // Google Cloud secret versions are integers and carry no ARN/staging labels;
     // they carry a per-version state (enabled/disabled/destroyed) instead.
     secrets: [
-      { name: 'gcloud-secret-1', value: 'v1', arn: '', stagingLabels: [], state: 'enabled' },
+      // gcloud-secret-1 carries a description (the "description" annotation) so a
+      // spec can assert the detail view surfaces it (#666 gcloud support).
+      { name: 'gcloud-secret-1', value: 'v1', arn: '', stagingLabels: [], state: 'enabled', description: 'app credentials' },
       { name: 'gcloud-secret-2', value: 'v2', arn: '', stagingLabels: [], state: 'enabled' },
     ],
     secretVersions: {
@@ -1013,11 +1019,15 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
         const versions = state.paramVersions[s1.name] || [];
         const v1 = versions.find((v: any) => v.version === s1.version);
         const v2 = versions.find((v: any) => v.version === s2.version);
+        // A SecureString param diff carries secret=true so the diff view masks
+        // both sides (mirrors the Go binding's value-type flag — #702).
+        const param = state.params.find((p: any) => p.name === s1.name);
         return {
           oldName: s1.name,
           newName: s2.name,
           oldValue: v1?.value || '',
           newValue: v2?.value || '',
+          secret: (param?.type || 'String') === 'SecureString',
         };
       },
       ParamAddTag: async (name: string, key: string, value: string) => {
@@ -1093,7 +1103,7 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
           stagingLabels: secret?.stagingLabels !== undefined ? secret.stagingLabels : ['AWSCURRENT'],
           state: secret?.state ?? '',
           value: secret?.value || 'mock-secret',
-          description: '',
+          description: secret?.description ?? '',
           createdDate: new Date().toISOString(),
           tags,
         };
@@ -1206,6 +1216,11 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
             stagedValue: s.value || '',
             description: '',
             warning: '',
+            // Mirror the backend's value-type secret flag: secret-service
+            // entries are secret material (the create path leaves it unset —
+            // the section-level flag masks those). A per-entry override wins so
+            // a SecureString param can be flagged too.
+            secret: s.secret ?? (service === 'secret' && s.operation !== 'create'),
           })),
           tagEntries: tagStaged.map((t: any) => ({
             name: t.name,

--- a/internal/gui/frontend/tests/secret.spec.ts
+++ b/internal/gui/frontend/tests/secret.spec.ts
@@ -557,3 +557,34 @@ test.describe('Secret version-meta heading is concept-driven (#419)', () => {
     await expect(page.locator('.detail-meta .badge-stage')).toHaveText(['AWSCURRENT', 'AWSPREVIOUS']);
   });
 });
+
+// #666: a Google Cloud secret's description (stored as the "description"
+// annotation) surfaces in the read view, the same as an AWS description. The
+// detail view already renders `description` when present, provider-agnostically;
+// this pins that a gcloud secret's description reaches and renders in the GUI.
+test.describe('Secret description display (#666)', () => {
+  test('Google Cloud: an annotation-backed description shows in the detail view', async ({ page }) => {
+    await setupWailsMocks(page, createGoogleCloudState());
+    await page.goto('/');
+    await waitForItemList(page);
+
+    // Google Cloud launches straight into the secret view; gcloud-secret-1 is
+    // seeded with a description.
+    await clickItemByName(page, 'gcloud-secret-1');
+    await expect(page.locator('.detail-panel')).toBeVisible();
+
+    const descSection = page.locator('.detail-section').filter({ has: page.locator('h4', { hasText: 'Description' }) });
+    await expect(descSection).toBeVisible();
+    await expect(descSection.locator('.description-text')).toHaveText('app credentials');
+  });
+
+  test('Google Cloud: a secret without a description omits the section', async ({ page }) => {
+    await setupWailsMocks(page, createGoogleCloudState());
+    await page.goto('/');
+    await waitForItemList(page);
+
+    await clickItemByName(page, 'gcloud-secret-2');
+    await expect(page.locator('.detail-panel')).toBeVisible();
+    await expect(page.locator('.detail-section h4', { hasText: 'Description' })).toHaveCount(0);
+  });
+});

--- a/internal/provider/gcloud/secret/secret.go
+++ b/internal/provider/gcloud/secret/secret.go
@@ -12,6 +12,11 @@
 //   - Deletion is permanent (no recovery window), so this store implements
 //     neither provider.Restorer nor provider.Describer.
 //   - Tags are secret "labels" mutated via an UpdateSecret read-modify-write.
+//   - A description is stored as a secret ANNOTATION under the "description" key.
+//     Google Cloud secrets have no native description field, but annotations
+//     (secretmanagerpb.Secret.Annotations, distinct from the labels that back
+//     suve's tag axis) are exactly "for client tools to store their own state",
+//     so a description annotation adds description support with no collision.
 package secret
 
 import (
@@ -81,6 +86,11 @@ type Store struct {
 
 // Compile-time assertion that Store implements the provider contract.
 var _ provider.Store = (*Store)(nil)
+
+// descriptionAnnotation is the secret-annotation key under which suve stores a
+// secret's free-text description. Annotations are distinct from labels (which
+// back the tag axis), so this never collides with a user tag.
+const descriptionAnnotation = "description"
 
 // New builds a Store backed by the given client for the given project id.
 func New(client Client, project string) *Store {
@@ -181,8 +191,9 @@ func (s *Store) versionsNewestFirst(ctx context.Context, name string) ([]*secret
 
 // Get retrieves the secret value at the given ref (latest when ref is latest)
 // and maps it to a domain.Entry. Type is always secret; the integer version and
-// creation time populate Version; the secret's labels become Tags. Extra is
-// left empty (Google Cloud has no ARN-like metadata to surface).
+// creation time populate Version; the secret's labels become Tags and its
+// "description" annotation becomes Description. Extra is left empty (Google
+// Cloud has no ARN-like metadata to surface).
 func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (*domain.Entry, error) {
 	version := ref.ID()
 	if version == "" {
@@ -218,11 +229,13 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 		entry.Modified = created
 	}
 
-	// Best-effort: labels live on the secret, not the version.
+	// Best-effort: labels and the description annotation live on the secret, not
+	// the version.
 	if sec, serr := s.client.GetSecret(ctx, &secretmanagerpb.GetSecretRequest{
 		Name: s.secretPath(name),
 	}); serr == nil && sec != nil {
 		entry.Tags = mapLabels(sec.GetLabels())
+		entry.Description = sec.GetAnnotations()[descriptionAnnotation]
 	}
 
 	return entry, nil
@@ -270,12 +283,12 @@ func (s *Store) List(ctx context.Context) ([]string, error) {
 
 // Create creates a new secret (create-only) and adds its initial value as the
 // first version. It returns a wrapped provider.ErrAlreadyExists if the secret
-// already exists. The valueType and description are ignored (Google Cloud
-// values are always secret and secrets carry no description field).
+// already exists. The valueType is ignored (Google Cloud values are always
+// secret); a non-empty description is stored as the "description" annotation.
 func (s *Store) Create(
-	ctx context.Context, name, value string, _ domain.ValueType, _ string, _ ...provider.WriteOption,
+	ctx context.Context, name, value string, _ domain.ValueType, description string, _ ...provider.WriteOption,
 ) (domain.Version, error) {
-	_, err := s.client.CreateSecret(ctx, s.createRequest(name))
+	_, err := s.client.CreateSecret(ctx, s.createRequest(name, description))
 	if err != nil {
 		if status.Code(err) == codes.AlreadyExists {
 			return domain.Version{}, fmt.Errorf("%w: %s", provider.ErrAlreadyExists, name)
@@ -288,13 +301,25 @@ func (s *Store) Create(
 }
 
 // Put adds a new version to the secret (upsert). If the secret does not yet
-// exist it is created first, then the version is added. The valueType and
-// description are ignored.
+// exist it is created first, then the version is added. The valueType is
+// ignored; a non-empty description is written to the "description" annotation
+// (updating it on an already-existing secret, mirroring the AWS Put contract).
+//
+// Unlike AWS (whose UpdateSecret sets value and description atomically), Secret
+// Manager needs a separate UpdateSecret for the annotation, so on an existing
+// secret the new version is committed first and the annotation second. A failure
+// to write the annotation is reported (never silently dropped, per #666), even
+// though the value version has already landed.
 func (s *Store) Put(
-	ctx context.Context, name, value string, _ domain.ValueType, _ string, _ ...provider.WriteOption,
+	ctx context.Context, name, value string, _ domain.ValueType, description string, _ ...provider.WriteOption,
 ) (domain.Version, error) {
 	sv, err := s.client.AddSecretVersion(ctx, s.addRequest(name, value))
 	if err == nil {
+		// The secret already existed: update its description annotation to match.
+		if aerr := s.applyDescription(ctx, name, description); aerr != nil {
+			return domain.Version{}, aerr
+		}
+
 		return domain.Version{ID: versionNumber(sv.GetName())}, nil
 	}
 
@@ -303,10 +328,16 @@ func (s *Store) Put(
 		return domain.Version{}, fmt.Errorf("failed to add secret version: %w", err)
 	}
 
-	if _, cerr := s.client.CreateSecret(ctx, s.createRequest(name)); cerr != nil {
+	if _, cerr := s.client.CreateSecret(ctx, s.createRequest(name, description)); cerr != nil {
 		// A concurrent create is fine; any other failure is fatal.
 		if status.Code(cerr) != codes.AlreadyExists {
 			return domain.Version{}, fmt.Errorf("failed to create secret: %w", cerr)
+		}
+
+		// A concurrent create won the race, so our annotation was not applied;
+		// set it now to honor the requested description.
+		if aerr := s.applyDescription(ctx, name, description); aerr != nil {
+			return domain.Version{}, aerr
 		}
 	}
 
@@ -323,19 +354,72 @@ func (s *Store) addVersion(ctx context.Context, name, value string) (domain.Vers
 	return domain.Version{ID: versionNumber(sv.GetName())}, nil
 }
 
-// createRequest builds a CreateSecretRequest with automatic replication.
-func (s *Store) createRequest(name string) *secretmanagerpb.CreateSecretRequest {
-	return &secretmanagerpb.CreateSecretRequest{
-		Parent:   s.parent(),
-		SecretId: name,
-		Secret: &secretmanagerpb.Secret{
-			Replication: &secretmanagerpb.Replication{
-				Replication: &secretmanagerpb.Replication_Automatic_{
-					Automatic: &secretmanagerpb.Replication_Automatic{},
-				},
+// createRequest builds a CreateSecretRequest with automatic replication. A
+// non-empty description is carried as the "description" annotation on the new
+// secret; an empty description leaves annotations unset.
+func (s *Store) createRequest(name, description string) *secretmanagerpb.CreateSecretRequest {
+	sec := &secretmanagerpb.Secret{
+		Replication: &secretmanagerpb.Replication{
+			Replication: &secretmanagerpb.Replication_Automatic_{
+				Automatic: &secretmanagerpb.Replication_Automatic{},
 			},
 		},
 	}
+
+	if description != "" {
+		sec.Annotations = map[string]string{descriptionAnnotation: description}
+	}
+
+	return &secretmanagerpb.CreateSecretRequest{
+		Parent:   s.parent(),
+		SecretId: name,
+		Secret:   sec,
+	}
+}
+
+// applyDescription writes a non-empty description to the "description"
+// annotation of an existing secret via a read-modify-write UpdateSecret,
+// preserving any other annotations. An empty description is a no-op (Put/Create
+// never clear an existing description, mirroring the AWS contract).
+func (s *Store) applyDescription(ctx context.Context, name, description string) error {
+	if description == "" {
+		return nil
+	}
+
+	annotations, err := s.currentAnnotations(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	annotations[descriptionAnnotation] = description
+
+	_, err = s.client.UpdateSecret(ctx, &secretmanagerpb.UpdateSecretRequest{
+		Secret: &secretmanagerpb.Secret{
+			Name:        s.secretPath(name),
+			Annotations: annotations,
+		},
+		UpdateMask: &fieldmaskpb.FieldMask{Paths: []string{"annotations"}},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update secret description: %w", err)
+	}
+
+	return nil
+}
+
+// currentAnnotations fetches the secret's current annotations as a mutable map.
+func (s *Store) currentAnnotations(ctx context.Context, name string) (map[string]string, error) {
+	sec, err := s.client.GetSecret(ctx, &secretmanagerpb.GetSecretRequest{
+		Name: s.secretPath(name),
+	})
+	if err != nil {
+		return nil, mapError(err, name, "get secret")
+	}
+
+	annotations := make(map[string]string, len(sec.GetAnnotations()))
+	maps.Copy(annotations, sec.GetAnnotations())
+
+	return annotations, nil
 }
 
 // addRequest builds an AddSecretVersionRequest carrying the given value.

--- a/internal/provider/gcloud/secret/secret_test.go
+++ b/internal/provider/gcloud/secret/secret_test.go
@@ -209,8 +209,9 @@ func TestGet(t *testing.T) {
 		},
 		getFunc: func(_ context.Context, _ *secretmanagerpb.GetSecretRequest) (*secretmanagerpb.Secret, error) {
 			return &secretmanagerpb.Secret{
-				Name:   "projects/my-project/secrets/my-secret",
-				Labels: map[string]string{"env": "prod", "team": "backend"},
+				Name:        "projects/my-project/secrets/my-secret",
+				Labels:      map[string]string{"env": "prod", "team": "backend"},
+				Annotations: map[string]string{"description": "app credentials"},
 			}, nil
 		},
 	}
@@ -226,6 +227,8 @@ func TestGet(t *testing.T) {
 	assert.Equal(t, created, *entry.Version.Created)
 	assert.Nil(t, entry.Extra)
 	assert.Equal(t, []domain.Tag{{Key: "env", Value: "prod"}, {Key: "team", Value: "backend"}}, entry.Tags)
+	// The "description" annotation surfaces as the neutral Description field.
+	assert.Equal(t, "app credentials", entry.Description)
 }
 
 func TestGet_NotFound(t *testing.T) {
@@ -335,6 +338,50 @@ func TestCreate(t *testing.T) {
 		_, err := store.Create(t.Context(), "my-secret", "value", domain.ValueTypeSecret, "")
 		require.ErrorIs(t, err, provider.ErrAlreadyExists)
 	})
+
+	t.Run("description sets the description annotation", func(t *testing.T) {
+		t.Parallel()
+
+		var annotations map[string]string
+
+		m := &mockClient{
+			createFunc: func(_ context.Context, req *secretmanagerpb.CreateSecretRequest) (*secretmanagerpb.Secret, error) {
+				annotations = req.GetSecret().GetAnnotations()
+
+				return &secretmanagerpb.Secret{Name: "projects/my-project/secrets/my-secret"}, nil
+			},
+			addFunc: func(_ context.Context, _ *secretmanagerpb.AddSecretVersionRequest) (*secretmanagerpb.SecretVersion, error) {
+				return &secretmanagerpb.SecretVersion{Name: versionName(1)}, nil
+			},
+		}
+		store := newStore(m)
+
+		_, err := store.Create(t.Context(), "my-secret", "value", domain.ValueTypeSecret, "app credentials")
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"description": "app credentials"}, annotations)
+	})
+
+	t.Run("empty description leaves annotations unset", func(t *testing.T) {
+		t.Parallel()
+
+		var annotations map[string]string
+
+		m := &mockClient{
+			createFunc: func(_ context.Context, req *secretmanagerpb.CreateSecretRequest) (*secretmanagerpb.Secret, error) {
+				annotations = req.GetSecret().GetAnnotations()
+
+				return &secretmanagerpb.Secret{Name: "projects/my-project/secrets/my-secret"}, nil
+			},
+			addFunc: func(_ context.Context, _ *secretmanagerpb.AddSecretVersionRequest) (*secretmanagerpb.SecretVersion, error) {
+				return &secretmanagerpb.SecretVersion{Name: versionName(1)}, nil
+			},
+		}
+		store := newStore(m)
+
+		_, err := store.Create(t.Context(), "my-secret", "value", domain.ValueTypeSecret, "")
+		require.NoError(t, err)
+		assert.Empty(t, annotations)
+	})
 }
 
 func TestPut(t *testing.T) {
@@ -379,6 +426,101 @@ func TestPut(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "1", v.ID)
 		assert.Equal(t, 2, addCalls)
+	})
+
+	t.Run("description updates the annotation on an existing secret", func(t *testing.T) {
+		t.Parallel()
+
+		var written map[string]string
+
+		var mask []string
+
+		m := &mockClient{
+			addFunc: func(_ context.Context, _ *secretmanagerpb.AddSecretVersionRequest) (*secretmanagerpb.SecretVersion, error) {
+				return &secretmanagerpb.SecretVersion{Name: versionName(4)}, nil
+			},
+			getFunc: func(_ context.Context, _ *secretmanagerpb.GetSecretRequest) (*secretmanagerpb.Secret, error) {
+				return &secretmanagerpb.Secret{Annotations: map[string]string{"other": "keep"}}, nil
+			},
+			updateFunc: func(_ context.Context, req *secretmanagerpb.UpdateSecretRequest) (*secretmanagerpb.Secret, error) {
+				written = req.GetSecret().GetAnnotations()
+				mask = req.GetUpdateMask().GetPaths()
+
+				return req.GetSecret(), nil
+			},
+		}
+		store := newStore(m)
+
+		v, err := store.Put(t.Context(), "my-secret", "value", domain.ValueTypeSecret, "rotated key")
+		require.NoError(t, err)
+		assert.Equal(t, "4", v.ID)
+		// The description annotation is merged in, preserving any other annotation.
+		assert.Equal(t, map[string]string{"other": "keep", "description": "rotated key"}, written)
+		assert.Equal(t, []string{"annotations"}, mask)
+	})
+
+	t.Run("description applied via update when a concurrent create wins the race", func(t *testing.T) {
+		t.Parallel()
+
+		var written map[string]string
+
+		m := &mockClient{
+			addFunc: func(_ context.Context, _ *secretmanagerpb.AddSecretVersionRequest) (*secretmanagerpb.SecretVersion, error) {
+				// First AddSecretVersion 404s (no secret yet); the retry after create succeeds.
+				if written == nil {
+					return nil, status.Error(codes.NotFound, "no secret")
+				}
+
+				return &secretmanagerpb.SecretVersion{Name: versionName(1)}, nil
+			},
+			createFunc: func(_ context.Context, _ *secretmanagerpb.CreateSecretRequest) (*secretmanagerpb.Secret, error) {
+				// A concurrent writer created the secret first.
+				return nil, status.Error(codes.AlreadyExists, "exists")
+			},
+			getFunc: func(_ context.Context, _ *secretmanagerpb.GetSecretRequest) (*secretmanagerpb.Secret, error) {
+				return &secretmanagerpb.Secret{}, nil
+			},
+			updateFunc: func(_ context.Context, req *secretmanagerpb.UpdateSecretRequest) (*secretmanagerpb.Secret, error) {
+				written = req.GetSecret().GetAnnotations()
+
+				return req.GetSecret(), nil
+			},
+		}
+		store := newStore(m)
+
+		_, err := store.Put(t.Context(), "my-secret", "value", domain.ValueTypeSecret, "raced desc")
+		require.NoError(t, err)
+		// Even though our create lost the race, the description annotation is applied.
+		assert.Equal(t, map[string]string{"description": "raced desc"}, written)
+	})
+
+	t.Run("description sets the annotation when creating on first write", func(t *testing.T) {
+		t.Parallel()
+
+		var addCalls int
+
+		var annotations map[string]string
+
+		m := &mockClient{
+			addFunc: func(_ context.Context, _ *secretmanagerpb.AddSecretVersionRequest) (*secretmanagerpb.SecretVersion, error) {
+				addCalls++
+				if addCalls == 1 {
+					return nil, status.Error(codes.NotFound, "no secret")
+				}
+
+				return &secretmanagerpb.SecretVersion{Name: versionName(1)}, nil
+			},
+			createFunc: func(_ context.Context, req *secretmanagerpb.CreateSecretRequest) (*secretmanagerpb.Secret, error) {
+				annotations = req.GetSecret().GetAnnotations()
+
+				return &secretmanagerpb.Secret{Name: "projects/my-project/secrets/my-secret"}, nil
+			},
+		}
+		store := newStore(m)
+
+		_, err := store.Put(t.Context(), "my-secret", "value", domain.ValueTypeSecret, "created with desc")
+		require.NoError(t, err)
+		assert.Equal(t, map[string]string{"description": "created with desc"}, annotations)
 	})
 }
 

--- a/internal/staging/cli/command.go
+++ b/internal/staging/cli/command.go
@@ -48,6 +48,14 @@ type CommandConfig struct {
 	// state. When nil, it defaults to AWSScopeResolver, preserving AWS behavior.
 	ScopeResolver staging.ScopeResolver
 
+	// HasDescription reports whether this service's writer honors a free-text
+	// description (AWS param/secret and Google Cloud secret). When true, `stage
+	// add`/`stage edit` register a --description flag; when false the flag is not
+	// registered at all, so a description on an unsupported provider (Azure Key
+	// Vault / App Configuration) is rejected as an unknown flag rather than being
+	// accepted and then silently dropped on apply.
+	HasDescription bool
+
 	// Namespace resolves the App Configuration namespace a single-item staging
 	// op targets, from the command context (the --namespace flag). It records
 	// the namespace on the staged entry as part of its identity. Nil for
@@ -81,6 +89,32 @@ func (c CommandConfig) valueTypeFor(cmd *cli.Command) (domain.ValueType, error) 
 	}
 
 	return c.ValueTypeFromCmd(cmd)
+}
+
+// descriptionFlags returns the --description flag for add/edit when the service
+// honors a description, or an empty slice otherwise (so an unsupported provider
+// rejects --description as an unknown flag rather than silently dropping it).
+func (c CommandConfig) descriptionFlags() []cli.Flag {
+	if !c.HasDescription {
+		return nil
+	}
+
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:  "description",
+			Usage: fmt.Sprintf("Description for the %s", c.ItemName),
+		},
+	}
+}
+
+// description reads the --description flag value; it is always "" when the flag
+// is not registered (unsupported provider).
+func (c CommandConfig) description(cmd *cli.Command) string {
+	if !c.HasDescription {
+		return ""
+	}
+
+	return cmd.String("description")
 }
 
 // namespaceFor returns the single-item namespace for this command context, or ""
@@ -234,12 +268,10 @@ func NewAddCommand(cfg CommandConfig) *cli.Command {
 		Usage:       fmt.Sprintf("Create new %s and stage it", cfg.ItemName),
 		ArgsUsage:   "<name> [value]",
 		Description: addDescription(cfg),
-		Flags: append([]cli.Flag{
-			&cli.StringFlag{
-				Name:  "description",
-				Usage: fmt.Sprintf("Description for the %s", cfg.ItemName),
-			},
-		}, cfg.ValueTypeFlags...),
+		// The --description flag is gated on HasDescription (#666: unsupported
+		// providers reject it rather than silently drop it); value-type flags are
+		// appended for providers with a value-type axis (AWS SSM param, #664).
+		Flags: append(cfg.descriptionFlags(), cfg.ValueTypeFlags...),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.Args().Len() < 1 {
 				return fmt.Errorf("usage: suve stage %s add <name> [value]", cfg.CommandName)
@@ -279,7 +311,7 @@ func NewAddCommand(cfg CommandConfig) *cli.Command {
 			return r.Run(ctx, AddOptions{
 				Name:        name,
 				Value:       value,
-				Description: cmd.String("description"),
+				Description: cfg.description(cmd),
 				Namespace:   cfg.namespaceFor(ctx),
 				ValueType:   valueType,
 			})
@@ -294,12 +326,10 @@ func NewEditCommand(cfg CommandConfig) *cli.Command {
 		Usage:       fmt.Sprintf("Edit %s value and stage changes", cfg.ItemName),
 		ArgsUsage:   "<name> [value]",
 		Description: editDescription(cfg),
-		Flags: append([]cli.Flag{
-			&cli.StringFlag{
-				Name:  "description",
-				Usage: fmt.Sprintf("Description for the %s", cfg.ItemName),
-			},
-		}, cfg.ValueTypeFlags...),
+		// The --description flag is gated on HasDescription (#666: unsupported
+		// providers reject it rather than silently drop it); value-type flags are
+		// appended for providers with a value-type axis (AWS SSM param, #664).
+		Flags: append(cfg.descriptionFlags(), cfg.ValueTypeFlags...),
 		Action: func(ctx context.Context, cmd *cli.Command) error {
 			if cmd.Args().Len() < 1 {
 				return fmt.Errorf("usage: suve stage %s edit <name> [value]", cfg.CommandName)
@@ -339,7 +369,7 @@ func NewEditCommand(cfg CommandConfig) *cli.Command {
 			return r.Run(ctx, EditOptions{
 				Name:        name,
 				Value:       value,
-				Description: cmd.String("description"),
+				Description: cfg.description(cmd),
 				Namespace:   cfg.namespaceFor(ctx),
 				ValueType:   valueType,
 			})

--- a/internal/staging/cli/command_internal_test.go
+++ b/internal/staging/cli/command_internal_test.go
@@ -3,14 +3,56 @@ package cli
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
 
 	"github.com/mpyw/suve/internal/staging"
 	stagingusecase "github.com/mpyw/suve/internal/usecase/staging"
 )
+
+// hasDescriptionFlag reports whether the built command registers a --description
+// flag.
+func hasDescriptionFlag(cmd *cli.Command) bool {
+	return slices.ContainsFunc(cmd.Flags, func(f cli.Flag) bool {
+		return slices.Contains(f.Names(), "description")
+	})
+}
+
+// TestCommandConfig_DescriptionFlagGating pins that add/edit register a
+// --description flag ONLY when the service honors a description (HasDescription).
+// A provider that does not (Azure Key Vault / App Configuration) must reject
+// --description as an unknown flag rather than accept it and drop it on apply
+// (#666 — the previously silent no-op).
+func TestCommandConfig_DescriptionFlagGating(t *testing.T) {
+	t.Parallel()
+
+	supported := CommandConfig{CommandName: "secret", ItemName: "secret", HasDescription: true}
+	assert.True(t, hasDescriptionFlag(NewAddCommand(supported)), "add registers --description when supported")
+	assert.True(t, hasDescriptionFlag(NewEditCommand(supported)), "edit registers --description when supported")
+
+	unsupported := CommandConfig{CommandName: "secret", ItemName: "secret", HasDescription: false}
+	assert.False(t, hasDescriptionFlag(NewAddCommand(unsupported)), "add omits --description when unsupported")
+	assert.False(t, hasDescriptionFlag(NewEditCommand(unsupported)), "edit omits --description when unsupported")
+
+	// Behavioral: an unsupported provider rejects --description at parse time,
+	// before the action runs (so no store is needed).
+	err := NewAddCommand(unsupported).Run(t.Context(), []string{"add", "my-secret", "value", "--description", "x"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "description", "the rejection names the offending flag")
+}
+
+// TestCommandConfig_Description pins the flag reader: it returns "" when the flag
+// is not registered (unsupported provider) and never panics.
+func TestCommandConfig_Description(t *testing.T) {
+	t.Parallel()
+
+	unsupported := CommandConfig{HasDescription: false}
+	assert.Empty(t, unsupported.description(&cli.Command{}))
+}
 
 func TestCommandConfig_NamespaceFor(t *testing.T) {
 	t.Parallel()

--- a/internal/staging/gcloud_secret_test.go
+++ b/internal/staging/gcloud_secret_test.go
@@ -76,6 +76,39 @@ func TestGoogleCloudSecretStrategy_Apply(t *testing.T) {
 		assert.True(t, putCalled)
 	})
 
+	t.Run("staged description reaches the store on apply", func(t *testing.T) {
+		t.Parallel()
+
+		var createDesc, putDesc string
+
+		store := &providermock.Store{
+			CreateFunc: func(_ context.Context, _, _ string, _ domain.ValueType, description string, _ ...provider.WriteOption) (domain.Version, error) {
+				createDesc = description
+
+				return domain.Version{ID: "1"}, nil
+			},
+			PutFunc: func(_ context.Context, _, _ string, _ domain.ValueType, description string, _ ...provider.WriteOption) (domain.Version, error) {
+				putDesc = description
+
+				return domain.Version{ID: "2"}, nil
+			},
+		}
+		s := staging.NewGoogleCloudSecretStrategy(store)
+
+		// A staged create carries the description to Create (#666: previously the
+		// value was accepted, shown in status/diff, then dropped on apply).
+		require.NoError(t, s.Apply(t.Context(), "sec", staging.Entry{
+			Operation: staging.OperationCreate, Value: lo.ToPtr("v1"), Description: lo.ToPtr("app credentials"),
+		}))
+		assert.Equal(t, "app credentials", createDesc)
+
+		// A staged edit carries it to Put.
+		require.NoError(t, s.Apply(t.Context(), "sec", staging.Entry{
+			Operation: staging.OperationUpdate, Value: lo.ToPtr("v2"), Description: lo.ToPtr("rotated key"),
+		}))
+		assert.Equal(t, "rotated key", putDesc)
+	})
+
 	t.Run("delete", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/usecase/gcloud/create.go
+++ b/internal/usecase/gcloud/create.go
@@ -10,8 +10,9 @@ import (
 
 // CreateInput holds input for the create use case.
 type CreateInput struct {
-	Name  string
-	Value string
+	Name        string
+	Value       string
+	Description string
 }
 
 // CreateOutput holds the result of the create use case.
@@ -29,7 +30,7 @@ type CreateUseCase struct {
 // if the secret already exists the provider returns a wrapped
 // provider.ErrAlreadyExists and no overwrite occurs.
 func (u *CreateUseCase) Execute(ctx context.Context, input CreateInput) (*CreateOutput, error) {
-	version, err := u.Writer.Create(ctx, input.Name, input.Value, domain.ValueTypeSecret, "")
+	version, err := u.Writer.Create(ctx, input.Name, input.Value, domain.ValueTypeSecret, input.Description)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create secret: %w", err)
 	}

--- a/internal/usecase/gcloud/gcloud_test.go
+++ b/internal/usecase/gcloud/gcloud_test.go
@@ -67,10 +67,11 @@ func TestShowUseCase(t *testing.T) {
 			assert.Equal(t, "3", ref.ID())
 
 			return &domain.Entry{
-				Name:    name,
-				Value:   "hello",
-				Version: domain.Version{ID: "3", State: "enabled"},
-				Tags:    []domain.Tag{{Key: "env", Value: "prod"}},
+				Name:        name,
+				Value:       "hello",
+				Version:     domain.Version{ID: "3", State: "enabled"},
+				Description: "app credentials",
+				Tags:        []domain.Tag{{Key: "env", Value: "prod"}},
 			}, nil
 		},
 	}
@@ -85,7 +86,56 @@ func TestShowUseCase(t *testing.T) {
 	assert.Equal(t, "hello", out.Value)
 	assert.Equal(t, "3", out.Version)
 	assert.Equal(t, "enabled", out.State)
+	assert.Equal(t, "app credentials", out.Description)
 	assert.Equal(t, []gcloud.ShowTag{{Key: "env", Value: "prod"}}, out.Tags)
+}
+
+// TestCreateUseCase_ThreadsDescription asserts the immediate create use case
+// forwards the description to the writer (stored as the "description"
+// annotation by the Google Cloud adapter) — the immediate axis of #666.
+func TestCreateUseCase_ThreadsDescription(t *testing.T) {
+	t.Parallel()
+
+	var gotDescription string
+
+	store := &providermock.Store{
+		CreateFunc: func(_ context.Context, _, _ string, _ domain.ValueType, description string, _ ...provider.WriteOption) (domain.Version, error) {
+			gotDescription = description
+
+			return domain.Version{ID: "1"}, nil
+		},
+	}
+
+	uc := &gcloud.CreateUseCase{Writer: store}
+	out, err := uc.Execute(t.Context(), gcloud.CreateInput{Name: "my-secret", Value: "v1", Description: "app credentials"})
+	require.NoError(t, err)
+	assert.Equal(t, "1", out.Version)
+	assert.Equal(t, "app credentials", gotDescription)
+}
+
+// TestUpdateUseCase_ThreadsDescription asserts the immediate update use case
+// forwards the description to the writer on Put.
+func TestUpdateUseCase_ThreadsDescription(t *testing.T) {
+	t.Parallel()
+
+	var gotDescription string
+
+	store := &providermock.Store{
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{Name: name, Value: "old"}, nil
+		},
+		PutFunc: func(_ context.Context, _, _ string, _ domain.ValueType, description string, _ ...provider.WriteOption) (domain.Version, error) {
+			gotDescription = description
+
+			return domain.Version{ID: "2"}, nil
+		},
+	}
+
+	uc := &gcloud.UpdateUseCase{Store: store}
+	out, err := uc.Execute(t.Context(), gcloud.UpdateInput{Name: "my-secret", Value: "v2", Description: "rotated key"})
+	require.NoError(t, err)
+	assert.Equal(t, "2", out.Version)
+	assert.Equal(t, "rotated key", gotDescription)
 }
 
 func TestDiffUseCase(t *testing.T) {

--- a/internal/usecase/gcloud/show.go
+++ b/internal/usecase/gcloud/show.go
@@ -28,6 +28,7 @@ type ShowOutput struct {
 	Value       string
 	Version     string // integer version number, or "" for an unknown/latest version
 	State       string // enabled/disabled/destroyed (best-effort), may be ""
+	Description string // the "description" annotation, "" when unset
 	CreatedDate *time.Time
 	Tags        []ShowTag
 }
@@ -55,6 +56,7 @@ func (u *ShowUseCase) Execute(ctx context.Context, input ShowInput) (*ShowOutput
 		Value:       entry.Value,
 		Version:     entry.Version.ID,
 		State:       entry.Version.State,
+		Description: entry.Description,
 		CreatedDate: entry.Version.Created,
 		Tags: lo.Map(entry.Tags, func(tag domain.Tag, _ int) ShowTag {
 			return ShowTag{Key: tag.Key, Value: tag.Value}

--- a/internal/usecase/gcloud/update.go
+++ b/internal/usecase/gcloud/update.go
@@ -11,8 +11,9 @@ import (
 
 // UpdateInput holds input for the update use case.
 type UpdateInput struct {
-	Name  string
-	Value string
+	Name        string
+	Value       string
+	Description string
 }
 
 // UpdateOutput holds the result of the update use case.
@@ -55,7 +56,7 @@ func (u *UpdateUseCase) Execute(ctx context.Context, input UpdateInput) (*Update
 		return nil, err
 	}
 
-	version, err := u.Store.Put(ctx, input.Name, input.Value, domain.ValueTypeSecret, "")
+	version, err := u.Store.Put(ctx, input.Name, input.Value, domain.ValueTypeSecret, input.Description)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update secret: %w", err)
 	}


### PR DESCRIPTION
Closes #750.

## Summary

Extracts the non-TUI portion of the #666 description work from `epic/tui` (landed there as `85d684f`, PR #726) to `main` as a standalone PR, per the maintainer decision that existing-behavior changes riding on `epic/tui` must land independently.

These change user-visible behavior of the existing CLI, independent of the TUI:

1. `suve gcloud secret create/update` gain `--description`, stored as the `description` secret **annotation**; `show` renders/emits it (text + JSON).
2. Staged descriptions are now honored on apply for Google Cloud (previously accepted, shown in status/diff, then silently dropped).
3. `stage add`/`stage edit` register `--description` **only** when the service honors it (`CommandConfig.HasDescription`: AWS param/secret, GCloud secret). **Azure Key Vault / App Configuration now reject `--description` as an unknown flag** instead of silently dropping it — a breaking-ish CLI change deliberately surfaced here rather than buried in the TUI merge.

## Scope

- `internal/provider/gcloud/secret/secret.go` — `description` annotation read-modify-write (`applyDescription`, `currentAnnotations`); create request carries it. `UpdateMask` isolation (`annotations` vs `labels`) keeps tag writes and description writes from clobbering each other; empty `--description` preserves the existing annotation (mirrors AWS).
- `internal/usecase/gcloud/{create,update,show}.go` — thread `Description`.
- `internal/cli/commands/gcloud/{create,update,show,stage}.go` — flag, help, presenter.
- `internal/staging/cli/command.go` — `HasDescription` gating.
- `internal/cli/commands/aws/stage/{param,secret}/command.go`, `internal/cli/commands/gcloud/stage.go` — `HasDescription: true`.
- Unit tests + `e2e/gcloud_secret_test.go` / `e2e/gcloud_stage_test.go`; `docs/gcloud.md`; GUI Playwright fixtures/spec.

## Extraction method

Produced via exact-content checkout of these paths from `origin/epic/tui`, so the content matches byte-for-byte and the later `main` → `epic/tui` merge-back is conflict-free. The TUI/capability bits (`internal/capability` `HasDescription` field + entry-form gating, GUI `models.ts` `hasDescription`) intentionally stay on `epic/tui`.

## Verification

- `go build ./...` — passes.
- `go test ./internal/... ./cmd/...` — all packages pass.
- `golangci-lint run --build-tags=e2e,production` — clean on touched packages (the only full-run finding is a pre-existing `frontend/dist` embed typecheck error present because the Svelte frontend isn't built in a plain checkout; CI builds it).
- e2e not run locally (needs Docker); CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)