### PR TITLE
test(tui): capture golden screens from the settled FinalModel, not the live frame stream (#764)

### DIFF
--- a/internal/tui/browser_golden_test.go
+++ b/internal/tui/browser_golden_test.go
@@ -486,7 +486,17 @@ func captureBrowserAfterKeys(t *testing.T, m *App, marker string, keys ...tea.Ke
 
 	var buf bytes.Buffer
 
-	waitFor(t, tm, &buf, marker)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		_, _ = io.Copy(&buf, tm.Output())
+		if bytes.Contains(buf.Bytes(), []byte(marker)) {
+			break
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	require.Contains(t, buf.String(), marker, "loaded content never rendered")
 
 	for _, k := range keys {
 		tm.Send(k)

--- a/internal/tui/dialog_golden_test.go
+++ b/internal/tui/dialog_golden_test.go
@@ -2,9 +2,7 @@
 package tui
 
 import (
-	"bytes"
 	"context"
-	"io"
 	"testing"
 	"time"
 
@@ -91,69 +89,32 @@ func (h *dialogHost) View() tea.View {
 }
 
 // captureDialog drives a hosted dialog to its rendered state (until marker
-// appears) and returns the byte stream, quitting via the host sentinel so no key
-// is typed into the embedded form.
-func captureDialog(t *testing.T, host *dialogHost, marker string) []byte {
+// appears), quits via the host sentinel (so no key is typed into the embedded
+// form), and renders the SETTLED final model's screen.
+//
+// Like the staging helpers, the golden is taken from the final
+// dialogHost.View().Content — a single coherent full render of the settled
+// dialog after the WindowSizeMsg and every sent message are processed — not from
+// the live teatest frame stream, which emits timing-dependent diff frames that
+// the vt replay intermittently corrupts under CI's parallel -race (#764).
+func captureDialog(t *testing.T, host *dialogHost, marker string) string {
 	t.Helper()
 
-	tm := teatest.NewTestModel(t, host, teatest.WithInitialTermSize(goldenTermWidth, goldenTermHeight))
-
-	var buf bytes.Buffer
-
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		_, _ = io.Copy(&buf, tm.Output())
-		if bytes.Contains(buf.Bytes(), []byte(marker)) {
-			break
-		}
-
-		time.Sleep(20 * time.Millisecond)
-	}
-
-	require.Contains(t, buf.String(), marker, "dialog content never rendered")
-
-	tm.Send(hostQuitMsg{})
-	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
-
-	_, _ = io.Copy(&buf, tm.Output())
-
-	return buf.Bytes()
+	return captureDialogSize(t, host, marker, goldenTermWidth, goldenTermHeight)
 }
 
 func dialogGolden(t *testing.T, host *dialogHost, marker string) {
 	t.Helper()
 
-	raw := captureDialog(t, host, marker)
-	golden.RequireEqual(t, renderVisibleScreen(t, raw))
+	golden.RequireEqual(t, captureDialog(t, host, marker))
 }
 
 // captureDialogSize is captureDialog at an explicit terminal size, so a dialog
 // can be goldened at the minimum supported 60×16 (the #686 clip/wrap fix).
-func captureDialogSize(t *testing.T, host *dialogHost, marker string, w, h int) []byte {
+func captureDialogSize(t *testing.T, host *dialogHost, marker string, w, h int) string {
 	t.Helper()
 
-	tm := teatest.NewTestModel(t, host, teatest.WithInitialTermSize(w, h))
-
-	var buf bytes.Buffer
-
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		_, _ = io.Copy(&buf, tm.Output())
-		if bytes.Contains(buf.Bytes(), []byte(marker)) {
-			break
-		}
-
-		time.Sleep(20 * time.Millisecond)
-	}
-
-	require.Contains(t, buf.String(), marker, "dialog content never rendered")
-
-	tm.Send(hostQuitMsg{})
-	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
-
-	_, _ = io.Copy(&buf, tm.Output())
-
-	return buf.Bytes()
+	return captureDialogWithKeysSize(t, host, marker, w, h)
 }
 
 // dialogGoldenSize goldens a hosted dialog rendered at an explicit terminal size
@@ -162,44 +123,42 @@ func captureDialogSize(t *testing.T, host *dialogHost, marker string, w, h int) 
 func dialogGoldenSize(t *testing.T, host *dialogHost, marker string, w, h int) {
 	t.Helper()
 
-	raw := captureDialogSize(t, host, marker, w, h)
-	golden.RequireEqual(t, renderVisibleScreenSize(t, raw, w, h))
+	golden.RequireEqual(t, captureDialogSize(t, host, marker, w, h))
 }
 
 // captureDialogWithKeys drives a hosted dialog, first replaying the given key
 // presses (so a golden can capture a post-interaction state — e.g. an immediate
-// delete after the mode toggle), then captures once the marker appears. The final
-// rendered screen reflects the last frame, so the pre-toggle frame in the stream
-// is harmless.
-func captureDialogWithKeys(t *testing.T, host *dialogHost, marker string, keys ...tea.KeyPressMsg) []byte {
+// delete after the mode toggle), waits for the marker to render, quits, and
+// renders the settled final model's screen at the default golden size.
+func captureDialogWithKeys(t *testing.T, host *dialogHost, marker string, keys ...tea.KeyPressMsg) string {
 	t.Helper()
 
-	tm := teatest.NewTestModel(t, host, teatest.WithInitialTermSize(goldenTermWidth, goldenTermHeight))
+	return captureDialogWithKeysSize(t, host, marker, goldenTermWidth, goldenTermHeight, keys...)
+}
+
+// captureDialogWithKeysSize is the shared dialog driver: at the given terminal
+// size it replays the keys, waits for the marker (so any async rebuild has
+// rendered), quits via the host sentinel, and renders the settled final model's
+// View().Content through the vt.
+func captureDialogWithKeysSize(t *testing.T, host *dialogHost, marker string, w, h int, keys ...tea.KeyPressMsg) string {
+	t.Helper()
+
+	tm := teatest.NewTestModel(t, host, teatest.WithInitialTermSize(w, h))
 
 	for _, k := range keys {
 		tm.Send(k)
 	}
 
-	var buf bytes.Buffer
-
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		_, _ = io.Copy(&buf, tm.Output())
-		if bytes.Contains(buf.Bytes(), []byte(marker)) {
-			break
-		}
-
-		time.Sleep(20 * time.Millisecond)
-	}
-
-	require.Contains(t, buf.String(), marker, "dialog content never rendered")
+	waitFor(t, tm, marker)
 
 	tm.Send(hostQuitMsg{})
-	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
 
-	_, _ = io.Copy(&buf, tm.Output())
+	fm := tm.FinalModel(t, teatest.WithFinalTimeout(3*time.Second))
 
-	return buf.Bytes()
+	final, ok := fm.(*dialogHost)
+	require.True(t, ok, "final model must be *dialogHost")
+
+	return renderVisibleScreenSize(t, []byte(final.View().Content), w, h)
 }
 
 // keyDownMsg / keyEnterMsg are the golden-driver key presses for navigating a
@@ -297,9 +256,8 @@ func TestDialog_DeleteAWSSecretImmediateGolden(t *testing.T) { //nolint:parallel
 
 	// From the default (staged) focus on Force, move down to the Mode row and
 	// toggle to immediate.
-	raw := captureDialogWithKeys(t, newDialogHost(m, nil), "(•) Apply immediately",
-		keyDownMsg(), keyDownMsg(), keyEnterMsg())
-	golden.RequireEqual(t, renderVisibleScreen(t, raw))
+	golden.RequireEqual(t, captureDialogWithKeys(t, newDialogHost(m, nil), "(•) Apply immediately",
+		keyDownMsg(), keyDownMsg(), keyEnterMsg()))
 }
 
 // TestDialog_DeleteGCloudSecretGolden renders the delete confirm for Google
@@ -342,8 +300,7 @@ func TestDialog_TagRemoveSelectGolden(t *testing.T) { //nolint:paralleltest // g
 
 	// Right toggles the inline action select from Add to Remove; the form rebuilds
 	// onto the Remove branch and shows the existing-tags select.
-	raw := captureDialogWithKeys(t, newDialogHost(m, cmd), "env=prod", keyRightMsg())
-	golden.RequireEqual(t, renderVisibleScreen(t, raw))
+	golden.RequireEqual(t, captureDialogWithKeys(t, newDialogHost(m, cmd), "env=prod", keyRightMsg()))
 }
 
 // TestDialog_TagAddOnlyWhenNoTagsGolden renders the tag form for an entry with NO
@@ -360,8 +317,7 @@ func TestDialog_TagAddOnlyWhenNoTagsGolden(t *testing.T) { //nolint:paralleltest
 
 	// Right cannot toggle to Remove (it is not offered); the form stays on the Add
 	// branch with the free-text key input.
-	raw := captureDialogWithKeys(t, newDialogHost(m, cmd), "Action", keyRightMsg())
-	golden.RequireEqual(t, renderVisibleScreen(t, raw))
+	golden.RequireEqual(t, captureDialogWithKeys(t, newDialogHost(m, cmd), "Action", keyRightMsg()))
 }
 
 // TestDialog_EntryFormStagedOnlyGolden renders the edit form as launched from the

--- a/internal/tui/staging_golden_test.go
+++ b/internal/tui/staging_golden_test.go
@@ -218,8 +218,7 @@ func secureStringCreateStagingApp() *App {
 func TestStaging_SecureStringParamCreateDiffViewGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
 	goldenEnv(t)
 
-	raw := captureStaging(t, secureStringCreateStagingApp(), "SECURE_CREATE", false)
-	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+	screen := captureStaging(t, secureStringCreateStagingApp(), "SECURE_CREATE", false)
 
 	assert.NotContains(t, screen, secureStringCreateValue, "no revealed SecureString param create value in the diff-view golden")
 	assert.Contains(t, screen, "•", "the SecureString param create row is masked with bullets, proving it renders (not just absent)")
@@ -232,8 +231,7 @@ func TestStaging_SecureStringParamCreateDiffViewGolden(t *testing.T) { //nolint:
 func TestStaging_SecureStringParamCreateValueViewGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
 	goldenEnv(t)
 
-	raw := captureStaging(t, secureStringCreateStagingApp(), "SECURE_CREATE", true)
-	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+	screen := captureStaging(t, secureStringCreateStagingApp(), "SECURE_CREATE", true)
 
 	assert.NotContains(t, screen, secureStringCreateValue, "no revealed SecureString param create value in the value-view golden")
 	assert.Contains(t, screen, "•", "the SecureString param create row is masked with bullets, proving it renders (not just absent)")
@@ -247,8 +245,7 @@ func TestStaging_SecureStringParamCreateValueViewGolden(t *testing.T) { //nolint
 func TestStaging_SecureStringParamDiffViewGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
 	goldenEnv(t)
 
-	raw := captureStaging(t, secureStringStagingApp(), "SECURE_TOKEN", false)
-	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+	screen := captureStaging(t, secureStringStagingApp(), "SECURE_TOKEN", false)
 
 	assert.Contains(t, screen, secureStringParamValue, "the SecureString param diff is revealed by default (#677/#735)")
 	assert.Contains(t, screen, "https://cdn-new.example.com", "a plaintext param row is shown too")
@@ -260,8 +257,7 @@ func TestStaging_SecureStringParamDiffViewGolden(t *testing.T) { //nolint:parall
 func TestStaging_SecureStringParamValueViewGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
 	goldenEnv(t)
 
-	raw := captureStaging(t, secureStringStagingApp(), "SECURE_TOKEN", true)
-	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+	screen := captureStaging(t, secureStringStagingApp(), "SECURE_TOKEN", true)
 
 	assert.NotContains(t, screen, secureStringParamValue, "no revealed SecureString param value in the value-view golden")
 	assert.Contains(t, screen, "•", "the SecureString param row is masked with bullets, proving it renders (not just absent)")
@@ -274,8 +270,7 @@ func TestStaging_SecureStringParamValueViewGolden(t *testing.T) { //nolint:paral
 func TestStaging_DiffViewGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
 	goldenEnv(t)
 
-	raw := captureStaging(t, stagingApp(), "prod/api/session", false)
-	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+	screen := captureStaging(t, stagingApp(), "prod/api/session", false)
 
 	assert.Contains(t, screen, secretStagedValue, "the secret remote-vs-staged diff is revealed by default (#735)")
 	golden.RequireEqual(t, screen)
@@ -287,8 +282,7 @@ func TestStaging_DiffViewGolden(t *testing.T) { //nolint:paralleltest // goldenE
 func TestStaging_DiffViewHiddenGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
 	goldenEnv(t)
 
-	raw := captureStagingKeys(t, stagingApp(), "prod/api/session", keyPress('x'))
-	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+	screen := captureStagingKeys(t, stagingApp(), "prod/api/session", keyPress('x'))
 
 	assert.NotContains(t, screen, secretStagedValue, "x hides the revealed secret diff")
 	assert.Contains(t, screen, "•", "the hidden diff still renders as masked bullets")
@@ -300,8 +294,7 @@ func TestStaging_DiffViewHiddenGolden(t *testing.T) { //nolint:paralleltest // g
 func TestStaging_ValueViewGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
 	goldenEnv(t)
 
-	raw := captureStaging(t, stagingApp(), "prod/api/session", true)
-	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+	screen := captureStaging(t, stagingApp(), "prod/api/session", true)
 
 	assert.NotContains(t, screen, secretStagedValue, "no revealed secret value in the value-view golden")
 	golden.RequireEqual(t, screen)
@@ -313,84 +306,95 @@ func TestStaging_ValueViewGolden(t *testing.T) { //nolint:paralleltest // golden
 func TestStaging_TagGateStatusGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
 	goldenEnv(t)
 
-	raw := captureStagingKeys(t, stagingApp(), "prod/api/old-key",
+	screen := captureStagingKeys(t, stagingApp(), "prod/api/old-key",
 		// Move to the delete-staged secret row (prod/api/old-key), then press `t`.
 		keyPress('j'), keyPress('j'), keyPress('j'), keyPress('j'), keyPress('t'))
-	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
 
 	assert.Contains(t, screen, "cannot tag: staged for deletion", "the gate surfaces a status message")
 	golden.RequireEqual(t, screen)
 }
 
 // captureStagingKeys drives a staging app to its loaded state, sends the given
-// keys, and returns the captured byte stream (for asserting a post-key frame).
-func captureStagingKeys(t *testing.T, m *App, marker string, presses ...tea.KeyPressMsg) []byte {
+// keys, quits, and renders the SETTLED final model's screen.
+//
+// The golden is taken from tm.FinalModel().View().Content — the full, coherent
+// screen of the settled model after every sent message and the quit are
+// processed — not from the live teatest frame stream. Bubble Tea emits diff
+// frames, and under CI's parallel -race the async load + WindowSizeMsg settle at
+// timing-dependent points, so replaying the raw frame stream through the vt
+// intermittently corrupts the final screen (dropped separators, uneven padding,
+// #764). Rendering the final View().Content is deterministic: one full-width
+// paint of the settled state, independent of frame timing.
+func captureStagingKeys(t *testing.T, m *App, marker string, presses ...tea.KeyPressMsg) string {
 	t.Helper()
 
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(browserTermWidth, browserTermHeight))
 
-	var buf bytes.Buffer
-
-	waitFor(t, tm, &buf, marker)
+	// Wait for the async staged review to land (the marker row rendered) before
+	// sending interaction keys, so the keys act on a loaded page.
+	waitFor(t, tm, marker)
 
 	for _, k := range presses {
 		tm.Send(k)
-		time.Sleep(50 * time.Millisecond)
 	}
 
-	time.Sleep(100 * time.Millisecond)
-
-	_, _ = io.Copy(&buf, tm.Output())
-
 	tm.Send(keyPress('q'))
-	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
 
-	_, _ = io.Copy(&buf, tm.Output())
-
-	return buf.Bytes()
+	return settledAppScreen(t, tm)
 }
 
 // captureStaging drives a staging app to its loaded state (optionally toggling to
-// value view with `v`) and returns the captured byte stream.
-func captureStaging(t *testing.T, m *App, marker string, valueView bool) []byte {
+// value view with `v`), quits, and renders the settled final model's screen.
+func captureStaging(t *testing.T, m *App, marker string, valueView bool) string {
 	t.Helper()
 
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(browserTermWidth, browserTermHeight))
 
-	var buf bytes.Buffer
-
-	waitFor(t, tm, &buf, marker)
+	waitFor(t, tm, marker)
 
 	if valueView {
 		tm.Send(keyPress('v'))
-		time.Sleep(100 * time.Millisecond)
-
-		_, _ = io.Copy(&buf, tm.Output())
 	}
 
 	tm.Send(keyPress('q'))
-	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
 
-	_, _ = io.Copy(&buf, tm.Output())
-
-	return buf.Bytes()
+	return settledAppScreen(t, tm)
 }
 
-// waitFor accumulates output until marker appears (or the deadline).
-func waitFor(t *testing.T, tm *teatest.TestModel, buf *bytes.Buffer, marker string) {
+// settledAppScreen waits for the program to finish, then renders the settled
+// *App final model's full-screen View().Content through the vt. Rendering the
+// settled View — not the live frame stream — is what makes the golden
+// deterministic under CI's parallel -race (#764).
+func settledAppScreen(t *testing.T, tm *teatest.TestModel) string {
 	t.Helper()
+
+	fm := tm.FinalModel(t, teatest.WithFinalTimeout(3*time.Second))
+
+	app, ok := fm.(*App)
+	require.True(t, ok, "final model must be *App")
+
+	return renderVisibleScreenSize(t, []byte(app.View().Content), browserTermWidth, browserTermHeight)
+}
+
+// waitFor drains the live output until marker appears (or the deadline). It only
+// gates on the async load having rendered; the golden is taken from the settled
+// FinalModel, not from this stream.
+func waitFor(t *testing.T, tm *teatest.TestModel, marker string) {
+	t.Helper()
+
+	var buf bytes.Buffer
 
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		_, _ = io.Copy(buf, tm.Output())
+		_, _ = io.Copy(&buf, tm.Output())
 		if bytes.Contains(buf.Bytes(), []byte(marker)) {
-			break
+			return
 		}
 
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	require.Contains(t, buf.String(), marker, "staging content never rendered")
+	require.Contains(t, buf.String(), marker, "content never rendered")
 }
 
 // TestStaging_ApplyConfirmGolden renders the apply confirmation dialog (target
@@ -431,9 +435,8 @@ func TestStaging_ApplyResultsGolden(t *testing.T) { //nolint:paralleltest // gol
 	})
 
 	// Focus Apply (row 1) and confirm to reach the results view.
-	raw := captureDialogWithKeys(t, newDialogHost(d, nil), "Apply results",
-		keyDownMsg(), keyEnterMsg())
-	golden.RequireEqual(t, renderVisibleScreen(t, raw))
+	golden.RequireEqual(t, captureDialogWithKeys(t, newDialogHost(d, nil), "Apply results",
+		keyDownMsg(), keyEnterMsg()))
 }
 
 // TestStaging_ApplyResultsScrollableGolden pins the #687 fix: an apply result set
@@ -462,9 +465,8 @@ func TestStaging_ApplyResultsScrollableGolden(t *testing.T) { //nolint:parallelt
 	})
 
 	// Focus Apply (row 1) and confirm to reach the results view.
-	raw := captureDialogWithKeys(t, newDialogHost(d, nil), "enter/esc: close",
-		keyDownMsg(), keyEnterMsg())
-	golden.RequireEqual(t, renderVisibleScreen(t, raw))
+	golden.RequireEqual(t, captureDialogWithKeys(t, newDialogHost(d, nil), "enter/esc: close",
+		keyDownMsg(), keyEnterMsg()))
 }
 
 // TestStaging_RoundTrip stages a secret create through the Step-4 mutator, then


### PR DESCRIPTION
Closes #764

## Root cause

The staging and dialog golden helpers (`captureStagingKeys`, `captureStaging`, `captureDialog`, `captureDialogSize`, `captureDialogWithKeys`) drove the app through teatest and captured the **live raw frame stream** — `io.Copy(&buf, tm.Output())` after fixed `time.Sleep` guesses — then replayed those bytes into a virtual terminal (`renderVisibleScreenSize`).

teatest's output buffer loses no bytes, so the flake was never lost bytes. It is that Bubble Tea renders **diff frames**: under CI's parallel `-race` the app's async loads and the `WindowSizeMsg`-driven width settle at timing-dependent points, so some lines get rendered at a stale width and are never re-padded. Replaying that mixed-width diff-frame stream into the vt intermittently yields a corrupted final screen — dropped ` • ` separators (TagGateStatus), uneven right-border padding (ApplyResultsScrollable). Not reproducible locally on macOS. A longer settle sleep (the earlier mitigation on #762) only reduced the odds.

## Fix

Capture the **settled final model's View**, not the live stream. After the interaction keys and the quit key/msg are sent, `tm.FinalModel(t, ...)` returns the model after the program finished — all messages processed, quit handled, width settled. `model.View().Content` (Bubble Tea v2 `tea.View`) is a single **coherent full-width render** of that settled state, deterministic and independent of frame timing. The helpers now feed `FinalModel().View().Content` into the same `renderVisibleScreenSize` vt and return the rendered screen string directly; call sites collapse to `golden.RequireEqual(t, captureX(...))` (or assert on the returned `screen`).

Removed the now-dead `io.Copy` stream drains, the `time.Sleep` settle guesses, and the buffer plumbing. `waitFor` is kept (and reused by the dialog helpers) solely to gate on the async load having rendered before keys are sent. The browser helpers are left on the live-stream capture (stable, out of scope); `captureBrowserAfterKeys` inlines its own marker-wait now that `waitFor` is repurposed.

Staging quits via `keyPress('q')` (matched at the app level as `keys.Quit` → `tea.Quit`, so it never reaches the page handler that would clear the transient `m.status` — the TagGateStatus message survives into the final View). Dialogs quit via the `hostQuitMsg{}` sentinel.

## Regenerated goldens

**None.** The settled-`View()` render is **byte-identical** to every committed golden (`git diff -- internal/tui/testdata/` is empty), so no `-update` was needed and **no secret value is newly unmasked** — the masking policy is unchanged.

## Verification

- `go test -count=1 ./internal/tui/ -run 'TestStaging_.*Golden|TestDialog_.*Golden'` — pass, no golden diffs.
- Determinism: `go test -race -count=3 ./internal/tui/` — all pass (14.3s).
- Full suite: `go build ./... && go test ./internal/tui/... -race` — all pass.
- `golangci-lint run --allow-parallel-runners ./internal/tui/...` — 0 issues.
- `bash .github/scripts/check-deadcode.sh` — OK, no dead code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)