### PR TITLE
fix(tui): forward DismissCmd through dialogAdapter so Esc on apply-results reloads (#744)

### DIFF
--- a/internal/tui/dialogs_wire.go
+++ b/internal/tui/dialogs_wire.go
@@ -20,3 +20,19 @@ func (a dialogAdapter) Update(msg tea.Msg) (dialog, tea.Cmd) {
 
 func (a dialogAdapter) View() string { return a.m.View() }
 func (a dialogAdapter) busy() bool   { return a.m.Busy() }
+
+// DismissCmd forwards the optional dialogs.DismissReloader seam through the
+// adapter, mirroring how pages_wire.go's copyable seam forwards CopyText. The
+// app stores every dialog as a dialogAdapter, so the shell's Back handler
+// asserts DismissReloader against the adapter — not the wrapped dialog. Without
+// this the assertion could never succeed and Esc on the apply-results view
+// would bare-pop, skipping the post-apply reload (#744). Returns the wrapped
+// dialog's command when it implements DismissReloader, else nil so the shell
+// bare-dismisses exactly as before.
+func (a dialogAdapter) DismissCmd() tea.Cmd {
+	if d, ok := a.m.(dialogs.DismissReloader); ok {
+		return d.DismissCmd()
+	}
+
+	return nil
+}

--- a/internal/tui/dismiss_reload_test.go
+++ b/internal/tui/dismiss_reload_test.go
@@ -1,0 +1,108 @@
+//nolint:testpackage // white-box: pushes a dialog through the real pushDialog so it is wrapped in dialogAdapter
+package tui
+
+import (
+	"context"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/tui/data"
+	"github.com/mpyw/suve/internal/tui/dialogs"
+	"github.com/mpyw/suve/internal/tui/styles"
+)
+
+// reloadlessDialog is a test-only dialogs.Model that does NOT implement
+// dialogs.DismissReloader, so Esc on it must bare-pop (no reload command).
+type reloadlessDialog struct{}
+
+func (reloadlessDialog) Update(tea.Msg) (dialogs.Model, tea.Cmd) { return reloadlessDialog{}, nil }
+func (reloadlessDialog) View() string                            { return "reloadless" }
+func (reloadlessDialog) Busy() bool                              { return false }
+
+// resultsPhaseApply builds a real apply dialog and drives it through
+// confirm → apply → results via the dialog's own public Update, returning the
+// dialogs.Model in its results phase. Reaching the results phase this way (not
+// by poking unexported fields) mirrors how the shell actually acquires it.
+func resultsPhaseApply(t *testing.T) dialogs.Model {
+	t.Helper()
+
+	svc := &goldenStaging{
+		service: "param", label: "Param",
+		applyResult: data.StagingApplyResult{
+			ServiceLabel: "Param",
+			Entries:      []data.ApplyEntryResult{{Name: "/app/web/CDN_URL", Status: "updated"}},
+		},
+	}
+
+	d := dialogs.NewApply(dialogs.ApplyInput{
+		Ctx: context.Background(), Targets: []data.StagingService{svc},
+		TargetLine: "aws", Title: "Apply staged changes — Param", EntryCount: 1, Styles: styles.New(),
+	})
+
+	d, _ = d.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	d, _ = d.Update(tea.KeyPressMsg{Code: tea.KeyDown})     // focus the Apply button
+	d, cmd := d.Update(tea.KeyPressMsg{Code: tea.KeyEnter}) // confirm → busy, returns the fan-out cmd
+	require.NotNil(t, cmd, "confirming apply returns the fan-out command")
+	require.True(t, d.Busy(), "the dialog is busy while applying")
+
+	d, _ = d.Update(cmd()) // fold the applyResultsMsg back in → results phase
+	require.False(t, d.Busy(), "the dialog left the busy phase once results arrived")
+
+	return d
+}
+
+// TestUpdate_EscOnApplyResultsReloadsThroughAdapter pins #744: the app stores
+// every dialog wrapped in dialogAdapter, so the shell's Back handler asserts
+// dialogs.DismissReloader against the ADAPTER, not the raw *applyDialog. The
+// adapter must forward DismissCmd so Esc on the apply-results view emits
+// MutationDoneMsg (the post-apply reload), instead of bare-popping and leaving
+// the staging sections + tab badge stale. The dialog-package tests missed this
+// because they assert DismissReloader on the raw *applyDialog, never through the
+// adapter the app actually pushes.
+func TestUpdate_EscOnApplyResultsReloadsThroughAdapter(t *testing.T) {
+	t.Parallel()
+
+	m := newApp(config{scope: provider.Scope{Provider: provider.ProviderAWS}, identity: awsIdentityFixture()})
+
+	// pushDialog wraps the dialog in dialogAdapter — the exact production wiring.
+	m.pushDialog(resultsPhaseApply(t), nil)
+	require.Len(t, m.dialogs, 1, "the results dialog is on the stack")
+
+	next, cmd := m.Update(specialKey(tea.KeyEscape))
+	m, ok := next.(*App)
+	require.True(t, ok, "Update returns *App")
+
+	require.NotNil(t, cmd, "Esc on the results view must emit the reload command, not bare-pop")
+	require.Len(t, m.dialogs, 1, "Esc does not bare-pop; the pop happens when MutationDoneMsg is handled")
+
+	done, ok := cmd().(dialogs.MutationDoneMsg)
+	require.True(t, ok, "the reload command emits MutationDoneMsg (the post-apply reload), not a bare pop")
+	assert.True(t, done.Staged, "the apply-results dismiss voices the applied outcome")
+
+	// Feeding the emitted MutationDoneMsg back pops the dialog (the reload path).
+	m = updateApp(t, m, done)
+	assert.Empty(t, m.dialogs, "handling MutationDoneMsg closes the results dialog")
+}
+
+// TestUpdate_EscOnNonReloaderBarePops pins the other side of #744: a dialog that
+// is NOT a dialogs.DismissReloader still bare-pops on Esc through the adapter —
+// the forwarded DismissCmd returns nil, so the shell falls back to the plain pop
+// with no reload command.
+func TestUpdate_EscOnNonReloaderBarePops(t *testing.T) {
+	t.Parallel()
+
+	m := newApp(config{scope: provider.Scope{Provider: provider.ProviderAWS}, identity: awsIdentityFixture()})
+	m.pushDialog(reloadlessDialog{}, nil)
+	require.Len(t, m.dialogs, 1, "the reloadless dialog is on the stack")
+
+	next, cmd := m.Update(specialKey(tea.KeyEscape))
+	m, ok := next.(*App)
+	require.True(t, ok, "Update returns *App")
+
+	assert.Empty(t, m.dialogs, "Esc bare-pops a non-DismissReloader dialog")
+	assert.Nil(t, cmd, "a bare pop emits no reload command")
+}

--- a/internal/tui/dismiss_reload_test.go
+++ b/internal/tui/dismiss_reload_test.go
@@ -40,7 +40,7 @@ func resultsPhaseApply(t *testing.T) dialogs.Model {
 
 	d := dialogs.NewApply(dialogs.ApplyInput{
 		Ctx: context.Background(), Targets: []data.StagingService{svc},
-		TargetLine: "aws", Title: "Apply staged changes — Param", EntryCount: 1, Styles: styles.New(),
+		TargetLine: string(provider.ProviderAWS), Title: "Apply staged changes — Param", EntryCount: 1, Styles: styles.New(),
 	})
 
 	d, _ = d.Update(tea.WindowSizeMsg{Width: 80, Height: 24})


### PR DESCRIPTION
Closes #744

## Root cause — a dead type assertion

The `DismissReloader` seam that makes Esc-closing the apply-results dialog reload the staging page was **dead code in production wiring**.

The app stores every dialog wrapped in `dialogAdapter` (`internal/tui/dialogs_wire.go`), which implemented only `Update`/`View`/`busy`. The shell's Back (Esc) handler at `internal/tui/app.go:532` does:

```go
if d, ok := m.dialogs[len(m.dialogs)-1].(dialogs.DismissReloader); ok { ... }
```

That asserts `DismissReloader` against the **adapter**, which never satisfied it — so the assertion was always `false`. Pressing **Esc** on the apply-results view therefore bare-popped the dialog **without** emitting `MutationDoneMsg`, so the post-apply staging reload never ran: applied entries stayed listed as staged and the Staging tab badge stayed inflated until a manual `ctrl+r`. Pressing **Enter** was unaffected (it routes through the dialog's done path), which is why manual QA and the dialog-package unit tests passed. This silently reintroduced the symptom #669 was closed for.

`(*applyDialog).DismissCmd` (`internal/tui/dialogs/apply.go`) was the only `DismissReloader` and was unreachable through the adapter.

## Fix

Give `dialogAdapter` a `DismissCmd()` that forwards to the wrapped dialog when it implements `dialogs.DismissReloader` (returning `nil` otherwise), mirroring how the `copyable` seam is forwarded in `pages_wire.go`. The adapter now satisfies `DismissReloader`, so the `app.go:532` assertion succeeds; a dialog that is **not** a `DismissReloader` returns `nil` and still bare-pops exactly as before (no change to the existing behavior).

## Regression test — through the adapter

The existing dialog-package tests asserted `DismissReloader` on the raw `*applyDialog`, never through the `dialogAdapter` the app actually stores — so they could not have caught this. New **app-level** tests in `internal/tui/dismiss_reload_test.go`:

- `TestUpdate_EscOnApplyResultsReloadsThroughAdapter` — builds a real `applyDialog`, drives it to the results phase via its public `Update`, pushes it through the real `pushDialog` (so it is wrapped in `dialogAdapter`, the exact production wiring), sends Esc through `App.Update`, and asserts the returned command emits `MutationDoneMsg` (the reload) — **not** a bare pop.
- `TestUpdate_EscOnNonReloaderBarePops` — a non-`DismissReloader` dialog still bare-pops on Esc (nil command).

Confirmed the results-phase test **fails without the fix** (temporarily renaming the adapter method → assertion falls through to a bare pop with a nil command) and **passes with it**.

## Verification

```
go build ./...                              # ok
go test ./internal/tui/...                  # ok
go test ./internal/tui/... -race            # ok
golangci-lint run --allow-parallel-runners ./internal/tui/...
# clean for changed files (one preexisting goconst in app.go, unmodified by this PR)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)