### PR TITLE
fix(tui): render values:on preview on its own line, revealed like the GUI (#734)

### DIFF
--- a/internal/tui/browser_golden_test.go
+++ b/internal/tui/browser_golden_test.go
@@ -2,9 +2,7 @@
 package tui
 
 import (
-	"bytes"
 	"context"
-	"io"
 	"testing"
 	"time"
 
@@ -33,11 +31,6 @@ func goldenEnv(t *testing.T) {
 	timeutil.ResetLocationCache()
 }
 
-// captureUntil runs a model through teatest, accumulating ALL output into a
-// private buffer until marker appears (so it never races FinalOutput's shared
-// reader, per the harness note), then quits and returns the full stream. The
-// final visible screen is the last frame — the loaded state — because the quit
-// is sent only after the marker proves the async loads landed.
 // browser goldens render at a two-pane size (≥110 columns) with enough height
 // for the version history; diff goldens use the default shell size.
 const (
@@ -45,31 +38,40 @@ const (
 	browserTermHeight = 34
 )
 
-func captureUntil(t *testing.T, model tea.Model, marker string, width, height int) []byte {
+// captureUntil drives a model to its loaded state (waiting for marker to render),
+// quits via `q`, and renders the SETTLED final model's screen at the given size.
+//
+// Like the staging/dialog helpers (#766), the golden is taken from the final
+// View().Content — a single coherent full render of the settled model after the
+// async load, the WindowSizeMsg, and the quit are all processed — not from the
+// live teatest frame stream. Bubble Tea emits diff frames, and under CI's
+// parallel -race those settle at timing-dependent points, so replaying the raw
+// stream through the vt intermittently corrupts the final screen (#764).
+func captureUntil(t *testing.T, model tea.Model, marker string, width, height int) string {
 	t.Helper()
 
 	tm := teatest.NewTestModel(t, model, teatest.WithInitialTermSize(width, height))
 
-	var buf bytes.Buffer
-
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		_, _ = io.Copy(&buf, tm.Output())
-		if bytes.Contains(buf.Bytes(), []byte(marker)) {
-			break
-		}
-
-		time.Sleep(20 * time.Millisecond)
-	}
-
-	require.Contains(t, buf.String(), marker, "loaded content never rendered")
+	waitFor(t, tm, marker)
 
 	tm.Send(keyPress('q'))
-	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
 
-	_, _ = io.Copy(&buf, tm.Output())
+	return settledScreen(t, tm, width, height)
+}
 
-	return buf.Bytes()
+// settledScreen waits for the program to finish, then renders the settled final
+// model's full-screen View().Content through the vt at the given size. It works
+// for any host that renders a tea.View (the browser *App and the diff/dialog
+// hosts alike), so the browser and diff goldens share one deterministic settle.
+func settledScreen(t *testing.T, tm *teatest.TestModel, width, height int) string {
+	t.Helper()
+
+	fm := tm.FinalModel(t, teatest.WithFinalTimeout(3*time.Second))
+
+	vm, ok := fm.(interface{ View() tea.View })
+	require.True(t, ok, "final model must render a tea.View")
+
+	return renderVisibleScreenSize(t, []byte(vm.View().Content), width, height)
 }
 
 // TestBrowser_AWSParamGolden renders the AWS param browser (masked SecureString
@@ -88,6 +90,32 @@ func TestBrowser_AWSParamGolden(t *testing.T) { //nolint:paralleltest // goldenE
 	browserGolden(t, m, "SecureString")
 }
 
+// TestBrowser_AWSParamValuesOnGolden pins #734: with values:on the list renders
+// each entry's value on its OWN indented second line (mirroring the version
+// history layout), so the value never collides with the right-aligned [staged]
+// badge on the name line. And because values:on is an EXPLICIT reveal (GUI
+// parity, the same policy as Compare/diff), a SecureString (secret) value is
+// SHOWN in the preview rather than masked.
+func TestBrowser_AWSParamValuesOnGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
+	goldenEnv(t)
+
+	probe := staticProbe{keys: map[data.StagedKey]struct{}{{Name: "/app/web/BASE_URL"}: {}}}
+
+	m := newApp(config{
+		scope:     provider.Scope{Provider: provider.ProviderAWS},
+		identity:  awsIdentityFixture(),
+		sourceFor: sourceForShape("param", awsParamSource(), probe),
+	})
+
+	// Press `v` to turn values on; the list reloads with the value under each name.
+	screen := captureBrowserKeys(t, m, "SecureString", 'v')
+
+	require.Contains(t, screen, "postgres://db.internal:5432/app",
+		"values:on reveals the SecureString value in the list preview (explicit reveal, GUI parity)")
+	require.Contains(t, screen, "[staged]", "the staged badge still renders on the name line")
+	golden.RequireEqual(t, screen)
+}
+
 // TestBrowser_AWSParamHistoryFocusGolden renders the AWS param browser after
 // pressing enter to move focus into the version history (#685): the history pane
 // carries the active selection cursor (▸) and the `esc: list` hint, while the
@@ -104,8 +132,7 @@ func TestBrowser_AWSParamHistoryFocusGolden(t *testing.T) { //nolint:paralleltes
 	})
 
 	// Drive to the loaded state, then press enter to focus the history pane.
-	raw := captureBrowserAfterKeys(t, m, "SecureString", keyEnterMsg())
-	golden.RequireEqual(t, renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight))
+	golden.RequireEqual(t, captureBrowserAfterKeys(t, m, "SecureString", keyEnterMsg()))
 }
 
 // TestBrowser_AWSParamHistoryValueRevealGolden pins #733: each version row shows
