### PR TITLE
fix(tui): always pretty-print JSON values and reflow on resize like the GUI (#732)

### DIFF
--- a/internal/tui/browser_golden_test.go
+++ b/internal/tui/browser_golden_test.go
@@ -267,9 +267,10 @@ func TestBrowser_CopyKeepsMaskGolden(t *testing.T) { //nolint:paralleltest // go
 	golden.RequireEqual(t, screen)
 }
 
-// TestBrowser_ParseJSONGolden pins #690: `J` pretty-prints a JSON value in the
-// browser detail value pane (parity with the diff page and the GUI).
-func TestBrowser_ParseJSONGolden(t *testing.T) { //nolint:paralleltest // goldenEnv calls t.Setenv (NO_COLOR/TZ), which forbids t.Parallel
+// TestBrowser_JSONFormattedGolden pins #732: a JSON value in the browser detail
+// value pane is pretty-printed BY DEFAULT (parity with the GUI, which formats
+// every JSON value) — no manual toggle needed.
+func TestBrowser_JSONFormattedGolden(t *testing.T) { //nolint:paralleltest // goldenEnv calls t.Setenv (NO_COLOR/TZ), which forbids t.Parallel
 	goldenEnv(t)
 
 	m := newApp(config{
@@ -278,9 +279,9 @@ func TestBrowser_ParseJSONGolden(t *testing.T) { //nolint:paralleltest // golden
 		sourceFor: sourceForShape("param", awsParamJSONSource(), nil),
 	})
 
-	screen := captureBrowserKeys(t, m, "db.internal", 'J')
+	screen := captureUntil(t, m, "db.internal", browserTermWidth, browserTermHeight)
 
-	assert.Contains(t, screen, `"host": "db.internal"`, "J pretty-prints the JSON value onto indented lines")
+	assert.Contains(t, screen, `"host": "db.internal"`, "the JSON value is pretty-printed onto indented lines by default")
 	golden.RequireEqual(t, screen)
 }
 

--- a/internal/tui/components/valuepane.go
+++ b/internal/tui/components/valuepane.go
@@ -21,15 +21,15 @@ const maxMaskWidth = 24
 // Reveal is per-pane and never persisted by the pane itself; the owning page
 // decides when to reset it (e.g. on selecting another entry). The raw value is
 // held privately and only rendered when revealed, so a masked pane never emits
-// the real value. A parse-JSON toggle pretty-prints a JSON value (parity with
-// the diff page and the GUI), gated behind reveal so a masked secret is never
-// normalized.
+// the real value. A revealed value that parses as JSON is ALWAYS pretty-printed
+// (parity with the GUI, which formats every JSON value rather than offering a
+// manual toggle; #732) — formatting is gated behind reveal so a masked secret is
+// never normalized.
 type ValuePane struct {
-	vp        viewport.Model
-	raw       string
-	secret    bool
-	masked    bool
-	parseJSON bool
+	vp     viewport.Model
+	raw    string
+	secret bool
+	masked bool
 }
 
 // NewValuePane builds an empty, masked value pane.
@@ -38,14 +38,12 @@ func NewValuePane() ValuePane {
 }
 
 // SetValue loads a value and whether it is secret (and thus masked by default).
-// A non-secret value is shown as-is; masking is reset to the secret default and
-// the parse-JSON toggle is cleared, so switching entries never carries a
-// previous reveal or format toggle forward.
+// A non-secret value is shown formatted-if-JSON; masking is reset to the secret
+// default, so switching entries never carries a previous reveal forward.
 func (p *ValuePane) SetValue(raw string, secret bool) {
 	p.raw = raw
 	p.secret = secret
 	p.masked = secret
-	p.parseJSON = false
 	p.syncContent()
 }
 
@@ -64,19 +62,6 @@ func (p *ValuePane) ToggleMask() {
 	}
 
 	p.masked = !p.masked
-	p.syncContent()
-}
-
-// ToggleParseJSON flips JSON pretty-printing of the value. It is a no-op while
-// the value is masked: the mask bullets are not JSON, and normalizing a still-
-// hidden secret could leak its structure (the diff page skips parse-json for a
-// secret for the same reason), so revealing it first (x) is required.
-func (p *ValuePane) ToggleParseJSON() {
-	if p.masked {
-		return
-	}
-
-	p.parseJSON = !p.parseJSON
 	p.syncContent()
 }
 
@@ -107,29 +92,6 @@ func (p *ValuePane) HintSuffix() string {
 	return ""
 }
 
-// ParseJSONHint is the "(J to format)" / "(J to unformat)" hint shown next to
-// the Value label when the visible value is JSON that `J` can pretty-print;
-// empty when the value is masked or is not JSON (so the toggle would do
-// nothing).
-func (p *ValuePane) ParseJSONHint() string {
-	if p.masked || !p.isJSON() {
-		return ""
-	}
-
-	if p.parseJSON {
-		return "(J to unformat)"
-	}
-
-	return "(J to format)"
-}
-
-// isJSON reports whether the raw value is JSON the parse-JSON toggle can format.
-func (p *ValuePane) isJSON() bool {
-	_, ok := jsonutil.TryFormat(p.raw)
-
-	return ok
-}
-
 // View renders the pane body (title is drawn by the owning page).
 func (p *ValuePane) View() string {
 	return p.vp.View()
@@ -141,18 +103,16 @@ func (p *ValuePane) syncContent() {
 }
 
 // display returns the string shown in the viewport: a mask that reveals neither
-// the value nor (beyond the cap) its length when masked; the JSON-formatted
-// value when revealed with the parse-JSON toggle on and the value is JSON; else
-// the raw value.
+// the value nor (beyond the cap) its length when masked; else the JSON-formatted
+// value when the (revealed) value parses as JSON — always pretty-printed like
+// the GUI (#732) — else the raw value.
 func (p *ValuePane) display() string {
 	if p.masked {
 		return MaskValue(p.raw)
 	}
 
-	if p.parseJSON {
-		if f, ok := jsonutil.TryFormat(p.raw); ok {
-			return f
-		}
+	if f, ok := jsonutil.TryFormat(p.raw); ok {
+		return f
 	}
 
 	return p.raw

--- a/internal/tui/pages/browser/browser.go
+++ b/internal/tui/pages/browser/browser.go
@@ -73,7 +73,6 @@ var (
 	recursiveKey = key.NewBinding(key.WithKeys("r"), key.WithHelp("r", "recursive/refresh"))
 	loadMoreKey  = key.NewBinding(key.WithKeys("L"), key.WithHelp("L", "load more"))
 	revealKey    = key.NewBinding(key.WithKeys("x"), key.WithHelp("x", "reveal"))
-	parseJSONKey = key.NewBinding(key.WithKeys("J"), key.WithHelp("J", "parse-json"))
 	compareKey   = key.NewBinding(key.WithKeys("c"), key.WithHelp("c", "compare"))
 	stagingKey   = key.NewBinding(key.WithKeys("S"), key.WithHelp("S", "staging"))
 	spaceKey     = key.NewBinding(key.WithKeys("space"), key.WithHelp("space", "pick/namespace"))

--- a/internal/tui/pages/browser/browser_test.go
+++ b/internal/tui/pages/browser/browser_test.go
@@ -507,11 +507,10 @@ func TestCopyDoesNotUnmask(t *testing.T) {
 	assert.Equal(t, "copied", m.actionStatus)
 }
 
-// TestParseJSONToggleFormatsValue pins #690: the detail value pane's `J` toggle
-// pretty-prints a JSON value in the browser (parity with the diff page and the
-// GUI), and toggles back to the raw compact form. A masked secret gates the
-// toggle off (the pane requires reveal first).
-func TestParseJSONToggleFormatsValue(t *testing.T) {
+// TestJSONValueAlwaysFormatted pins #732: the detail value pane pretty-prints a
+// JSON value BY DEFAULT (parity with the GUI, which formats every JSON value) —
+// no manual toggle. The compact single-line form never reaches the screen.
+func TestJSONValueAlwaysFormatted(t *testing.T) {
 	t.Parallel()
 
 	const compact = `{"host":"db.internal","port":5432}`
@@ -528,26 +527,43 @@ func TestParseJSONToggleFormatsValue(t *testing.T) {
 	m, _ = update(t, m, detailLoadedMsg{seq: m.detailSeq, d: data.Detail{Name: "/app/cfg", Value: compact}})
 
 	m.valuePane.SetSize(80, 20)
-	require.Contains(t, m.valuePane.View(), compact, "a non-secret JSON value renders raw by default")
-	require.NotContains(t, m.valuePane.View(), indentedMember, "the raw form is not indented")
-
-	// `J` pretty-prints it.
-	m, _ = update(t, m, keyPress('J'))
-	m.valuePane.SetSize(80, 20)
-	assert.Contains(t, m.valuePane.View(), indentedMember, "J pretty-prints the JSON value onto indented lines")
-	assert.NotContains(t, m.valuePane.View(), compact, "the compact single-line form is gone once formatted")
-
-	// `J` again toggles back to the compact form.
-	m, _ = update(t, m, keyPress('J'))
-	m.valuePane.SetSize(80, 20)
-	assert.Contains(t, m.valuePane.View(), compact, "J toggles back to the raw value")
-	assert.NotContains(t, m.valuePane.View(), indentedMember, "the formatting is undone")
+	assert.Contains(t, m.valuePane.View(), indentedMember, "a non-secret JSON value is pretty-printed by default")
+	assert.NotContains(t, m.valuePane.View(), compact, "the compact single-line form is never shown")
 }
 
-// TestParseJSONToggleGatedWhileMasked pins that `J` is a no-op while a secret is
-// masked (the pane requires reveal first, so a masked secret is never
-// normalized), and works once revealed.
-func TestParseJSONToggleGatedWhileMasked(t *testing.T) {
+// TestJSONValueReflowsOnResize pins #732's repaint fix: a WindowSizeMsg re-syncs
+// the value pane content so the formatted JSON reflows to the new width and does
+// not clip.
+func TestJSONValueReflowsOnResize(t *testing.T) {
+	t.Parallel()
+
+	const (
+		compact        = `{"host":"db.internal","port":5432,"tls":true}`
+		indentedMember = `  "host": "db.internal"`
+	)
+
+	src := &stubSource{svcCap: awsParamCap()}
+	m := newModel(t, src)
+
+	m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{{Name: "/app/cfg"}}}})
+	m, _ = update(t, m, detailLoadedMsg{seq: m.detailSeq, d: data.Detail{Name: "/app/cfg", Value: compact}})
+
+	// Render once at a wide size, then drive a window resize and re-render: the
+	// pane's content must reflect the new width, not a stale frame.
+	m, _ = update(t, m, tea.WindowSizeMsg{Width: 120, Height: 34})
+	wide := m.View(120, 34)
+	require.Contains(t, wide, indentedMember, "the formatted JSON renders")
+
+	m, _ = update(t, m, tea.WindowSizeMsg{Width: 90, Height: 24})
+	narrow := m.View(90, 24)
+	require.NotEqual(t, wide, narrow, "a resize re-renders the pane at the new size")
+	assert.Contains(t, narrow, indentedMember, "the formatted JSON is still present (not clipped) after the resize")
+}
+
+// TestJSONFormattingGatedWhileMasked pins that a masked secret is never formatted
+// (its bullets are not JSON, and normalizing a still-hidden secret could leak its
+// structure), and that revealing it (x) pretty-prints the JSON.
+func TestJSONFormattingGatedWhileMasked(t *testing.T) {
 	t.Parallel()
 
 	const compact = `{"token":"abc"}`
@@ -559,17 +575,13 @@ func TestParseJSONToggleGatedWhileMasked(t *testing.T) {
 	m, _ = update(t, m, detailLoadedMsg{seq: m.detailSeq, d: data.Detail{Name: "/s", Value: compact, Secret: true}})
 	require.True(t, m.valuePane.Masked(), "secret starts masked")
 
-	// J while masked does nothing — the pane stays masked (no format, no reveal).
-	m, _ = update(t, m, keyPress('J'))
 	m.valuePane.SetSize(80, 20)
-	assert.True(t, m.valuePane.Masked(), "J must not reveal a masked secret")
-	assert.NotContains(t, m.valuePane.View(), "token", "J must not format (or leak) a masked secret")
+	assert.NotContains(t, m.valuePane.View(), "token", "a masked secret is never formatted (or leaked)")
 
-	// Reveal, then J formats.
+	// Reveal: the JSON is pretty-printed.
 	m, _ = update(t, m, keyPress('x'))
-	m, _ = update(t, m, keyPress('J'))
 	m.valuePane.SetSize(80, 20)
-	assert.Contains(t, m.valuePane.View(), `  "token": "abc"`, "once revealed, J formats the JSON onto indented lines")
+	assert.Contains(t, m.valuePane.View(), `  "token": "abc"`, "once revealed, the JSON is formatted onto indented lines")
 }
 
 // TestMouseClickSelectEqualsKeySelect pins the epic's mouse rule: a click on a

--- a/internal/tui/pages/browser/help.go
+++ b/internal/tui/pages/browser/help.go
@@ -13,8 +13,8 @@ import (
 // (#681). The map adapts to focus (a focused filter shows only commit/cancel;
 // the list and history panes advertise their own transitions) and gates each
 // binding on capability (tags only with HasTags, restore only with HasRestore,
-// load-more only with a next page, copy/reveal/parse-json only with a loaded
-// detail), so the bar never lists a key that would do nothing here.
+// load-more only with a next page, copy/reveal only with a loaded detail), so
+// the bar never lists a key that would do nothing here.
 func (m *Model) HelpKeyMap() help.KeyMap {
 	// A focused header field owns every keystroke (CapturesInput), so only the
 	// commit transition is meaningful while editing.
@@ -83,7 +83,7 @@ func (m *Model) viewColumn() []key.Binding {
 	col := []key.Binding{prefixKey, filterKey, valuesKey, recursiveKey}
 
 	if m.detailOK {
-		col = append(col, revealKey, parseJSONKey)
+		col = append(col, revealKey)
 	}
 
 	// Load-more only applies while a next page is pending (secret pagination).

--- a/internal/tui/pages/browser/update.go
+++ b/internal/tui/pages/browser/update.go
@@ -306,13 +306,6 @@ func (m *Model) handleActionKey(msg tea.KeyPressMsg) (bool, tea.Cmd) {
 		m.history.SetReveal(!m.valuePane.Masked())
 
 		return true, nil
-	case key.Matches(msg, parseJSONKey):
-		// Parse-JSON pretty-prints a JSON value in the detail pane (parity with the
-		// diff page's `J` and the GUI). It is a no-op while a secret is masked (the
-		// pane gates it behind reveal).
-		m.valuePane.ToggleParseJSON()
-
-		return true, nil
 	case key.Matches(msg, stagingKey):
 		return true, func() tea.Msg { return nav.OpenStaging{} }
 	case key.Matches(msg, compareKey):

--- a/internal/tui/pages/browser/view.go
+++ b/internal/tui/pages/browser/view.go
@@ -264,14 +264,11 @@ func (m *Model) renderDetail(innerW, innerH int) (body string, valueLabelTop, hi
 	return fitLines(lines, innerH), valueLabelTop, historyTop, historyH
 }
 
-// valueLabelLine renders the "Value  (x to reveal)" / "(J to format)" label row.
+// valueLabelLine renders the "Value  (x to reveal)" label row. A JSON value is
+// always pretty-printed (GUI parity, #732), so there is no format toggle hint.
 func (m *Model) valueLabelLine(width int) string {
 	label := m.styles.PaneTitle.Render("Value")
 	if hint := m.valuePane.HintSuffix(); hint != "" {
-		label += "   " + m.styles.PageHint.Render(hint)
-	}
-
-	if hint := m.valuePane.ParseJSONHint(); hint != "" {
 		label += "   " + m.styles.PageHint.Render(hint)
 	}
 

--- a/internal/tui/pages/diff/diff.go
+++ b/internal/tui/pages/diff/diff.go
@@ -1,8 +1,10 @@
 // Package diff renders the TUI's unified-diff page: two versions of one entry
 // compared with github.com/aymanbagabas/go-udiff (the same engine the CLI uses),
-// colorized per line in a scrollable viewport. `J` re-diffs with parse-json
-// normalization (parity with the CLI's --parse-json), recomputing the diff from
-// the already-fetched values without another round trip.
+// colorized per line in a scrollable viewport. A value that parses as JSON is
+// ALWAYS pretty-printed before diffing (parity with the GUI, which formats every
+// JSON value; #732) — no manual toggle. When pretty-printing collapses the two
+// sides to identical text even though the raw values differ (a whitespace-only
+// difference), the page says so rather than showing a bare "(no differences)".
 package diff
 
 import (
@@ -29,11 +31,6 @@ import (
 //
 //nolint:gochecknoglobals // immutable page-local binding
 var scrollKey = key.NewBinding(key.WithKeys("up", "down"), key.WithHelp("↑/↓", "scroll"))
-
-// parseJSONKey toggles JSON normalization of both values before diffing.
-//
-//nolint:gochecknoglobals // immutable page-local binding
-var parseJSONKey = key.NewBinding(key.WithKeys("J"), key.WithHelp("J", "parse-json"))
 
 // maskKey toggles masking of a secret diff. The Compare/diff view is a surface
 // the user explicitly opened to inspect the change, so its values are REVEALED
@@ -67,9 +64,8 @@ type Model struct {
 	width  int
 	height int
 
-	content   data.DiffContent
-	loaded    bool
-	parseJSON bool
+	content data.DiffContent
+	loaded  bool
 	// masked hides a secret diff's values. It defaults to false: an explicitly
 	// opened Compare/diff view reveals values so the diff is meaningful
 	// (#702/#735); `x` toggles it to mask both sides.
@@ -166,17 +162,12 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 	}
 }
 
-// handleKey handles the page-local keys (parse-json toggle, back) and forwards
-// the rest to the viewport for scrolling.
+// handleKey handles the page-local keys (mask toggle, back) and forwards the
+// rest to the viewport for scrolling.
 func (m *Model) handleKey(msg tea.KeyPressMsg) (*Model, tea.Cmd) {
 	switch {
 	case key.Matches(msg, m.keys.Back):
 		return m, func() tea.Msg { return nav.PopPage{} }
-	case key.Matches(msg, parseJSONKey):
-		m.parseJSON = !m.parseJSON
-		m.render()
-
-		return m, nil
 	case key.Matches(msg, maskKey):
 		m.masked = !m.masked
 		m.render()
@@ -192,11 +183,11 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) (*Model, tea.Cmd) {
 }
 
 // HelpKeyMap reports the diff page's context-aware bindings for the help bar:
-// scroll and parse-json always, the mask toggle only on a loaded secret diff
-// (`x` is a no-op on a non-secret diff, so it is hidden there), then back. The
-// help bar makes `J`/`x`/esc discoverable — previously undocumented (#681).
+// scroll always, the mask toggle only on a loaded secret diff (`x` is a no-op on
+// a non-secret diff, so it is hidden there), then back. The help bar makes
+// `x`/esc discoverable — previously undocumented (#681).
 func (m *Model) HelpKeyMap() help.KeyMap {
-	bindings := []key.Binding{scrollKey, parseJSONKey}
+	bindings := []key.Binding{scrollKey}
 
 	if m.loaded && m.content.Secret {
 		bindings = append(bindings, maskKey)
@@ -216,8 +207,8 @@ func (m *Model) resizeViewport() {
 	m.render()
 }
 
-// render recomputes the colorized diff into the viewport for the current
-// parse-json state.
+// render recomputes the colorized diff into the viewport. A value that parses as
+// JSON is always pretty-printed before diffing (GUI parity, #732).
 func (m *Model) render() {
 	if !m.loaded {
 		return
@@ -229,13 +220,12 @@ func (m *Model) render() {
 	// change, so a secret's values are shown by default (#702/#735). Pressing `x`
 	// masks BOTH sides before diffing (per-line, length-capped bullets), so a
 	// change still shows as differing runs without disclosing content — and while
-	// masked, parse-json is skipped: the bullets are not JSON, and normalizing the
+	// masked, formatting is skipped: the bullets are not JSON, and normalizing the
 	// raw secret first could leak its structure.
-	switch {
-	case m.content.Secret && m.masked:
+	if m.content.Secret && m.masked {
 		oldVal = components.MaskValue(oldVal)
 		newVal = components.MaskValue(newVal)
-	case m.parseJSON:
+	} else {
 		if f, ok := jsonutil.TryFormat(oldVal); ok {
 			oldVal = f
 		}
@@ -246,6 +236,18 @@ func (m *Model) render() {
 	}
 
 	raw := output.DiffRaw(m.content.OldLabel, m.content.NewLabel, oldVal, newVal)
+
+	// A whitespace-only difference collapses under pretty-printing: the formatted
+	// sides are identical even though the raw values differ. Say so, rather than a
+	// bare "(no differences)", so a real (formatting-hidden) change is not read as
+	// no change at all — mirroring the GUI's always-formatted comparison (#732).
+	if raw == "" && (!m.content.Secret || !m.masked) && m.content.OldValue != m.content.NewValue {
+		m.vp.SetContent(m.styles.PageHint.Render(
+			"(no differences after JSON formatting — the values differ only in whitespace/formatting)"))
+
+		return
+	}
+
 	m.vp.SetContent(m.colorize(raw))
 }
 

--- a/internal/tui/pages/diff/diff_test.go
+++ b/internal/tui/pages/diff/diff_test.go
@@ -103,10 +103,11 @@ func TestSecretDiffHiddenEqualLengthsMaskToNoDifference(t *testing.T) {
 	assert.Contains(t, out, "(no differences)", "equal-length masked values diff as identical")
 }
 
-// TestParamDiffShownAndParseJSONToggle pins the non-secret path: a param diff
-// renders the real content (not masked), and the J toggle re-diffs with
-// jsonutil.TryFormat normalization (parity with the CLI's --parse-json).
-func TestParamDiffShownAndParseJSONToggle(t *testing.T) {
+// TestParamDiffAlwaysFormatsJSON pins the non-secret path: a param diff renders
+// the real content (not masked), and a JSON value is ALWAYS pretty-printed
+// before diffing (GUI parity, #732) — no manual toggle. The compact single-line
+// objects never reach the screen; the expanded, indented JSON does.
+func TestParamDiffAlwaysFormatsJSON(t *testing.T) {
 	t.Setenv("NO_COLOR", "1")
 
 	m := newDiff(t)
@@ -118,20 +119,36 @@ func TestParamDiffShownAndParseJSONToggle(t *testing.T) {
 		Secret:   false,
 	}})
 
-	before := m.View(100, 40)
-	assert.Contains(t, before, `{"a":1}`, "a non-secret param value is shown verbatim, never masked")
-	assert.Contains(t, before, `{"a":2}`)
-	assert.NotContains(t, before, "•", "a non-secret diff has no mask bullets")
+	out := m.View(100, 40)
+	assert.Contains(t, out, `"a": 1`, "the JSON old value is pretty-printed by default")
+	assert.Contains(t, out, `"a": 2`, "the JSON new value is pretty-printed by default")
+	assert.NotContains(t, out, `{"a":1}`, "the compact single-line form is never shown")
+	assert.NotContains(t, out, "•", "a non-secret diff has no mask bullets")
+}
 
-	// Toggle parse-json: both sides reformat, so the diff now shows the expanded,
-	// indented JSON (the "a": N lines) rather than the compact objects.
-	m, _ = m.Update(keyPress('J'))
-	require.True(t, m.parseJSON, "J enables parse-json")
+// TestDiffReflowsOnResize pins #732's repaint fix: a WindowSizeMsg re-syncs the
+// viewport content so formatted JSON reflows to the new width and never clips.
+func TestDiffReflowsOnResize(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
 
-	after := m.View(100, 40)
-	assert.Contains(t, after, `"a": 1`, "parse-json expands the old value")
-	assert.Contains(t, after, `"a": 2`, "parse-json expands the new value")
-	assert.NotContains(t, after, `{"a":1}`, "the compact form is gone after formatting")
+	m := newDiff(t)
+	m, _ = m.Update(loadedMsg{content: data.DiffContent{
+		OldLabel: "cfg#1",
+		NewLabel: "cfg#2",
+		OldValue: `{"host":"a.internal","port":1}`,
+		NewValue: `{"host":"b.internal","port":2}`,
+		Secret:   false,
+	}})
+
+	wide := m.vp.View()
+
+	// A height/width change must re-render the viewport content (not leave a stale,
+	// clipped frame from the old size).
+	m, _ = m.Update(tea.WindowSizeMsg{Width: 60, Height: 12})
+	narrow := m.vp.View()
+
+	require.NotEqual(t, wide, narrow, "a resize re-syncs the viewport content")
+	assert.Contains(t, narrow, `"host": "a.internal"`, "the formatted JSON is still present after the resize")
 }
 
 // diffShortDescs flattens the diff page's short-help descriptions.
@@ -157,7 +174,7 @@ func TestHelpKeyMap_MaskGatedOnSecret(t *testing.T) {
 		OldLabel: "a#1", NewLabel: "a#2", OldValue: "1", NewValue: "2", Secret: false,
 	}})
 	assert.NotContains(t, diffShortDescs(nonSecret), "hide/show", "a non-secret diff has no mask toggle")
-	assert.Contains(t, diffShortDescs(nonSecret), "parse-json", "parse-json is always available")
+	assert.NotContains(t, diffShortDescs(nonSecret), "parse-json", "the parse-json toggle is gone (JSON is always formatted, #732)")
 	assert.Contains(t, diffShortDescs(nonSecret), "back", "esc back is always available")
 
 	secret := newDiff(t)

--- a/internal/tui/testdata/TestBrowser_FullHelpGolden.golden
+++ b/internal/tui/testdata/TestBrowser_FullHelpGolden.golden
@@ -31,4 +31,4 @@ enter history           / filter               e edit                    shift+t
 esc   back              v values               d delete                  1/2/3     jump to tab
 space pick/namespace    r recursive/refresh    t tag                     ?         help
                         x reveal               R restore                 q         quit
-                        J parse-json           y copy
+                                               y copy

--- a/internal/tui/testdata/TestBrowser_JSONFormattedGolden.golden
+++ b/internal/tui/testdata/TestBrowser_JSONFormattedGolden.golden
@@ -4,7 +4,7 @@ suve  aws · profile:dev · account:123456789012 · region:ap-northeast-1
 prefix: —   filter: —   values:off  recursive:on  ⟳
 ╭────────────────────────────────────────────╮╭────────────────────────────────────────────────────────────────────────╮
 │entries (1)                                 ││/app/web/CONFIG                                                         │
-│▸ /app/web/CONFIG                           ││Value   (J to unformat)                                                 │
+│▸ /app/web/CONFIG                           ││Value                                                                   │
 │                                            ││{                                                                       │
 │                                            ││  "host": "db.internal",                                                │
 │                                            ││  "port": 5432,                                                         │


### PR DESCRIPTION
Closes #732

## Problem

The TUI offered a manual `Shift+J` parse-json toggle on the diff page and the browser detail value pane (follow-up to #690). Pressing it grew the content height without a full repaint, so the value clipped/cut off. The maintainer prefers the GUI's behavior: a value that parses as JSON is **always** pretty-printed, sidestepping the toggle-repaint problem entirely.

## Change

**Always-format JSON (toggle removed).** A revealed value that parses as JSON is now pretty-printed by default on both surfaces — the diff page and the browser value pane — mirroring the GUI's `formatJsonValue` (which formats every JSON value, no toggle). The `J` toggle was **removed** rather than kept-and-fixed, per the issue's "prefer always-formatted like GUI" direction: it is simpler and eliminates the height-change-without-repaint bug at the root. Deleted the now-unused `ToggleParseJSON` / `ParseJSONHint` / `parseJSON` state and the browser `parseJSONKey` binding (deadcode gate clean).

**Repaint on resize.** The diff page re-syncs its viewport content on `tea.WindowSizeMsg` (`resizeViewport` → `render`), and the value pane re-syncs in `SetSize`, so formatted content reflows to the new terminal size instead of clipping. New unit tests drive a `WindowSizeMsg` and assert the viewport content updates (`TestDiffReflowsOnResize`, `TestJSONValueReflowsOnResize`).

**Formatting-collapsed notice (issue point 3).** With always-format, a real value difference can still collapse under pretty-printing when the two sides differ only in whitespace/formatting. In that case (formatted diff empty but raw values differ, non-masked) the diff page now shows a clear notice — "(no differences after JSON formatting — the values differ only in whitespace/formatting)" — instead of a bare "(no differences)". Note: the GUI does not surface an explicit message here (it just always formats); this notice is a TUI addition for the case the issue describes.

Formatting stays gated behind reveal on both surfaces: a masked secret is never normalized (its bullets are not JSON, and normalizing a hidden secret could leak its structure).

## Goldens

Regenerated with `-update` (settled-FinalModel capture, post-#766):

- `TestBrowser_ParseJSONGolden` → renamed `TestBrowser_JSONFormattedGolden`: the JSON value now renders pretty-printed **by default** (no `J` press, no "(J to unformat)" hint).
- `TestBrowser_FullHelpGolden`: drops the `J parse-json` help entry.

**No secret is newly unmasked.** The only content that changed is a non-secret plaintext param's JSON *format*; every secret golden (AWS/GCloud/Azure secret + SecureString diff/value panes) is byte-for-byte unchanged, and the mask policy is untouched — a masked secret still shows only bullets.

## Verification

- `go build ./...` — clean
- `go test ./internal/tui/...` — pass
- `go test -race -count=2 ./internal/tui/...` — pass
- `golangci-lint run --allow-parallel-runners ./internal/tui/...` — 0 issues
- `bash .github/scripts/check-deadcode.sh` — Dead code gate OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)