### PR TITLE
fix(aws): show param/secret descriptions (read + display parity)

### DIFF
--- a/e2e/aws_param_test.go
+++ b/e2e/aws_param_test.go
@@ -2065,6 +2065,21 @@ func TestAWSParam_CreateWithDescription(t *testing.T) {
 	stdout, _, err := runCommand(t, paramcreate.Command(), "--description", "Test parameter description", paramName, "value")
 	require.NoError(t, err)
 	assert.Contains(t, stdout, "Created")
+
+	// #753: the description must round-trip back through `show` (adapter Get
+	// reads it best-effort via DescribeParameters; the show presenter renders it).
+	t.Run("show-renders-description", func(t *testing.T) {
+		stdout, _, err := runCommand(t, cmdparam.ShowCommand(), paramName)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "Description")
+		assert.Contains(t, stdout, "Test parameter description")
+	})
+
+	t.Run("show-json-includes-description", func(t *testing.T) {
+		stdout, _, err := runCommand(t, cmdparam.ShowCommand(), "--output=json", paramName)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, `"description": "Test parameter description"`)
+	})
 }
 
 // TestAWSParam_CreateDuplicate tests creating a duplicate parameter.

--- a/e2e/aws_secret_test.go
+++ b/e2e/aws_secret_test.go
@@ -702,6 +702,39 @@ func TestAWSSecret_CreateAndTag(t *testing.T) {
 	assert.Contains(t, stdout, "team: suve")
 }
 
