### PR TITLE
fix(tui): let x reveal a create-staged secret in the staging diff view (#760)

### DIFF
--- a/internal/tui/pages/staging/help.go
+++ b/internal/tui/pages/staging/help.go
@@ -19,9 +19,11 @@ func (m *Model) HelpKeyMap() help.KeyMap {
 	return keys.Bindings{Short: m.shortHelp(), Full: m.fullHelp()}
 }
 
-// xKey is the view-aware `x` binding: "hide" in diff view, "reveal" in value view.
+// xKey is the view-aware `x` binding: "hide" in diff view, "reveal" in value
+// view. A create row is the exception in diff view — it renders as a lone
+// masked value that `x` reveals per-row (#760), so its label reads "reveal".
 func (m *Model) xKey() key.Binding {
-	if m.diffView {
+	if m.diffView && !m.selectedIsCreate() {
 		return hideKey
 	}
 

--- a/internal/tui/pages/staging/staging_test.go
+++ b/internal/tui/pages/staging/staging_test.go
@@ -274,6 +274,74 @@ func TestUpdate_DiffViewRevealedByDefault(t *testing.T) {
 	assert.Contains(t, m.View(100, 30), staged1, "toggling back shows the values again")
 }
 
+// TestUpdate_CreateRevealInDiffView pins #760: in the DEFAULT diff view a
+// create-staged secret is masked by default (a create is a lone new value, not a
+// remote-vs-staged comparison, #719) but MUST be revealable in place with `x`.
+// The create-in-diff branch renders through the per-row reveal (maskValue /
+// m.reveal), so `x` on a create row toggles that per-row reveal even in diff
+// view — while an update row keeps the reveal-by-default page-level hide (#735)
+// untouched. Before the fix `x` on a create flipped only m.diffHidden, which the
+// create branch never reads, so the create value was permanently masked.
+func TestUpdate_CreateRevealInDiffView(t *testing.T) {
+	t.Parallel()
+
+	const (
+		createStaged = "CREATE-SECRET-VALUE"
+		updateRemote = "UPDATE-REMOTE-VALUE"
+		updateStaged = "UPDATE-STAGED-VALUE"
+	)
+
+	sec := &stubService{
+		service: "secret", label: "Secret", svcCap: capFor("aws", "secret"),
+		review: data.StagingReview{Entries: []data.StagedDiffRow{
+			{Name: "prod/api/new", Type: data.StagedDiffNormal, Operation: "create", StagedValue: createStaged},
+			{Name: "prod/api/old", Type: data.StagedDiffNormal, Operation: "update", RemoteValue: updateRemote, StagedValue: updateStaged},
+		}},
+	}
+	m := newModel(t, sec)
+	require.True(t, m.diffView, "diff is the default view")
+	require.Len(t, m.rows, 2, "one create row and one update row")
+
+	// Default diff view: the create is MASKED (masked-by-default per #719) while
+	// the update's remote-vs-staged comparison is REVEALED (reveal-by-default,
+	// #735).
+	screen := m.View(100, 30)
+	assert.NotContains(t, screen, createStaged, "a create is masked by default in diff view (#719)")
+	assert.Contains(t, screen, updateRemote, "an update reveals its remote by default (#735)")
+	assert.Contains(t, screen, updateStaged, "an update reveals its staged value by default (#735)")
+
+	// Select the create row and press `x`: the create value is now REVEALED in
+	// place (per-row reveal), and the update rows are untouched.
+	m.selected = 0
+	m, cmd := m.Update(keyPress('x'))
+	assert.Nil(t, cmd, "x dispatches no command on a create row")
+	require.True(t, m.reveal, "x on a create row toggles the per-row reveal, not the page-level hide")
+	require.False(t, m.diffHidden, "x on a create row must not touch the page-level diff hide")
+
+	screen = m.View(100, 30)
+	assert.Contains(t, screen, createStaged, "x reveals the create-staged secret in diff view (#760)")
+	assert.Contains(t, screen, updateStaged, "revealing a create leaves the update reveal untouched")
+
+	// The `x` help label reads "reveal" (not "hide") while a create row is
+	// selected, since for a create `x` reveals.
+	assert.Equal(t, "reveal", m.xKey().Help().Desc, "x reads 'reveal' on a selected create row")
+
+	// Select the update row: `x` still toggles the page-level hide (#735) — it
+	// masks the update comparison, unchanged by the fix.
+	m.selected = 1
+	m, _ = m.Update(keyPress('x'))
+	require.True(t, m.diffHidden, "x on an update row hides the diff view (page-level, #735)")
+
+	screen = m.View(100, 30)
+	assert.NotContains(t, screen, updateRemote, "x hides the update's remote comparison (#735)")
+	assert.NotContains(t, screen, updateStaged, "x hides the update's staged comparison (#735)")
+
+	// `x` again reveals the update comparison: the page-level hide toggles back.
+	m, _ = m.Update(keyPress('x'))
+	require.False(t, m.diffHidden, "x toggles the page-level hide back to revealed")
+	assert.Contains(t, m.View(100, 30), updateStaged, "toggling back shows the update comparison again")
+}
+
 // tagOpsReview is a param section with one staged tag add and one staged tag
 // removal (no entry rows), used to exercise the tag-row key handling.
 func tagOpsReview() data.StagingReview {

--- a/internal/tui/pages/staging/update.go
+++ b/internal/tui/pages/staging/update.go
@@ -177,7 +177,11 @@ func (m *Model) moveSelection(delta int) {
 //
 //   - In DIFF view the remote-vs-staged comparison is revealed by default (the
 //     surface the user explicitly opened to inspect the change, #735); `x`
-//     toggles a page-level HIDE so the diff can still be masked.
+//     toggles a page-level HIDE so the diff can still be masked. A CREATE row is
+//     the exception: it has no remote to compare against, so the diff renders it
+//     as a lone masked value via the per-row reveal (#719), not the page-level
+//     hide. On a create row `x` therefore toggles that per-row reveal so the
+//     create value is revealable in place, masked-by-default (#760).
 //   - In VALUE view the raw staged value is masked by default; `x` unmasks only
 //     the SELECTED row's value (never page-global), and moving the selection
 //     resets it (#694).
@@ -186,13 +190,23 @@ func (m *Model) moveSelection(delta int) {
 // (including tag rows) — so a user who learned `x` never destroys a staged
 // change by peeking (#682).
 func (m *Model) onReveal() {
-	if m.diffView {
+	if m.diffView && !m.selectedIsCreate() {
 		m.diffHidden = !m.diffHidden
 
 		return
 	}
 
 	m.reveal = !m.reveal
+}
+
+// selectedIsCreate reports whether the selected row is a create-staged entry.
+// The diff view renders a create as a lone masked value through the per-row
+// reveal (m.reveal), not the page-level diff hide, so `x` on a create must
+// toggle that per-row reveal even in diff view (#760).
+func (m *Model) selectedIsCreate() bool {
+	row, ok := m.selectedRow()
+
+	return ok && row.kind == rowEntry && row.entry.Operation == operationCreate
 }
 
 // onEnter opens the full-diff detail for an entry row. On a tag row it is a

--- a/internal/tui/testdata/TestStaging_SecureStringParamCreateDiffViewGolden.golden
+++ b/internal/tui/testdata/TestStaging_SecureStringParamCreateDiffViewGolden.golden
@@ -31,4 +31,4 @@ Param (2)                                                                       
 
 
 
- ↑/↓ move • e edit • u unstage • x hide • enter detail • v view • tab next tab • 1/2/3 jump to tab • ? help • q quit
+ ↑/↓ move • e edit • u unstage • x reveal • enter detail • v view • tab next tab • 1/2/3 jump to tab • ? help • q quit


### PR DESCRIPTION
Closes #760

## The bug

On the TUI staging page in the **default diff view**, a **create-staged** secret value was masked (correct per #719) but the `x` reveal toggle was a **complete no-op** on a create row — the value could only be revealed after first switching to value view (`v`) then `x`, which is undiscoverable (the help bar even labeled `x` as "hide" in diff view).

## Root cause — two reveal states of opposite polarity

The staging page has two independent reveal states:

- `m.reveal` — value-view, per-selected-row unmask (default **masked**).
- `m.diffHidden` — diff-view, page-level hide (default **revealed**, #735).

In diff view the **create** branch renders via `maskValue` (which consults `m.reveal`), while update/delete render via `maskDiffValue` (which consults `m.diffHidden`). But `onReveal` in diff view only toggled `m.diffHidden` — which the create branch never reads — so a create value stayed permanently masked and `x` did nothing.

## The fix

`onReveal` now toggles the per-row `m.reveal` when the **selected row is a create**, even in diff view, so `x` flips the state the create branch actually consults. A create stays **masked-by-default** (`m.reveal` defaults false and reveals only the selected row per #694/#719) but is now **revealable in place** with `x`, honoring the settled reveal policy.

Update/delete diff behavior is unchanged: reveal-by-default, `x` hides page-level via `m.diffHidden` (#735). The `x` help label now reads "reveal" on a selected create row instead of "hide".

## Verification

- Added `TestUpdate_CreateRevealInDiffView`: a create-staged SECRET is masked by default in diff view and revealed on `x`; an update-staged secret still reveals-by-default and hides on `x` (guards #735). Confirmed the test **FAILS** before the fix and **PASSES** after (stashed the two source-file changes, ran the test → fail; restored → pass).
- Refreshed `TestStaging_SecureStringParamCreateDiffViewGolden` (help-bar label `x hide` → `x reveal`, since its selected row is a create). The golden's own assertions still prove the create value stays masked (bullets only, no cleartext).
- `go build ./...`, `go test ./internal/tui/...` (+ `-race`), `golangci-lint run --allow-parallel-runners ./internal/tui/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)