### PR TITLE
fix(tui): make the staging help bar adapt to the selected row kind (#683)

### DIFF
--- a/internal/tui/pages/staging/help.go
+++ b/internal/tui/pages/staging/help.go
@@ -11,10 +11,20 @@ import (
 // page's row/section actions (`e`/`u`/`t`/`x`/enter/`v`/`a`/`r`…) used to live
 // only in an in-body hint line because the global-only help bar could not show
 // them (#655); now the bar renders them per page (#681), so they are the single
-// discoverability surface here too. `x` is view-aware — it hides a revealed diff
-// in diff view and reveals a masked value in value view (see onReveal) — so its
-// label follows the current view. esc joins the map only while the auto-unstaged
-// notice is showing, the sole thing esc dismisses here.
+// discoverability surface here too.
+//
+// The bar adapts to BOTH the current view AND the selected row's kind so it lists
+// exactly what the selected row supports and never advertises a no-op (#683):
+//
+//   - `x` is view-aware — it hides a revealed diff in diff view and reveals a
+//     masked value in value view (see onReveal) — so its label follows the view.
+//   - `e` edit, `enter` detail, `t` tags and `x` reveal/hide gate on the selected
+//     row's kind, cross-checked against the update.go handlers, so a tag row or a
+//     delete-staged entry never lists an action that would silently do nothing
+//     there (editSelected/onEnter/tagSelected all return early on those rows).
+//
+// esc joins the map only while the auto-unstaged notice is showing, the sole
+// thing esc dismisses here.
 func (m *Model) HelpKeyMap() help.KeyMap {
 	return keys.Bindings{Short: m.shortHelp(), Full: m.fullHelp()}
 }
@@ -30,21 +40,107 @@ func (m *Model) xKey() key.Binding {
 	return revealKey
 }
 
-// shortHelp is the one-line hint: move plus the most-used row actions.
-func (m *Model) shortHelp() []key.Binding {
-	return []key.Binding{moveKey, editKey, unstageKey, m.xKey(), detailKey, viewKey}
+// Row-scoped action applicability, each mirroring the guard in the matching
+// update.go handler so the help lists exactly what the selected row supports.
+// When nothing is selected (an empty or not-yet-loaded page) they default to the
+// entry-row set, leaving that pre-load state's help unchanged — the row-kind
+// gating is scoped to a loaded, selected row (#683). `u` unstage is always
+// listed: it is the page's signature action and applies to every row kind.
+
+// canEditRow reports whether `e` edit acts on the selected row: only a staged
+// create/update entry (editSelected no-ops on a tag row and a staged delete).
+func (m *Model) canEditRow() bool {
+	row, ok := m.selectedRow()
+
+	return !ok || (row.kind == rowEntry && row.entry.Operation != operationDelete)
 }
 
-// fullHelp is the expanded reference: navigate / row actions / section+global.
+// canDetailRow reports whether `enter` opens detail for the selected row: only an
+// entry row, any operation (onEnter no-ops on a tag row).
+func (m *Model) canDetailRow() bool {
+	row, ok := m.selectedRow()
+
+	return !ok || row.kind == rowEntry
+}
+
+// canTagRow reports whether `t` tags the selected row's item: every row except a
+// delete-staged entry, which tagSelected gates off (ErrCannotTagDelete, #684).
+func (m *Model) canTagRow() bool {
+	row, ok := m.selectedRow()
+
+	return !ok || row.kind != rowEntry || row.entry.Operation != operationDelete
+}
+
+// canRevealRow reports whether `x` reveals/hides a value for the selected row.
+// Only entry rows carry a value; on a tag row `x` has no row value to act on, so
+// advertising its "reveal"/"hide" label there would be misleading.
+func (m *Model) canRevealRow() bool {
+	row, ok := m.selectedRow()
+
+	return !ok || row.kind == rowEntry
+}
+
+// shortHelp is the one-line hint: move plus the most-used actions applicable to
+// the selected row (unstage works on every row kind; edit / x / detail gate on
+// the row).
+func (m *Model) shortHelp() []key.Binding {
+	short := []key.Binding{moveKey}
+
+	if m.canEditRow() {
+		short = append(short, editKey)
+	}
+
+	short = append(short, unstageKey)
+
+	if m.canRevealRow() {
+		short = append(short, m.xKey())
+	}
+
+	if m.canDetailRow() {
+		short = append(short, detailKey)
+	}
+
+	return append(short, viewKey)
+}
+
+// fullHelp is the expanded reference: navigate / row actions / section+global,
+// each column gated on the selected row's kind so it lists only keys that act
+// here.
 func (m *Model) fullHelp() [][]key.Binding {
-	navigate := []key.Binding{moveKey, detailKey}
+	navigate := []key.Binding{moveKey}
+	if m.canDetailRow() {
+		navigate = append(navigate, detailKey)
+	}
+
 	if m.noticeVisible() {
 		navigate = append(navigate, m.keys.Back)
 	}
 
 	return [][]key.Binding{
 		navigate,
-		{editKey, unstageKey, tagKey, m.xKey()},
+		m.rowActionsColumn(),
 		{viewKey, applyKey, resetKey, applyAllKey, resetAllKey, refreshKey},
 	}
+}
+
+// rowActionsColumn is the row-action group for the selected row: unstage on every
+// row; edit / tag / x gated to the rows their handlers actually act on.
+func (m *Model) rowActionsColumn() []key.Binding {
+	var col []key.Binding
+
+	if m.canEditRow() {
+		col = append(col, editKey)
+	}
+
+	col = append(col, unstageKey)
+
+	if m.canTagRow() {
+		col = append(col, tagKey)
+	}
+
+	if m.canRevealRow() {
+		col = append(col, m.xKey())
+	}
+
+	return col
 }

--- a/internal/tui/pages/staging/staging_test.go
+++ b/internal/tui/pages/staging/staging_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"testing"
 
+	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -717,4 +718,93 @@ func TestUpdate_MouseClickHeaderMatchesKeys(t *testing.T) {
 	fx, fy := regionOrigin(t, m, regionRefresh)
 	_, cmd = m.Update(tea.MouseClickMsg{X: fx, Y: fy, Button: tea.MouseLeft})
 	require.NotNil(t, cmd, "clicking refresh reloads the sections")
+}
+
+// helpDescs flattens a set of help bindings to their visible descriptions, so a
+// test asserts on the labels the bar shows without depending on key glyphs.
+func helpDescs(bindings []key.Binding) []string {
+	descs := make([]string, 0, len(bindings))
+	for _, b := range bindings {
+		descs = append(descs, b.Help().Desc)
+	}
+
+	return descs
+}
+
+// fullHelpDescs flattens every full-help column to its descriptions.
+func fullHelpDescs(cols [][]key.Binding) []string {
+	descs := make([]string, 0, len(cols))
+	for _, col := range cols {
+		descs = append(descs, helpDescs(col)...)
+	}
+
+	return descs
+}
+
+// rowKindHelpReview holds one section with all three help-relevant row kinds: a
+// staged update entry, a staged delete entry, and a staged tag add — so a test
+// can move the selection across kinds and assert the help adapts (#683). Row
+// order is entries then tags: 0=update, 1=delete, 2=tag add.
+func rowKindHelpReview() data.StagingReview {
+	return data.StagingReview{
+		Entries: []data.StagedDiffRow{
+			{Name: "/app/UPD", Type: data.StagedDiffNormal, Operation: "update", RemoteValue: "a", StagedValue: "b"},
+			{Name: "/app/GONE", Type: data.StagedDiffNormal, Operation: "delete", RemoteValue: "c"},
+		},
+		Tags: []data.StagedTagRow{{
+			Name: "/app/ITEM",
+			Adds: []data.Tag{{Key: "owner", Value: "team"}},
+		}},
+	}
+}
+
+// TestHelp_AdaptsToSelectedRowKind pins #683: the staging help bar lists exactly
+// the actions the SELECTED row supports, so it never advertises a no-op. `e` edit
+// and `enter` detail are silent no-ops on a tag row (editSelected/onEnter return
+// early), `e` edit and `t` tags are no-ops on a delete-staged entry
+// (editSelected/tagSelected gate them), and `x` reveal/hide has no row value on a
+// tag row — the bar drops each where it would do nothing while keeping `u`
+// unstage on every row.
+func TestHelp_AdaptsToSelectedRowKind(t *testing.T) {
+	t.Parallel()
+
+	sec := &stubService{
+		service: "param", label: "Param", svcCap: capFor("aws", "param"),
+		review: rowKindHelpReview(),
+	}
+	m := newModel(t, sec)
+	require.Len(t, m.rows, 3, "one update, one delete, one tag-add row")
+
+	short := func() []string { return helpDescs(m.HelpKeyMap().ShortHelp()) }
+	full := func() []string { return fullHelpDescs(m.HelpKeyMap().FullHelp()) }
+
+	// Entry row (update): every row action is applicable.
+	m.selected = 0
+
+	assert.Contains(t, short(), "edit", "an entry row advertises edit")
+	assert.Contains(t, short(), "detail", "an entry row advertises enter/detail")
+	assert.Contains(t, short(), "unstage", "an entry row advertises unstage")
+	assert.Contains(t, full(), "edit", "the full help lists edit on an entry row")
+	assert.Contains(t, full(), "tags", "the full help lists tags on an entry row")
+
+	// Delete-staged entry: edit and tag are gated no-ops; detail still opens.
+	m.selected = 1
+
+	assert.NotContains(t, short(), "edit", "a delete-staged entry hides edit (editSelected no-ops)")
+	assert.Contains(t, short(), "detail", "detail still opens on a delete-staged entry (onEnter acts)")
+	assert.Contains(t, short(), "unstage", "a delete-staged entry keeps unstage")
+	assert.NotContains(t, full(), "edit", "the full help drops edit on a delete-staged entry")
+	assert.NotContains(t, full(), "tags", "a delete-staged entry cannot be tagged (#684)")
+
+	// Tag row: edit and enter/detail are no-ops; unstage/move/view remain.
+	m.selected = 2
+
+	assert.NotContains(t, short(), "edit", "a tag row hides edit (not an entry)")
+	assert.NotContains(t, short(), "detail", "a tag row hides enter/detail (onEnter no-ops)")
+	assert.Contains(t, short(), "unstage", "a tag row keeps unstage (u removes the staged tag change)")
+	assert.Contains(t, short(), "move", "a tag row keeps move")
+	assert.Contains(t, short(), "view", "a tag row keeps view")
+	assert.NotContains(t, full(), "edit", "the full help drops edit on a tag row")
+	assert.NotContains(t, full(), "detail", "the full help drops detail on a tag row")
+	assert.Contains(t, full(), "unstage", "the full help keeps unstage on a tag row")
 }

--- a/internal/tui/testdata/TestStaging_TagGateStatusGolden.golden
+++ b/internal/tui/testdata/TestStaging_TagGateStatusGolden.golden
@@ -31,4 +31,4 @@ Secret (2)                                                                      
 
 
 cannot tag: staged for deletion — reset first
- ↑/↓ move • e edit • u unstage • x hide • enter detail • v view • tab next tab • 1/2/3 jump to tab • ? help • q quit
+ ↑/↓ move • u unstage • x hide • enter detail • v view • tab next tab • 1/2/3 jump to tab • ? help • q quit


### PR DESCRIPTION
Closes #683

## Problem

The staging page's adaptive help bar (`internal/tui/pages/staging/help.go`) adapted to the **view** (diff vs value, via `m.xKey()`) but never consulted the **selected row kind**. So on a tag row or a delete-staged entry the bar still advertised `e edit` and `enter detail`, which are silent no-ops there (`editSelected`/`onEnter`/`tagSelected` all return early on those rows). The destructive half of the bug was already fixed (#682/#728, #681/#743); this closes the remaining discoverability half.

## Fix

`shortHelp()`/`fullHelp()` now consult `m.selectedRow()` and gate each row-scoped binding on the selected row's kind + operation, cross-checked against the actual `update.go` handlers so the bar lists exactly what the row supports — never a no-op, never hiding a working action:

| binding | applies to | mirrors handler |
| --- | --- | --- |
| `e` edit | staged create/update entry only | `editSelected` (no-op on tag row / delete) |
| `enter` detail | entry row, any operation | `onEnter` (no-op on tag row; works on delete) |
| `t` tags | every row except a delete-staged entry | `tagSelected` (gated with `ErrCannotTagDelete`, #684) |
| `x` reveal/hide | entry rows (they carry a value) | `onReveal` |
| `u` unstage | every row (page's signature action) | `unstageSelected` |

The predicates default to the entry-row set when nothing is selected, so the empty / pre-load help stays unchanged — the row-kind gating is scoped to a loaded, selected row. The view-aware `x` label (`m.xKey()`) is preserved. This mirrors how `internal/tui/pages/browser/help.go` already gates its help columns on capability/state.

## Tests

`TestHelp_AdaptsToSelectedRowKind` (staging package, white-box) builds one section with all three help-relevant row kinds (update entry, delete entry, tag add) and moves the selection across them, asserting the short and full help:

- entry (update): includes `edit`, `detail`, `unstage`; full includes `edit` + `tags`.
- delete-staged entry: excludes `edit`; keeps `detail`, `unstage`; full excludes `edit` + `tags`.
- tag row: excludes `edit` and `detail`; keeps `unstage`, `move`, `view`; full excludes `edit`/`detail`, keeps `unstage`.

## Golden

Regenerated the one affected staging golden, `TestStaging_TagGateStatusGolden` (its selection sits on the delete-staged row). The only change is the help-bar line — `e edit` dropped — with no secret newly unmasked:

```
- ↑/↓ move • e edit • u unstage • x hide • enter detail • v view • tab next tab • 1/2/3 jump to tab • ? help • q quit
+ ↑/↓ move • u unstage • x hide • enter detail • v view • tab next tab • 1/2/3 jump to tab • ? help • q quit
```

## Verification

- `go build ./...` — ok
- `go test ./internal/tui/...` — ok
- `go test -race -count=2 ./internal/tui/...` — ok
- `golangci-lint run --allow-parallel-runners ./internal/tui/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)