### PR TITLE
test(tui): emulator-backed e2e coverage (AWS/localstack foundation) (#676)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -135,6 +135,55 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         continue-on-error: true
 
+  e2e-aws-tui:
+    # TUI e2e: drives the real TUI App (teatest) against localstack, exercising
+    # the browse → stage → apply loop over the real data path. Separate from
+    # e2e-aws (which filters `^TestAWS`) because the TUI tests use the
+    # `^TestTUIAWS` prefix; this job runs exactly those and uploads coverage.
+    name: E2E Test (AWS TUI)
+    runs-on: ubuntu-latest
+    services:
+      localstack:
+        image: localstack/localstack:4
+        ports:
+          - 4566:4566
+        env:
+          SERVICES: ssm,secretsmanager,events
+          DEBUG: 0
+        options: >-
+          --health-cmd "curl -f http://localhost:4566/_localstack/health"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up toolchain (mise)
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4
+        with:
+          install_args: "go"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Wait for localstack
+        run: |
+          timeout 60 bash -c 'until curl -sf http://localhost:4566/_localstack/health; do sleep 2; done'
+
+      - name: Run TUI e2e tests with coverage
+        run: |
+          COVERPKG=$(go list ./... | grep -v testutil | grep -v /e2e | grep -v internal/gui | grep -v /cmd/ | tr '\n' ',')
+          go test -v -race -tags e2e -run '^TestTUIAWS' -coverprofile=coverage-e2e-tui.txt -covermode=atomic -coverpkg=$COVERPKG ./e2e/...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ./coverage-e2e-tui.txt
+          flags: e2e
+          name: codecov-suve-e2e-aws-tui
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        continue-on-error: true
+
   e2e-gcloud:
     name: E2E Test (Google Cloud)
     runs-on: ubuntu-latest

--- a/e2e/aws_tui_test.go
+++ b/e2e/aws_tui_test.go
@@ -1,0 +1,246 @@
+//go:build e2e
+
+//nolint:paralleltest,dogsled,gosec // E2E tests: sequential execution, ignored cleanup output, G101 false positive
+package e2e_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	teatest "github.com/charmbracelet/x/exp/teatest/v2"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cmdparam "github.com/mpyw/suve/internal/cli/commands/aws/param"
+	paramcreate "github.com/mpyw/suve/internal/cli/commands/aws/param/create"
+	paramdelete "github.com/mpyw/suve/internal/cli/commands/aws/param/delete"
+	secretcreate "github.com/mpyw/suve/internal/cli/commands/aws/secret/create"
+	secretdelete "github.com/mpyw/suve/internal/cli/commands/aws/secret/delete"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/staging"
+	"github.com/mpyw/suve/internal/tui"
+)
+
+// =============================================================================
+// TUI E2E Tests (AWS / localstack)
+//
+// These tests drive the real TUI App — the same model internal/tui/run.go
+// builds at launch, wired to registry-backed provider stores — through teatest
+// against localstack. They exercise the full read/write data path
+// (data source → usecase → provider store → emulator), not mocks, mirroring how
+// the CLI e2e suites build real stores. This is the AWS/localstack foundation
+// for #676; Google Cloud and Azure TUI e2e are left as follow-ups.
+//
+// The suite reuses the AWS localstack harness from aws_test.go (setupEnv,
+// newStore) and the closed-network compose runner from compose.test.yaml, which
+// sets SUVE_STAGING_KEY so the staging store never blocks on an OS keychain.
+// =============================================================================
+
+// tuiTermWidth/tuiTermHeight match the TUI's own two-pane golden size: the
+// browser needs ≥110 columns to render the list and detail panes side by side.
+const (
+	tuiTermWidth  = 120
+	tuiTermHeight = 34
+
+	// tuiWaitTimeout bounds each async gate. Localstack round-trips (list, get,
+	// apply) go over the compose network, so it is generous relative to the
+	// in-process unit teatest waits.
+	tuiWaitTimeout = 15 * time.Second
+)
+
+// awsTUIScope is the localstack AWS scope every TUI e2e launches with. It
+// matches newStore()'s scope (account 000000000000, region us-east-1) so the
+// TUI's registry-resolved stores and staging bucket line up with what the test
+// seeds via the CLI and the staging store.
+func awsTUIScope() provider.Scope {
+	return provider.AWSScope("000000000000", "us-east-1")
+}
+
+// newTUIModel builds the real TUI model for the launched service tab, wired to
+// registry-backed stores pointed at localstack (via setupEnv's AWS_ENDPOINT_URL).
+func newTUIModel(t *testing.T, service string) tea.Model {
+	t.Helper()
+
+	model, err := tui.NewE2EModel(t.Context(), awsTUIScope(), service)
+	require.NoError(t, err, "building the TUI model must succeed for a resolvable AWS scope")
+
+	return model
+}
+
+// keyRune builds a printable key press (matches the tui package's own helper).
+func keyRune(r rune) tea.KeyPressMsg { return tea.KeyPressMsg{Code: r, Text: string(r)} }
+
+// waitForScreen gates on marker appearing in the live output stream since the
+// last read, so navigation keys are only sent once the awaited async frame has
+// rendered.
+func waitForScreen(t *testing.T, tm *teatest.TestModel, marker string) {
+	t.Helper()
+
+	teatest.WaitFor(t, tm.Output(), func(b []byte) bool {
+		return bytes.Contains(b, []byte(marker))
+	}, teatest.WithDuration(tuiWaitTimeout), teatest.WithCheckInterval(50*time.Millisecond))
+}
+
+// finalScreen quits the program and returns the settled final model's full
+// screen content. Rendering the settled View — not the live diff-frame stream —
+// is what makes the assertion deterministic (the tui package's golden harness
+// uses the same discipline for the same reason).
+func finalScreen(t *testing.T, tm *teatest.TestModel) string {
+	t.Helper()
+
+	tm.Send(keyRune('q'))
+
+	fm := tm.FinalModel(t, teatest.WithFinalTimeout(5*time.Second))
+
+	vm, ok := fm.(interface{ View() tea.View })
+	require.True(t, ok, "final model must render a tea.View")
+
+	return vm.View().Content
+}
+
+// TestTUIAWS_ParamBrowse seeds two SSM parameters and drives the TUI param
+// browser: it launches, lists the real entries, and shows the selected entry's
+// detail (name, value, type) over the real read path. The seeded params are
+// String type — plaintext on the value-type axis — so their values render
+// unmasked in the detail pane (no masking-policy concern).
+func TestTUIAWS_ParamBrowse(t *testing.T) {
+	setupEnv(t)
+
+	const (
+		alphaName  = "/suve-e2e-tui/alpha"
+		bravoName  = "/suve-e2e-tui/bravo"
+		alphaValue = "alpha-value-1"
+		bravoValue = "bravo-value-2"
+	)
+
+	for _, name := range []string{alphaName, bravoName} {
+		_, _, _ = runCommand(t, paramdelete.Command(), "--yes", name)
+	}
+
+	t.Cleanup(func() {
+		for _, name := range []string{alphaName, bravoName} {
+			_, _, _ = runCommand(t, paramdelete.Command(), "--yes", name)
+		}
+	})
+
+	_, _, err := runCommand(t, paramcreate.Command(), alphaName, alphaValue)
+	require.NoError(t, err)
+	_, _, err = runCommand(t, paramcreate.Command(), bravoName, bravoValue)
+	require.NoError(t, err)
+
+	tm := teatest.NewTestModel(t, newTUIModel(t, string(staging.ServiceParam)),
+		teatest.WithInitialTermSize(tuiTermWidth, tuiTermHeight))
+
+	// Gate on the async list landing (both real entries rendered).
+	waitForScreen(t, tm, alphaName)
+
+	screen := finalScreen(t, tm)
+
+	assert.Contains(t, screen, alphaName, "the param browser lists the first seeded entry")
+	assert.Contains(t, screen, bravoName, "the param browser lists the second seeded entry")
+	assert.Contains(t, screen, alphaValue,
+		"the detail pane shows the selected String param's value over the real read path")
+	assert.Contains(t, screen, "String", "the detail pane shows the entry's value type")
+}
+
+// TestTUIAWS_SecretBrowse seeds a Secrets Manager secret and drives the TUI
+// secret browser: it lists the real secret and, on the explicit-reveal surface
+// (the `x` key, GUI parity), fetches and shows the secret value from localstack.
+// The value is masked until that explicit reveal.
+func TestTUIAWS_SecretBrowse(t *testing.T) {
+	setupEnv(t)
+
+	const (
+		secretName  = "suve-e2e-tui/token"
+		secretValue = "s3cr3t-token-value"
+	)
+
+	_, _, _ = runCommand(t, secretdelete.Command(), "--yes", "--force", secretName)
+	t.Cleanup(func() {
+		_, _, _ = runCommand(t, secretdelete.Command(), "--yes", "--force", secretName)
+	})
+
+	_, _, err := runCommand(t, secretcreate.Command(), secretName, secretValue)
+	require.NoError(t, err)
+
+	tm := teatest.NewTestModel(t, newTUIModel(t, string(staging.ServiceSecret)),
+		teatest.WithInitialTermSize(tuiTermWidth, tuiTermHeight))
+
+	// Gate on the async list landing, then explicitly reveal the value with `x`.
+	waitForScreen(t, tm, secretName)
+	tm.Send(keyRune('x'))
+
+	screen := finalScreen(t, tm)
+
+	assert.Contains(t, screen, secretName, "the secret browser lists the seeded secret")
+	assert.Contains(t, screen, secretValue,
+		"pressing x explicitly reveals the secret value fetched from the emulator")
+}
+
+// TestTUIAWS_StageApply exercises the browse → stage → apply loop end-to-end: a
+// param is pre-staged for update through the shared staging store, then the TUI
+// applies it via the Staging tab's apply-all dialog. The applied value is
+// verified through the CLI show path, proving the write reached localstack
+// through the real TUI apply path.
+func TestTUIAWS_StageApply(t *testing.T) {
+	setupEnv(t)
+	setupTempHome(t)
+
+	const (
+		paramName   = "/suve-e2e-tui-apply/param"
+		originalVal = "original-value"
+		stagedVal   = "applied-via-tui"
+	)
+
+	_, _, _ = runCommand(t, paramdelete.Command(), "--yes", paramName)
+	t.Cleanup(func() {
+		_, _, _ = runCommand(t, paramdelete.Command(), "--yes", paramName)
+	})
+
+	_, _, err := runCommand(t, paramcreate.Command(), paramName, originalVal)
+	require.NoError(t, err)
+
+	// Pre-stage an update through the same staging store the TUI reads (matched
+	// scope), mirroring the CLI staging e2e's seeding.
+	store := newStore()
+	require.NoError(t, store.StageEntry(t.Context(), staging.ServiceParam,
+		staging.EntryKey{Name: paramName}, staging.Entry{
+			Operation: staging.OperationUpdate,
+			Value:     lo.ToPtr(stagedVal),
+			StagedAt:  time.Now(),
+		}))
+
+	tm := teatest.NewTestModel(t, newTUIModel(t, string(staging.ServiceParam)),
+		teatest.WithInitialTermSize(tuiTermWidth, tuiTermHeight))
+
+	// Jump to the Staging tab (global key "3") and wait for the staged entry.
+	tm.Send(keyRune('3'))
+	waitForScreen(t, tm, paramName)
+
+	// Open the apply-all confirmation dialog ("A"), then focus the Apply action
+	// (Down) and confirm (Enter) — the same choreography the apply-dialog golden
+	// drives.
+	tm.Send(keyRune('A'))
+	waitForScreen(t, tm, "Ignore conflicts")
+
+	tm.Send(tea.KeyPressMsg{Code: tea.KeyDown})
+	tm.Send(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	// The results view reports the applied entry — the apply has committed to the
+	// emulator by the time this status renders.
+	waitForScreen(t, tm, "updated")
+
+	// Quit the program directly: the results dialog captures input first (`q`
+	// would go to the dialog, not the shell), and the assertion below is the
+	// CLI-verified side effect, not a final screen.
+	require.NoError(t, tm.Quit())
+	tm.WaitFinished(t, teatest.WithFinalTimeout(5*time.Second))
+
+	// The staged update must have reached localstack through the TUI apply path.
+	stdout, _, err := runCommand(t, cmdparam.ShowCommand(), "--raw", paramName)
+	require.NoError(t, err)
+	assert.Equal(t, stagedVal, stdout, "the TUI apply wrote the staged value to the emulator")
+}

--- a/internal/tui/e2e.go
+++ b/internal/tui/e2e.go
@@ -1,0 +1,25 @@
+//go:build e2e
+
+package tui
+
+import (
+	"context"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/mpyw/suve/internal/provider"
+)
+
+// NewE2EModel builds the root TUI model for a launched scope and initial service
+// exactly as Run does — the same registry-backed read/write/staging seams over
+// real provider stores — but returns the tea.Model instead of running a live
+// program. The emulator-backed e2e suite (package e2e, build tag `e2e`) drives
+// this model through teatest against localstack, exercising the real data path
+// (data source → usecase → provider store → emulator) rather than mocks.
+//
+// It is compiled only under the `e2e` build tag and is never linked into a
+// shipped binary; internal/tui itself still imports no cloud SDK, so the
+// architecture boundary is unchanged.
+func NewE2EModel(ctx context.Context, scope provider.Scope, service string) (tea.Model, error) {
+	return newModel(ctx, scope, service)
+}

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -37,8 +37,27 @@ var registry = func() *provider.Registry {
 // initial tab ("param"/"secret", or "" for the group default). It mirrors the
 // GUI's Run entry shape (internal/gui/run.go) adapted to the terminal.
 func Run(ctx context.Context, scope provider.Scope, service string) error {
-	if err := ensureResolvable(ctx, scope); err != nil {
+	model, err := newModel(ctx, scope, service)
+	if err != nil {
 		return err
+	}
+
+	// Alt-screen and mouse capture are requested through the model's returned
+	// tea.View (Bubble Tea v2 reads them there each frame), so the program needs
+	// only the context here.
+	_, err = tea.NewProgram(model, tea.WithContext(ctx)).Run()
+
+	return err
+}
+
+// newModel builds the root app model for a launched scope and initial service,
+// wiring the registry-backed sourceFactory as the read/write/staging seams. It
+// is the shared construction point for the interactive Run entry above and the
+// e2e harness (NewE2EModel), which drives the very same model through teatest
+// against emulator-backed provider stores instead of a live terminal.
+func newModel(ctx context.Context, scope provider.Scope, service string) (*App, error) {
+	if err := ensureResolvable(ctx, scope); err != nil {
+		return nil, err
 	}
 
 	factory := newSourceFactory(ctx, scope)
@@ -57,12 +76,7 @@ func Run(ctx context.Context, scope provider.Scope, service string) error {
 		runCtx:        ctx,
 	})
 
-	// Alt-screen and mouse capture are requested through the model's returned
-	// tea.View (Bubble Tea v2 reads them there each frame), so the program needs
-	// only the context here.
-	_, err := tea.NewProgram(model, tea.WithContext(ctx)).Run()
-
-	return err
+	return model, nil
 }
 
 // ensureResolvable verifies the launched scope can resolve at least one store

--- a/mise.toml
+++ b/mise.toml
@@ -109,6 +109,29 @@ $compose run --rm --no-deps -e SUVE_LOCALSTACK_ENDPOINT=http://localstack:4566 t
 '
 '''
 
+# TUI e2e: drives the real TUI App (teatest) against localstack over the same
+# closed compose network as e2e-aws. Split into its own task/CI job (the TUI
+# tests use the TestTUIAWS prefix so the plain e2e-aws CI filter `^TestAWS`
+# skips them) so the interactive-model path has a dedicated, coverage-uploading
+# lane. `mise e2e-aws` (no -run filter) still runs these too.
+[tasks.e2e-aws-tui]
+description = "Run TUI E2E tests (teatest) against localstack, fully inside Docker (no host ports)"
+shell = "bash -c"
+run = '''
+set -euo pipefail
+project="suve-test-$$"
+compose="docker compose -f compose.test.yaml -p $project"
+cleanup() { $compose --profile "*" down -v >/dev/null 2>&1 || true; }
+trap cleanup EXIT INT TERM
+docker volume create suve-test-go-cache >/dev/null
+docker volume create suve-test-go-build-cache >/dev/null
+$compose --profile aws up -d localstack
+$compose run --rm --no-deps -e SUVE_LOCALSTACK_ENDPOINT=http://localstack:4566 test-runner bash -c '
+  n=0; until curl -sf "$SUVE_LOCALSTACK_ENDPOINT/_localstack/health" >/dev/null 2>&1; do n=$((n+1)); [ "$n" -ge 120 ] && { echo "localstack not ready after 120s" >&2; exit 1; }; sleep 1; done
+  go test -tags=e2e -v -run "^TestTUIAWS" ./e2e/...
+'
+'''
+
 [tasks.e2e-gcloud]
 description = "Run Google Cloud Secret Manager E2E tests, fully inside Docker (no host ports)"
 shell = "bash -c"


### PR DESCRIPTION
Closes #676

Follow-up from Epic #650 / #752: adds emulator-backed e2e coverage that drives the **real TUI `App`** through `teatest` against **localstack**, exercising the browse → stage → apply loop over the real data path (`data.Source` → usecase → provider `Store` → emulator) — not mocks. It mirrors how the existing CLI e2e suites build real stores.

## What the e2e drives and asserts

`e2e/aws_tui_test.go` (build tag `e2e`), scope `provider.AWSScope("000000000000", "us-east-1")`:

- **`TestTUIAWS_ParamBrowse`** — seeds two SSM params, launches the param browser, and asserts both real entries are listed and the selected entry's detail pane shows its value + type (String params, so the value renders unmasked — no masking-policy concern).
- **`TestTUIAWS_SecretBrowse`** — seeds a Secrets Manager secret, launches the secret browser, asserts it is listed, then presses `x` (the explicit-reveal surface, GUI parity) and asserts the value fetched from the emulator is shown. Masked until that explicit reveal.
- **`TestTUIAWS_StageApply`** — pre-stages a param update through the shared staging store (matched scope), launches the TUI, jumps to the Staging tab, applies via the apply-all dialog (`A` → Down → Enter), and **verifies through the CLI `show --raw` path that the staged value was written to localstack** — proving the write reached the emulator through the real TUI apply path.

## Production seam

`internal/tui` imports no cloud SDK (architecture test). To let the `e2e` package build the exact launch-path model:

- `run.go` extracts `newModel()` as the shared construction point for the interactive `Run` and the harness.
- `e2e.go` (`//go:build e2e`) adds `NewE2EModel`, compiled only under the `e2e` tag — never linked into a shipped binary. The e2e package (which may use the sanctioned provider constructors, same as the CLI e2e) builds real stores; the TUI itself still imports no SDK.

## Task + CI wiring

- `mise e2e-aws-tui` — mirrors `e2e-aws` (closed compose network, no host ports, `SUVE_STAGING_KEY` set by `compose.test.yaml` so staging never blocks on a keychain). Runs `-run '^TestTUIAWS'`.
- **CI job `e2e-aws-tui`** in `.github/workflows/test.yml` — mirrors `e2e-aws` with **coverage upload** (`flags: e2e`). The TUI tests use the `TestTUIAWS` prefix so the existing `e2e-aws` job's `^TestAWS` filter skips them (no double-run); `mise e2e-aws` with no filter still runs them.

## Verification

Ran against localstack locally:

```
=== RUN   TestTUIAWS_ParamBrowse
--- PASS: TestTUIAWS_ParamBrowse (0.53s)
=== RUN   TestTUIAWS_SecretBrowse
--- PASS: TestTUIAWS_SecretBrowse (0.07s)
=== RUN   TestTUIAWS_StageApply
--- PASS: TestTUIAWS_StageApply (0.17s)
PASS
ok  	github.com/mpyw/suve/e2e	0.792s
```

Gates: `go build ./...`, `go vet -tags e2e ./e2e/...`, `go test ./internal/tui/...` (green), `golangci-lint run --allow-parallel-runners --build-tags=e2e ./e2e/...` (0 issues), and `mise e2e-aws-tui` all pass.

## Follow-ups

- Google Cloud and Azure TUI e2e (their emulators already exist in `compose.test.yaml` / `.github/workflows/test.yml`; this PR scopes to the AWS/localstack foundation the issue asked to start with).

🤖 Generated with [Claude Code](https://claude.com/claude-code)