### PR TITLE
test(updatecheck): pin pre-release version comparison (no false nag on alpha builds)

### DIFF
--- a/internal/updatecheck/updatecheck_test.go
+++ b/internal/updatecheck/updatecheck_test.go
@@ -334,6 +334,14 @@ func TestSemverComparison(t *testing.T) {
 		{name: "newer patch", current: "v1.2.3", latest: "v1.2.4", wantNotice: true},
 		{name: "equal", current: "v1.2.3", latest: "v1.2.3", wantNotice: false},
 		{name: "older", current: "v1.2.3", latest: "v1.2.2", wantNotice: false},
+		// Pre-release current versions (e.g. a v2.0.0-alpha.1 build) must compare
+		// with SemVer 2.0 precedence and never nag a pre-release user to
+		// "downgrade" to the last stable — /releases/latest excludes pre-releases,
+		// so the last stable is what fetchLatest returns for such a build.
+		{name: "prerelease current, last stable is older -> no nag", current: "v2.0.0-alpha.1", latest: "v1.6.1", wantNotice: false},
+		{name: "prerelease current, final release is newer -> nag", current: "v2.0.0-alpha.1", latest: "v2.0.0", wantNotice: true},
+		{name: "prerelease current, later prerelease -> nag", current: "v2.0.0-alpha.1", latest: "v2.0.0-alpha.2", wantNotice: true},
+		{name: "prerelease current equals latest -> no nag", current: "v2.0.0-alpha.1", latest: "v2.0.0-alpha.1", wantNotice: false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Confirms the update-check does not misbehave for a pre-release build such as `v2.0.0-alpha.1`:

- `semver.IsValid("v2.0.0-alpha.1")` is true (not treated as unparseable/dev).
- `golang.org/x/mod/semver` compares pre-releases with SemVer 2.0 precedence (`v2.0.0-alpha.1 < v2.0.0`, `v2.0.0-alpha.1 > v1.6.1`).
- `fetchLatestRelease` hits `/releases/latest`, which GitHub returns EXCLUDING pre-releases — so a pre-release build sees the last stable as latest and is NOT nagged to 'downgrade'; the final release correctly nags.

Adds regression cases (previously the table had no pre-release entries). Test-only. Note (release hygiene, not code): alpha/rc must be published as GitHub **pre-releases** so `/releases/latest` keeps skipping them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)