+// TestAWSSecret_CreateWithDescription guards #753: a secret created with a
+// description must surface it back through `show` (text and JSON). The adapter
+// already reads it via DescribeSecret; this proves the show presenter renders it.
+func TestAWSSecret_CreateWithDescription(t *testing.T) {
+	setupEnv(t)
+
+	secretName := "suve-e2e-create/with-description"
+
+	// Cleanup
+	_, _, _ = runCommand(t, secretdelete.Command(), "--yes", "--force", secretName)
+	t.Cleanup(func() {
+		_, _, _ = runCommand(t, secretdelete.Command(), "--yes", "--force", secretName)
+	})
+
+	// Create secret with description
+	stdout, _, err := runCommand(t, secretcreate.Command(), "--description", "app credentials", secretName, "value")
+	require.NoError(t, err)
+	assert.Contains(t, stdout, "Created")
+
+	t.Run("show-renders-description", func(t *testing.T) {
+		stdout, _, err := runCommand(t, cmdsecret.ShowCommand(), secretName)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, "Description")
+		assert.Contains(t, stdout, "app credentials")
+	})
+
+	t.Run("show-json-includes-description", func(t *testing.T) {
+		stdout, _, err := runCommand(t, cmdsecret.ShowCommand(), "--output=json", secretName)
+		require.NoError(t, err)
+		assert.Contains(t, stdout, `"description": "app credentials"`)
+	})
+}
+
 // TestAWSSecret_CreateDuplicate tests creating a duplicate secret.
 func TestAWSSecret_CreateDuplicate(t *testing.T) {
 	setupEnv(t)

--- a/internal/cli/commands/aws/param/show.go
+++ b/internal/cli/commands/aws/param/show.go
@@ -23,13 +23,14 @@ import (
 
 // showJSONOutput represents the JSON output structure for the show command.
 type showJSONOutput struct {
-	Name       string            `json:"name"`
-	Version    int64             `json:"version"`
-	Type       string            `json:"type"`
-	JSONParsed *bool             `json:"json_parsed,omitempty"` //nolint:tagliatelle // snake_case for backwards compatibility
-	Modified   string            `json:"modified,omitempty"`
-	Tags       map[string]string `json:"tags"`
-	Value      string            `json:"value"`
+	Name        string            `json:"name"`
+	Version     int64             `json:"version"`
+	Type        string            `json:"type"`
+	JSONParsed  *bool             `json:"json_parsed,omitempty"` //nolint:tagliatelle // snake_case for backwards compatibility
+	Modified    string            `json:"modified,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Tags        map[string]string `json:"tags"`
+	Value       string            `json:"value"`
 }
 
 // showPresenter renders SSM Parameter Store show output byte-for-byte as before.
@@ -93,6 +94,10 @@ func (p *showPresenter) RenderText(stdout io.Writer, value string) {
 		out.Field("Modified", timeutil.FormatRFC3339(*result.LastModified))
 	}
 
+	if result.Description != "" {
+		out.Field("Description", result.Description)
+	}
+
 	if len(result.Tags) > 0 {
 		out.Field("Tags", fmt.Sprintf("%d tag(s)", len(result.Tags)))
 
@@ -121,6 +126,10 @@ func (p *showPresenter) RenderJSON(stdout io.Writer, value string) error {
 
 	if result.LastModified != nil {
 		jsonOut.Modified = timeutil.FormatRFC3339(*result.LastModified)
+	}
+
+	if result.Description != "" {
+		jsonOut.Description = result.Description
 	}
 
 	jsonOut.Tags = make(map[string]string)

--- a/internal/cli/commands/aws/param/show_test.go
+++ b/internal/cli/commands/aws/param/show_test.go
@@ -1,0 +1,101 @@
+package param_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	awsparam "github.com/mpyw/suve/internal/cli/commands/aws/param"
+	"github.com/mpyw/suve/internal/domain"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/providermock"
+	"github.com/mpyw/suve/internal/version/awsparamversion"
+)
+
+// TestShowPresenter_RendersDescription guards #753: a parameter carrying a
+// description must surface it in both the text and JSON show output.
+func TestShowPresenter_RendersDescription(t *testing.T) {
+	t.Parallel()
+
+	store := &providermock.Store{
+		ResolveFunc: func(_ context.Context, _, _ string) (provider.VersionRef, error) {
+			return provider.VersionRef{}, nil
+		},
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{
+				Name:        name,
+				Value:       "hunter2",
+				Type:        domain.ValueTypePlaintext,
+				Version:     domain.Version{ID: "3"},
+				Description: "app credentials",
+			}, nil
+		},
+	}
+
+	spec, err := awsparamversion.Parse("/my/param")
+	require.NoError(t, err)
+
+	presenter := awsparam.NewShowPresenter(store, spec)
+	require.NoError(t, presenter.Fetch(t.Context()))
+
+	var buf, errBuf bytes.Buffer
+
+	value := presenter.Value(false, &errBuf)
+
+	presenter.RenderText(&buf, value)
+	text := buf.String()
+	assert.Contains(t, text, "Description")
+	assert.Contains(t, text, "app credentials")
+
+	buf.Reset()
+	require.NoError(t, presenter.RenderJSON(&buf, value))
+
+	var jsonOut map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &jsonOut))
+	assert.Equal(t, "app credentials", jsonOut["description"])
+}
+
+// TestShowPresenter_OmitsEmptyDescription guards that a parameter without a
+// description renders neither the text field nor the JSON key.
+func TestShowPresenter_OmitsEmptyDescription(t *testing.T) {
+	t.Parallel()
+
+	store := &providermock.Store{
+		ResolveFunc: func(_ context.Context, _, _ string) (provider.VersionRef, error) {
+			return provider.VersionRef{}, nil
+		},
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{
+				Name:    name,
+				Value:   "hunter2",
+				Type:    domain.ValueTypePlaintext,
+				Version: domain.Version{ID: "3"},
+			}, nil
+		},
+	}
+
+	spec, err := awsparamversion.Parse("/my/param")
+	require.NoError(t, err)
+
+	presenter := awsparam.NewShowPresenter(store, spec)
+	require.NoError(t, presenter.Fetch(t.Context()))
+
+	var buf, errBuf bytes.Buffer
+
+	value := presenter.Value(false, &errBuf)
+
+	presenter.RenderText(&buf, value)
+	assert.NotContains(t, buf.String(), "Description")
+
+	buf.Reset()
+	require.NoError(t, presenter.RenderJSON(&buf, value))
+
+	var jsonOut map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &jsonOut))
+	_, hasDescription := jsonOut["description"]
+	assert.False(t, hasDescription)
+}

--- a/internal/cli/commands/aws/secret/show.go
+++ b/internal/cli/commands/aws/secret/show.go
@@ -19,13 +19,14 @@ import (
 
 // showJSONOutput represents the JSON output structure for the show command.
 type showJSONOutput struct {
-	Name      string            `json:"name"`
-	ARN       string            `json:"arn"`
-	VersionID string            `json:"versionId,omitempty"`
-	Stages    []string          `json:"stages,omitempty"`
-	Created   string            `json:"created,omitempty"`
-	Tags      map[string]string `json:"tags"`
-	Value     string            `json:"value"`
+	Name        string            `json:"name"`
+	ARN         string            `json:"arn"`
+	VersionID   string            `json:"versionId,omitempty"`
+	Stages      []string          `json:"stages,omitempty"`
+	Created     string            `json:"created,omitempty"`
+	Description string            `json:"description,omitempty"`
+	Tags        map[string]string `json:"tags"`
+	Value       string            `json:"value"`
 }
 
 // showPresenter renders Secrets Manager show output byte-for-byte as before.
@@ -82,6 +83,10 @@ func (p *showPresenter) RenderText(stdout io.Writer, value string) {
 		out.Field("Created", timeutil.FormatRFC3339(*result.CreatedDate))
 	}
 
+	if result.Description != "" {
+		out.Field("Description", result.Description)
+	}
+
 	if len(result.Tags) > 0 {
 		out.Field("Tags", fmt.Sprintf("%d tag(s)", len(result.Tags)))
 
@@ -112,6 +117,10 @@ func (p *showPresenter) RenderJSON(stdout io.Writer, value string) error {
 
 	if result.CreatedDate != nil {
 		jsonOut.Created = timeutil.FormatRFC3339(*result.CreatedDate)
+	}
+
+	if result.Description != "" {
+		jsonOut.Description = result.Description
 	}
 
 	jsonOut.Tags = make(map[string]string)

--- a/internal/cli/commands/aws/secret/show_test.go
+++ b/internal/cli/commands/aws/secret/show_test.go
@@ -1,0 +1,96 @@
+package secret_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	awssecret "github.com/mpyw/suve/internal/cli/commands/aws/secret"
+	"github.com/mpyw/suve/internal/domain"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/providermock"
+	"github.com/mpyw/suve/internal/version/awssecretversion"
+)
+
+// TestShowPresenter_RendersDescription guards #753: a secret carrying a
+// description must surface it in both the text and JSON show output.
+func TestShowPresenter_RendersDescription(t *testing.T) {
+	t.Parallel()
+
+	store := &providermock.Store{
+		ResolveFunc: func(_ context.Context, _, _ string) (provider.VersionRef, error) {
+			return provider.VersionRef{}, nil
+		},
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{
+				Name:        name,
+				Value:       "s3cr3t",
+				Type:        domain.ValueTypeSecret,
+				Version:     domain.Version{ID: "v1"},
+				Description: "app credentials",
+			}, nil
+		},
+	}
+
+	spec, err := awssecretversion.Parse("my-secret")
+	require.NoError(t, err)
+
+	presenter := awssecret.NewShowPresenter(store, spec)
+	require.NoError(t, presenter.Fetch(t.Context()))
+
+	var buf, errBuf bytes.Buffer
+
+	value := presenter.Value(false, &errBuf)
+
+	presenter.RenderText(&buf, value)
+	text := buf.String()
+	assert.Contains(t, text, "Description")
+	assert.Contains(t, text, "app credentials")
+
+	buf.Reset()
+	require.NoError(t, presenter.RenderJSON(&buf, value))
+
+	var jsonOut map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &jsonOut))
+	assert.Equal(t, "app credentials", jsonOut["description"])
+}
+
+// TestShowPresenter_OmitsEmptyDescription guards that a secret without a
+// description renders neither the text field nor the JSON key.
+func TestShowPresenter_OmitsEmptyDescription(t *testing.T) {
+	t.Parallel()
+
+	store := &providermock.Store{
+		ResolveFunc: func(_ context.Context, _, _ string) (provider.VersionRef, error) {
+			return provider.VersionRef{}, nil
+		},
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{Name: name, Value: "s3cr3t", Type: domain.ValueTypeSecret}, nil
+		},
+	}
+
+	spec, err := awssecretversion.Parse("my-secret")
+	require.NoError(t, err)
+
+	presenter := awssecret.NewShowPresenter(store, spec)
+	require.NoError(t, presenter.Fetch(t.Context()))
+
+	var buf, errBuf bytes.Buffer
+
+	value := presenter.Value(false, &errBuf)
+
+	presenter.RenderText(&buf, value)
+	assert.NotContains(t, buf.String(), "Description")
+
+	buf.Reset()
+	require.NoError(t, presenter.RenderJSON(&buf, value))
+
+	var jsonOut map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &jsonOut))
+	_, hasDescription := jsonOut["description"]
+	assert.False(t, hasDescription)
+}

--- a/internal/gui/frontend/tests/description-display.spec.ts
+++ b/internal/gui/frontend/tests/description-display.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupWailsMocks,
+  waitForItemList,
+  clickItemByName,
+  navigateTo,
+} from './fixtures/wails-mock';
+
+// #753: AWS param/secret descriptions are written but were never shown back.
+// Once the adapter Get populates Entry.Description and the CLI show renders it,
+// the GUI needs no code change — the detail pane already gates on a non-empty
+// description. These specs prove the description flows through to the detail
+// pane for both AWS services (and stays hidden when empty).
+test.describe('AWS description display (#753)', () => {
+  test.describe('Parameter', () => {
+    test.beforeEach(async ({ page }) => {
+      await setupWailsMocks(page, {
+        params: [
+          { name: '/app/described', type: 'String', value: 'v', description: 'parameter description text' },
+          { name: '/app/plain', type: 'String', value: 'v' },
+        ],
+      });
+      await page.goto('/');
+      await waitForItemList(page);
+    });
+
+    test('renders the description in the detail pane', async ({ page }) => {
+      await clickItemByName(page, '/app/described');
+      const section = page.locator('.detail-section').filter({ hasText: 'Description' });
+      await expect(section).toBeVisible();
+      await expect(section.locator('.description-text')).toContainText('parameter description text');
+    });
+
+    test('omits the description section when empty', async ({ page }) => {
+      await clickItemByName(page, '/app/plain');
+      await expect(page.locator('.detail-panel')).toBeVisible();
+      await expect(page.locator('.description-text')).toHaveCount(0);
+    });
+  });
+
+  test.describe('Secret', () => {
+    test.beforeEach(async ({ page }) => {
+      await setupWailsMocks(page, {
+        secrets: [
+          { name: 'described-secret', value: 'v', description: 'secret description text' },
+          { name: 'plain-secret', value: 'v' },
+        ],
+      });
+      await page.goto('/');
+      await waitForItemList(page);
+      await navigateTo(page, 'Secret');
+    });
+
+    test('renders the description in the detail pane', async ({ page }) => {
+      await clickItemByName(page, 'described-secret');
+      const section = page.locator('.detail-section').filter({ hasText: 'Description' });
+      await expect(section).toBeVisible();
+      await expect(section.locator('.description-text')).toContainText('secret description text');
+    });
+
+    test('omits the description section when empty', async ({ page }) => {
+      await clickItemByName(page, 'plain-secret');
+      await expect(page.locator('.detail-panel')).toBeVisible();
+      await expect(page.locator('.description-text')).toHaveCount(0);
+    });
+  });
+});

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -12,6 +12,9 @@ export interface Parameter {
   // omitted is the null/default namespace. Populated into ParamListEntry.namespace
   // by ParamList so the GUI can filter by namespace client-side (#425).
   namespace?: string;
+  // Optional human-readable description surfaced by ParamShow. Empty / omitted
+  // renders nothing (the detail pane gates on a non-empty value).
+  description?: string;
 }
 
 export interface Secret {
@@ -29,6 +32,9 @@ export interface Secret {
   stagingLabels?: string[];
   state?: string;
   versionId?: string;
+  // Optional human-readable description surfaced by SecretShow. Empty / omitted
+  // renders nothing (the detail pane gates on a non-empty value).
+  description?: string;
 }
 
 export interface Tag {
@@ -957,7 +963,7 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
           version: currentVersion?.version || 1,
           type: showType,
           secret: showType === 'SecureString',
-          description: '',
+          description: param?.description ?? '',
           lastModified: currentVersion?.lastModified || new Date().toISOString(),
           tags,
         };
@@ -1093,7 +1099,7 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
           stagingLabels: secret?.stagingLabels !== undefined ? secret.stagingLabels : ['AWSCURRENT'],
           state: secret?.state ?? '',
           value: secret?.value || 'mock-secret',
-          description: '',
+          description: secret?.description ?? '',
           createdDate: new Date().toISOString(),
           tags,
         };

--- a/internal/provider/aws/param/param.go
+++ b/internal/provider/aws/param/param.go
@@ -156,6 +156,26 @@ func (s *Store) Get(ctx context.Context, name string, ref provider.VersionRef) (
 		})
 	}
 
+	// Description is best-effort too: GetParameter's output carries no description,
+	// so it lives in the parameter metadata returned by DescribeParameters. A
+	// metadata-read failure must not fail the value read (same discipline as tags).
+	descOutput, err := s.client.DescribeParameters(ctx, &ssm.DescribeParametersInput{
+		ParameterFilters: []types.ParameterStringFilter{{
+			Key:    aws.String("Name"),
+			Option: aws.String("Equals"),
+			Values: []string{aws.ToString(p.Name)},
+		}},
+	})
+	if err == nil && descOutput != nil {
+		// Equals filters to the exact name, but match defensively in case an
+		// emulator treats it as a prefix filter.
+		if meta, ok := lo.Find(descOutput.Parameters, func(m types.ParameterMetadata) bool {
+			return aws.ToString(m.Name) == aws.ToString(p.Name)
+		}); ok {
+			entry.Description = aws.ToString(meta.Description)
+		}
+	}
+
 	return entry, nil
 }
 

--- a/internal/provider/aws/param/param_test.go
+++ b/internal/provider/aws/param/param_test.go
@@ -194,6 +194,11 @@ func TestGet_LatestWithTypeMappingAndTags(t *testing.T) {
 				{Key: aws.String("env"), Value: aws.String("prod")},
 			}}, nil
 		},
+		describe: func(_ *ssm.DescribeParametersInput) (*ssm.DescribeParametersOutput, error) {
+			return &ssm.DescribeParametersOutput{Parameters: []types.ParameterMetadata{
+				{Name: aws.String("/my/param"), Description: aws.String("app credentials")},
+			}}, nil
+		},
 	})
 
 	entry, err := store.Get(t.Context(), "/my/param", provider.NewVersionRef(""))
@@ -202,9 +207,39 @@ func TestGet_LatestWithTypeMappingAndTags(t *testing.T) {
 	assert.Equal(t, "hunter2", entry.Value)
 	assert.Equal(t, domain.ValueTypeSecret, entry.Type)
 	assert.Equal(t, "3", entry.Version.ID)
+	assert.Equal(t, "app credentials", entry.Description)
 	require.Len(t, entry.Tags, 1)
 	assert.Equal(t, "env", entry.Tags[0].Key)
 	assert.Equal(t, "prod", entry.Tags[0].Value)
+}
+
+// TestGet_DescriptionReadIsBestEffort guards that a DescribeParameters failure
+// (the only source of a parameter's description) leaves Description empty but
+// does not fail the value read, mirroring the best-effort tags discipline.
+func TestGet_DescriptionReadIsBestEffort(t *testing.T) {
+	t.Parallel()
+
+	store := param.New(&mockClient{
+		getParameter: func(_ *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
+			return &ssm.GetParameterOutput{Parameter: &types.Parameter{
+				Name:    aws.String("/my/param"),
+				Value:   aws.String("hunter2"),
+				Version: 1,
+				Type:    types.ParameterTypeString,
+			}}, nil
+		},
+		listTags: func(_ *ssm.ListTagsForResourceInput) (*ssm.ListTagsForResourceOutput, error) {
+			return &ssm.ListTagsForResourceOutput{}, nil
+		},
+		describe: func(_ *ssm.DescribeParametersInput) (*ssm.DescribeParametersOutput, error) {
+			return nil, assert.AnError
+		},
+	})
+
+	entry, err := store.Get(t.Context(), "/my/param", provider.NewVersionRef(""))
+	require.NoError(t, err)
+	assert.Equal(t, "hunter2", entry.Value)
+	assert.Empty(t, entry.Description)
 }
 
 func TestGet_SpecificVersionSuffix(t *testing.T) {
@@ -222,6 +257,9 @@ func TestGet_SpecificVersionSuffix(t *testing.T) {
 		},
 		listTags: func(_ *ssm.ListTagsForResourceInput) (*ssm.ListTagsForResourceOutput, error) {
 			return &ssm.ListTagsForResourceOutput{}, nil
+		},
+		describe: func(_ *ssm.DescribeParametersInput) (*ssm.DescribeParametersOutput, error) {
+			return &ssm.DescribeParametersOutput{}, nil
 		},
 	})
 


### PR DESCRIPTION
Closes #753.

## Problem

AWS param/secret support writing `--description`, but it was never shown back:

- `aws param` never read its description at all — `Get` called only `GetParameter`, whose output has no Description field, so `Entry.Description` was always empty for every frontend (CLI, GUI, TUI).
- Neither `aws param` nor `aws secret` CLI `show` rendered the description, even though `aws secret`'s adapter already populates it via `DescribeSecret`.

## Fix

1. **`aws param` adapter `Get`** (`internal/provider/aws/param/param.go`): after the `GetParameter` value read, a **best-effort** `DescribeParameters` call filtered on the exact name (`ParameterStringFilter` with key `Name`, option `Equals`) populates `Entry.Description` from the returned `ParameterMetadata.Description`. A metadata-read failure does **not** fail the `Get` — same discipline as the existing best-effort `ListTagsForResource`. One extra API call per param read (accepted trade-off per the issue).
2. **`aws secret` CLI `show`** (`internal/cli/commands/aws/secret/show.go`): render `Description` in text (`out.Field`) and JSON (`description,omitempty`), only when non-empty.
3. **`aws param` CLI `show`** (`internal/cli/commands/aws/param/show.go`): same treatment. `param.ShowOutput` already carries `Description`; it now flows adapter → usecase → presenter.

## GUI / TUI need no code change

The GUI (`ParamView.svelte` / `SecretView.svelte`) and TUI already gate a Description section on a non-empty value and read it from their Go structs. Once the adapter populates the field, they surface it automatically. gcloud parity is unchanged.

## Tests (three layers)

- **Go unit**: `param` adapter `Get` now asserts `Description` surfaces, plus a best-effort-failure guard (`DescribeParameters` error leaves it empty, does not fail the read). New show-presenter unit tests for both `aws param` and `aws secret` (text + JSON present when set, omitted when empty).
- **e2e** (localstack, compile-verified with `go vet -tags e2e ./e2e/...`; not run here — CI runs it): `aws param` / `aws secret` create-with-description now `show` and assert the description appears in text and JSON output.
- **GUI Playwright**: new `description-display.spec.ts` (+ `wails-mock.ts` fixture serving a per-entry description) proves the AWS param/secret detail pane renders the description and hides the section when empty.

## Verification

- `go build ./...` — clean
- `go test ./internal/... ./cmd/...` — pass
- `golangci-lint run` on the changed packages — 0 issues
- e2e / Playwright — compile / consistency only, not run (no Docker / no `node_modules` locally)

## Caveat

The `aws param` e2e assertion depends on localstack returning `Description` from `DescribeParameters` with an `Equals` name filter. If localstack omits it, that one e2e case would need adjustment; the unit tests fully cover the adapter logic regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)