### PR TITLE
feat(staging,gui): secret display policy — mask/reveal flags through diff and staging review

### DIFF
--- a/internal/gui/frontend/src/lib/DiffDisplay.svelte
+++ b/internal/gui/frontend/src/lib/DiffDisplay.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { computeInlineDiff } from './diff-utils';
+  import { maskValue } from './viewUtils';
 
   interface Props {
     oldValue: string;
@@ -8,12 +9,50 @@
     newLabel?: string;
     oldSubLabel?: string;
     newSubLabel?: string;
+    // secret marks BOTH sides as secret material. A Compare/diff view is a
+    // surface the user explicitly opened to inspect the change, so a secret diff
+    // is REVEALED by default (#702/#735); the Hide/Show toggle masks it. Use
+    // oldSecret/newSecret to mark only one side (e.g. a delete whose staged side
+    // is the literal "(deleted)" sentinel, not secret material).
+    secret?: boolean;
+    oldSecret?: boolean;
+    newSecret?: boolean;
   }
 
-  let { oldValue, newValue, oldLabel = 'Old', newLabel = 'New', oldSubLabel = '', newSubLabel = '' }: Props = $props();
+  let {
+    oldValue,
+    newValue,
+    oldLabel = 'Old',
+    newLabel = 'New',
+    oldSubLabel = '',
+    newSubLabel = '',
+    secret = false,
+    oldSecret = secret,
+    newSecret = secret,
+  }: Props = $props();
 
-  let diff = $derived(computeInlineDiff(oldValue, newValue));
+  // Explicit diff surfaces reveal by default; the toggle hides again.
+  let revealed = $state(true);
+  let anySecret = $derived(oldSecret || newSecret);
+
+  let displayOld = $derived(oldSecret && !revealed ? maskValue(oldValue) : oldValue);
+  let displayNew = $derived(newSecret && !revealed ? maskValue(newValue) : newValue);
+  let diff = $derived(computeInlineDiff(displayOld, displayNew));
 </script>
