### PR TITLE
fix(tui): render a visible text-input cursor in dialogs (#765)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 
+	"charm.land/bubbles/v2/cursor"
 	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
@@ -259,6 +260,14 @@ func (m *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case awsIdentityErrMsg:
 		m.identityLoading = false
 
+		return m, nil
+	case cursor.BlinkMsg:
+		// Swallow the embedded text inputs' virtual-cursor blink so the focused
+		// field's caret stays steadily rendered: the app draws the real terminal
+		// cursor at that caret (see App.View / dialogCursor), which it locates by the
+		// field's steady virtual-cursor cell. Dropping the blink keeps that cell —
+		// and thus the caret position — present every frame instead of flickering
+		// off, and the real cursor still blinks natively (#765).
 		return m, nil
 	case tea.KeyPressMsg:
 		return m.handleKey(msg)
@@ -1018,7 +1027,13 @@ func (m *App) View() tea.View {
 		return view
 	}
 
-	view.SetContent(m.render())
+	screen := m.render()
+	view.SetContent(screen)
+	// Set the real terminal cursor at the focused text field's caret so a visible
+	// caret is drawn there — the embedded huh form's virtual cursor alone does not
+	// surface one under AltScreen (#765). The caret is read from the composited
+	// screen we just built, so it tracks the field wherever the dialog is drawn.
+	view.Cursor = m.dialogCursor(screen)
 
 	return view
 }

--- a/internal/tui/cursor.go
+++ b/internal/tui/cursor.go
@@ -1,0 +1,108 @@
+package tui
+
+import (
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+)
+
+// dialogCursor returns the real terminal cursor for the focused text field of an
+// open dialog, or nil when no dialog is open or none of its fields is a text
+// input. It takes the already-composited screen so the caret is read from the
+// exact frame the terminal will draw.
+//
+// Why the app must drive the real cursor: the dialogs embed huh forms, whose
+// bubbles text inputs draw a *virtual* cursor (a reverse-video cell) into their
+// View string rather than exposing a caret position. That virtual cell does not
+// reliably surface a visible caret — it blinks itself off, and the app renders
+// under AltScreen with view.Cursor unset, which hides the real terminal cursor
+// entirely — so the user cannot see where they are typing (#765). huh v2 exposes
+// neither the caret position nor a real-cursor toggle, so the app instead locates
+// the caret directly in the composited screen: the focused text input paints a
+// steady reverse-video cell there (the app keeps it steady by swallowing the
+// blink; see App.Update), and nothing else in the TUI uses reverse video, so that
+// cell's screen position is the caret. Reading the final frame keeps the caret
+// correct regardless of where the dialog overlay is composited.
+func (m *App) dialogCursor(screen string) *tea.Cursor {
+	if len(m.dialogs) == 0 {
+		return nil
+	}
+
+	col, row, ok := cursorCellPos(screen)
+	if !ok {
+		return nil
+	}
+
+	return tea.NewCursor(col, row)
+}
+
+// cursorCellPos finds the caret by locating the first cell drawn with the
+// reverse-video (SGR 7) attribute — the virtual cursor a focused bubbles text
+// input paints, and the only reverse-video cell the TUI ever draws. It returns
+// the caret's display column and row (col measured in terminal cells, so wide
+// runes and the ANSI styling before the caret are accounted for), and ok=false
+// when no such cell is present (no text input is focused).
+func cursorCellPos(screen string) (col, row int, ok bool) {
+	for r, line := range strings.Split(screen, "\n") {
+		if idx := indexReverseSGR(line); idx >= 0 {
+			return lipgloss.Width(line[:idx]), r, true
+		}
+	}
+
+	return 0, 0, false
+}
+
+// indexReverseSGR returns the byte index of the first SGR escape in line that
+// enables the reverse attribute, or -1. It parses each CSI ...m sequence and
+// skips the multi-parameter 256-color (38;5;n) and truecolor (38;2;r;g;b) color
+// specs, so a color parameter that merely contains a 7 (e.g. 38;5;7) is never
+// mistaken for the reverse attribute.
+func indexReverseSGR(line string) int {
+	const csi = "\x1b[" // Control Sequence Introducer
+
+	for i := 0; i < len(line); {
+		if strings.HasPrefix(line[i:], csi) {
+			j := i + len(csi)
+			for j < len(line) && (line[j] == ';' || (line[j] >= '0' && line[j] <= '9')) {
+				j++
+			}
+
+			if j < len(line) && line[j] == 'm' && sgrHasReverse(line[i+len(csi):j]) {
+				return i
+			}
+
+			i = j + 1
+
+			continue
+		}
+
+		i++
+	}
+
+	return -1
+}
+
+// sgrHasReverse reports whether an SGR parameter list (the bytes between "\x1b["
+// and "m") turns the reverse attribute on, correctly stepping over color
+// introducers so their sub-parameters are not misread as attributes.
+func sgrHasReverse(params string) bool {
+	parts := strings.Split(params, ";")
+	for i := 0; i < len(parts); i++ {
+		switch parts[i] {
+		case "38", "48", "58": // color introducer: skip its sub-parameters
+			if i+1 < len(parts) {
+				switch parts[i+1] {
+				case "5": // 256-color: introducer, "5", index
+					i += 2
+				case "2": // truecolor: introducer, "2", r, g, b
+					i += 4
+				}
+			}
+		case "7": // reverse on
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/tui/cursor_test.go
+++ b/internal/tui/cursor_test.go
@@ -1,0 +1,225 @@
+//nolint:testpackage // white-box: drives the real App/dialog wiring and the unexported cursor scanner
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/tui/data"
+	"github.com/mpyw/suve/internal/tui/nav"
+)
+
+// --- unit tests for the reverse-cursor-cell scanner ---
+
+func TestSGRHasReverse(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		params string
+		want   bool
+	}{
+		"bare reverse":            {"7", true},
+		"reverse then fg color":   {"7;38;2;2;186;132", true},
+		"fg color then reverse":   {"38;2;2;186;132;7", true},
+		"reset":                   {"", false},
+		"reverse off":             {"27", false},
+		"256 color index 7 only":  {"38;5;7", false}, // must NOT be read as reverse
+		"256 color 7 bg only":     {"48;5;7", false},
+		"256 color 7 then revers": {"38;5;7;7", true},
+		"truecolor with 7 in rgb": {"38;2;7;7;7", false}, // 7s are r/g/b, not reverse
+		"truecolor rgb then rev":  {"38;2;7;7;7;7", true},
+		"plain fg":                {"38;5;238", false},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.want, sgrHasReverse(tc.params))
+		})
+	}
+}
+
+func TestCursorCellPos(t *testing.T) {
+	t.Parallel()
+
+	// Row 0: prompt "> " then "ab" then a reverse-video cursor cell.
+	line := "\x1b[38;2;247;128;226m> \x1b[mab" + lipgloss.NewStyle().Reverse(true).Render(" ") + "   "
+	content := "title\n" + line
+
+	col, row, ok := cursorCellPos(content)
+	require.True(t, ok)
+	assert.Equal(t, 1, row, "cursor is on the second line")
+	assert.Equal(t, 4, col, `caret sits after "> ab" (4 display cells)`)
+}
+
+func TestCursorCellPos_NoReverse(t *testing.T) {
+	t.Parallel()
+
+	content := "just\n\x1b[38;5;7mcolored\x1b[m text with a 7 in the color"
+	_, _, ok := cursorCellPos(content)
+	assert.False(t, ok, "a color parameter containing 7 must not be read as a caret")
+}
+
+// --- end-to-end tests: the App draws a real caret at the focused text field ---
+
+// drainCmd runs a command tree eagerly, returning every produced message so a
+// test can feed the initialization messages back into the model synchronously.
+func drainCmd(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+
+	msg := cmd()
+	if msg == nil {
+		return nil
+	}
+
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var out []tea.Msg
+		for _, c := range batch {
+			out = append(out, drainCmd(c)...)
+		}
+
+		return out
+	}
+
+	return []tea.Msg{msg}
+}
+
+// applyMsg feeds a message to the App and eagerly settles every command it
+// produces (draining batches), returning the updated App. It uses a checked type
+// assertion so the root model contract is verified as it drives the shell.
+func applyMsg(t *testing.T, m *App, msg tea.Msg) *App {
+	t.Helper()
+
+	next, cmd := m.Update(msg)
+
+	app, ok := next.(*App)
+	require.True(t, ok, "App.Update must return *App")
+
+	for _, sub := range drainCmd(cmd) {
+		app = applyMsg(t, app, sub)
+	}
+
+	return app
+}
+
+// openTextDialog builds a real App, sizes it, dispatches the given open-dialog
+// message, settles the resulting dialog's init commands, and replays any extra
+// keys (navigation, typing). It returns the App with the dialog open.
+func openTextDialog(t *testing.T, service string, open tea.Msg, keys ...tea.Msg) *App {
+	t.Helper()
+
+	m := newApp(config{
+		scope:   provider.Scope{Provider: provider.ProviderAWS},
+		service: service,
+		mutatorFor: func(string) data.Mutator {
+			return capMutator{cap: goldenCap("aws", service)}
+		},
+	})
+
+	m = applyMsg(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
+	m = applyMsg(t, m, open)
+
+	for _, k := range keys {
+		m = applyMsg(t, m, k)
+	}
+
+	return m
+}
+
+func typeKey(r rune) tea.KeyPressMsg { return tea.KeyPressMsg{Code: r, Text: string(r)} }
+
+// requireCaretOnScreen asserts the App draws a real cursor and that it lands on
+// the reverse-video caret cell actually drawn in the composited screen — proving
+// the visible caret and the terminal cursor coincide at the insertion point.
+func requireCaretOnScreen(t *testing.T, m *App) tea.Position {
+	t.Helper()
+
+	view := m.View()
+	require.NotNil(t, view.Cursor, "a focused text field must have a real terminal cursor")
+
+	lines := strings.Split(view.Content, "\n")
+	require.Less(t, view.Cursor.Y, len(lines), "cursor row is within the screen")
+
+	idx := indexReverseSGR(lines[view.Cursor.Y])
+	require.GreaterOrEqual(t, idx, 0, "the cursor row must carry the drawn caret cell")
+	assert.Equal(t, view.Cursor.X, lipgloss.Width(lines[view.Cursor.Y][:idx]),
+		"the real cursor must sit on the drawn caret cell")
+
+	return view.Cursor.Position
+}
+
+func TestAppCursor_EntryFormName(t *testing.T) {
+	t.Parallel()
+
+	m := openTextDialog(t, "param", nav.OpenEntryForm{Service: "param"}, typeKey('a'), typeKey('b'))
+	pos := requireCaretOnScreen(t, m)
+
+	// Typing one more rune advances the caret by exactly one cell.
+	m = applyMsg(t, m, typeKey('c'))
+	next := requireCaretOnScreen(t, m)
+
+	assert.Equal(t, pos.Y, next.Y, "still on the name row")
+	assert.Equal(t, pos.X+1, next.X, "the caret tracks the inserted rune")
+}
+
+func TestAppCursor_EntryFormValue(t *testing.T) {
+	t.Parallel()
+
+	// Tab off the name field, past the Type select, onto the multi-line Value field.
+	m := openTextDialog(t, "param", nav.OpenEntryForm{Service: "param"},
+		tea.KeyPressMsg{Code: tea.KeyTab}, tea.KeyPressMsg{Code: tea.KeyTab},
+		typeKey('x'))
+	requireCaretOnScreen(t, m)
+}
+
+func TestAppCursor_RestoreName(t *testing.T) {
+	t.Parallel()
+
+	m := openTextDialog(t, "secret", nav.OpenRestore{Service: "secret", Name: "prod/api/deleted"},
+		typeKey('z'))
+	requireCaretOnScreen(t, m)
+}
+
+func TestAppCursor_TagKey(t *testing.T) {
+	t.Parallel()
+
+	// The tag form opens on the Action select (no caret); tab to the Key input.
+	m := openTextDialog(t, "param", nav.OpenTag{Service: "param", Name: "/app/api/DB"},
+		tea.KeyPressMsg{Code: tea.KeyTab}, typeKey('k'))
+	requireCaretOnScreen(t, m)
+}
+
+func TestAppCursor_NoneWhenNoTextField(t *testing.T) {
+	t.Parallel()
+
+	// The delete-confirm dialog has only selects/confirm rows — no text caret.
+	m := openTextDialog(t, "secret", nav.OpenDelete{Service: "secret", Name: "prod/api/old"})
+	assert.Nil(t, m.View().Cursor, "a dialog with no focused text field draws no cursor")
+
+	// The tag form opens focused on the Action select — also no caret yet.
+	m2 := openTextDialog(t, "param", nav.OpenTag{Service: "param", Name: "/app/api/DB"})
+	assert.Nil(t, m2.View().Cursor, "a select-focused dialog draws no cursor")
+}
+
+func TestAppCursor_NoneWhenNoDialog(t *testing.T) {
+	t.Parallel()
+
+	m := newApp(config{
+		scope:   provider.Scope{Provider: provider.ProviderAWS},
+		service: "param",
+		mutatorFor: func(string) data.Mutator {
+			return capMutator{cap: goldenCap("aws", "param")}
+		},
+	})
+	m = applyMsg(t, m, tea.WindowSizeMsg{Width: 100, Height: 30})
+
+	assert.Nil(t, m.View().Cursor, "no cursor is drawn when no dialog is open")
+}


### PR DESCRIPTION
Closes #765

## Cause confirmed (empirically)

Not the compositor. I traced the render path end-to-end with throwaway tests:

- The bubbles text input's virtual cursor (a reverse-video cell) **is** present in the huh field's `View()` string **and survives lipgloss compositing** into `App.View().Content` — so candidate cause 1 (compositor strips it) is **false**.
- The real defect is **cause 2**: `App.View()` renders under `AltScreen` and never sets `view.Cursor`, so Bubble Tea hides the real terminal cursor; and the virtual cursor is not a reliable substitute — it blinks itself off, and huh v2 exposes neither the caret position nor a real-cursor toggle. Net: no visible caret at the insertion point.

(A teatest aside: teatest renders under a no-color/ascii profile that strips *all* styling — reverse **and** background color — so it cannot be used to judge caret visibility. Verification is done by inspecting `App.View()` directly.)

## Fix

Drive the **real terminal cursor**:

- `App.View()` locates the caret directly in the composited screen it just built — the focused text input paints the only reverse-video cell the TUI ever draws (confirmed: no other code path uses reverse video) — and sets `view.Cursor` there. Reading the final frame keeps the caret correct wherever the dialog overlay is composited.
- `App.Update` swallows the virtual-cursor `cursor.BlinkMsg` so that marker (and thus the caret position) stays steady every frame instead of flickering off; the real terminal cursor still blinks natively.

Covers the entry-form name + value, tag key, and restore name inputs, and draws **no** cursor when a dialog has no focused text field (delete-confirm, a select-focused tag form) or when no dialog is open.

## Verification

- `go build ./...`, `go test ./internal/tui/...` and `-race`: pass.
- `golangci-lint run --allow-parallel-runners ./internal/tui/...`: 0 issues.
- Regression tests (`internal/tui/cursor_test.go`): unit tests for the reverse-SGR scanner (incl. the `38;5;7` false-positive guard), plus end-to-end tests asserting `view.Cursor` is non-nil and sits **exactly on** the reverse-video caret cell in the composited screen, tracks typed runes, and is nil when no text field is focused. Not blink-dependent (the blink is swallowed).

## Goldens

No golden changes. Goldens render under `NO_COLOR`, where the caret is a plain cell, and `view.Cursor` is not captured as a grid cell — so nothing changed. Rebased onto the latest `epic/tui` (including #766's settled-FinalModel golden harness) and all golden tests pass. No secret is newly unmasked (content rendering is untouched; only `view.Cursor` is added).

🤖 Generated with [Claude Code](https://claude.com/claude-code)