@@ -123,8 +150,7 @@ func TestBrowser_AWSParamHistoryValueRevealGolden(t *testing.T) { //nolint:paral
 	})
 
 	// The default masked screen shows bullets in the history; press `x` to reveal.
-	raw := captureBrowserKeys(t, m, "SecureString", 'x')
-	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+	screen := captureBrowserKeys(t, m, "SecureString", 'x')
 
 	require.Contains(t, screen, "postgres://db.internal:5432/app", "x reveals the current and history values")
 	golden.RequireEqual(t, screen)
@@ -152,8 +178,7 @@ func TestBrowser_DeleteStagedGateStatusGolden(t *testing.T) { //nolint:parallelt
 		sourceFor: sourceForShape("secret", awsSecretSource(), probe),
 	})
 
-	raw := captureBrowserAfterKeys(t, m, "Version ID", keyPress('t'))
-	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+	screen := captureBrowserAfterKeys(t, m, "Version ID", keyPress('t'))
 
 	require.Contains(t, screen, "cannot tag: staged for deletion", "the gate surfaces a status message rather than the tag dialog")
 	golden.RequireEqual(t, screen)
@@ -192,8 +217,7 @@ func awsParamStagedBannerApp(entry, tags bool) *App {
 func TestBrowser_StagedValueBannerGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
 	goldenEnv(t)
 
-	raw := captureUntil(t, awsParamStagedBannerApp(true, false), "staged value changes", browserTermWidth, browserTermHeight)
-	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+	screen := captureUntil(t, awsParamStagedBannerApp(true, false), "staged value changes", browserTermWidth, browserTermHeight)
 
 	require.Contains(t, screen, "⚠ staged value changes — S: staging", "value-only shows the value-change banner")
 	require.NotContains(t, screen, "tag changes", "value-only must not mention tag changes")
@@ -205,8 +229,7 @@ func TestBrowser_StagedValueBannerGolden(t *testing.T) { //nolint:paralleltest /
 func TestBrowser_StagedTagBannerGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
 	goldenEnv(t)
 
-	raw := captureUntil(t, awsParamStagedBannerApp(false, true), "staged tag changes", browserTermWidth, browserTermHeight)
-	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+	screen := captureUntil(t, awsParamStagedBannerApp(false, true), "staged tag changes", browserTermWidth, browserTermHeight)
 
 	require.Contains(t, screen, "⚠ staged tag changes — S: staging", "tag-only shows the tag-change banner")
 	require.NotContains(t, screen, "value and tag", "tag-only must not use the combined wording")
@@ -218,8 +241,7 @@ func TestBrowser_StagedTagBannerGolden(t *testing.T) { //nolint:paralleltest // 
 func TestBrowser_StagedValueAndTagBannerGolden(t *testing.T) { //nolint:paralleltest // goldenEnv sets NO_COLOR/TZ
 	goldenEnv(t)
 
-	raw := captureUntil(t, awsParamStagedBannerApp(true, true), "staged value and tag changes", browserTermWidth, browserTermHeight)
-	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+	screen := captureUntil(t, awsParamStagedBannerApp(true, true), "staged value and tag changes", browserTermWidth, browserTermHeight)
 
 	require.Contains(t, screen, "⚠ staged value and tag changes — S: staging", "both shows the combined banner")
 	golden.RequireEqual(t, screen)
@@ -238,8 +260,7 @@ func TestBrowser_CopyKeepsMaskGolden(t *testing.T) { //nolint:paralleltest // go
 		sourceFor: sourceForShape("param", awsParamSource(), nil),
 	})
 
-	raw := captureBrowserKeys(t, m, "SecureString", 'y')
-	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+	screen := captureBrowserKeys(t, m, "SecureString", 'y')
 
 	assert.Contains(t, screen, "copied (value stays masked)", "the copy status shows")
 	assert.NotContains(t, screen, "postgres://db.internal:5432/app", "the copied secret is NOT revealed on screen")
@@ -257,8 +278,7 @@ func TestBrowser_ParseJSONGolden(t *testing.T) { //nolint:paralleltest // golden
 		sourceFor: sourceForShape("param", awsParamJSONSource(), nil),
 	})
 
-	raw := captureBrowserKeys(t, m, "db.internal", 'J')
-	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+	screen := captureBrowserKeys(t, m, "db.internal", 'J')
 
 	assert.Contains(t, screen, `"host": "db.internal"`, "J pretty-prints the JSON value onto indented lines")
 	golden.RequireEqual(t, screen)
@@ -394,8 +414,7 @@ func TestDiff_AWSParamSecureStringGolden(t *testing.T) { //nolint:paralleltest /
 
 	host := newDiffHost(diffReq(awsParamSecureStringDiffSource(), "/app/api/DATABASE_URL", "13", "14"))
 
-	raw := captureUntil(t, host, "diff:", goldenTermWidth, goldenTermHeight)
-	screen := renderVisibleScreenSize(t, raw, goldenTermWidth, goldenTermHeight)
+	screen := captureUntil(t, host, "diff:", goldenTermWidth, goldenTermHeight)
 
 	require.Contains(t, screen, secureStringDiffValue, "the SecureString diff is revealed by default (#702/#735)")
 	require.Contains(t, screen, secureStringDiffOldValue, "both SecureString versions are shown")
@@ -435,82 +454,40 @@ func TestDiff_AzureKVGolden(t *testing.T) { //nolint:paralleltest // goldenEnv c
 func browserGolden(t *testing.T, m *App, marker string) {
 	t.Helper()
 
-	raw := captureUntil(t, m, marker, browserTermWidth, browserTermHeight)
-	golden.RequireEqual(t, renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight))
+	golden.RequireEqual(t, captureUntil(t, m, marker, browserTermWidth, browserTermHeight))
 }
 
-// captureBrowserKeys drives a browser app to its loaded state (marker), then
-// sends keys (each followed by a short settle) before quitting — so a golden can
-// capture the screen after a key toggle (copy, parse-json).
-func captureBrowserKeys(t *testing.T, m *App, marker string, keys ...rune) []byte {
+// captureBrowserKeys drives a browser app to its loaded state (marker), sends the
+// given rune keys, quits, and renders the SETTLED final model's screen — so a
+// golden can capture the screen after a key toggle (copy, parse-json, values).
+func captureBrowserKeys(t *testing.T, m *App, marker string, keys ...rune) string {
 	t.Helper()
 
-	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(browserTermWidth, browserTermHeight))
-
-	var buf bytes.Buffer
-
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		_, _ = io.Copy(&buf, tm.Output())
-		if bytes.Contains(buf.Bytes(), []byte(marker)) {
-			break
-		}
-
-		time.Sleep(20 * time.Millisecond)
+	presses := make([]tea.KeyPressMsg, len(keys))
+	for i, k := range keys {
+		presses[i] = keyPress(k)
 	}
 
-	require.Contains(t, buf.String(), marker, "loaded content never rendered")
-
-	for _, k := range keys {
-		tm.Send(keyPress(k))
-		time.Sleep(100 * time.Millisecond)
-
-		_, _ = io.Copy(&buf, tm.Output())
-	}
-
-	tm.Send(keyPress('q'))
-	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
-
-	_, _ = io.Copy(&buf, tm.Output())
-
-	return buf.Bytes()
+	return captureBrowserAfterKeys(t, m, marker, presses...)
 }
 
 // captureBrowserAfterKeys drives a browser app to its loaded state (waiting for
-// marker), sends follow-up key presses (e.g. enter to focus the history), lets
-// the frame settle, then quits and returns the full captured stream.
-func captureBrowserAfterKeys(t *testing.T, m *App, marker string, keys ...tea.KeyPressMsg) []byte {
+// marker), sends follow-up key presses (e.g. enter to focus the history or `v` to
+// toggle values), quits, and renders the settled final model's screen.
+func captureBrowserAfterKeys(t *testing.T, m *App, marker string, keys ...tea.KeyPressMsg) string {
 	t.Helper()
 
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(browserTermWidth, browserTermHeight))
 
-	var buf bytes.Buffer
-
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		_, _ = io.Copy(&buf, tm.Output())
-		if bytes.Contains(buf.Bytes(), []byte(marker)) {
-			break
-		}
-
-		time.Sleep(20 * time.Millisecond)
-	}
-
-	require.Contains(t, buf.String(), marker, "loaded content never rendered")
+	waitFor(t, tm, marker)
 
 	for _, k := range keys {
 		tm.Send(k)
-		time.Sleep(100 * time.Millisecond)
-
-		_, _ = io.Copy(&buf, tm.Output())
 	}
 
 	tm.Send(keyPress('q'))
-	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
 
-	_, _ = io.Copy(&buf, tm.Output())
-
-	return buf.Bytes()
+	return settledScreen(t, tm, browserTermWidth, browserTermHeight)
 }
 
 // diffGolden drives a diff host to its loaded state at the shell size and
@@ -518,6 +495,5 @@ func captureBrowserAfterKeys(t *testing.T, m *App, marker string, keys ...tea.Ke
 func diffGolden(t *testing.T, host *diffHost, marker string) {
 	t.Helper()
 
-	raw := captureUntil(t, host, marker, goldenTermWidth, goldenTermHeight)
-	golden.RequireEqual(t, renderVisibleScreenSize(t, raw, goldenTermWidth, goldenTermHeight))
+	golden.RequireEqual(t, captureUntil(t, host, marker, goldenTermWidth, goldenTermHeight))
 }

--- a/internal/tui/components/entrylist.go
+++ b/internal/tui/components/entrylist.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"slices"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -9,13 +10,14 @@ import (
 )
 
 // ListRow is one presentation-ready entry row. The owning page precomputes the
-// value preview (masked when appropriate) and badges, so the list widget stays
-// dumb — it never sees a raw secret value.
+// value preview and badges, so the list widget stays dumb.
 type ListRow struct {
 	// Name is the entry name (the primary column).
 	Name string
-	// Preview is an optional value preview shown after the name in values-mode
-	// (already masked by the caller for secrets); empty hides it.
+	// Preview is an optional value preview rendered on an indented SECOND line
+	// beneath the name (values-mode); empty draws no value line, so the row is a
+	// single line. The caller flattens/truncates it — an explicit values:on is a
+	// reveal, so a secret value is shown, mirroring the GUI (#734).
 	Preview string
 	// Badges are trailing chips (e.g. "staged", "(NULL)") shown right of the row.
 	Badges []string
@@ -119,19 +121,20 @@ func (l *EntryList) Scroll(delta int) {
 
 // RowAtLine maps a 0-based content line (relative to the list body, i.e. below
 // its title/border) to a row index, or (0, false) when the line is the footer
-// or past the last visible row. Clicks derive their target through this, never
-// a hard-coded coordinate.
+// or past the last visible row. A row's name line and its value line both map
+// back to that row, so a click anywhere in a row selects it. Clicks derive their
+// target through this, never a hard-coded coordinate.
 func (l *EntryList) RowAtLine(line int) (int, bool) {
 	if line < 0 || len(l.rows) == 0 {
 		return 0, false
 	}
 
-	idx := l.offset + line
-	if idx >= len(l.rows) || line >= l.visibleRows() {
+	_, rowOf := l.window()
+	if line >= len(rowOf) {
 		return 0, false
 	}
 
-	return idx, true
+	return rowOf[line], true
 }
 
 // View renders the list body (without a title/border; the page frames it) into
@@ -142,17 +145,7 @@ func (l *EntryList) View() string {
 		return ""
 	}
 
-	visible := l.visibleRows()
-	lines := make([]string, 0, l.height)
-
-	for i := range visible {
-		idx := l.offset + i
-		if idx >= len(l.rows) {
-			break
-		}
-
-		lines = append(lines, l.renderRow(idx))
-	}
+	lines, _ := l.window()
 
 	if l.hasMore {
 		lines = append(lines, l.styles.PageHint.Render(truncate("  … load more (L)", l.width)))
@@ -163,11 +156,47 @@ func (l *EntryList) View() string {
 		lines = append(lines, "")
 	}
 
-	return strings.Join(lines, "\n")
+	return strings.Join(lines[:l.height], "\n")
 }
 
-// renderRow renders one row: a cursor for the selection, the name, an optional
-// value preview, and trailing badges, all clamped to width.
+// window renders the visible content lines for the current offset (capped at the
+// visible line budget) and, parallel to them, the row index each line belongs
+// to — so View draws them and RowAtLine maps a clicked line back to its row
+// without the two drifting apart (mirrors HistoryTable.window).
+func (l *EntryList) window() (lines []string, rowOf []int) {
+	visible := l.visibleRows()
+
+	for row := l.offset; row < len(l.rows) && len(lines) < visible; row++ {
+		for _, line := range l.rowLines(row) {
+			if len(lines) >= visible {
+				break
+			}
+
+			lines = append(lines, line)
+			rowOf = append(rowOf, row)
+		}
+	}
+
+	return lines, rowOf
+}
+
+// rowLines returns one row's rendered lines: the name header line (cursor + name
+// + right-aligned badges) and, when a value preview is present, an indented value
+// line beneath it (values-mode). The value line shares the history table's indent
+// so it reads as a detail of the name above it (#734).
+func (l *EntryList) rowLines(idx int) []string {
+	lines := []string{l.renderRow(idx)}
+
+	if preview := l.rows[idx].Preview; preview != "" {
+		lines = append(lines, l.styles.PageHint.Render(truncate("     "+preview, l.width)))
+	}
+
+	return lines
+}
+
+// renderRow renders one row's header line: a cursor for the selection, the name,
+// and trailing right-aligned badges, all clamped to width. The value preview is
+// drawn separately on the next line by rowLines.
 func (l *EntryList) renderRow(idx int) string {
 	row := l.rows[idx]
 
@@ -187,9 +216,6 @@ func (l *EntryList) renderRow(idx int) string {
 	}
 
 	left := cursor + name
-	if row.Preview != "" {
-		left += l.styles.PageHint.Render("  " + row.Preview)
-	}
 
 	badges := renderBadges(l.styles, row.Badges)
 	if badges == "" {
@@ -205,8 +231,10 @@ func (l *EntryList) renderRow(idx int) string {
 	return truncate(left+strings.Repeat(" ", gap)+badges, l.width)
 }
 
-// visibleRows is how many entry rows fit, reserving one line for the load-more
-// footer when there is a next page.
+// visibleRows is the window's height in rendered lines, reserving one line for
+// the load-more footer when there is a next page. It is the per-View line budget
+// window() fills, not a row count: a values-mode row renders as two lines, so the
+// offset math below converts between the two by summing per-row line counts.
 func (l *EntryList) visibleRows() int {
 	if l.hasMore {
 		return max(l.height-1, 0)
@@ -215,15 +243,45 @@ func (l *EntryList) visibleRows() int {
 	return l.height
 }
 
-// maxOffset is the furthest the list can scroll so the last row stays visible.
+// maxOffset caps scrolling so the last row's final line stays reachable at the
+// bottom of the window. Because a values-mode row renders as two lines, this is
+// not len(rows)-visible: it is the smallest row offset whose rows [offset..end]
+// fill (without exceeding) the line budget, found by walking rows from the end
+// and accumulating their rendered line counts until the next row would overflow.
 func (l *EntryList) maxOffset() int {
-	return max(len(l.rows)-l.visibleRows(), 0)
+	budget := l.visibleRows()
+	if budget <= 0 || len(l.rows) == 0 {
+		return 0
+	}
+
+	total := 0
+	offset := len(l.rows)
+
+	for i := range slices.Backward(l.rows) {
+		h := len(l.rowLines(i))
+		if total+h > budget {
+			break
+		}
+
+		total += h
+		offset = i
+	}
+
+	// When even the last row alone overflows the budget, it can still be scrolled
+	// to (its top line at the pane top), so cap the offset at the last row.
+	return min(offset, len(l.rows)-1)
 }
 
-// ensureVisible scrolls the viewport so the selection is on-screen.
+// ensureVisible keeps the selected row's rendered lines fully inside the
+// line-budget window. It scrolls up when the selection starts above the window,
+// and down when the selection's lines extend past the window bottom — walking up
+// from the selected row accumulating line counts to find the smallest offset that
+// still shows the selected row's final line — then clamps to the valid range.
+// Line counts come from rowLines, the same source window() uses, so the scroll
+// math and the mouse hit-map never disagree.
 func (l *EntryList) ensureVisible() {
-	visible := l.visibleRows()
-	if visible <= 0 {
+	budget := l.visibleRows()
+	if budget <= 0 || len(l.rows) == 0 {
 		l.offset = 0
 
 		return
@@ -233,8 +291,23 @@ func (l *EntryList) ensureVisible() {
 		l.offset = l.selected
 	}
 
-	if l.selected >= l.offset+visible {
-		l.offset = l.selected - visible + 1
+	// Find the smallest offset whose rows [offset..selected] fit the budget, so
+	// the selected row's last line lands at or above the window bottom.
+	total := 0
+	minOffset := l.selected
+
+	for i := l.selected; i >= 0; i-- {
+		h := len(l.rowLines(i))
+		if total+h > budget {
+			break
+		}
+
+		total += h
+		minOffset = i
+	}
+
+	if l.offset < minOffset {
+		l.offset = minOffset
 	}
 
 	l.offset = clamp(l.offset, 0, l.maxOffset())

--- a/internal/tui/components/entrylist_internal_test.go
+++ b/internal/tui/components/entrylist_internal_test.go
@@ -1,0 +1,139 @@
+package components
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/tui/styles"
+)
+
+// listWindowRowSpan returns the number of rendered lines the window currently
+// draws for row idx, derived from window()'s parallel rowOf slice — the ground
+// truth for "how much of a row is on-screen" without hard-coding line offsets.
+func listWindowRowSpan(l *EntryList, idx int) int {
+	_, rowOf := l.window()
+
+	n := 0
+
+	for _, r := range rowOf {
+		if r == idx {
+			n++
+		}
+	}
+
+	return n
+}
+
+// valuedListRows builds n rows that each carry a value preview, so each renders
+// as two lines (name header + indented value line).
+func valuedListRows(n int) []ListRow {
+	rows := make([]ListRow, n)
+	for i := range rows {
+		rows[i] = ListRow{
+			Name:    "/app/key-" + string(rune('A'+i)),
+			Preview: "value-" + string(rune('A'+i)),
+		}
+	}
+
+	return rows
+}
+
+// TestEntryListValuesOffSingleLine pins that with no preview each row is a single
+// line and the classic rows-minus-height offset math applies.
+func TestEntryListValuesOffSingleLine(t *testing.T) {
+	t.Parallel()
+
+	rows := make([]ListRow, 6)
+	for i := range rows {
+		rows[i] = ListRow{Name: "/app/key-" + string(rune('A'+i))}
+	}
+
+	l := NewEntryList(styles.New())
+	l.SetRows(rows, false)
+	l.SetSize(40, 4)
+
+	for i := range rows {
+		require.Lenf(t, l.rowLines(i), 1, "values:off row %d must be a single line", i)
+	}
+
+	l.Scroll(100)
+	assert.Equal(t, l.Len()-l.height, l.maxOffset(), "single-line rows: maxOffset is rows minus height")
+}
+
+// TestEntryListValuesOnTwoLines pins the #734 layout: a row with a value preview
+// renders as two lines — the name header and an indented value line beneath it.
+func TestEntryListValuesOnTwoLines(t *testing.T) {
+	t.Parallel()
+
+	l := NewEntryList(styles.New())
+	l.SetRows([]ListRow{
+		{Name: "/app/db", Preview: "postgres://db.internal:5432/app", Badges: []string{"staged"}},
+	}, false)
+	l.SetSize(60, 6)
+
+	lines := l.rowLines(0)
+	require.Len(t, lines, 2, "a valued row renders as name header + value line")
+	assert.Contains(t, lines[0], "/app/db", "the name is on the header line")
+	assert.Contains(t, lines[0], "[staged]", "the badge stays on the header line, uncollided")
+	assert.NotContains(t, lines[0], "postgres", "the value is NOT on the name line")
+	assert.Contains(t, lines[1], "     postgres://db.internal:5432/app",
+		"the value is on its own second line, indented under the header")
+}
+
+// TestEntryListRowAtLineMapsBothLines pins that a click on either line of a
+// two-line valued row selects that row (the mouse hit-map honors multi-line rows).
+func TestEntryListRowAtLineMapsBothLines(t *testing.T) {
+	t.Parallel()
+
+	l := NewEntryList(styles.New())
+	l.SetRows(valuedListRows(3), false)
+	l.SetSize(40, 6)
+
+	// Rows render as: line0=name0, line1=value0, line2=name1, line3=value1, ...
+	got := map[int]int{}
+
+	for line := range 6 {
+		if idx, ok := l.RowAtLine(line); ok {
+			got[line] = idx
+		}
+	}
+
+	assert.Equal(t, 0, got[0], "line 0 maps to row 0 (name)")
+	assert.Equal(t, 0, got[1], "line 1 maps to row 0 (value)")
+	assert.Equal(t, 1, got[2], "line 2 maps to row 1 (name)")
+	assert.Equal(t, 1, got[3], "line 3 maps to row 1 (value)")
+}
+
+// TestEntryListSelectLastRowFullyVisible pins that selecting the last row brings
+// both of its rendered lines into a short window, even though earlier rows are
+// two lines each (line-based scroll math, mirroring the history table).
+func TestEntryListSelectLastRowFullyVisible(t *testing.T) {
+	t.Parallel()
+
+	l := NewEntryList(styles.New())
+	l.SetRows(valuedListRows(8), false)
+	l.SetSize(40, 5) // fits ~2 rows
+
+	last := l.Len() - 1
+	l.SelectIndex(last)
+
+	assert.Equal(t, len(l.rowLines(last)), listWindowRowSpan(&l, last),
+		"selecting the last row must show all of its rendered lines")
+}
+
+// TestEntryListLoadMoreReservesFooterLine pins that the load-more footer still
+// takes the last visible line when a next page is reported, with two-line rows.
+func TestEntryListLoadMoreReservesFooterLine(t *testing.T) {
+	t.Parallel()
+
+	l := NewEntryList(styles.New())
+	l.SetRows(valuedListRows(8), true) // hasMore
+	l.SetSize(40, 5)
+
+	view := l.View()
+	assert.Contains(t, view, "load more (L)", "the footer renders when there is a next page")
+	assert.Len(t, strings.Split(view, "\n"), l.height, "the view is padded to exactly the pane height")
+}

--- a/internal/tui/help_test.go
+++ b/internal/tui/help_test.go
@@ -143,8 +143,7 @@ func TestBrowser_FullHelpGolden(t *testing.T) { //nolint:paralleltest // goldenE
 		sourceFor: sourceForShape("secret", awsSecretSource(), nil),
 	})
 
-	raw := captureBrowserKeys(t, m, "Version ID", '?')
-	screen := renderVisibleScreenSize(t, raw, browserTermWidth, browserTermHeight)
+	screen := captureBrowserKeys(t, m, "Version ID", '?')
 
 	require.Contains(t, screen, "edit", "the full help lists the edit key")
 	require.Contains(t, screen, "restore", "the full help lists the restore key (AWS secret)")

--- a/internal/tui/pages/browser/rows.go
+++ b/internal/tui/pages/browser/rows.go
@@ -11,10 +11,6 @@ import (
 	"github.com/mpyw/suve/internal/tui/styles"
 )
 
-// previewMask is the fixed masked preview shown for a secret value in the list,
-// so a golden never carries a real value.
-const previewMask = "••••••"
-
 // rebuildRows recomputes the list rows from the loaded items, the staged-key
 // set, and the values/namespace modes.
 func (m *Model) rebuildRows() {
@@ -22,7 +18,7 @@ func (m *Model) rebuildRows() {
 		row := components.ListRow{Name: it.Name}
 
 		if m.valuesOn && it.Value != nil {
-			row.Preview = previewValue(*it.Value, it.Secret)
+			row.Preview = previewValue(*it.Value)
 		}
 
 		var badges []string
@@ -45,15 +41,16 @@ func (m *Model) rebuildRows() {
 	m.list.SetRows(rows, m.nextToken != "")
 }
 
-// previewValue renders a list value preview, masking secrets.
-func previewValue(value string, secret bool) string {
-	if secret {
-		return previewMask
-	}
-
+// previewValue renders a list value preview: a single, truncated, newline-
+// flattened line. It is only ever called under values:on — an EXPLICIT reveal, so
+// it SHOWS the real value like the GUI, including secrets (mirroring the
+// Compare/diff reveal policy), rather than masking it (#734). The detail value
+// pane keeps its own separate mask/reveal.
+func previewValue(value string) string {
 	const maxPreview = 40
 
-	value = strings.ReplaceAll(value, "\n", " ")
+	replacer := strings.NewReplacer("\n", " ", "\r", " ", "\t", " ")
+	value = replacer.Replace(value)
 
 	if len([]rune(value)) > maxPreview {
 		return string([]rune(value)[:maxPreview]) + "…"

--- a/internal/tui/testdata/TestBrowser_AWSParamValuesOnGolden.golden
+++ b/internal/tui/testdata/TestBrowser_AWSParamValuesOnGolden.golden
@@ -1,0 +1,34 @@
+suve  aws · profile:dev · account:123456789012 · region:ap-northeast-1
+ Param Secret Staging(1)
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+prefix: —   filter: —   values:on  recursive:on  ⟳
+╭────────────────────────────────────────────╮╭────────────────────────────────────────────────────────────────────────╮
+│entries (3)                                 ││/app/api/DATABASE_URL                                                   │
+│▸ /app/api/DATABASE_URL                     ││Value   (x to reveal)                                                   │
+│     postgres://db.internal:5432/app        ││••••••••••••••••••••••••                                                │
+│  /app/api/REDIS_URL                        ││                                                                        │
+│     postgres://db.internal:5432/app        ││                                                                        │
+│  /app/web/BASE_URL                 [staged]││                                                                        │
+│     postgres://db.internal:5432/app        ││Version     14 (current)                                                │
+│                                            ││Type        SecureString                                                │
+│                                            ││Modified    2026-07-01 09:30:00                                         │
+│                                            ││Tags        env=prod · team=api                                         │
+│                                            ││                                                                        │
+│                                            ││History   enter: history · c: compare mode                              │
+│                                            ││▹ #14  2026-07-01  current                                              │
+│                                            ││     ••••••••••••••••••••••••                                           │
+│                                            ││  #13  2026-06-24                                                       │
+│                                            ││     ••••••••••••••••••••••••                                           │
+│                                            ││  #12  2026-06-02                                                       │
+│                                            ││     ••••••••••••••••••••••••                                           │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+│                                            ││                                                                        │
+╰────────────────────────────────────────────╯╰────────────────────────────────────────────────────────────────────────╯
+ ↑/↓ move • / filter • e edit • n new • enter history • tab next tab • 1/2/3 jump to tab • ? help • q quit


### PR DESCRIPTION
Closes #734

## Problem

The browser list's `values:on` mode had two related bugs (post-audit finding from epic #704):

1. **Layout.** `EntryList.renderRow` appended the value preview onto the SAME line as the name and right-aligned the badges, so a long value collided with the `[staged]` badge — "too ugly", and it broke the badge.
2. **Masking.** `values:on` still rendered secret values as `••••••`, which is pointless: the GUI SHOWS the value in this mode.

## Fix

### 1. Value on its own second line (mirrors the history table)

`EntryList` now renders a values-mode row as TWO lines, mirroring `HistoryTable`'s `rowLines` layout:
- **Line 1:** cursor + name + right-aligned badges (`[staged]`, `(NULL)`, …)
- **Line 2:** the indented value preview, under the name

When `values:off`, a row is a single name line, exactly as before (no value line). The height/scroll math (`visibleRows`/`maxOffset`/`ensureVisible`) and the mouse hit-map (`RowAtLine` via a new `window()`) are now line-based — the same line-accounting `HistoryTable` uses — so a click on either the name line or the value line still selects the right row, and keyboard/wheel scrolling keeps a two-line selection fully visible.

### 2. Reveal, don't mask, under values:on (GUI parity)

Per the settled display policy, `values:on` is an EXPLICIT reveal (the same theme as Compare/diff and staging-diff). `previewValue` no longer masks secrets — it returns the real (truncated, newline-flattened) value, so the list shows it like the GUI. `values:off` is unchanged, and the DETAIL value pane's separate mask/reveal (`x`) and the history value masking are untouched.

## Browser golden helpers → deterministic FinalModel

The browser golden helpers (`captureUntil`, `captureBrowserKeys`, `captureBrowserAfterKeys`) still captured the LIVE teatest frame stream — they were left out of #766's fix. This converts them to the same pattern #766 applied to staging/dialog: send keys, quit, then render `tm.FinalModel(t, …).View().Content` through `renderVisibleScreenSize`. A shared `settledScreen` helper handles both the browser `*App` and the diff host (any `View() tea.View`). The live-stream `io.Copy`/sleep plumbing is removed. `go test -race -count=3 ./internal/tui/` passes stably.

## Goldens

Every existing browser/diff golden re-passes byte-identically after the helper conversion (no existing `.golden` file changed), which proves the FinalModel settle is deterministic. One new golden pins the fix:

- **`TestBrowser_AWSParamValuesOnGolden`** (new) — presses `v` on the AWS param browser.
  - **Before:** value crammed inline and masked, e.g. `▸ /app/api/DATABASE_URL  ••••••`, colliding with `[staged]`.
  - **After:** name + `[staged]` on line 1, and the REVEALED value on an indented line 2, e.g. `     postgres://db.internal:5432/app`. The detail pane and version history stay masked (untouched). No unexpected/leaked content — only this fixture's intended value is revealed, exactly as the GUI would show it.

## Verification

- `go build ./...` ✓
- `go test ./internal/tui/...` ✓ (added `entrylist_internal_test.go`: two-line layout, `RowAtLine` maps both lines, last-row visibility, load-more footer, values:off single-line)
- `go test -race -count=3 ./internal/tui/` ✓ (determinism)
- `golangci-lint run --allow-parallel-runners ./internal/tui/...` → 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)