### PR TITLE
test(tui): harden AWS TUI e2e — gate detail assertions on the async value (#788)

### DIFF
--- a/e2e/aws_tui_test.go
+++ b/e2e/aws_tui_test.go
@@ -134,8 +134,15 @@ func TestTUIAWS_ParamBrowse(t *testing.T) {
 	tm := teatest.NewTestModel(t, newTUIModel(t, string(staging.ServiceParam)),
 		teatest.WithInitialTermSize(tuiTermWidth, tuiTermHeight))
 
-	// Gate on the async list landing (both real entries rendered).
-	waitForScreen(t, tm, alphaName)
+	// Gate on the detail pane's async Show completing by waiting for the selected
+	// entry's value — not just the list name. The detail loads AFTER the list, so
+	// the value appearing proves both the list read and the async detail read
+	// landed before we quit, and the assertion never races the "select an entry"
+	// placeholder frame. A single gate (not list-then-value) is deliberate:
+	// waitForScreen consumes the output buffer, so when the list+detail frames
+	// batch a first wait on the name would swallow the value and a second wait
+	// would block forever.
+	waitForScreen(t, tm, alphaValue)
 
 	screen := finalScreen(t, tm)
 
@@ -169,9 +176,13 @@ func TestTUIAWS_SecretBrowse(t *testing.T) {
 	tm := teatest.NewTestModel(t, newTUIModel(t, string(staging.ServiceSecret)),
 		teatest.WithInitialTermSize(tuiTermWidth, tuiTermHeight))
 
-	// Gate on the async list landing, then explicitly reveal the value with `x`.
+	// Gate on the async list landing, then explicitly reveal the value with `x`
+	// and wait for the async fetch+reveal to render the value before capturing —
+	// the reveal triggers a fresh emulator read, so gating on the list alone
+	// would race the masked → revealed transition.
 	waitForScreen(t, tm, secretName)
 	tm.Send(keyRune('x'))
+	waitForScreen(t, tm, secretValue)
 
 	screen := finalScreen(t, tm)
 


### PR DESCRIPTION
## Summary

The AWS TUI e2e tests (`e2e/aws_tui_test.go`) assert on detail-pane content after waiting only for the **LIST** marker. Under CI load the async detail load hasn't completed when the screen is captured, so the detail pane still shows `select an entry` and the assertion fails with `does not contain "<value>"`. This has been flaking `E2E Test (AWS TUI)` across PRs.

## Fix

Gate each assertion on the content that proves the async read finished, not just the list name:

- **`TestTUIAWS_ParamBrowse`**: wait for the selected entry's value (`alphaValue`) instead of the list name. The detail loads *after* the list, so the value appearing proves both the list and the async detail read landed. A **single** gate (not name-then-value) is deliberate — `waitForScreen` drains the shared output buffer (`tm.Output()` is a consuming `bytes.Buffer`), so when the list+detail frames batch, a first wait on the name swallows the value and a second wait blocks forever. Confirmed by observing exactly that failure before switching to a single value gate.
- **`TestTUIAWS_SecretBrowse`**: after pressing `x` to reveal, wait for the revealed secret value (a fresh emulator read) before capturing.
- **`TestTUIAWS_StageApply`**: already gated on `"updated"` before its CLI-read verification — unchanged.

## Verification

Ran against localstack via `mise e2e-aws-tui` (twice), all pass reliably:

```
--- PASS: TestTUIAWS_ParamBrowse (0.54s)
--- PASS: TestTUIAWS_SecretBrowse (0.12s)
--- PASS: TestTUIAWS_StageApply (0.17s)
PASS
ok  	github.com/mpyw/suve/e2e	0.845s
```

- `go build ./...` clean
- `go test ./internal/tui/...` green
- `golangci-lint run --allow-parallel-runners --build-tags=e2e ./e2e/...` → 0 issues

The mirrored gcloud fix is pushed to PR #786's branch (`tui/e2e-gcloud`); the azure test will get the same treatment when it lands.

Closes #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)