+
+{#if anySecret}
+  <div class="diff-mask-toggle">
+    <button
+      type="button"
+      class="btn-mask-toggle"
+      class:active={!revealed}
+      title={revealed ? 'Hide secret values' : 'Show secret values'}
+      onclick={() => (revealed = !revealed)}
+    >
+      {revealed ? 'Hide' : 'Show'}
+    </button>
+  </div>
+{/if}
 
 <div class="diff-container">
   <div class="diff-side">
@@ -37,6 +76,31 @@
 </div>
 
 <style>
+  .diff-mask-toggle {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 8px;
+  }
+
+  .btn-mask-toggle {
+    padding: 4px 10px;
+    font-size: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    border-radius: 4px;
+    background: transparent;
+    color: #ccc;
+    cursor: pointer;
+  }
+
+  .btn-mask-toggle:hover {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  .btn-mask-toggle.active {
+    border-color: #4a9eff;
+    color: #4a9eff;
+  }
+
   .diff-container {
     display: flex;
     gap: 16px;

--- a/internal/gui/frontend/src/lib/ParamView.svelte
+++ b/internal/gui/frontend/src/lib/ParamView.svelte
@@ -811,6 +811,7 @@
     <DiffDisplay
       oldValue={diffResult.oldValue}
       newValue={diffResult.newValue}
+      secret={diffResult.secret}
       oldLabel="Old"
       newLabel="New"
       oldSubLabel={`v${diffMode.selectedVersions[0]}`}

--- a/internal/gui/frontend/src/lib/SecretView.svelte
+++ b/internal/gui/frontend/src/lib/SecretView.svelte
@@ -830,6 +830,7 @@
     <DiffDisplay
       oldValue={formatJsonValue(diffResult.oldValue)}
       newValue={formatJsonValue(diffResult.newValue)}
+      secret={true}
       oldLabel="Old"
       newLabel="New"
       oldSubLabel={diffResult.oldVersionId}

--- a/internal/gui/frontend/src/lib/StagingSection.svelte
+++ b/internal/gui/frontend/src/lib/StagingSection.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { gui } from '../../wailsjs/go/models';
   import DiffDisplay from './DiffDisplay.svelte';
+  import { maskValue } from './viewUtils';
   import './common.css';
 
   interface Props {
@@ -16,6 +17,12 @@
     // Whether to show each entry's namespace as a badge (Azure App Configuration
     // only). "(NULL)" is the null/default namespace.
     showNamespace?: boolean;
+    // Whether this whole section renders secret material (the Secret service).
+    // OR'd with each entry's own value-type flag so both a secret-service entry
+    // and a SecureString param are masked. Mirrors the TUI's `sec.secret ||
+    // e.Secret` (staging/view.go) — the section flag also covers a secret-service
+    // create, whose per-entry flag the usecase leaves unset (#715).
+    secret?: boolean;
     onapply: () => void;
     onreset: () => void;
     onedit: (entry: gui.StagingDiffEntry) => void;
@@ -37,6 +44,7 @@
     viewMode,
     hasTags = true,
     showNamespace = false,
+    secret = false,
     onapply,
     onreset,
     onedit,
@@ -119,6 +127,7 @@
     <ul class="entry-list">
       {#each entries as entry}
         {@const tagEntry = findTagEntry(entry.name)}
+        {@const rowSecret = secret || entry.secret}
         <li class="entry-item">
           <div class="entry-header">
             <span class="operation-badge" style="background: {getOperationColor(entry.operation || '')}">
@@ -167,9 +176,15 @@
           {#if entry.operation === 'delete'}
             {#if viewMode === 'diff'}
               <div class="entry-diff">
+                <!-- The remote-vs-staged comparison is revealed by default (the
+                     user explicitly opened this diff, #735); the DiffDisplay
+                     Hide/Show toggle can mask it. Only the remote side is secret
+                     — the staged side is the literal "(deleted)" sentinel — so
+                     pass oldSecret rather than secret (which would mask both). -->
                 <DiffDisplay
                   oldValue={entry.remoteValue || ''}
                   newValue="(deleted)"
+                  oldSecret={rowSecret}
                   oldLabel="Remote"
                   newLabel="Staged"
                   oldSubLabel={entry.remoteIdentifier || ''}
@@ -184,13 +199,14 @@
                 <DiffDisplay
                   oldValue={entry.remoteValue || ''}
                   newValue={entry.stagedValue}
+                  secret={rowSecret}
                   oldLabel="Remote"
                   newLabel="Staged"
                   oldSubLabel={entry.remoteIdentifier || ''}
                 />
               </div>
             {:else}
-              <pre class="entry-value">{entry.stagedValue}</pre>
+              <pre class="entry-value">{rowSecret ? maskValue(entry.stagedValue) : entry.stagedValue}</pre>
             {/if}
           {/if}
         </li>

--- a/internal/gui/frontend/src/lib/StagingView.svelte
+++ b/internal/gui/frontend/src/lib/StagingView.svelte
@@ -584,6 +584,7 @@
         entries={secretEntries}
         tagEntries={secretTagEntries}
         hasTags={secretSvc?.hasTags ?? true}
+        secret={true}
         {viewMode}
         onapply={() => openApplyModal('secret')}
         onreset={() => openResetModal('secret')}

--- a/internal/gui/frontend/tests/secret-service-mask.spec.ts
+++ b/internal/gui/frontend/tests/secret-service-mask.spec.ts
@@ -1,0 +1,190 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupWailsMocks,
+  createSecretStagedState,
+  createParamStagedState,
+  createStagedValue,
+  navigateTo,
+  waitForItemList,
+  clickItemByName,
+} from './fixtures/wails-mock';
+
+// ============================================================================
+// GUI secret-service diff reveal vs passive masking (#714, #715, #735)
+//
+// Per the confirmed policy, an EXPLICIT diff surface — the "Version Comparison"
+// modal and the staging DIFF view's remote-vs-staged ± comparison — is REVEALED
+// by default (the user opened it to inspect the change), with a Hide/Show toggle
+// (#735). PASSIVE surfaces stay masked by default:
+//
+//   - the staging VALUE view (plain staged-value listing),
+//   - a staged CREATE (a lone new value, not a remote-vs-staged comparison).
+//
+// These tests assert the diff comparison reveals and the toggle hides, while the
+// passive value view and create values remain masked with bullets/asterisks.
+// ============================================================================
+
+test.describe('Secret-service version diff reveal + hide toggle (#714/#735)', () => {
+  test.beforeEach(async ({ page }) => {
+    // Default mock state ships my-secret with three versions carrying
+    // distinctive cleartext values.
+    await setupWailsMocks(page);
+    await page.goto('/');
+    await navigateTo(page, 'Secret');
+    await waitForItemList(page);
+  });
+
+  test('reveals both sides of a secret version comparison by default, hides on toggle', async ({ page }) => {
+    await clickItemByName(page, 'my-secret');
+
+    await page.getByRole('button', { name: /Compare/i }).click();
+    await page.locator('.diff-checkbox input').first().check();
+    await page.locator('.diff-checkbox input').nth(1).check();
+    await page.getByRole('button', { name: 'Show Diff' }).click();
+
+    await expect(page.getByText('Version Comparison')).toBeVisible();
+
+    // Revealed by default: the explicit comparison shows real values so the diff
+    // is meaningful (#735).
+    let oldSide = (await page.locator('.diff-value.diff-old').textContent()) ?? '';
+    let newSide = (await page.locator('.diff-value.diff-new').textContent()) ?? '';
+    expect(oldSide + newSide).toContain('secret-value');
+
+    // The Hide toggle masks both sides — no cleartext version value remains.
+    await page.locator('.btn-mask-toggle').click();
+    oldSide = (await page.locator('.diff-value.diff-old').textContent()) ?? '';
+    newSide = (await page.locator('.diff-value.diff-new').textContent()) ?? '';
+    for (const side of [oldSide, newSide]) {
+      expect(side).not.toContain('secret-value-1');
+      expect(side).not.toContain('secret-value-old');
+      expect(side).not.toContain('secret-value-initial');
+      expect(side).not.toContain('secret-value');
+    }
+    expect(oldSide).toMatch(/\*/);
+    expect(newSide).toMatch(/\*/);
+  });
+});
+
+test.describe('Secret-service staging review masking (#715)', () => {
+  // Distinctive cleartext that must never reach the staging review.
+  const UPDATE_VALUE = 'super-secret-staged-update';
+  const CREATE_VALUE = 'super-secret-staged-create';
+  const REMOTE_VALUE = 'remote-value'; // the mock's remote value for non-create entries
+
+  async function gotoSecretStaging(page: import('@playwright/test').Page) {
+    await setupWailsMocks(
+      page,
+      createSecretStagedState([
+        createStagedValue('my-secret', 'update', UPDATE_VALUE),
+        createStagedValue('new-secret', 'create', CREATE_VALUE),
+        createStagedValue('old-secret', 'delete'),
+      ]),
+    );
+    await page.goto('/');
+    await navigateTo(page, 'Staging');
+    // Wait until the secret section's staged rows are rendered.
+    await expect(page.locator('.entry-item').first()).toBeVisible();
+  }
+
+  test('reveals staged/remote comparison values in diff view (create stays masked), hides on toggle', async ({ page }) => {
+    await gotoSecretStaging(page);
+    // Default view mode is Diff.
+    await expect(page.getByRole('button', { name: 'Diff' })).toHaveClass(/active/);
+
+    let body = (await page.locator('.staging-content').textContent()) ?? '';
+    // An update/delete is a real remote-vs-staged comparison → revealed by
+    // default so the change is meaningful (#735).
+    expect(body).toContain(UPDATE_VALUE);
+    expect(body).toContain(REMOTE_VALUE);
+    // A create is a lone new value (no comparison) → stays masked (#719).
+    expect(body).not.toContain(CREATE_VALUE);
+    expect(body).toMatch(/\*/);
+    // The delete sentinel stays readable (it is not secret material).
+    expect(body).toContain('(deleted)');
+
+    // Hiding every comparison (each toggle clicked once) masks the revealed values.
+    const toggles = page.locator('.btn-mask-toggle');
+    const count = await toggles.count();
+    for (let i = 0; i < count; i++) {
+      await toggles.nth(i).click();
+    }
+    body = (await page.locator('.staging-content').textContent()) ?? '';
+    expect(body).not.toContain(UPDATE_VALUE);
+    expect(body).not.toContain(REMOTE_VALUE);
+    expect(body).toMatch(/\*/);
+  });
+
+  test('masks staged values in value view', async ({ page }) => {
+    await gotoSecretStaging(page);
+    await page.getByRole('button', { name: 'Value' }).click();
+    await expect(page.getByRole('button', { name: 'Value' })).toHaveClass(/active/);
+
+    const body = (await page.locator('.staging-content').textContent()) ?? '';
+    expect(body).not.toContain(UPDATE_VALUE);
+    expect(body).not.toContain(CREATE_VALUE);
+    expect(body).toMatch(/\*/);
+  });
+});
+
+test.describe('SecureString-param staging review masking (per-entry flag, #715)', () => {
+  // A SecureString param lives in the non-secret Param section, so only the
+  // per-entry DiffEntry.Secret flag can mask it — this isolates that path from
+  // the secret section's service-axis flag.
+  const SECURE_VALUE = 'securestring-staged-plaintext';
+
+  test('masks a SecureString param staged value in the Param section', async ({ page }) => {
+    await setupWailsMocks(page, {
+      ...createParamStagedState([
+        { name: '/app/secure/token', operation: 'update', value: SECURE_VALUE, secret: true },
+      ]),
+    });
+    await page.goto('/');
+    await navigateTo(page, 'Staging');
+    await expect(page.locator('.entry-item').first()).toBeVisible();
+
+    // Value view renders the staged value directly.
+    await page.getByRole('button', { name: 'Value' }).click();
+    const body = (await page.locator('.staging-content').textContent()) ?? '';
+    expect(body).not.toContain(SECURE_VALUE);
+    expect(body).toMatch(/\*/);
+  });
+});
+
+test.describe('SecureString-param staging review CREATE masking (#719)', () => {
+  // A create has no remote to fetch, so the diff usecase used to leave its
+  // Secret flag false — the create-staged value rendered in cleartext. The flag
+  // now derives from the staged value type (SecureString ⇒ secret), so a
+  // create-staged SecureString param is masked like every other secret value.
+  const SECURE_CREATE_VALUE = 'securestring-created-plaintext';
+
+  async function gotoParamCreateStaging(page: import('@playwright/test').Page) {
+    await setupWailsMocks(page, {
+      ...createParamStagedState([
+        { name: '/app/secure/new-token', operation: 'create', value: SECURE_CREATE_VALUE, secret: true },
+      ]),
+    });
+    await page.goto('/');
+    await navigateTo(page, 'Staging');
+    await expect(page.locator('.entry-item').first()).toBeVisible();
+  }
+
+  test('masks a create-staged SecureString param value in diff view', async ({ page }) => {
+    await gotoParamCreateStaging(page);
+    // Default view mode is Diff; a create renders its staged value directly.
+    await expect(page.getByRole('button', { name: 'Diff' })).toHaveClass(/active/);
+
+    const body = (await page.locator('.staging-content').textContent()) ?? '';
+    expect(body).not.toContain(SECURE_CREATE_VALUE);
+    expect(body).toMatch(/\*/);
+  });
+
+  test('masks a create-staged SecureString param value in value view', async ({ page }) => {
+    await gotoParamCreateStaging(page);
+    await page.getByRole('button', { name: 'Value' }).click();
+    await expect(page.getByRole('button', { name: 'Value' })).toHaveClass(/active/);
+
+    const body = (await page.locator('.staging-content').textContent()) ?? '';
+    expect(body).not.toContain(SECURE_CREATE_VALUE);
+    expect(body).toMatch(/\*/);
+  });
+});

--- a/internal/gui/frontend/tests/securestring-diff.spec.ts
+++ b/internal/gui/frontend/tests/securestring-diff.spec.ts
@@ -1,0 +1,74 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupWailsMocks,
+  createParam,
+  waitForItemList,
+  clickItemByName,
+  type MockState,
+} from './fixtures/wails-mock';
+
+// ============================================================================
+// SecureString param diff reveal + hide toggle (GUI counterpart of #677 — #702)
+//
+// A SecureString param's Version Comparison is a surface the user explicitly
+// opened to inspect the change, so its values are REVEALED by default (#702/
+// #735). The DiffDisplay Hide/Show toggle can still mask both sides, matching
+// the detail pane's masked-by-default behavior on demand.
+// ============================================================================
+
+// Distinctive cleartext values that must NEVER appear in the diff modal.
+const OLD_SECRET = 'securestring-plaintext-old';
+const NEW_SECRET = 'securestring-plaintext-new-longer';
+
+function secureStringDiffState(): Partial<MockState> {
+  return {
+    params: [createParam('/app/secure/token', NEW_SECRET, 'SecureString')],
+    paramVersions: {
+      '/app/secure/token': [
+        { version: 2, value: NEW_SECRET, type: 'SecureString', isCurrent: true, lastModified: new Date().toISOString() },
+        { version: 1, value: OLD_SECRET, type: 'SecureString', isCurrent: false, lastModified: new Date(Date.now() - 86400000).toISOString() },
+      ],
+    },
+  };
+}
+
+test.describe('SecureString param diff masking', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupWailsMocks(page, secureStringDiffState());
+    await page.goto('/');
+    await waitForItemList(page);
+  });
+
+  test('reveals both sides of a SecureString version diff by default, and hides on toggle', async ({ page }) => {
+    await clickItemByName(page, '/app/secure/token');
+
+    await page.getByRole('button', { name: /Compare/i }).click();
+    await page.locator('.diff-checkbox input').first().check();
+    await page.locator('.diff-checkbox input').nth(1).check();
+    await page.getByRole('button', { name: 'Show Diff' }).click();
+
+    await expect(page.getByText('Version Comparison')).toBeVisible();
+
+    // Revealed by default: both cleartext values are shown so the diff is useful.
+    let oldSide = (await page.locator('.diff-value.diff-old').textContent()) ?? '';
+    let newSide = (await page.locator('.diff-value.diff-new').textContent()) ?? '';
+    expect(oldSide).toContain(OLD_SECRET);
+    expect(newSide).toContain(NEW_SECRET);
+
+    // The Hide toggle masks both sides (bullets/asterisks), so a change still
+    // shows without disclosing content.
+    await page.locator('.btn-mask-toggle').click();
+    oldSide = (await page.locator('.diff-value.diff-old').textContent()) ?? '';
+    newSide = (await page.locator('.diff-value.diff-new').textContent()) ?? '';
+    expect(oldSide).not.toContain(OLD_SECRET);
+    expect(oldSide).not.toContain('plaintext-old');
+    expect(newSide).not.toContain(NEW_SECRET);
+    expect(newSide).not.toContain('plaintext-new');
+    expect(oldSide).toMatch(/\*/);
+    expect(newSide).toMatch(/\*/);
+
+    // Show again brings the values back.
+    await page.locator('.btn-mask-toggle').click();
+    expect((await page.locator('.diff-value.diff-new').textContent()) ?? '').toContain(NEW_SECRET);
+  });
+});

--- a/internal/gui/frontend/wailsjs/go/models.ts
+++ b/internal/gui/frontend/wailsjs/go/models.ts
@@ -77,17 +77,19 @@ export namespace gui {
 	    newName: string;
 	    oldValue: string;
 	    newValue: string;
-	
+	    secret: boolean;
+
 	    static createFrom(source: any = {}) {
 	        return new ParamDiffResult(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.oldName = source["oldName"];
 	        this.newName = source["newName"];
 	        this.oldValue = source["oldValue"];
 	        this.newValue = source["newValue"];
+	        this.secret = source["secret"];
 	    }
 	}
 	export class ParamListEntry {
@@ -796,11 +798,12 @@ export namespace gui {
 	    stagedValue?: string;
 	    description?: string;
 	    warning?: string;
-	
+	    secret: boolean;
+
 	    static createFrom(source: any = {}) {
 	        return new StagingDiffEntry(source);
 	    }
-	
+
 	    constructor(source: any = {}) {
 	        if ('string' === typeof source) source = JSON.parse(source);
 	        this.name = source["name"];
@@ -812,6 +815,7 @@ export namespace gui {
 	        this.stagedValue = source["stagedValue"];
 	        this.description = source["description"];
 	        this.warning = source["warning"];
+	        this.secret = source["secret"];
 	    }
 	}
 	export class StagingDiffTagEntry {

--- a/internal/gui/param.go
+++ b/internal/gui/param.go
@@ -95,6 +95,10 @@ type ParamDiffResult struct {
 	NewName  string `json:"newName"`
 	OldValue string `json:"oldValue"`
 	NewValue string `json:"newValue"`
+	// Secret reports whether either version is a SecureString (secret) value, so
+	// the diff view masks both sides. A SecureString param is a secret on the
+	// value-type axis even though it lives on the param service (#702).
+	Secret bool `json:"secret"`
 }
 
 // ParamSetResult represents the result of setting a parameter.
@@ -315,6 +319,7 @@ func (a *App) ParamDiff(spec1Str, spec2Str, namespace string) (*ParamDiffResult,
 		NewName:  result.NewName,
 		OldValue: result.OldValue,
 		NewValue: result.NewValue,
+		Secret:   result.Secret,
 	}, nil
 }
 

--- a/internal/gui/staging.go
+++ b/internal/gui/staging.go
@@ -167,6 +167,11 @@ type StagingDiffEntry struct {
 	StagedValue      string  `json:"stagedValue,omitempty"`
 	Description      *string `json:"description,omitempty"`
 	Warning          string  `json:"warning,omitempty"`
+	// Secret reports whether this entry's values are secret material (a
+	// SecureString param, or any secret-service entry) so the staging review
+	// masks them instead of rendering cleartext. Mirrors the TUI's per-row flag
+	// (staging/view.go); threaded from stagingusecase.DiffEntry.Secret (#715).
+	Secret bool `json:"secret"`
 }
 
 // StagingDiffTagEntry represents a single diff tag entry.
@@ -829,6 +834,7 @@ func (a *App) StagingDiff(service string, name string) (*StagingDiffResult, erro
 			StagedValue:      e.StagedValue,
 			Description:      e.Description,
 			Warning:          e.Warning,
+			Secret:           e.Secret,
 		}
 	})
 

--- a/internal/staging/aws_param.go
+++ b/internal/staging/aws_param.go
@@ -175,6 +175,9 @@ func (s *AWSParamStrategy) FetchCurrent(ctx context.Context, name string) (*Fetc
 	return &FetchResult{
 		Value:      entry.Value,
 		Identifier: "#" + entry.Version.ID,
+		// A SecureString param is secret material even on the param service, so the
+		// staged diff must mask it (#677).
+		Secret: entry.Type == domain.ValueTypeSecret,
 	}, nil
 }
 

--- a/internal/staging/aws_param_test.go
+++ b/internal/staging/aws_param_test.go
@@ -357,6 +357,22 @@ func TestParamStrategy_FetchCurrent(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "current-value", result.Value)
 		assert.Equal(t, "#5", result.Identifier)
+		assert.False(t, result.Secret, "a String param is not secret")
+	})
+
+	t.Run("securestring is secret", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &providermock.Store{
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) {
+				return &domain.Entry{Value: "current-secret", Type: domain.ValueTypeSecret, Version: domain.Version{ID: "5"}}, nil
+			},
+		}
+
+		s := staging.NewAWSParamStrategy(mock)
+		result, err := s.FetchCurrent(t.Context(), "/app/param")
+		require.NoError(t, err)
+		assert.True(t, result.Secret, "a SecureString param must be flagged secret (#677)")
 	})
 
 	t.Run("error", func(t *testing.T) {

--- a/internal/staging/aws_secret.go
+++ b/internal/staging/aws_secret.go
@@ -173,6 +173,7 @@ func (s *AWSSecretStrategy) FetchCurrent(ctx context.Context, name string) (*Fet
 	return &FetchResult{
 		Value:      entry.Value,
 		Identifier: "#" + awssecretversion.TruncateVersionID(entry.Version.ID),
+		Secret:     true, // Secrets Manager values are always secret material.
 	}, nil
 }
 

--- a/internal/staging/azure_keyvault_secret.go
+++ b/internal/staging/azure_keyvault_secret.go
@@ -145,6 +145,7 @@ func (s *AzureKeyVaultSecretStrategy) FetchCurrent(ctx context.Context, name str
 	return &FetchResult{
 		Value:      entry.Value,
 		Identifier: "#" + entry.Version.ID,
+		Secret:     true, // Key Vault values are always secret material.
 	}, nil
 }
 

--- a/internal/staging/gcloud_secret.go
+++ b/internal/staging/gcloud_secret.go
@@ -154,6 +154,7 @@ func (s *GoogleCloudSecretStrategy) FetchCurrent(ctx context.Context, name strin
 	return &FetchResult{
 		Value:      entry.Value,
 		Identifier: "#" + entry.Version.ID,
+		Secret:     true, // Secret Manager values are always secret material.
 	}, nil
 }
 

--- a/internal/staging/service.go
+++ b/internal/staging/service.go
@@ -85,6 +85,11 @@ type FetchResult struct {
 	Value string
 	// Identifier is a display string for the version (e.g., "#3" for SSM Parameter Store, "#abc123" for Secrets Manager).
 	Identifier string
+	// Secret reports whether the fetched value is secret material (a Secrets
+	// Manager/Key Vault/Secret Manager value, or a SecureString param), so a
+	// staged-diff consumer masks it. A SecureString param is a secret on the
+	// value-type axis even though it lives on the param service (#677).
+	Secret bool
 }
 
 // EditFetchResult holds the result of fetching a value for editing.

--- a/internal/usecase/param/diff.go
+++ b/internal/usecase/param/diff.go
@@ -22,6 +22,11 @@ type DiffOutput struct {
 	NewName    string
 	NewVersion int64
 	NewValue   string
+	// Secret reports whether either version is a SecureString (secret) value, so
+	// a consumer masks both sides before rendering the diff. A SecureString param
+	// is a secret on the value-type axis even though it lives on the param service
+	// axis, so masking must key off this flag, not the service (#677/#702).
+	Secret bool
 }
 
 // DiffUseCase executes diff operations.
@@ -48,6 +53,7 @@ func (u *DiffUseCase) Execute(ctx context.Context, input DiffInput) (*DiffOutput
 		NewName:    entry2.Name,
 		NewVersion: parseVersion(entry2.Version.ID),
 		NewValue:   entry2.Value,
+		Secret:     entry1.Type == domain.ValueTypeSecret || entry2.Type == domain.ValueTypeSecret,
 	}, nil
 }
 

--- a/internal/usecase/param/diff_test.go
+++ b/internal/usecase/param/diff_test.go
@@ -56,6 +56,42 @@ func TestDiffUseCase_Execute(t *testing.T) {
 	assert.Equal(t, "/app/config", output.NewName)
 	assert.Equal(t, int64(2), output.NewVersion)
 	assert.Equal(t, "new-value", output.NewValue)
+	assert.False(t, output.Secret, "a plaintext (String) param diff is not secret")
+}
+
+// getByRefTyped is getByRef but stamps every entry with a fixed value type, so a
+// test can exercise the SecureString-secret path.
+func getByRefTyped(values map[string]string, typ domain.ValueType) func(context.Context, string, provider.VersionRef) (*domain.Entry, error) {
+	return func(_ context.Context, name string, ref provider.VersionRef) (*domain.Entry, error) {
+		id := ref.ID()
+
+		val, ok := values[id]
+		if !ok {
+			return nil, errUnexpectedCall
+		}
+
+		return &domain.Entry{Name: name, Value: val, Type: typ, Version: domain.Version{ID: id}}, nil
+	}
+}
+
+// TestDiffUseCase_Execute_SecureStringIsSecret pins that a SecureString param
+// diff carries Secret=true, so both frontends mask it (#677/#702).
+func TestDiffUseCase_Execute_SecureStringIsSecret(t *testing.T) {
+	t.Parallel()
+
+	store := &providermock.Store{
+		ResolveFunc: resolveBySuffix(map[string]string{"#1": "1", "#2": "2"}),
+		GetFunc:     getByRefTyped(map[string]string{"1": "old-secret", "2": "new-secret"}, domain.ValueTypeSecret),
+	}
+
+	uc := &param.DiffUseCase{Reader: store}
+
+	spec1, _ := awsparamversion.Parse("/app/config#1")
+	spec2, _ := awsparamversion.Parse("/app/config#2")
+
+	output, err := uc.Execute(t.Context(), param.DiffInput{Spec1: spec1, Spec2: spec2})
+	require.NoError(t, err)
+	assert.True(t, output.Secret, "a SecureString param diff must be flagged secret")
 }
 
 func TestDiffUseCase_Execute_Spec1Error(t *testing.T) {

--- a/internal/usecase/staging/diff.go
+++ b/internal/usecase/staging/diff.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/parallel"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/staging"
@@ -42,6 +43,11 @@ type DiffEntry struct {
 	StagedValue   string
 	Description   *string
 	Warning       string // For warnings like "already deleted in AWS"
+	// Secret reports whether the entry's values are secret material (a secret
+	// service, or a SecureString param), so a consumer masks both the remote and
+	// staged values in the review. Keyed off the value type, not the service, so
+	// a SecureString param is masked too (#677).
+	Secret bool
 }
 
 // DiffTagEntry represents a single diff result for tag changes.
@@ -252,6 +258,7 @@ func (u *DiffUseCase) processDiffResult(ctx context.Context, key staging.EntryKe
 		AWSIdentifier: fetchResult.Identifier,
 		StagedValue:   stagedValue,
 		Description:   entry.Description,
+		Secret:        fetchResult.Secret,
 	}, nil
 }
 
@@ -287,6 +294,10 @@ func (u *DiffUseCase) handleFetchError(ctx context.Context, key staging.EntryKey
 			Operation:   entry.Operation,
 			StagedValue: lo.FromPtr(entry.Value),
 			Description: entry.Description,
+			// A create has no remote to fetch, so derive Secret from the staged
+			// value type: a SecureString param (or any secret-typed staged value)
+			// is masked in the review like every other secret value (#719).
+			Secret: entry.ValueType == domain.ValueTypeSecret,
 		}, nil
 
 	case staging.OperationUpdate:

--- a/internal/usecase/staging/diff_test.go
+++ b/internal/usecase/staging/diff_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/staging"
 	"github.com/mpyw/suve/internal/staging/store/testutil"
@@ -100,6 +101,35 @@ func TestDiffUseCase_Execute_UpdateDiff(t *testing.T) {
 	assert.Equal(t, "old-value", entry.AWSValue)
 	assert.Equal(t, "new-value", entry.StagedValue)
 	assert.Equal(t, "#5", entry.AWSIdentifier)
+	assert.False(t, entry.Secret, "a plaintext param staged diff is not secret")
+}
+
+// TestDiffUseCase_Execute_SecretFlagFromFetch pins that a staged diff surfaces
+// the fetch result's Secret flag, so a SecureString param (secret fetch) is
+// masked in the review even on the param service (#677).
+func TestDiffUseCase_Execute_SecretFlagFromFetch(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/token"}, staging.Entry{
+		Operation: staging.OperationUpdate,
+		Value:     lo.ToPtr("new-secret"),
+		StagedAt:  time.Now(),
+	}))
+
+	strategy := newMockDiffStrategy()
+	strategy.fetchResults["/app/token"] = &staging.FetchResult{
+		Value:      "old-secret",
+		Identifier: "#5",
+		Secret:     true,
+	}
+
+	uc := &usecasestaging.DiffUseCase{Strategy: strategy, Store: store}
+
+	output, err := uc.Execute(t.Context(), usecasestaging.DiffInput{})
+	require.NoError(t, err)
+	require.Len(t, output.Entries, 1)
+	assert.True(t, output.Entries[0].Secret, "a secret fetch result flags the diff entry secret")
 }
 
 func TestDiffUseCase_Execute_CreateDiff(t *testing.T) {
@@ -129,6 +159,37 @@ func TestDiffUseCase_Execute_CreateDiff(t *testing.T) {
 	assert.Equal(t, usecasestaging.DiffEntryCreate, entry.Type)
 	assert.Equal(t, "new-value", entry.StagedValue)
 	assert.Equal(t, "new param", *entry.Description)
+	assert.False(t, entry.Secret, "a plaintext param create staged diff is not secret")
+}
+
+// TestDiffUseCase_Execute_CreateDiff_SecretFromValueType pins that a staged
+// SecureString-param CREATE flags the diff entry secret from its staged value
+// type — a create has no remote to fetch, so the Secret flag must come from the
+// staged ValueType rather than a fetch result (#719).
+func TestDiffUseCase_Execute_CreateDiff_SecretFromValueType(t *testing.T) {
+	t.Parallel()
+
+	store := testutil.NewMockStore()
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam, staging.EntryKey{Name: "/app/secret"}, staging.Entry{
+		Operation: staging.OperationCreate,
+		Value:     lo.ToPtr("new-secret"),
+		ValueType: domain.ValueTypeSecret,
+		StagedAt:  time.Now(),
+	}))
+
+	strategy := newMockDiffStrategy()
+	strategy.fetchErrors["/app/secret"] = provider.ErrNotFound
+
+	uc := &usecasestaging.DiffUseCase{Strategy: strategy, Store: store}
+
+	output, err := uc.Execute(t.Context(), usecasestaging.DiffInput{})
+	require.NoError(t, err)
+	require.Len(t, output.Entries, 1)
+
+	entry := output.Entries[0]
+	assert.Equal(t, usecasestaging.DiffEntryCreate, entry.Type)
+	assert.Equal(t, "new-secret", entry.StagedValue)
+	assert.True(t, entry.Secret, "a SecureString param create flags the diff entry secret from its staged value type")
 }
 
 func TestDiffUseCase_Execute_DeleteDiff(t *testing.T) {


### PR DESCRIPTION
Closes #751

## Summary

Extracts the non-TUI **secret display policy** work from `epic/tui` onto `main` for standalone review (maintainer decision: existing-behavior changes riding on `epic/tui` land as standalone PRs). Scope is the non-TUI portion of commits `bcdea34`, `7f85fab`, `9ac5186`, `df02906`.

The `Secret` flag is threaded through the diff and staging use cases and surfaced as `secret` JSON fields to the GUI:

- **staging** (`internal/staging/{service,aws_param,aws_secret,azure_keyvault_secret,gcloud_secret}.go`) — `FetchResult.Secret`.
- **usecase** (`internal/usecase/param/diff.go`, `internal/usecase/staging/diff.go`) — `Secret` on the diff outputs. SecureString is keyed off the value type (not the service); create derives from the staged `ValueType`.
- **gui** (`internal/gui/param.go`, `internal/gui/staging.go`) — `secret` JSON fields on the param/staging DTOs; Svelte reveal/mask behavior in `DiffDisplay/ParamView/SecretView/StagingSection/StagingView.svelte`; hand-synced `wailsjs/go/models.ts`.
- **tests** — `secret-service-mask.spec.ts`, `securestring-diff.spec.ts` (Playwright) and Go unit coverage in the checked-out `*_test.go` files.

## Behavior

Display-surface policy (settled — see #751): explicit diff/compare surfaces **reveal secrets by default with a Hide toggle** (secret-service diffs and SecureString param diffs); passive value/review surfaces **mask** with an explicit reveal; **copy never unmasks**. The staging review masks secret material (including create-staged entries) per-entry OR'd with the section-level flag.

## Extraction notes

- **Exact-content extraction** for a conflict-free merge-back: every file except `models.ts` is byte-identical to `epic/tui`, so merging `main` back into `epic/tui` will shrink #657's diff to TUI-only changes.
- **`models.ts` partial**: only the `secret` fields (on `ParamDiffResult` and `StagingDiffEntry`) are brought over. The `hasDescription` field on `ServiceCapability` — which belongs to the TUI-era capability lift — is intentionally excluded (main's GUI `ServiceCapability` Go struct has no `HasDescription`).
- The TUI consumers of these same flags stay on `epic/tui`.

## Verification

- `go build ./...` — clean.
- `go test ./internal/... ./cmd/...` — all pass.
- `golangci-lint` on the changed packages — no issues in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)