### PR TITLE
fix(tui): cap version history at 10 like the GUI (#747)

### DIFF
--- a/internal/tui/data/data.go
+++ b/internal/tui/data/data.go
@@ -31,6 +31,12 @@ import (
 	"github.com/mpyw/suve/internal/version/awssecretversion"
 )
 
+// historyLimit caps how many version-history rows the browser fetches per
+// selection. It matches the GUI's cap (ParamLog/SecretLog pass 10) so both
+// front-ends bound the same surface identically; without it a secret with many
+// versions would fetch every version's value on each selection change (#747).
+const historyLimit int32 = 10
+
 // ListParams are the list inputs a browser header collects.
 type ListParams struct {
 	Prefix    string
@@ -329,7 +335,7 @@ func (s *paramSource) History(ctx context.Context, name, namespace string) ([]Hi
 
 	uc := &param.LogUseCase{Reader: store}
 
-	out, err := uc.Execute(ctx, param.LogInput{Name: name})
+	out, err := uc.Execute(ctx, param.LogInput{Name: name, MaxResults: historyLimit})
 	if err != nil {
 		return nil, err
 	}
@@ -493,7 +499,7 @@ func (s *secretSource) History(ctx context.Context, name, _ string) ([]HistoryRo
 
 	uc := &secret.LogUseCase{Reader: s.store}
 
-	out, err := uc.Execute(ctx, secret.LogInput{Name: name})
+	out, err := uc.Execute(ctx, secret.LogInput{Name: name, MaxResults: historyLimit})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tui/data/data_test.go
+++ b/internal/tui/data/data_test.go
@@ -2,6 +2,7 @@ package data_test
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -231,6 +232,80 @@ func TestSecretSourceHistoryCarriesValues(t *testing.T) {
 	require.Len(t, rows, 2)
 	assert.Equal(t, "token-v2", rows[0].Value)
 	assert.True(t, rows[0].Secret, "every secret history value is masked by default")
+}
+
+// TestParamSourceHistoryCapsAtLimit pins #747: the param history fetch bounds the
+// version list to 10 (GUI parity), so even a name with far more versions renders
+// at most 10 rows and issues at most 10 per-version value fetches.
+func TestParamSourceHistoryCapsAtLimit(t *testing.T) {
+	t.Parallel()
+
+	all := make([]domain.Version, 25)
+	for i := range all {
+		all[i] = domain.Version{ID: strconv.Itoa(25 - i)} // newest first
+	}
+
+	var gets int
+
+	store := &providermock.Store{
+		HistoryFunc: func(context.Context, string) ([]domain.Version, error) {
+			return all, nil
+		},
+		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+			return provider.NewVersionRef(spec[1:]), nil
+		},
+		GetFunc: func(_ context.Context, name string, ref provider.VersionRef) (*domain.Entry, error) {
+			gets++
+
+			return &domain.Entry{Name: name, Value: "v" + ref.ID(), Version: domain.Version{ID: ref.ID()}}, nil
+		},
+	}
+
+	src := data.NewParamSource(capFor(t, "aws", "param"), func(context.Context, string) (provider.Store, error) {
+		return store, nil
+	})
+
+	rows, err := src.History(context.Background(), "/app/x", "")
+	require.NoError(t, err)
+	require.Len(t, rows, 10, "history is capped at 10 rows like the GUI")
+	assert.Equal(t, 10, gets, "only the capped set's values are fetched, not every version's")
+}
+
+// TestSecretSourceHistoryCapsAtLimit pins #747 for the secret service: a secret
+// with many versions bounds the per-selection value fetches to 10.
+func TestSecretSourceHistoryCapsAtLimit(t *testing.T) {
+	t.Parallel()
+
+	all := make([]domain.Version, 25)
+	for i := range all {
+		all[i] = domain.Version{ID: "v" + strconv.Itoa(25-i)} // newest first
+	}
+
+	var gets int
+
+	store := &providermock.Store{
+		HistoryFunc: func(context.Context, string) ([]domain.Version, error) {
+			return all, nil
+		},
+		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+			return provider.NewVersionRef(spec[1:]), nil
+		},
+		GetFunc: func(_ context.Context, name string, ref provider.VersionRef) (*domain.Entry, error) {
+			gets++
+
+			return &domain.Entry{
+				Name: name, Value: "token-" + ref.ID(), Type: domain.ValueTypeSecret,
+				Version: domain.Version{ID: ref.ID()},
+			}, nil
+		},
+	}
+
+	src := data.NewSecretSource(capFor(t, "aws", "secret"), store)
+
+	rows, err := src.History(context.Background(), "prod/key", "")
+	require.NoError(t, err)
+	require.Len(t, rows, 10, "history is capped at 10 rows like the GUI")
+	assert.Equal(t, 10, gets, "only the capped set's values are fetched, not every version's")
 }
 
 func metaLabels(rows []data.MetaRow) []string {


### PR DESCRIPTION
Closes #747

## Problem

The TUI loaded version history with no `MaxResults`, fetching **every** version. For the secret service the log use case fetches the value of every returned version (`internal/usecase/secret/log.go`), so a single selection change against a long-lived secret issued an unbounded burst of value reads — a real per-selection cost (latency, provider rate limits) and a GUI-parity break, since the GUI caps the same surface at 10 (`ParamLog(name, 10, …)`, `SecretLog(name, 10)`).

## Fix

Pass `MaxResults: 10` at both `internal/tui/data/data.go` history call sites (param and secret), via a named `historyLimit` constant documented as matching the GUI cap. The use cases already cap the version list to `MaxResults` **before** fetching per-version values, so this bounds both the rows rendered and the value reads issued.

## Tests

Added `TestParamSourceHistoryCapsAtLimit` and `TestSecretSourceHistoryCapsAtLimit` in `internal/tui/data/data_test.go`: each mock store returns 25 versions and counts `GetFunc` calls. The tests assert the history returns exactly 10 rows **and** that only 10 per-version value fetches occur, proving the limit flows through to the use case and bounds the value reads.

## Gates

- `go build ./...` — OK
- `go test ./internal/tui/... ./internal/tui/data/...` (and `-race` on data) — pass
- `golangci-lint run --allow-parallel-runners ./internal/tui/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)