### PR TITLE
fix(tui): only offer Remove tag when the entry has removable tags (#761)

### DIFF
--- a/internal/tui/dialog_golden_test.go
+++ b/internal/tui/dialog_golden_test.go
@@ -346,11 +346,11 @@ func TestDialog_TagRemoveSelectGolden(t *testing.T) { //nolint:paralleltest // g
 	golden.RequireEqual(t, renderVisibleScreen(t, raw))
 }
 
-// TestDialog_TagRemoveEmptyGolden renders the tag form after toggling to Remove
-// on an entry with NO tags: instead of a free-text key, Remove shows a
-// "(no tags to remove)" note, the empty state that keeps an untag from being
-// invited when there is nothing to remove (#705).
-func TestDialog_TagRemoveEmptyGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
+// TestDialog_TagAddOnlyWhenNoTagsGolden renders the tag form for an entry with NO
+// loaded tags: the Action toggle offers Add only — Remove is not offered, since
+// there is nothing to remove, so the user is never lured into an unusable Remove
+// (#761). Toggling right stays on Add.
+func TestDialog_TagAddOnlyWhenNoTagsGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
 	goldenEnv(t)
 
 	m, cmd := dialogs.NewTagForm(dialogs.TagInput{
@@ -358,7 +358,9 @@ func TestDialog_TagRemoveEmptyGolden(t *testing.T) { //nolint:paralleltest // go
 		Service: "param", Styles: styles.New(), Name: "/app/api/DATABASE_URL",
 	})
 
-	raw := captureDialogWithKeys(t, newDialogHost(m, cmd), "(no tags to remove)", keyRightMsg())
+	// Right cannot toggle to Remove (it is not offered); the form stays on the Add
+	// branch with the free-text key input.
+	raw := captureDialogWithKeys(t, newDialogHost(m, cmd), "Action", keyRightMsg())
 	golden.RequireEqual(t, renderVisibleScreen(t, raw))
 }
 

--- a/internal/tui/dialogs/dialogs_test.go
+++ b/internal/tui/dialogs/dialogs_test.go
@@ -767,23 +767,23 @@ func TestTagForm_StagedOnlyIsAddOnly(t *testing.T) {
 	assert.Contains(t, view, "Add tag", "the staged-only tag form offers Add")
 	assert.NotContains(t, view, "Remove tag", "the staged-only tag form offers no Remove action")
 
-	// A browser launch (not staged-only) still offers Remove.
+	// A browser launch (not staged-only) with removable tags still offers Remove.
 	bm, _ := NewTagForm(TagInput{
 		Ctx: context.Background(), Mutator: mut, Service: "param", Styles: styles.New(), Name: "/app/X",
+		Tags: []data.Tag{{Key: "env", Value: "prod"}},
 	})
 	b, ok := bm.(*tagForm)
 	require.True(t, ok)
 
 	_, _ = b.Update(tea.KeyPressMsg{Code: tea.KeyRight})
-	assert.True(t, b.remove, "a browser launch can toggle to Remove")
+	assert.True(t, b.remove, "a browser launch with tags can toggle to Remove")
 }
 
-// TestTagForm_RemoveEmptyState pins the #705 empty state: an entry with no tags
-// has nothing to untag, so Remove shows a "(no tags to remove)" note instead of a
-// free-text key, and completing the Remove action is blocked — the guard reopens
-// with the note rather than dead-ending on a guaranteed-failing untag, and no
-// untag is ever submitted.
-func TestTagForm_RemoveEmptyState(t *testing.T) {
+// TestTagForm_EmptyTagsFallbackToAdd pins the #761 defensive fallback: if the
+// Remove action is somehow active with an empty tag set (it should never be
+// offered), rebuilding the form falls back to Add rather than building a select
+// with nothing to pick.
+func TestTagForm_EmptyTagsFallbackToAdd(t *testing.T) {
 	t.Parallel()
 
 	mut := &fakeMutator{svcCap: awsParamCap()}
@@ -793,18 +793,10 @@ func TestTagForm_RemoveEmptyState(t *testing.T) {
 	d, ok := m.(*tagForm)
 	require.True(t, ok)
 
-	_, isNote := d.removeField().(*huh.Note)
-	assert.True(t, isNote, "with no tags, Remove shows a note, not a free-text key")
-
 	d.remove = true
 	require.NotNil(t, d.rebuildForm())
-	assert.Contains(t, stripANSI(d.View()), "(no tags to remove)", "the empty state names why nothing can be removed")
-
-	// The empty Remove has no key to route, and the completion guard blocks it (see
-	// the teatest TestTUI_TagRemoveEmptyBlocksSubmit for the end-to-end proof that
-	// no untag is submitted). Here we pin that nothing has been routed yet.
-	assert.Empty(t, mut.tagKey, "no untag key is set for an entry with no tags")
-	assert.False(t, d.busy)
+	assert.False(t, d.remove, "an empty tag set falls back to Add rather than a dead-end Remove")
+	assert.NotContains(t, stripANSI(d.View()), "(no tags to remove)", "no dead-end note is rendered")
 }
 
 // TestTagForm_ActionToggleMorphsKeyField pins that toggling the action select
@@ -831,6 +823,33 @@ func TestTagForm_ActionToggleMorphsKeyField(t *testing.T) {
 	assert.True(t, d.remove, "right toggles the action to Remove")
 	assert.True(t, d.builtRemove, "the form rebuilt onto the Remove branch")
 	assert.Contains(t, stripANSI(d.View()), "env=prod", "the Remove select is now shown")
+}
+
+// TestTagForm_EmptyTagsHidesRemove pins the #761 fix: an entry with no loaded
+// tags has nothing to untag, so the Action toggle offers Add only — the user is
+// never lured into a Remove that cannot select anything. Toggling the action can
+// never reach Remove, and the "(no tags to remove)" dead-end is never rendered.
+func TestTagForm_EmptyTagsHidesRemove(t *testing.T) {
+	t.Parallel()
+
+	mut := &fakeMutator{svcCap: awsParamCap()}
+	m, _ := NewTagForm(TagInput{
+		Ctx: context.Background(), Mutator: mut, Service: "param", Styles: styles.New(), Name: "/app/X",
+		// No Tags: an empty tag set must not offer Remove.
+	})
+	d, ok := m.(*tagForm)
+	require.True(t, ok)
+
+	require.False(t, d.remove, "the form starts on Add")
+
+	// Toggling the inline action select right cannot reach Remove: it is not
+	// offered when there is nothing to remove.
+	_, _ = d.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	assert.False(t, d.remove, "an entry with no tags never offers Remove, so the action stays on Add")
+
+	// The empty-state dead-end note is never rendered.
+	assert.NotContains(t, stripANSI(d.View()), "(no tags to remove)", "no dead-end note is ever shown")
+	assert.Empty(t, mut.tagKey, "no tag write is routed")
 }
 
 // TestDeleteConfirm_ResultVoicing pins the delete status voicing, including the

--- a/internal/tui/dialogs/tagform.go
+++ b/internal/tui/dialogs/tagform.go
@@ -29,8 +29,9 @@ type tagForm struct {
 	namespace string
 	// tags is the entry's current tag set, seeding the Remove action's choices so
 	// an untag can only target a tag that is actually present (#705). Empty when the
-	// caller has none to offer (e.g. the staging review page), in which case Remove
-	// shows an empty state rather than a blind free-text key.
+	// caller has none to offer (e.g. the staging review page, or an entry with no
+	// loaded tags), in which case the Remove action is not offered at all (#761)
+	// rather than luring the user into a select with nothing to pick.
 	tags []data.Tag
 
 	remove   bool
@@ -38,7 +39,7 @@ type tagForm struct {
 	tagValue string // Add: the value to add
 	// removeKey is the key chosen for removal, bound to the Remove action's select
 	// (seeded from tags). It is distinct from the Add key so a typed Add key never
-	// masquerades as a removable one, keeping the empty-tags guard honest.
+	// masquerades as a removable one.
 	removeKey string
 	staged    bool
 	// stagedOnly hides the mode toggle and forces a staged tag write (the staging
@@ -63,7 +64,8 @@ type TagInput struct {
 	Name      string
 	Namespace string
 	// Tags is the entry's current tag set, offered as the Remove action's choices
-	// (#705). Empty when the caller has none to offer.
+	// (#705). Empty when the caller has none to offer, in which case the Remove
+	// action is not offered (#761).
 	Tags []data.Tag
 	// StagedOnly opens the dialog from a staged-only surface (the staging review
 	// page): the mode toggle is hidden and the tag write is forced staged.
@@ -95,14 +97,26 @@ func NewTagForm(in TagInput) (Model, tea.Cmd) {
 }
 
 func (d *tagForm) rebuildForm() tea.Cmd {
-	// Remove is offered only on a surface that can supply the entry's current tag
-	// set to constrain it (the browser). A staged-only surface (the staging review
-	// page) knows only the staged deltas, never the remote tag set, so it offers
-	// Add only — removing a remote tag is done from the browser, where the tag set
-	// is visible; this keeps Remove from becoming a guaranteed empty-state dead-end
-	// there (#705), mirroring how the mode toggle is hidden on that surface.
+	// Defensive: Remove is only ever offered when there are removable tags (below),
+	// so d.remove cannot be true with an empty tag set — but if it somehow is (e.g.
+	// a stale toggle), fall back to Add rather than rendering a dead-end. This keeps
+	// removeField's select honest: it is only built over a non-empty tag set.
+	if d.remove && len(d.tags) == 0 {
+		d.remove = false
+	}
+
+	// Remove is offered only when the entry has a current tag set to constrain it
+	// (#705 made Remove a select over existing tags, dropping the free-text
+	// fallback). Two surfaces have no removable tags and so offer Add only:
+	//   - a staged-only surface (the staging review page) knows only the staged
+	//     deltas, never the remote tag set — removing a remote tag is done from the
+	//     browser, where the tag set is visible;
+	//   - an entry with no loaded tags has nothing to untag at all.
+	// Offering Remove in either state is a dead-end: the user picks it and then
+	// cannot select anything (#761). Gating it here mirrors how the mode toggle is
+	// hidden on the staged-only surface.
 	actionOpts := []huh.Option[bool]{huh.NewOption("Add tag", false)}
-	if !d.stagedOnly {
+	if !d.stagedOnly && len(d.tags) > 0 {
 		actionOpts = append(actionOpts, huh.NewOption("Remove tag", true))
 	}
 
@@ -146,15 +160,11 @@ func (d *tagForm) rebuildForm() tea.Cmd {
 
 // removeField builds the Remove action's key field: a select of the entry's
 // current tags (labelled "key=value", valued by key so it routes straight to
-// RemoveTag), or a read-only note when the entry has no tags. The select binds
-// removeKey, which huh seeds to the first tag on build, so a Remove always has a
-// valid target; the note path is blocked from submitting by the empty-tags guard
-// in Update.
+// RemoveTag). The select binds removeKey, which huh seeds to the first tag on
+// build, so a Remove always has a valid target. It is only reached with a
+// non-empty tag set — Remove is not offered otherwise (#761) — so there is no
+// empty-state branch to guard.
 func (d *tagForm) removeField() huh.Field {
-	if len(d.tags) == 0 {
-		return huh.NewNote().Title("Tag").Description("(no tags to remove)")
-	}
-
 	opts := lo.Map(d.tags, func(t data.Tag, _ int) huh.Option[string] {
 		return huh.NewOption(t.Key+"="+t.Value, t.Key)
 	})
@@ -223,14 +233,6 @@ func (d *tagForm) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 	switch d.form.State {
 	case huh.StateCompleted:
-		// A Remove on an entry with no tags has nothing to target: reopen with a
-		// note rather than dead-ending on a guaranteed-failing untag (#705).
-		if d.remove && len(d.tags) == 0 {
-			d.err = "no tags to remove"
-
-			return d, d.rebuildForm()
-		}
-
 		d.busy = true
 
 		return d, d.submit()

--- a/internal/tui/tagform_interaction_test.go
+++ b/internal/tui/tagform_interaction_test.go
@@ -116,11 +116,12 @@ func TestTUI_TagRemoveRoutesSelectedKey(t *testing.T) {
 	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
 }
 
-// TestTUI_TagRemoveEmptyBlocksSubmit drives a Remove on an entry with NO tags
-// through the real event loop: completing the form never submits an untag — the
-// empty-tags guard reopens the "(no tags to remove)" note instead of routing a
-// guaranteed-failing empty untag to the mutator (#705).
-func TestTUI_TagRemoveEmptyBlocksSubmit(t *testing.T) {
+// TestTUI_TagEmptyNeverOffersRemove drives the tag dialog for an entry with NO
+// tags through the real event loop: the Action toggle never reaches Remove
+// (right-arrow is a no-op with a single Add option), so the user is never lured
+// into an unusable Remove and the "(no tags to remove)" dead-end never renders
+// (#761). No untag is ever routed.
+func TestTUI_TagEmptyNeverOffersRemove(t *testing.T) {
 	t.Parallel()
 
 	mut := &recordingMutator{cap: capability.ServiceCapability{Service: "param", HasTags: true, HasStaging: true}}
@@ -131,24 +132,26 @@ func TestTUI_TagRemoveEmptyBlocksSubmit(t *testing.T) {
 	host := newDialogHost(m, cmd)
 	tm := teatest.NewTestModel(t, host, teatest.WithInitialTermSize(goldenTermWidth, goldenTermHeight))
 
-	tm.Send(keyRightMsg()) // Add -> Remove
+	tm.Send(keyRightMsg()) // no-op: Remove is not offered, so the action stays on Add
 
 	for range 6 {
-		tm.Send(keyEnterMsg()) // try to complete; the guard must catch every completion
+		tm.Send(keyEnterMsg()) // an empty Add key fails required-field validation; nothing completes
 	}
 
-	// Give the loop time to process every enter (and any guarded rebuild).
+	// Give the loop time to process every key.
 	time.Sleep(300 * time.Millisecond)
 
 	remove, add, _, _ := mut.snapshot()
-	assert.False(t, remove, "no untag is submitted when the entry has no tags")
-	assert.False(t, add, "no tag write is submitted at all")
+	assert.False(t, remove, "no untag is ever submitted for an entry with no tags")
+	assert.False(t, add, "no tag write is submitted without a key")
 
-	// The empty state is still on screen (never dead-ended into a submit).
+	// The dead-end note is never rendered, and the action never reaches Remove.
 	var buf bytes.Buffer
 
 	_, _ = io.Copy(&buf, tm.Output())
-	assert.Contains(t, buf.String(), "(no tags to remove)", "the empty state persists")
+	out := buf.String()
+	assert.NotContains(t, out, "(no tags to remove)", "the dead-end note is never shown")
+	assert.NotContains(t, out, "Remove tag", "the action toggle never reaches Remove")
 
 	tm.Send(hostQuitMsg{})
 	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))

--- a/internal/tui/testdata/TestDialog_TagAddOnlyWhenNoTagsGolden.golden
+++ b/internal/tui/testdata/TestDialog_TagAddOnlyWhenNoTagsGolden.golden
@@ -2,12 +2,13 @@
 │Tag — /app/api/DATABASE_URL                           │
 │                                                      │
 │┃ Action                                              │
-│┃ ← Remove tag →                                      │
+│┃ ← Add tag →                                         │
 │                                                      │
-│  Tag                                                 │
+│  Key                                                 │
+│  >                                                   │
 │                                                      │
-│  (no tags to remove)                                 │
-│                                                      │
+│  Value                                               │
+│  > (add only)                                        │
 │                                                      │
 │  Mode                                                │
 │  (•) Stage    ( ) Apply immediately                  │


### PR DESCRIPTION
Closes #761

## The dead-end

In the TUI tag dialog, the **Action** toggle offered "Remove tag" for any non-`stagedOnly` surface regardless of whether the entry had any removable tags. Since #705 constrained Remove to a select over the entry's existing tags (dropping the pre-#705 free-text fallback), an **empty** loaded tag set (`d.tags`, sourced from the browser's `m.detail.Tags`) rendered a non-selectable `(no tags to remove)` note and blocked submit. So the user could pick "Remove tag" and then be unable to select anything — a consistent dead-end reported as "Remove Tag が選べない".

## The fix

Gate the "Remove tag" Action option on there being removable tags: it is appended only when `!d.stagedOnly && len(d.tags) > 0`. This mirrors the existing precedent where Remove is already hidden on the `stagedOnly` surface.

- Entry **with** loaded tags → Action offers Add + Remove; Remove select works (unchanged, #705).
- Entry with **no** loaded tags → Action offers Add only; the user is never lured into an unusable Remove.

A defensive fallback in `rebuildForm` resets `d.remove` to `false` if it is ever `true` with an empty tag set, so `removeField`'s select is only ever built over a non-empty set. The now-unreachable `(no tags to remove)` note and the empty-tags submit guard are removed (no dead code left behind).

## Follow-up (out of scope for this PR)

There is a secondary sub-case: an entry that **has** remote tags but whose best-effort tag load returned empty (a provider tag fetch failing silently — AWS/gcloud/azure all load tags best-effort and leave them empty on error). Gating Remove on `len(d.tags) > 0` means Remove will not appear in that state either. A complete fix (refreshing/fetching the entry's tags when the dialog opens so a best-effort miss no longer makes Remove impossible) is larger and left as a follow-up. This PR eliminates the primary defect — the reported "選べない" dead-end.

## Verification

- `go build ./...`
- `go test ./internal/tui/...` and `-race` — all pass
- `golangci-lint run --allow-parallel-runners ./internal/tui/...` — 0 issues
- `.github/scripts/check-deadcode.sh` — gate OK
- New empty-tags regression test (`TestTagForm_EmptyTagsHidesRemove`) FAILS before the fix (Remove offered, dead-end note shown) and PASSES after (Remove hidden). Golden `TestDialog_TagRemoveEmptyGolden` (empty-remove note) is replaced by `TestDialog_TagAddOnlyWhenNoTagsGolden` (Add-only), and the `TestTUI_TagRemoveEmptyBlocksSubmit` teatest is reframed as `TestTUI_TagEmptyNeverOffersRemove`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)