### PR TITLE
fix(tui): fence cross-tab list responses and reset stale detail on selection move (#746, #748)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -157,6 +157,12 @@ type App struct {
 	// stagedCounts holds the last staged-item count each service's browser
 	// reported, totalled into the Staging tab's count badge.
 	stagedCounts map[string]int
+
+	// pageGen is a monotonic page-generation counter. Each browser page built by
+	// pageForTab is stamped with the next value so a superseded prior page's
+	// in-flight response — whose per-Model seq resets and can collide with the new
+	// page's — is dropped rather than spliced into the new tab (#746).
+	pageGen int
 }
 
 // newApp builds the root model from a launch config: it derives the tab set
@@ -801,7 +807,8 @@ func (m *App) pageForTab(i int) (page, tea.Cmd) {
 
 	if m.sourceFor != nil {
 		if source, staging := m.sourceFor(tab.Service); source != nil {
-			p := newBrowserPage(m.runCtx, source, staging, m.styles, m.keys)
+			m.pageGen++
+			p := newBrowserPage(m.runCtx, m.pageGen, source, staging, m.styles, m.keys)
 
 			return p, p.Init()
 		}

--- a/internal/tui/pages/browser/browser.go
+++ b/internal/tui/pages/browser/browser.go
@@ -109,6 +109,15 @@ type Model struct {
 	staging data.StagingProbe // may be nil (no staging badges)
 	svcCap  capability.ServiceCapability
 
+	// token is this page instance's generation, stamped into every *LoadedMsg it
+	// emits and checked when one lands. The per-Model seq counters reset to the
+	// same value in each freshly built page, so on a tab switch the previous tab's
+	// in-flight response could still match the new tab's seq; the token is unique
+	// per page creation (bumped by the app in pageForTab), so a superseded prior
+	// page's message is dropped instead of splicing its data into the new tab
+	// (#746).
+	token int
+
 	styles styles.Styles
 	keys   keys.Map
 
@@ -204,8 +213,11 @@ const (
 
 // New builds a browser page over a data source. ctx is the Run context threaded
 // through every fetch. staging may be nil when the service has no staging
-// workflow.
-func New(ctx context.Context, source data.Source, staging data.StagingProbe, st styles.Styles, km keys.Map) *Model {
+// workflow. token is the page-generation identity the app assigns per page
+// creation so a superseded prior page's in-flight response is dropped (#746).
+func New(
+	ctx context.Context, token int, source data.Source, staging data.StagingProbe, st styles.Styles, km keys.Map,
+) *Model {
 	prefix := textinput.New()
 	prefix.Prompt = ""
 
@@ -216,6 +228,7 @@ func New(ctx context.Context, source data.Source, staging data.StagingProbe, st 
 
 	m := &Model{
 		ctx:              ctx,
+		token:            token,
 		source:           source,
 		staging:          staging,
 		svcCap:           source.Capability(),

--- a/internal/tui/pages/browser/browser_test.go
+++ b/internal/tui/pages/browser/browser_test.go
@@ -75,11 +75,23 @@ func lookup(prov, service string) capability.ServiceCapability {
 	return capability.ServiceCapability{}
 }
 
-// newModel builds a browser model over a stub source.
+// newModel builds a browser model over a stub source. Its page-generation token
+// is 0, matching the zero-value token on the *LoadedMsg literals the other tests
+// build directly; tokenModel builds one with an explicit token for the cross-page
+// fencing test (#746).
 func newModel(t *testing.T, src *stubSource) *Model {
 	t.Helper()
 
-	m := New(context.Background(), src, nil, styles.New(), keys.Default())
+	return tokenModel(t, 0, src)
+}
+
+// tokenModel builds a browser model with an explicit page-generation token, so a
+// test can simulate two tab pages (distinct tokens) and prove a prior page's
+// response is fenced off (#746).
+func tokenModel(t *testing.T, token int, src *stubSource) *Model {
+	t.Helper()
+
+	m := New(context.Background(), token, src, nil, styles.New(), keys.Default())
 	m.width, m.height = 120, 30
 
 	return m
@@ -127,6 +139,90 @@ func TestStaleListResponseDropped(t *testing.T) {
 	m, _ = update(t, m, listLoadedMsg{seq: 2, res: data.ListResult{Items: []data.Item{{Name: "fresh"}}}})
 	require.Len(t, m.items, 1)
 	assert.Equal(t, "fresh", m.items[0].Name)
+}
+
+// TestCrossPageListResponseFenced pins the page-generation fence (#746): a list
+// response left in flight by a PRIOR tab's page must not splice its entries into
+// the freshly built new tab's page, even though the new page's per-Model seq
+// resets to the same value the prior response carries. Before the fix,
+// onListLoaded checked seq alone (1 == 1 → applied); the page token distinguishes
+// the two pages and drops the superseded one.
+func TestCrossPageListResponseFenced(t *testing.T) {
+	t.Parallel()
+
+	// Page A is the first tab; it issues its initial list load (seq → 1).
+	pageA := tokenModel(t, 1, &stubSource{svcCap: awsParamCap()})
+	_ = pageA.loadListCmd(false)
+	require.Equal(t, 1, pageA.listSeq)
+
+	// Page B is the second tab's freshly built page: its listSeq ALSO resets to 1,
+	// so A's response would collide on seq alone.
+	pageB := tokenModel(t, 2, &stubSource{svcCap: awsSecretCap()})
+	_ = pageB.loadListCmd(false)
+	require.Equal(t, 1, pageB.listSeq)
+
+	// A's in-flight response lands after the switch to B. Its seq (1) matches B's
+	// listSeq (1) — the pre-fix collision — but its page token (1) does not match
+	// B's (2), so B drops it and its (empty) list is untouched.
+	stale := listLoadedMsg{token: 1, seq: 1, res: data.ListResult{Items: []data.Item{{Name: "from-tab-A"}}}}
+	pageB, _ = update(t, pageB, stale)
+	assert.Empty(t, pageB.items, "a prior page's list response must not splice into the new tab (#746)")
+
+	// B's own response (matching token) applies normally.
+	own := listLoadedMsg{token: 2, seq: 1, res: data.ListResult{Items: []data.Item{{Name: "from-tab-B"}}}}
+	pageB, _ = update(t, pageB, own)
+	require.Len(t, pageB.items, 1)
+	assert.Equal(t, "from-tab-B", pageB.items[0].Name, "the new tab's own response still applies")
+}
+
+// TestSelectionMoveResetsDetailOK pins the stale-detail-seed fix (#748): moving
+// the selection to a new entry marks the loaded detail not-OK immediately, so the
+// value-seeded openEdit/openTag no-op during the load window (like they do before
+// the first load) instead of opening a dialog for the PREVIOUS entry — matching
+// openDelete, which always targets the live selection.
+func TestSelectionMoveResetsDetailOK(t *testing.T) {
+	t.Parallel()
+
+	src := &stubSource{svcCap: awsParamCap()}
+	m := newModel(t, src)
+
+	// Load a two-item list and item A's detail, so detailOK is true and m.detail
+	// describes A.
+	m, _ = update(t, m, listLoadedMsg{seq: m.listSeq, res: data.ListResult{Items: []data.Item{
+		{Name: "/app/a"}, {Name: "/app/b"},
+	}}})
+	m, _ = update(t, m, detailLoadedMsg{seq: m.detailSeq, d: data.Detail{Name: "/app/a", Value: "aaa"}})
+	require.True(t, m.detailOK)
+	require.Equal(t, "/app/a", m.detail.Name)
+
+	// Move down to item B. selectionCmd issues a fresh detail load but must mark the
+	// loaded detail stale immediately.
+	_ = m.move(1)
+	assert.False(t, m.detailOK, "detailOK resets when the selection moves to a new entry (#748)")
+
+	// openEdit is a no-op in the load window: no dialog seeded from the old entry A.
+	assert.Nil(t, m.openEdit(), "openEdit no-ops while the new selection's detail is loading")
+
+	// openDelete still targets the LIVE selection (item B), never the stale detail.
+	delCmd := m.openDelete()
+	require.NotNil(t, delCmd)
+	del, ok := delCmd().(nav.OpenDelete)
+	require.True(t, ok)
+	assert.Equal(t, "/app/b", del.Name, "openDelete uses the live selection, not the stale detail")
+
+	// When B's detail lands, detailOK is true again and now describes B; openEdit
+	// then seeds B (not A).
+	m, _ = update(t, m, detailLoadedMsg{seq: m.detailSeq, d: data.Detail{Name: "/app/b", Value: "bbb"}})
+	require.True(t, m.detailOK)
+	editCmd := m.openEdit()
+	require.NotNil(t, editCmd)
+	form, ok := editCmd().(nav.OpenEntryForm)
+	require.True(t, ok)
+	assert.Equal(t, "/app/b", form.Name, "openEdit seeds the freshly loaded entry")
+
+	// A same-entry reload keeps detailOK true — no value-pane flicker.
+	_ = m.selectionCmd()
+	assert.True(t, m.detailOK, "a same-entry reload keeps detailOK (no flicker)")
 }
 
 // TestPrefixDebounceSequenceGuard pins the debounce: a burst of edits schedules

--- a/internal/tui/pages/browser/cmds.go
+++ b/internal/tui/pages/browser/cmds.go
@@ -7,30 +7,38 @@ import (
 )
 
 // Async result messages. Each carries the sequence its fetch was issued with, so
-// the reducer can drop a stale response (a fetch that a newer one superseded).
+// the reducer can drop a stale response (a fetch that a newer one superseded),
+// plus the page-generation token so a superseded PRIOR page's response (whose seq
+// can collide with the new page's reset seq after a tab switch) is dropped too
+// (#746).
 type (
 	listLoadedMsg struct {
+		token  int
 		seq    int
 		append bool
 		res    data.ListResult
 		err    error
 	}
 	detailLoadedMsg struct {
-		seq int
-		d   data.Detail
-		err error
+		token int
+		seq   int
+		d     data.Detail
+		err   error
 	}
 	historyLoadedMsg struct {
-		seq  int
-		rows []data.HistoryRow
-		err  error
+		token int
+		seq   int
+		rows  []data.HistoryRow
+		err   error
 	}
 	stagedLoadedMsg struct {
-		seq  int
-		snap data.StagingSnapshot
-		err  error
+		token int
+		seq   int
+		snap  data.StagingSnapshot
+		err   error
 	}
 	namespacesLoadedMsg struct {
+		token int
 		seq   int
 		names []string
 		err   error
@@ -56,6 +64,7 @@ func (m *Model) listParams() data.ListParams {
 func (m *Model) loadListCmd(appendPage bool) tea.Cmd {
 	m.listSeq++
 	m.loading = true
+	token := m.token
 	seq := m.listSeq
 	ctx := m.ctx
 	source := m.source
@@ -64,13 +73,14 @@ func (m *Model) loadListCmd(appendPage bool) tea.Cmd {
 	return func() tea.Msg {
 		res, err := source.List(ctx, params)
 
-		return listLoadedMsg{seq: seq, append: appendPage, res: res, err: err}
+		return listLoadedMsg{token: token, seq: seq, append: appendPage, res: res, err: err}
 	}
 }
 
 // loadDetailCmd issues a detail (Show) fetch for name/namespace.
 func (m *Model) loadDetailCmd(name, namespace string) tea.Cmd {
 	m.detailSeq++
+	token := m.token
 	seq := m.detailSeq
 	ctx := m.ctx
 	source := m.source
@@ -78,7 +88,7 @@ func (m *Model) loadDetailCmd(name, namespace string) tea.Cmd {
 	return func() tea.Msg {
 		d, err := source.Show(ctx, name, namespace)
 
-		return detailLoadedMsg{seq: seq, d: d, err: err}
+		return detailLoadedMsg{token: token, seq: seq, d: d, err: err}
 	}
 }
 
@@ -86,6 +96,7 @@ func (m *Model) loadDetailCmd(name, namespace string) tea.Cmd {
 // so a history failure never blanks the value (GUI Promise.allSettled parity).
 func (m *Model) loadHistoryCmd(name, namespace string) tea.Cmd {
 	m.historySeq++
+	token := m.token
 	seq := m.historySeq
 	ctx := m.ctx
 	source := m.source
@@ -93,13 +104,14 @@ func (m *Model) loadHistoryCmd(name, namespace string) tea.Cmd {
 	return func() tea.Msg {
 		rows, err := source.History(ctx, name, namespace)
 
-		return historyLoadedMsg{seq: seq, rows: rows, err: err}
+		return historyLoadedMsg{token: token, seq: seq, rows: rows, err: err}
 	}
 }
 
 // loadStagedCmd probes which items have staged changes.
 func (m *Model) loadStagedCmd() tea.Cmd {
 	m.stagedSeq++
+	token := m.token
 	seq := m.stagedSeq
 	ctx := m.ctx
 	probe := m.staging
@@ -107,13 +119,14 @@ func (m *Model) loadStagedCmd() tea.Cmd {
 	return func() tea.Msg {
 		snap, err := probe.Staged(ctx)
 
-		return stagedLoadedMsg{seq: seq, snap: snap, err: err}
+		return stagedLoadedMsg{token: token, seq: seq, snap: snap, err: err}
 	}
 }
 
 // loadNamespacesCmd discovers App Configuration namespaces for the header filter.
 func (m *Model) loadNamespacesCmd() tea.Cmd {
 	m.nsSeq++
+	token := m.token
 	seq := m.nsSeq
 	ctx := m.ctx
 	source := m.source
@@ -121,7 +134,7 @@ func (m *Model) loadNamespacesCmd() tea.Cmd {
 	return func() tea.Msg {
 		names, err := source.Namespaces(ctx)
 
-		return namespacesLoadedMsg{seq: seq, names: names, err: err}
+		return namespacesLoadedMsg{token: token, seq: seq, names: names, err: err}
 	}
 }
 
@@ -141,10 +154,27 @@ func (m *Model) selectionCmd() tea.Cmd {
 		return nil
 	}
 
+	// m.detail still describes whatever entry it was last loaded for. When the
+	// selection moves to a DIFFERENT entry, that loaded detail is now stale, so
+	// mark it not-OK until the fresh detail lands: openEdit/openTag gate on
+	// detailOK, so this keeps them from seeding a dialog for the PREVIOUS entry
+	// during the load window — matching openDelete, which reads the live selection
+	// (#748). A reload of the SAME entry keeps detailOK, so its value pane never
+	// flickers.
+	if m.detailKey() != dataStagedKey(item) {
+		m.detailOK = false
+	}
+
 	return tea.Batch(
 		m.loadDetailCmd(item.Name, item.Namespace),
 		m.loadHistoryCmd(item.Name, item.Namespace),
 	)
+}
+
+// detailKey is the identity of the entry m.detail currently holds (name +
+// namespace), used to tell a same-entry reload from a real selection move.
+func (m *Model) detailKey() data.StagedKey {
+	return data.StagedKey{Name: m.detail.Name, Namespace: m.detail.Namespace}
 }
 
 // selectedItem returns the item under the list's selection by INDEX, not name:

--- a/internal/tui/pages/browser/update.go
+++ b/internal/tui/pages/browser/update.go
@@ -65,8 +65,10 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 // onListLoaded applies a list response when it is not stale, rebuilds the rows,
 // and (re)loads the selection's detail/history.
 func (m *Model) onListLoaded(msg listLoadedMsg) tea.Cmd {
-	if msg.seq != m.listSeq {
-		return nil // stale response — a newer list load supersedes it
+	if msg.token != m.token || msg.seq != m.listSeq {
+		// Stale response: a newer list load supersedes it (seq), or it belongs to a
+		// prior page whose seq collides with this one after a tab switch (token, #746).
+		return nil
 	}
 
 	m.loading = false
@@ -107,8 +109,8 @@ func (m *Model) onListLoaded(msg listLoadedMsg) tea.Cmd {
 // successful load clears the detail error so a prior transient failure never
 // lingers over the freshly-loaded value.
 func (m *Model) onDetailLoaded(msg detailLoadedMsg) {
-	if msg.seq != m.detailSeq {
-		return
+	if msg.token != m.token || msg.seq != m.detailSeq {
+		return // stale seq, or a prior page's response after a tab switch (#746)
 	}
 
 	if msg.err != nil {
@@ -128,8 +130,8 @@ func (m *Model) onDetailLoaded(msg detailLoadedMsg) {
 // own error line (never clearing the already-loaded value); a successful load
 // clears it so a prior transient failure never lingers over good history.
 func (m *Model) onHistoryLoaded(msg historyLoadedMsg) {
-	if msg.seq != m.historySeq {
-		return
+	if msg.token != m.token || msg.seq != m.historySeq {
+		return // stale seq, or a prior page's response after a tab switch (#746)
 	}
 
 	if msg.err != nil {
@@ -154,8 +156,8 @@ func (m *Model) onHistoryLoaded(msg historyLoadedMsg) {
 // — so the two surfaces share one count rather than oscillating between a
 // deduplicated-key count and entries+tags (#693).
 func (m *Model) onStagedLoaded(msg stagedLoadedMsg) tea.Cmd {
-	if msg.seq != m.stagedSeq {
-		return nil
+	if msg.token != m.token || msg.seq != m.stagedSeq {
+		return nil // stale seq, or a prior page's response after a tab switch (#746)
 	}
 
 	if msg.err != nil {
@@ -213,8 +215,8 @@ func (m *Model) reload() tea.Cmd {
 // onNamespacesLoaded merges discovered namespaces into the header filter,
 // preserving the null option first and the all-namespaces option last.
 func (m *Model) onNamespacesLoaded(msg namespacesLoadedMsg) {
-	if msg.seq != m.nsSeq || msg.err != nil {
-		return
+	if msg.token != m.token || msg.seq != m.nsSeq || msg.err != nil {
+		return // stale seq, or a prior page's response after a tab switch (#746)
 	}
 
 	// Preserve the currently-selected namespace VALUE across the rebuild, so an

--- a/internal/tui/pages_wire.go
+++ b/internal/tui/pages_wire.go
@@ -85,11 +85,13 @@ func newStaticDiffPage(content data.DiffContent, st styles.Styles, km keys.Map) 
 	return diffPage{m: diff.NewStatic(content, st, km)}
 }
 
-// newBrowserPage builds the browser page adapter for a service source.
+// newBrowserPage builds the browser page adapter for a service source. token is
+// the page-generation identity the app bumps per page creation so a superseded
+// prior page's in-flight response is dropped rather than spliced in (#746).
 func newBrowserPage(
-	ctx context.Context, source data.Source, staging data.StagingProbe, st styles.Styles, km keys.Map,
+	ctx context.Context, token int, source data.Source, staging data.StagingProbe, st styles.Styles, km keys.Map,
 ) browserPage {
-	return browserPage{m: browser.New(ctx, source, staging, st, km)}
+	return browserPage{m: browser.New(ctx, token, source, staging, st, km)}
 }
 
 // newDiffPage builds the diff page adapter from a navigation request.


### PR DESCRIPTION
Closes #746
Closes #748

Two browser-page async/timing bugs, one PR. Both are fixes to how a browser
page fences off responses it should ignore; no rendering changes.

## #746 — cross-tab list-response splice (Medium)

Switching tabs (`App.setTab` → `pageForTab`) swaps in a freshly built
`browser.Model`, which resets its per-`Model` monotonic `seq` counters to the
same values. The previous tab's in-flight list load carries `seq:1`, and the
new tab's own initial load also uses `seq:1`, so `onListLoaded` (which checked
`seq` alone) could apply the old tab's entries to the new tab — visibly wrong
(but still correctly masked) data until the next reload.

**Fix — page-generation token.** The app keeps a monotonic `pageGen` counter and
bumps it every time `pageForTab` builds a browser page, threading the value into
`browser.New`. The browser stamps its `token` into every `*LoadedMsg` it emits,
and each handler drops a message whose `token` != the current page's token,
alongside the existing `seq` check. This covers **all five** async loads —
list, detail, history, staged, and namespaces — so no superseded prior-page
response can land on the new page. Deterministic and unit-testable; no context
cancellation or timing needed.

## #748 — stale detail seed on selection move (Low)

Moving the browser selection issues an async detail load but left
`m.detail`/`m.detailOK` pointing at the PREVIOUS entry until the response
landed. `openEdit`/`openTag` seed their dialogs from `m.detail` while
`openDelete` reads the live `selectedItem()`, so in the load window `e`/`t`
targeted the old entry while `d` targeted the new one.

**Fix — reset `detailOK` on identity change.** `selectionCmd` now marks
`detailOK = false` when the newly-selected entry's identity differs from the one
`m.detail` was loaded for, so `openEdit`/`openTag` no-op (like they do before the
first load) until the fresh detail arrives — matching `openDelete`'s
live-selection behavior. A same-entry reload keeps `detailOK`, so the value pane
never flickers.

## Tests

- `TestCrossPageListResponseFenced` — builds two pages with distinct tokens (1
  and 2), both with `listSeq == 1`, then delivers page A's `listLoadedMsg{token:1,
  seq:1}` to page B; asserts B's items stay empty (fails before the fix: the
  entry spliced in), and B's own `token:2` response still applies.
- `TestSelectionMoveResetsDetailOK` — loads entry A's detail, moves to entry B,
  asserts `detailOK` is false immediately, `openEdit` is a no-op, and
  `openDelete` still targets the live entry B; after B's detail lands `openEdit`
  seeds B, and a same-entry reload keeps `detailOK`.

Both new tests were confirmed fail-before / pass-after by reverting each guard.

## Verification

```
go build ./...                                              # ok
go test ./internal/tui/...                                  # ok (all packages)
go test -race -count=2 ./internal/tui/...                   # ok
golangci-lint run --allow-parallel-runners ./internal/tui/...  # 0 issues
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)