### PR TITLE
fix(tui): scroll history by rendered line height so selection and bottom versions stay reachable (#745)

### DIFF
--- a/internal/tui/components/historytable.go
+++ b/internal/tui/components/historytable.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"slices"
 	"strings"
 
 	"github.com/mpyw/suve/internal/tui/styles"
@@ -309,17 +310,50 @@ func (t *HistoryTable) renderRow(idx int) string {
 	return truncate(strings.Join(parts, "  "), t.width)
 }
 
+// visibleRows returns the window's height in rendered lines. It is the per-View
+// line budget window() fills, not a row count: a row renders as 1–3 lines, so
+// the offset math below converts between the two by summing per-row line counts.
 func (t *HistoryTable) visibleRows() int { return t.height }
 
-// maxOffset caps scrolling so the last row stays reachable.
+// maxOffset caps scrolling so the last row's final line stays reachable at the
+// bottom of the window. Because rows render as 1–3 lines, this is not
+// len(rows)-height: it is the smallest row offset whose rows [offset..end] fill
+// (without exceeding) the line budget, found by walking rows from the end and
+// accumulating their rendered line counts until the next row would overflow.
 func (t *HistoryTable) maxOffset() int {
-	return max(len(t.rows)-t.visibleRows(), 0)
+	budget := t.visibleRows()
+	if budget <= 0 || len(t.rows) == 0 {
+		return 0
+	}
+
+	total := 0
+	offset := len(t.rows)
+
+	for i := range slices.Backward(t.rows) {
+		h := len(t.rowLines(i))
+		if total+h > budget {
+			break
+		}
+
+		total += h
+		offset = i
+	}
+
+	// When even the last row alone overflows the budget, it can still be scrolled
+	// to (its top line at the pane top), so cap the offset at the last row.
+	return min(offset, len(t.rows)-1)
 }
 
-// ensureVisible keeps the selection on-screen.
+// ensureVisible keeps the selected row's rendered lines fully inside the
+// line-budget window. It scrolls up when the selection starts above the window,
+// and down when the selection's lines extend past the window bottom — walking up
+// from the selected row accumulating line counts to find the smallest offset
+// that still shows the selected row's final line — then clamps to the valid
+// range. Line counts come from rowLines, the same source window() uses, so the
+// scroll math and the mouse hit-map never disagree.
 func (t *HistoryTable) ensureVisible() {
-	visible := t.visibleRows()
-	if visible <= 0 {
+	budget := t.visibleRows()
+	if budget <= 0 || len(t.rows) == 0 {
 		t.offset = 0
 
 		return
@@ -329,8 +363,23 @@ func (t *HistoryTable) ensureVisible() {
 		t.offset = t.selected
 	}
 
-	if t.selected >= t.offset+visible {
-		t.offset = t.selected - visible + 1
+	// Find the smallest offset whose rows [offset..selected] fit the budget, so
+	// the selected row's last line lands at or above the window bottom.
+	total := 0
+	minOffset := t.selected
+
+	for i := t.selected; i >= 0; i-- {
+		h := len(t.rowLines(i))
+		if total+h > budget {
+			break
+		}
+
+		total += h
+		minOffset = i
+	}
+
+	if t.offset < minOffset {
+		t.offset = minOffset
 	}
 
 	t.offset = clamp(t.offset, 0, t.maxOffset())

--- a/internal/tui/components/historytable_internal_test.go
+++ b/internal/tui/components/historytable_internal_test.go
@@ -1,0 +1,186 @@
+package components
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/tui/styles"
+)
+
+// windowRowSpan returns the number of rendered lines the window currently draws
+// for row idx, derived from window()'s parallel rowOf slice. It is the ground
+// truth for "how much of a row is on-screen" without hard-coding line offsets.
+func windowRowSpan(t *HistoryTable, idx int) int {
+	_, rowOf := t.window()
+
+	n := 0
+
+	for _, r := range rowOf {
+		if r == idx {
+			n++
+		}
+	}
+
+	return n
+}
+
+// windowLinesForRow returns the rendered lines the window currently draws for
+// row idx, in order, so a test can compare them against rowLines(idx).
+func windowLinesForRow(t *HistoryTable, idx int) []string {
+	lines, rowOf := t.window()
+
+	var out []string
+
+	for i, r := range rowOf {
+		if r == idx {
+			out = append(out, lines[i])
+		}
+	}
+
+	return out
+}
+
+// valuedRows builds n version rows that each carry a (non-secret) value, so each
+// renders as two lines (header + value). Non-secret keeps reveal state out of the
+// picture: the value line is present and identical whether or not the table is
+// revealed.
+func valuedRows(n int) []HistoryEntry {
+	rows := make([]HistoryEntry, n)
+	for i := range rows {
+		rows[i] = HistoryEntry{
+			Label: "#" + string(rune('A'+i)),
+			Date:  "2026-07-13",
+			Value: "value-" + string(rune('A'+i)),
+		}
+	}
+
+	return rows
+}
+
+// TestHistoryTableRowLineHeights documents the multi-line-row premise the scroll
+// math must honor: a valued row is two lines and a Key Vault tag row is three.
+func TestHistoryTableRowLineHeights(t *testing.T) {
+	t.Parallel()
+
+	tbl := NewHistoryTable(styles.New())
+	tbl.SetRows([]HistoryEntry{
+		{Label: "#A", Value: "v"},
+		{Label: "#B", Value: "v", TagsLine: "env=prod"},
+	})
+	tbl.SetSize(40, 6)
+
+	require.Len(t, tbl.rowLines(0), 2, "a valued row renders as header + value line")
+	require.Len(t, tbl.rowLines(1), 3, "a valued row with a Key Vault tag renders as header + value + tag line")
+}
+
+// TestHistoryTableSelectLastRowFullyVisible pins the core #745 fix: selecting the
+// last row must bring all of that row's rendered lines (header AND value) into the
+// window, even though earlier rows are multi-line and the window is only 6 lines.
+func TestHistoryTableSelectLastRowFullyVisible(t *testing.T) {
+	t.Parallel()
+
+	tbl := NewHistoryTable(styles.New())
+	rows := valuedRows(8)
+	// Give the last row a Key Vault tag line so it is a 3-line row — the worst case.
+	rows[len(rows)-1].TagsLine = "env=prod"
+	tbl.SetRows(rows)
+	tbl.SetSize(40, 6)
+
+	last := tbl.Len() - 1
+	tbl.SelectIndex(last)
+
+	want := tbl.rowLines(last)
+	got := windowLinesForRow(&tbl, last)
+	assert.Equal(t, want, got, "selecting the last row must show all of its rendered lines (header, value, tag)")
+	assert.Len(t, got, len(want), "the selected row must be fully, not partially, visible")
+}
+
+// TestHistoryTableScrollReachesBottom pins that wheel scrolling can advance the
+// offset far enough for the last row's final line to reach the window: with 2-line
+// rows and a 6-line window, maxOffset must expose the whole last row, not stop 3
+// rows short the way the old len(rows)-height math did.
+func TestHistoryTableScrollReachesBottom(t *testing.T) {
+	t.Parallel()
+
+	tbl := NewHistoryTable(styles.New())
+	tbl.SetRows(valuedRows(8))
+	tbl.SetSize(40, 6)
+
+	// A big wheel delta clamps to maxOffset.
+	tbl.Scroll(100)
+
+	last := tbl.Len() - 1
+	want := tbl.rowLines(last)
+	got := windowLinesForRow(&tbl, last)
+	assert.Equal(t, want, got, "wheel-scrolling to the bottom must fully reveal the last row")
+
+	// The offset the fix produces is strictly larger than the old rows-minus-lines
+	// math (8 - 6 = 2), which is what left the bottom rows unreachable.
+	assert.Greater(t, tbl.offset, tbl.Len()-tbl.height, "line-based maxOffset must exceed the old rows-minus-lines value")
+}
+
+// TestHistoryTableBottomRowsReachableHalfScreen is the direct regression for the
+// filed scenario: with N valued rows and a window that fits only about half of
+// them, keyboard-selecting each of the bottom rows must keep it fully visible.
+func TestHistoryTableBottomRowsReachableHalfScreen(t *testing.T) {
+	t.Parallel()
+
+	const n = 10
+
+	tbl := NewHistoryTable(styles.New())
+	tbl.SetRows(valuedRows(n)) // 20 rendered lines
+	tbl.SetSize(40, 6)         // fits ~3 rows
+
+	for i := range n {
+		tbl.SelectIndex(i)
+		assert.Equalf(t, len(tbl.rowLines(i)), windowRowSpan(&tbl, i),
+			"selecting row %d must keep all its lines visible", i)
+	}
+}
+
+// TestHistoryTableKeyboardWalkKeepsSelectionVisible walks the selection down one
+// row at a time (as the down key does) and asserts the selection is never drawn
+// off-screen — the exact failure the issue describes.
+func TestHistoryTableKeyboardWalkKeepsSelectionVisible(t *testing.T) {
+	t.Parallel()
+
+	tbl := NewHistoryTable(styles.New())
+	tbl.SetRows(valuedRows(9))
+	tbl.SetSize(40, 6)
+
+	for range tbl.Len() - 1 {
+		tbl.Move(1)
+		sel := tbl.Selected()
+		assert.Equalf(t, len(tbl.rowLines(sel)), windowRowSpan(&tbl, sel),
+			"row %d must be fully visible after moving down onto it", sel)
+	}
+}
+
+// TestHistoryTableSingleLineWheel keeps the original wheel premise green: with
+// single-line rows (no value), lines == rows, and maxOffset behaves like the
+// classic rows-minus-height value.
+func TestHistoryTableSingleLineWheel(t *testing.T) {
+	t.Parallel()
+
+	rows := make([]HistoryEntry, 8)
+	for i := range rows {
+		rows[i] = HistoryEntry{Label: "#" + string(rune('A'+i))}
+	}
+
+	tbl := NewHistoryTable(styles.New())
+	tbl.SetRows(rows)
+	tbl.SetSize(40, 5)
+
+	for i := range rows {
+		require.Lenf(t, tbl.rowLines(i), 1, "row %d must be a single line", i)
+	}
+
+	tbl.Scroll(100)
+	assert.Equal(t, tbl.Len()-tbl.height, tbl.maxOffset(), "single-line rows: maxOffset is rows minus height")
+	assert.Equal(t, tbl.maxOffset(), tbl.offset, "a large wheel clamps to maxOffset")
+
+	last := tbl.Len() - 1
+	assert.Equal(t, tbl.rowLines(last), windowLinesForRow(&tbl, last), "the last single-line row is reachable")
+}


### PR DESCRIPTION
Closes #745

## Root cause: rows counted as lines

`internal/tui/components/historytable.go` conflated **rows** with rendered **lines**. A history row renders as 1-3 lines (`rowLines`: version header + optional indented value line + optional Key Vault per-version tag line), but the scroll math treated the line budget as a row capacity:

- `visibleRows()` returned `t.height` — a **line** budget.
- `maxOffset()` was `len(t.rows) - t.visibleRows()` — rows minus lines.
- `ensureVisible()` assumed `visible` **rows** fit in the window.
- `window()` correctly emits up to `visible` **lines** starting at row `offset` — so `offset` is a row index while the budget is lines.

Since #733, every secret-service history row and every SecureString param row carries a value line (>= 2 lines/row). In that common case the selected row scrolled off-screen (selected but undrawn), and the bottom versions could never reach the top of the pane by wheel or keyboard. The one existing wheel test built rows with **no value** (single-line, `lines == rows`), the only case where the old math happened to work — which is why the bug went untested.

## Fix: offset math on rendered heights

- `maxOffset()` walks rows from the end, accumulating `len(rowLines(i))`, and returns the smallest offset whose rows fill (without exceeding) the `t.height` line budget — the largest offset that still shows the last row's final line at/above the bottom. When even the last row overflows the budget alone, it caps at the last row so it stays scrollable.
- `ensureVisible()` scrolls up when the selection starts above `offset`, and walks up from the selected row accumulating line counts to find the smallest offset that still shows the selected row's final line, then clamps to `[0, maxOffset()]`.

Line counts come from the same `rowLines()` source `window()` uses, so the scroll math and the mouse hit-map (`RowAtLine`/`rowOf`) never disagree. `window()`/`rowLines()`/`RowAtLine` are unchanged (they already worked in lines).

## Tests

New white-box tests in `internal/tui/components/historytable_internal_test.go` build 2-line valued rows and a 3-line Key Vault tag row at a small height (6 lines) and assert, deriving all expectations from `rowLines`/`window` output (no magic numbers):

- Selecting the last row makes all of its rendered lines (header **and** value/tag) visible in `window()`.
- Wheel-scrolling to the bottom fully reveals the last row (offset advances past the old `len(rows)-height` value).
- With N valued rows at a half-screen height, keyboard-selecting each bottom row keeps it fully visible.
- The original single-line wheel premise stays green (`lines == rows`, classic rows-minus-height `maxOffset`).

These tests fail on the old rows-as-lines math (selection renders off-screen, `windowRowSpan == 0`) and pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)