### PR TITLE
Merge main into epic/tui: GUI Description input (#767) + reconcile capability

### DIFF
--- a/internal/gui/capabilities_internal_test.go
+++ b/internal/gui/capabilities_internal_test.go
@@ -93,6 +93,37 @@ func TestApp_Capabilities_ForceDeleteAndRecoveryWindowAWSOnly(t *testing.T) {
 	}
 }
 
+// TestApp_Capabilities_HasDescription pins the HasDescription capability that
+// gates the create/edit Description input (#767): AWS Param + Secret and Google
+// Cloud Secret persist a description; Azure App Configuration and Key Vault
+// ignore it, so their inputs stay hidden.
+func TestApp_Capabilities_HasDescription(t *testing.T) {
+	t.Parallel()
+
+	caps := (&App{}).Capabilities()
+
+	tests := []struct {
+		provider       string
+		service        string
+		hasDescription bool
+	}{
+		{string(provider.ProviderAWS), "param", true},
+		{string(provider.ProviderAWS), "secret", true},
+		{string(provider.ProviderGoogleCloud), "secret", true},
+		{string(provider.ProviderAzure), "param", false},
+		{string(provider.ProviderAzure), "secret", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.provider+"/"+tt.service, func(t *testing.T) {
+			t.Parallel()
+
+			svc := findService(t, caps, tt.provider, tt.service)
+			assert.Equal(t, tt.hasDescription, svc.HasDescription, "HasDescription")
+		})
+	}
+}
+
 func TestApp_ParamTypeOptions_ScopeAware(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gui/frontend/src/lib/ParamView.svelte
+++ b/internal/gui/frontend/src/lib/ParamView.svelte
@@ -34,6 +34,10 @@
   const stagingEnabled = $derived(capability?.hasStaging ?? true);
   const tagsEnabled = $derived(capability?.hasTags ?? true);
   const historyEnabled = $derived(capability?.hasVersionHistory ?? true);
+  // The Description input is shown only where the provider persists it (AWS
+  // param); Azure App Configuration ignores it, so it stays hidden there.
+  // Default false so a capability object missing the field hides the input.
+  const descriptionEnabled = $derived(capability?.hasDescription ?? false);
 
   // The namespace axis (Azure calls it a "label") exists only for Azure App
   // Configuration; ParamView under the Azure provider is always App Config
@@ -127,7 +131,7 @@
   // Parameter type options are provider-driven (fetched from the backend), so
   // the UI never hardcodes SSM type strings.
   let paramTypeOptions: string[] = $state([]);
-  let setForm = $state({ name: '', value: '', type: '', namespace: '' });
+  let setForm = $state({ name: '', value: '', type: '', namespace: '', description: '' });
   let isEditMode = $state(false);
   let deleteTarget = $state('');
   let modalLoading = $state(false);
@@ -302,10 +306,11 @@
   function openSetModal(name?: string) {
     if (name && paramDetail) {
       // Edit targets the selected entry's own namespace (read-only in the form).
-      setForm = { name, value: paramDetail.value, type: paramDetail.type, namespace: selectedEntryNamespace };
+      // Pre-fill the current description so an unchanged edit round-trips it.
+      setForm = { name, value: paramDetail.value, type: paramDetail.type, namespace: selectedEntryNamespace, description: paramDetail.description ?? '' };
       isEditMode = true;
     } else {
-      setForm = { name: prefix || '', value: '', type: paramTypeOptions[0] ?? '', namespace: defaultCreateNamespace() };
+      setForm = { name: prefix || '', value: '', type: paramTypeOptions[0] ?? '', namespace: defaultCreateNamespace(), description: '' };
       isEditMode = false;
     }
     modalError = '';
@@ -325,8 +330,11 @@
       // App Config: create targets the form's namespace; edit targets the
       // existing entry's namespace. Other providers ignore this argument.
       const targetNamespace = isEdit ? selectedEntryNamespace : setForm.namespace;
+      // Only send a description where the provider supports it; the binding also
+      // drops it server-side for providers that ignore it (#767).
+      const description = descriptionEnabled ? setForm.description : '';
       if (immediate) {
-        await ParamSet(setForm.name, setForm.value, setForm.type, targetNamespace);
+        await ParamSet(setForm.name, setForm.value, setForm.type, targetNamespace, description);
         await loadParams({ prefix, filter, recursive, withValue });
         if (isEdit) {
           await selectParam(setForm.name, selectedEntryNamespace);
@@ -742,6 +750,19 @@
         rows="5"
       ></textarea>
     </div>
+    {#if descriptionEnabled}
+      <div class="form-group">
+        <label for="param-description">Description</label>
+        <input
+          id="param-description"
+          type="text"
+          class="form-input"
+          data-testid="param-description-input"
+          bind:value={setForm.description}
+          placeholder="Optional description"
+        />
+      </div>
+    {/if}
     {#if stagingEnabled}
       <label class="checkbox-label immediate-checkbox">
         <input type="checkbox" bind:checked={immediateMode} />

--- a/internal/gui/frontend/src/lib/SecretView.svelte
+++ b/internal/gui/frontend/src/lib/SecretView.svelte
@@ -31,6 +31,10 @@
   const tagsPerVersion = $derived(capability?.tagsPerVersion ?? false);
   const historyEnabled = $derived(capability?.hasVersionHistory ?? true);
   const restoreEnabled = $derived(capability?.hasRestore ?? true);
+  // The Description input is shown only where the provider persists it (AWS
+  // Secrets Manager, Google Cloud Secret Manager); Azure Key Vault ignores it,
+  // so it stays hidden. Default false so a capability missing the field hides it.
+  const descriptionEnabled = $derived(capability?.hasDescription ?? false);
   const forceDeleteEnabled = $derived(capability?.hasForceDelete ?? true);
   const recoveryWindowEnabled = $derived(capability?.hasRecoveryWindow ?? true);
 
@@ -107,8 +111,8 @@
   let showDeleteModal = $state(false);
   let showDiffModal = $state(false);
   let showRestoreModal = $state(false);
-  let createForm = $state({ name: '', value: '' });
-  let editForm = $state({ name: '', value: '' });
+  let createForm = $state({ name: '', value: '', description: '' });
+  let editForm = $state({ name: '', value: '', description: '' });
   let deleteTarget = $state('');
   let forceDelete = $state(false);
   let modalLoading = $state(false);
@@ -249,7 +253,7 @@
 
   // Create modal
   function openCreateModal() {
-    createForm = { name: prefix || '', value: '' };
+    createForm = { name: prefix || '', value: '', description: '' };
     modalError = '';
     showCreateModal = true;
   }
@@ -263,8 +267,11 @@
     modalLoading = true;
     modalError = '';
     try {
+      // Only send a description where the provider supports it; the binding also
+      // drops it server-side for providers that ignore it (#767).
+      const description = descriptionEnabled ? createForm.description : '';
       if (immediate) {
-        await SecretCreate(createForm.name, createForm.value);
+        await SecretCreate(createForm.name, createForm.value, description);
         await loadSecrets({ prefix, filter, withValue });
       } else {
         await StagingAdd('secret', createForm.name, createForm.value, '');
@@ -281,7 +288,8 @@
   // Edit modal
   function openEditModal() {
     if (secretDetail) {
-      editForm = { name: secretDetail.name, value: secretDetail.value };
+      // Pre-fill the current description so an unchanged edit round-trips it.
+      editForm = { name: secretDetail.name, value: secretDetail.value, description: secretDetail.description ?? '' };
     }
     modalError = '';
     showEditModal = true;
@@ -296,8 +304,11 @@
     modalLoading = true;
     modalError = '';
     try {
+      // Only send a description where the provider supports it; the binding also
+      // drops it server-side for providers that ignore it (#767).
+      const description = descriptionEnabled ? editForm.description : '';
       if (immediate) {
-        await SecretUpdate(editForm.name, editForm.value);
+        await SecretUpdate(editForm.name, editForm.value, description);
         await Promise.all([
           loadSecrets({ prefix, filter, withValue }),
           selectSecret(editForm.name)
@@ -727,6 +738,19 @@
         rows="5"
       ></textarea>
     </div>
+    {#if descriptionEnabled}
+      <div class="form-group">
+        <label for="secret-description">Description</label>
+        <input
+          id="secret-description"
+          type="text"
+          class="form-input"
+          data-testid="secret-description-input"
+          bind:value={createForm.description}
+          placeholder="Optional description"
+        />
+      </div>
+    {/if}
     {#if stagingEnabled}
       <label class="checkbox-label immediate-checkbox">
         <input type="checkbox" bind:checked={immediateMode} />
@@ -767,6 +791,19 @@
         rows="8"
       ></textarea>
     </div>
+    {#if descriptionEnabled}
+      <div class="form-group">
+        <label for="edit-secret-description">Description</label>
+        <input
+          id="edit-secret-description"
+          type="text"
+          class="form-input"
+          data-testid="edit-secret-description-input"
+          bind:value={editForm.description}
+          placeholder="Optional description"
+        />
+      </div>
+    {/if}
     {#if stagingEnabled}
       <label class="checkbox-label immediate-checkbox">
         <input type="checkbox" bind:checked={immediateMode} />

--- a/internal/gui/frontend/tests/description-input.spec.ts
+++ b/internal/gui/frontend/tests/description-input.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect } from '@playwright/test';
+import {
+  setupWailsMocks,
+  waitForItemList,
+  waitForViewLoaded,
+  clickItemByName,
+  navigateTo,
+  openCreateModal,
+  createGoogleCloudState,
+  createAzureState,
+} from './fixtures/wails-mock';
+
+// #767: the GUI can DISPLAY a description but had no INPUT to set one on
+// create/edit. These specs prove the Description input appears for the services
+// that persist a description (AWS param/secret, Google Cloud secret), is HIDDEN
+// for Azure (App Configuration / Key Vault, which ignore it), and that its value
+// flows through create (round-trips to the detail pane) and edit (pre-filled
+// from the current description).
+test.describe('Description input (#767)', () => {
+  test.describe('AWS Parameter', () => {
+    test.beforeEach(async ({ page }) => {
+      await setupWailsMocks(page, {
+        params: [
+          { name: '/app/described', type: 'String', value: 'v', description: 'existing description' },
+        ],
+      });
+      await page.goto('/');
+      await waitForItemList(page);
+    });
+
+    test('shows the Description input on create', async ({ page }) => {
+      await openCreateModal(page);
+      await expect(page.getByTestId('param-description-input')).toBeVisible();
+    });
+
+    test('flows the description through create and round-trips to the detail pane', async ({ page }) => {
+      await openCreateModal(page);
+      await page.locator('#param-name').fill('/app/new');
+      await page.locator('#param-value').fill('new-value');
+      await page.getByTestId('param-description-input').fill('brand new description');
+      await page.locator('.immediate-checkbox input').check();
+      await page.getByRole('button', { name: 'Save' }).click();
+
+      await clickItemByName(page, '/app/new');
+      const section = page.locator('.detail-section').filter({ hasText: 'Description' });
+      await expect(section.locator('.description-text')).toContainText('brand new description');
+    });
+
+    test('pre-fills the current description on edit', async ({ page }) => {
+      await clickItemByName(page, '/app/described');
+      await page.getByRole('button', { name: 'Edit' }).click();
+      await expect(page.getByTestId('param-description-input')).toHaveValue('existing description');
+    });
+  });
+
+  test.describe('AWS Secret', () => {
+    test.beforeEach(async ({ page }) => {
+      await setupWailsMocks(page, {
+        secrets: [
+          { name: 'described-secret', value: 'v', description: 'existing secret description' },
+        ],
+      });
+      await page.goto('/');
+      await waitForItemList(page);
+      await navigateTo(page, 'Secret');
+    });
+
+    test('shows the Description input on create', async ({ page }) => {
+      await openCreateModal(page);
+      await expect(page.getByTestId('secret-description-input')).toBeVisible();
+    });
+
+    test('flows the description through create and round-trips to the detail pane', async ({ page }) => {
+      await openCreateModal(page);
+      await page.locator('#secret-name').fill('new-secret');
+      await page.locator('#secret-value').fill('new-value');
+      await page.getByTestId('secret-description-input').fill('brand new secret description');
+      await page.locator('.immediate-checkbox input').check();
+      await page.getByRole('button', { name: 'Create' }).click();
+
+      await clickItemByName(page, 'new-secret');
+      const section = page.locator('.detail-section').filter({ hasText: 'Description' });
+      await expect(section.locator('.description-text')).toContainText('brand new secret description');
+    });
+
+    test('pre-fills the current description on edit', async ({ page }) => {
+      await clickItemByName(page, 'described-secret');
+      await page.getByRole('button', { name: 'Edit' }).click();
+      await expect(page.getByTestId('edit-secret-description-input')).toHaveValue('existing secret description');
+    });
+  });
+
+  test.describe('Google Cloud Secret', () => {
+    test.beforeEach(async ({ page }) => {
+      await setupWailsMocks(page, createGoogleCloudState());
+      await page.goto('/');
+      await waitForItemList(page);
+      await navigateTo(page, 'Secret');
+    });
+
+    test('shows the Description input on create', async ({ page }) => {
+      await openCreateModal(page);
+      await expect(page.getByTestId('secret-description-input')).toBeVisible();
+    });
+  });
+
+  test.describe('Azure (hidden)', () => {
+    test('App Configuration hides the Description input on create', async ({ page }) => {
+      await setupWailsMocks(page, createAzureState());
+      await page.goto('/');
+      await waitForViewLoaded(page);
+      await navigateTo(page, 'App Configuration');
+      await openCreateModal(page);
+      await expect(page.getByTestId('param-description-input')).toHaveCount(0);
+    });
+
+    test('Key Vault hides the Description input on create and edit', async ({ page }) => {
+      await setupWailsMocks(page, createAzureState());
+      await page.goto('/');
+      await waitForViewLoaded(page);
+      await navigateTo(page, 'Key Vault');
+      await openCreateModal(page);
+      await expect(page.getByTestId('secret-description-input')).toHaveCount(0);
+      await page.getByRole('button', { name: 'Cancel' }).click();
+
+      await clickItemByName(page, 'kv-secret');
+      await page.getByRole('button', { name: 'Edit' }).click();
+      await expect(page.getByTestId('edit-secret-description-input')).toHaveCount(0);
+    });
+  });
+});

--- a/internal/gui/frontend/tests/fixtures/wails-mock.ts
+++ b/internal/gui/frontend/tests/fixtures/wails-mock.ts
@@ -130,6 +130,7 @@ export interface ServiceCapability {
   hasForceDelete: boolean;
   hasRecoveryWindow: boolean;
   hasNamespaces: boolean;
+  hasDescription: boolean;
 }
 
 export interface ProviderCapability {
@@ -295,8 +296,8 @@ export const defaultCapabilities: ProviderCapability[] = [
     displayName: 'AWS',
     scopeFields: [],
     services: [
-      { service: 'param', displayName: 'Param', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, tagsPerVersion: false, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: false },
-      { service: 'secret', displayName: 'Secret', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, tagsPerVersion: false, hasRestore: true, hasStaging: true, hasForceDelete: true, hasRecoveryWindow: true, hasNamespaces: false },
+      { service: 'param', displayName: 'Param', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, tagsPerVersion: false, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: false, hasDescription: true },
+      { service: 'secret', displayName: 'Secret', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, tagsPerVersion: false, hasRestore: true, hasStaging: true, hasForceDelete: true, hasRecoveryWindow: true, hasNamespaces: false, hasDescription: true },
     ],
   },
   {
@@ -304,7 +305,7 @@ export const defaultCapabilities: ProviderCapability[] = [
     displayName: 'Google Cloud',
     scopeFields: ['project'],
     services: [
-      { service: 'secret', displayName: 'Secret', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, tagsPerVersion: false, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: false },
+      { service: 'secret', displayName: 'Secret', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, tagsPerVersion: false, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: false, hasDescription: true },
     ],
   },
   {
@@ -312,8 +313,8 @@ export const defaultCapabilities: ProviderCapability[] = [
     displayName: 'Azure',
     scopeFields: [],
     services: [
-      { service: 'param', displayName: 'App Configuration', hasVersionHistory: false, hasVersionSpecifiers: false, hasTags: true, tagsPerVersion: false, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: true },
-      { service: 'secret', displayName: 'Key Vault', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, tagsPerVersion: true, hasRestore: true, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: false },
+      { service: 'param', displayName: 'App Configuration', hasVersionHistory: false, hasVersionSpecifiers: false, hasTags: true, tagsPerVersion: false, hasRestore: false, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: true, hasDescription: false },
+      { service: 'secret', displayName: 'Key Vault', hasVersionHistory: true, hasVersionSpecifiers: true, hasTags: true, tagsPerVersion: true, hasRestore: true, hasStaging: true, hasForceDelete: false, hasRecoveryWindow: false, hasNamespaces: false, hasDescription: false },
     ],
   },
 ];
@@ -993,7 +994,7 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
           entries: versions.map((v: any) => ({ ...v, secret: v.type === 'SecureString' })),
         };
       },
-      ParamSet: async (name: string, value: string, _type: string, namespace?: string) => {
+      ParamSet: async (name: string, value: string, _type: string, namespace?: string, description?: string) => {
         // Simulate error if configured
         if (state.simulateError?.operation === 'ParamSet') {
           throw new Error(state.simulateError.message);
@@ -1002,11 +1003,15 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
         // create under a new namespace doesn't collide with the same key
         // elsewhere. Empty namespace is the null/default.
         const ns = namespace ?? '';
+        const desc = description ?? '';
         const existing = state.params.find((p: any) => p.name === name && (p.namespace ?? '') === ns);
         if (existing) {
           existing.value = value;
+          // Empty description preserves the existing one (a no-op on update),
+          // mirroring the CLI/adapter contract threaded through the binding.
+          if (desc) existing.description = desc;
         } else {
-          state.params.push({ name, type: 'String', value, namespace: ns });
+          state.params.push({ name, type: 'String', value, namespace: ns, description: desc });
         }
         return { name, version: 2, isCreated: !existing };
       },
@@ -1125,17 +1130,21 @@ export async function setupWailsMocks(page: Page, customState?: Partial<MockStat
           entries: versions.map((v) => ({ ...v, tags: v.tags ?? [] })),
         };
       },
-      SecretCreate: async (name: string, value: string) => {
+      SecretCreate: async (name: string, value: string, description?: string) => {
         // Simulate error if configured
         if (state.simulateError?.operation === 'SecretCreate') {
           throw new Error(state.simulateError.message);
         }
-        state.secrets.push({ name, value });
+        state.secrets.push({ name, value, description: description ?? '' });
         return { name, versionId: 'v1', arn: `arn:aws:secretsmanager:us-east-1:123456789:secret:${name}` };
       },
-      SecretUpdate: async (name: string, value: string) => {
+      SecretUpdate: async (name: string, value: string, description?: string) => {
         const existing = state.secrets.find((s: any) => s.name === name);
-        if (existing) existing.value = value;
+        if (existing) {
+          existing.value = value;
+          // Empty description preserves the existing one (a no-op on update).
+          if (description) existing.description = description;
+        }
         return { name, versionId: 'v2', arn: '' };
       },
       SecretDelete: async (name: string, force?: boolean) => {

--- a/internal/gui/frontend/wailsjs/go/gui/App.d.ts
+++ b/internal/gui/frontend/wailsjs/go/gui/App.d.ts
@@ -30,7 +30,7 @@ export function ParamLog(arg1:string,arg2:number,arg3:string):Promise<gui.ParamL
 
 export function ParamRemoveTag(arg1:string,arg2:string,arg3:string):Promise<void>;
 
-export function ParamSet(arg1:string,arg2:string,arg3:string,arg4:string):Promise<gui.ParamSetResult>;
+export function ParamSet(arg1:string,arg2:string,arg3:string,arg4:string,arg5:string):Promise<gui.ParamSetResult>;
 
 export function ParamShow(arg1:string,arg2:string):Promise<gui.ParamShowResult>;
 
@@ -42,7 +42,7 @@ export function PickImportPath():Promise<string>;
 
 export function SecretAddTag(arg1:string,arg2:string,arg3:string):Promise<void>;
 
-export function SecretCreate(arg1:string,arg2:string):Promise<gui.SecretCreateResult>;
+export function SecretCreate(arg1:string,arg2:string,arg3:string):Promise<gui.SecretCreateResult>;
 
 export function SecretDelete(arg1:string,arg2:boolean):Promise<gui.SecretDeleteResult>;
 
@@ -58,7 +58,7 @@ export function SecretRestore(arg1:string):Promise<gui.SecretRestoreResult>;
 
 export function SecretShow(arg1:string):Promise<gui.SecretShowResult>;
 
-export function SecretUpdate(arg1:string,arg2:string):Promise<gui.SecretUpdateResult>;
+export function SecretUpdate(arg1:string,arg2:string,arg3:string):Promise<gui.SecretUpdateResult>;
 
 export function SelectScope(arg1:gui.ScopeSelection):Promise<void>;
 

--- a/internal/gui/frontend/wailsjs/go/gui/App.js
+++ b/internal/gui/frontend/wailsjs/go/gui/App.js
@@ -58,8 +58,8 @@ export function ParamRemoveTag(arg1, arg2, arg3) {
   return window['go']['gui']['App']['ParamRemoveTag'](arg1, arg2, arg3);
 }
 
-export function ParamSet(arg1, arg2, arg3, arg4) {
-  return window['go']['gui']['App']['ParamSet'](arg1, arg2, arg3, arg4);
+export function ParamSet(arg1, arg2, arg3, arg4, arg5) {
+  return window['go']['gui']['App']['ParamSet'](arg1, arg2, arg3, arg4, arg5);
 }
 
 export function ParamShow(arg1, arg2) {
@@ -82,8 +82,8 @@ export function SecretAddTag(arg1, arg2, arg3) {
   return window['go']['gui']['App']['SecretAddTag'](arg1, arg2, arg3);
 }
 
-export function SecretCreate(arg1, arg2) {
-  return window['go']['gui']['App']['SecretCreate'](arg1, arg2);
+export function SecretCreate(arg1, arg2, arg3) {
+  return window['go']['gui']['App']['SecretCreate'](arg1, arg2, arg3);
 }
 
 export function SecretDelete(arg1, arg2) {
@@ -114,8 +114,8 @@ export function SecretShow(arg1) {
   return window['go']['gui']['App']['SecretShow'](arg1);
 }
 
-export function SecretUpdate(arg1, arg2) {
-  return window['go']['gui']['App']['SecretUpdate'](arg1, arg2);
+export function SecretUpdate(arg1, arg2, arg3) {
+  return window['go']['gui']['App']['SecretUpdate'](arg1, arg2, arg3);
 }
 
 export function SelectScope(arg1) {

--- a/internal/gui/frontend/wailsjs/go/models.ts
+++ b/internal/gui/frontend/wailsjs/go/models.ts
@@ -285,6 +285,7 @@ export namespace gui {
 	    hasNamespaces: boolean;
 	    hasForceDelete: boolean;
 	    hasRecoveryWindow: boolean;
+	    hasDescription: boolean;
 	
 	    static createFrom(source: any = {}) {
 	        return new ServiceCapability(source);
@@ -303,6 +304,7 @@ export namespace gui {
 	        this.hasNamespaces = source["hasNamespaces"];
 	        this.hasForceDelete = source["hasForceDelete"];
 	        this.hasRecoveryWindow = source["hasRecoveryWindow"];
+	        this.hasDescription = source["hasDescription"];
 	    }
 	}
 	export class ProviderCapability {

--- a/internal/gui/param.go
+++ b/internal/gui/param.go
@@ -331,10 +331,22 @@ func (a *App) ParamDiff(spec1Str, spec2Str, namespace string) (*ParamDiffResult,
 // other provider. It must name a single concrete namespace — a filter value
 // (`*` or a `,`-list) is rejected, since a write targets exactly one
 // (key, namespace).
-func (a *App) ParamSet(name, value, paramType, namespace string) (*ParamSetResult, error) {
+//
+// description is a human-readable description persisted by providers that
+// support it (AWS Param). An empty description preserves the existing one on
+// update (a no-op), matching the CLI/adapter contract. Providers without the
+// capability (Azure App Configuration) drop it server-side (#767).
+func (a *App) ParamSet(name, value, paramType, namespace, description string) (*ParamSetResult, error) {
 	namespace, err := a.validateParamNamespace(namespace)
 	if err != nil {
 		return nil, err
+	}
+
+	// Defense in depth: only honor a description where the provider persists it.
+	// The frontend hides the input for Azure, but drop it here too so a stale or
+	// forged call cannot smuggle one past the capability gate.
+	if !a.descriptionSupported() {
+		description = ""
 	}
 
 	store, err := a.paramStoreForNamespace(namespace)
@@ -348,9 +360,10 @@ func (a *App) ParamSet(name, value, paramType, namespace string) (*ParamSetResul
 	createUC := &param.CreateUseCase{Writer: store}
 
 	createResult, err := createUC.Execute(a.ctx, param.CreateInput{
-		Name:  name,
-		Value: value,
-		Type:  valueType,
+		Name:        name,
+		Value:       value,
+		Type:        valueType,
+		Description: description,
 	})
 	if err == nil {
 		return &ParamSetResult{
@@ -367,9 +380,10 @@ func (a *App) ParamSet(name, value, paramType, namespace string) (*ParamSetResul
 	updateUC := &param.UpdateUseCase{Store: store}
 
 	updateResult, err := updateUC.Execute(a.ctx, param.UpdateInput{
-		Name:  name,
-		Value: value,
-		Type:  valueType,
+		Name:        name,
+		Value:       value,
+		Type:        valueType,
+		Description: description,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/gui/param_internal_test.go
+++ b/internal/gui/param_internal_test.go
@@ -79,6 +79,96 @@ func TestParamList_PopulatesSecretAndType(t *testing.T) {
 	assert.Equal(t, paramtype.SecureString, byName["/my/secure"].Type)
 }
 
+// TestParamSet_ThreadsDescription asserts the GUI ParamSet binding forwards the
+// description argument into the create use case (and, on the already-exists
+// fallback, into the update use case), so a description set in the GUI form
+// reaches the provider writer (#767).
+//
+//nolint:paralleltest // overrides the package-global registry.
+func TestParamSet_ThreadsDescription(t *testing.T) {
+	var gotCreateDescription, gotPutDescription string
+
+	store := &providermock.Store{
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			// The update path Gets the current entry before Put; return one so the
+			// fallback reaches Put rather than a not-found error.
+			return &domain.Entry{Name: name, Value: "old", Type: domain.ValueTypePlaintext}, nil
+		},
+		CreateFunc: func(
+			_ context.Context, _, _ string, _ domain.ValueType, description string, _ ...provider.WriteOption,
+		) (domain.Version, error) {
+			gotCreateDescription = description
+
+			return domain.Version{ID: "1"}, nil
+		},
+		PutFunc: func(
+			_ context.Context, _, _ string, _ domain.ValueType, description string, _ ...provider.WriteOption,
+		) (domain.Version, error) {
+			gotPutDescription = description
+
+			return domain.Version{ID: "2"}, nil
+		},
+	}
+
+	orig := registry
+	registry = provider.NewRegistry()
+	registry.Register(provider.ProviderAWS, fakeFactory{store: store})
+
+	t.Cleanup(func() { registry = orig })
+
+	app := &App{ctx: t.Context(), scope: provider.Scope{Provider: provider.ProviderAWS}}
+
+	// Create path: a fresh key routes to Create and carries the description.
+	res, err := app.ParamSet("/my/param", "v", "String", "", "my description")
+	require.NoError(t, err)
+	assert.True(t, res.IsCreated)
+	assert.Equal(t, "my description", gotCreateDescription)
+
+	// Update path: when the key already exists, ParamSet falls back to Put and
+	// must forward the description there too.
+	store.CreateFunc = func(
+		context.Context, string, string, domain.ValueType, string, ...provider.WriteOption,
+	) (domain.Version, error) {
+		return domain.Version{}, provider.ErrAlreadyExists
+	}
+
+	res, err = app.ParamSet("/my/param", "v2", "String", "", "updated description")
+	require.NoError(t, err)
+	assert.False(t, res.IsCreated)
+	assert.Equal(t, "updated description", gotPutDescription)
+}
+
+// TestParamSet_DropsDescriptionForAzure asserts the server-side guard: Azure App
+// Configuration ignores descriptions, so the binding must drop any value even if
+// the frontend (which hides the input) is bypassed — defense in depth (#767).
+//
+//nolint:paralleltest // overrides the package-global registry.
+func TestParamSet_DropsDescriptionForAzure(t *testing.T) {
+	var gotDescription string
+
+	store := &providermock.Store{
+		CreateFunc: func(
+			_ context.Context, _, _ string, _ domain.ValueType, description string, _ ...provider.WriteOption,
+		) (domain.Version, error) {
+			gotDescription = description
+
+			return domain.Version{ID: "1"}, nil
+		},
+	}
+
+	orig := registry
+	registry = provider.NewRegistry()
+	registry.Register(provider.ProviderAzure, fakeFactory{store: store})
+
+	t.Cleanup(func() { registry = orig })
+
+	app := &App{ctx: t.Context(), scope: provider.Scope{Provider: provider.ProviderAzure, StoreName: "store"}}
+
+	_, err := app.ParamSet("app/config", "v", "", "", "should-be-dropped")
+	require.NoError(t, err)
+	assert.Empty(t, gotDescription, "Azure App Configuration must not receive a description")
+}
+
 // TestParamListWithNamespaces_PopulatesSecretAndType covers the App
 // Configuration list path: its values are always plaintext, so Secret stays
 // false and Type is the plaintext display, matching the detail path (#491).

--- a/internal/gui/providers.go
+++ b/internal/gui/providers.go
@@ -131,6 +131,21 @@ type ServiceCapability struct {
 	// delete immediately or govern retention by policy, so no "recoverable until"
 	// date is shown.
 	HasRecoveryWindow bool `json:"hasRecoveryWindow"`
+	// HasDescription is true when a create/update may carry a human-readable
+	// description that the provider persists (AWS Param + Secret, Google Cloud
+	// Secret). Azure App Configuration and Key Vault writers ignore it, so the
+	// frontend hides the Description input there and the binding drops any value.
+	HasDescription bool `json:"hasDescription"`
+}
+
+// descriptionSupported reports whether the current provider persists a
+// create/update description. It is the server-side backstop for the capability-
+// gated Description input: AWS (Param + Secret) and Google Cloud (Secret) honor
+// it; Azure App Configuration and Key Vault writers ignore it, so the binding
+// drops any description a stale/forged frontend might send (defense in depth,
+// #767). Mirrors ServiceCapability.HasDescription.
+func (a *App) descriptionSupported() bool {
+	return a.currentScope().Provider != provider.ProviderAzure
 }
 
 // ProviderCapability describes a provider and the services it offers.
@@ -163,12 +178,12 @@ func (a *App) Capabilities() []ProviderCapability {
 				{
 					Service: serviceParam, DisplayName: "Param",
 					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: false,
-					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false,
+					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false, HasDescription: true,
 				},
 				{
 					Service: serviceSecret, DisplayName: displayNameSecret,
 					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: true,
-					HasStaging: true, HasForceDelete: true, HasRecoveryWindow: true,
+					HasStaging: true, HasForceDelete: true, HasRecoveryWindow: true, HasDescription: true,
 				},
 			},
 		},
@@ -180,7 +195,7 @@ func (a *App) Capabilities() []ProviderCapability {
 				{
 					Service: serviceSecret, DisplayName: displayNameSecret,
 					HasVersionHistory: true, HasVersionSpecifiers: true, HasTags: true, HasRestore: false,
-					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false,
+					HasStaging: true, HasForceDelete: false, HasRecoveryWindow: false, HasDescription: true,
 				},
 			},
 		},

--- a/internal/gui/secret.go
+++ b/internal/gui/secret.go
@@ -227,18 +227,25 @@ func (a *App) SecretLog(name string, maxResults int32) (*SecretLogResult, error)
 	return &SecretLogResult{Name: result.Name, Entries: entries}, nil
 }
 
-// SecretCreate creates a new secret.
-func (a *App) SecretCreate(name, value string) (*SecretCreateResult, error) {
+// SecretCreate creates a new secret. description is a human-readable description
+// persisted by providers that support it (AWS Secrets Manager, Google Cloud
+// Secret Manager); Azure Key Vault drops it server-side (#767).
+func (a *App) SecretCreate(name, value, description string) (*SecretCreateResult, error) {
 	store, err := a.secretStore()
 	if err != nil {
 		return nil, err
 	}
 
+	if !a.descriptionSupported() {
+		description = ""
+	}
+
 	uc := &secret.CreateUseCase{Writer: store}
 
 	result, err := uc.Execute(a.ctx, secret.CreateInput{
-		Name:  name,
-		Value: value,
+		Name:        name,
+		Value:       value,
+		Description: description,
 	})
 	if err != nil {
 		return nil, err
@@ -250,18 +257,25 @@ func (a *App) SecretCreate(name, value string) (*SecretCreateResult, error) {
 	}, nil
 }
 
-// SecretUpdate updates an existing secret.
-func (a *App) SecretUpdate(name, value string) (*SecretUpdateResult, error) {
+// SecretUpdate updates an existing secret. An empty description preserves the
+// existing one (a no-op), matching the CLI/adapter contract; Azure Key Vault
+// drops it server-side (#767).
+func (a *App) SecretUpdate(name, value, description string) (*SecretUpdateResult, error) {
 	store, err := a.secretStore()
 	if err != nil {
 		return nil, err
 	}
 
+	if !a.descriptionSupported() {
+		description = ""
+	}
+
 	uc := &secret.UpdateUseCase{Store: store}
 
 	result, err := uc.Execute(a.ctx, secret.UpdateInput{
-		Name:  name,
-		Value: value,
+		Name:        name,
+		Value:       value,
+		Description: description,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/gui/secret_internal_test.go
+++ b/internal/gui/secret_internal_test.go
@@ -1,0 +1,110 @@
+//go:build production || dev
+
+package gui
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/domain"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/providermock"
+)
+
+// TestSecretCreate_ThreadsDescription asserts the GUI SecretCreate binding
+// forwards the description argument into the create use case, so a description
+// set in the GUI form reaches the provider writer (#767).
+//
+//nolint:paralleltest // overrides the package-global registry.
+func TestSecretCreate_ThreadsDescription(t *testing.T) {
+	var gotDescription string
+
+	store := &providermock.Store{
+		CreateFunc: func(
+			_ context.Context, _, _ string, _ domain.ValueType, description string, _ ...provider.WriteOption,
+		) (domain.Version, error) {
+			gotDescription = description
+
+			return domain.Version{ID: "v1"}, nil
+		},
+	}
+
+	orig := registry
+	registry = provider.NewRegistry()
+	registry.Register(provider.ProviderAWS, fakeFactory{store: store})
+
+	t.Cleanup(func() { registry = orig })
+
+	app := &App{ctx: t.Context(), scope: provider.Scope{Provider: provider.ProviderAWS}}
+
+	_, err := app.SecretCreate("my-secret", "v", "app credentials")
+	require.NoError(t, err)
+	assert.Equal(t, "app credentials", gotDescription)
+}
+
+// TestSecretUpdate_ThreadsDescription asserts the GUI SecretUpdate binding
+// forwards the description into the update use case's Put (#767).
+//
+//nolint:paralleltest // overrides the package-global registry.
+func TestSecretUpdate_ThreadsDescription(t *testing.T) {
+	var gotDescription string
+
+	store := &providermock.Store{
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{Name: name, Value: "old", Type: domain.ValueTypeSecret}, nil
+		},
+		PutFunc: func(
+			_ context.Context, _, _ string, _ domain.ValueType, description string, _ ...provider.WriteOption,
+		) (domain.Version, error) {
+			gotDescription = description
+
+			return domain.Version{ID: "v2"}, nil
+		},
+	}
+
+	orig := registry
+	registry = provider.NewRegistry()
+	registry.Register(provider.ProviderAWS, fakeFactory{store: store})
+
+	t.Cleanup(func() { registry = orig })
+
+	app := &App{ctx: t.Context(), scope: provider.Scope{Provider: provider.ProviderAWS}}
+
+	_, err := app.SecretUpdate("my-secret", "v2", "rotated key")
+	require.NoError(t, err)
+	assert.Equal(t, "rotated key", gotDescription)
+}
+
+// TestSecretCreate_DropsDescriptionForAzure asserts the server-side guard: Azure
+// Key Vault ignores descriptions, so the binding drops any value even if the
+// frontend (which hides the input) is bypassed — defense in depth (#767).
+//
+//nolint:paralleltest // overrides the package-global registry.
+func TestSecretCreate_DropsDescriptionForAzure(t *testing.T) {
+	var gotDescription string
+
+	store := &providermock.Store{
+		CreateFunc: func(
+			_ context.Context, _, _ string, _ domain.ValueType, description string, _ ...provider.WriteOption,
+		) (domain.Version, error) {
+			gotDescription = description
+
+			return domain.Version{ID: "v1"}, nil
+		},
+	}
+
+	orig := registry
+	registry = provider.NewRegistry()
+	registry.Register(provider.ProviderAzure, fakeFactory{store: store})
+
+	t.Cleanup(func() { registry = orig })
+
+	app := &App{ctx: t.Context(), scope: provider.Scope{Provider: provider.ProviderAzure, VaultName: "vault"}}
+
+	_, err := app.SecretCreate("kv-secret", "v", "should-be-dropped")
+	require.NoError(t, err)
+	assert.Empty(t, gotDescription, "Azure Key Vault must not receive a description")
+}


### PR DESCRIPTION
Brings the `main`-direct GUI Description input (#767, PR #769) back into the integration branch so #657's final merge is conflict-free.

Conflict resolution:
- `internal/gui/providers.go` — kept epic/tui's `capability` package aliases (`ServiceCapability = capability.ServiceCapability`, `Capabilities() → capability.All()`); `capability.All()` already carries `HasDescription`, so #767's gating works through the alias. Kept main's `descriptionSupported()` server-side guard.
- `internal/gui/frontend/wailsjs/go/models.ts` — `hasDescription` retained (whitespace-only conflict).
- `internal/gui/capabilities_internal_test.go` — re-added a local `findService` helper (removed by the capability lift) so #767's `HasDescription` gating test compiles.

Verified: default `go build ./...`, GUI `go build -tags production ./internal/gui/...`, TUI/capability/architecture tests all pass locally (GUI test needs a built frontend/dist, which CI provides). Part of Epic #752 (final-integration prep).

🤖 Generated with [Claude Code](https://claude.com/claude-code)