### PR TITLE
feat(tui): double-Esc discard guard + Value newlines (enter) with shift+enter/ctrl+s submit (#790, #791)

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -101,6 +101,15 @@ type dialog interface {
 	busy() bool
 }
 
+// escInterceptor is a dialog that wants to own the Back (Esc) key rather than be
+// bare-popped — the create/edit/tag forms' discard guard (#790). The shell
+// forwards Esc into such a dialog's Update when interceptEsc reports true; the
+// dialog then arms a discard confirmation (dirty) or emits CanceledMsg (clean).
+// dialogAdapter forwards this to the wrapped dialogs.EscInterceptor.
+type escInterceptor interface {
+	interceptEsc() bool
+}
+
 // awsIdentityMsg carries a resolved AWS identity back to the model.
 type awsIdentityMsg struct{ id components.AWSIdentity }
 
@@ -527,12 +536,22 @@ func (m *App) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 
 		if key.Matches(msg, m.keys.Back) && !m.topDialogBusy() {
+			top := len(m.dialogs) - 1
+
+			// A free-text form guards against an accidental discard: it owns Esc
+			// itself (a dirty form arms a "press esc again" confirmation, a clean
+			// form closes) rather than being bare-popped (#790). Forwarding the Esc
+			// lets the form decide; it emits CanceledMsg when it actually closes.
+			if g, ok := m.dialogs[top].(escInterceptor); ok && g.interceptEsc() {
+				return m.updateTopDialog(msg)
+			}
+
 			// A dialog that has already mutated (the apply results view) closes on
 			// Back with the same reload+voice as enter, so the staging page and its
 			// badge refresh; the returned command emits MutationDoneMsg, which
 			// onMutationDone turns into the single pop+reload+voice. Every other
 			// dialog is bare-dismissed.
-			if d, ok := m.dialogs[len(m.dialogs)-1].(dialogs.DismissReloader); ok {
+			if d, ok := m.dialogs[top].(dialogs.DismissReloader); ok {
 				if cmd := d.DismissCmd(); cmd != nil {
 					return m, cmd
 				}
@@ -1037,6 +1056,13 @@ func (m *App) View() tea.View {
 	view := tea.NewView("")
 	view.AltScreen = true
 	view.MouseMode = tea.MouseModeCellMotion
+	// Request keyboard enhancements so an enhanced-keyboard terminal (Kitty
+	// protocol) reports shift+enter distinctly from a plain Enter, which lets the
+	// create/edit/tag forms bind shift+enter to submit while Enter inserts a
+	// newline in the Value textarea (#791). Bubble Tea v2 always requests basic key
+	// disambiguation with this set; terminals without the protocol (e.g. macOS
+	// Terminal.app) collapse shift+enter to Enter, so ctrl+s is the portable submit.
+	view.KeyboardEnhancements.ReportAlternateKeys = true
 
 	if m.width <= 0 || m.height <= 0 {
 		return view

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mpyw/suve/internal/tui/data"
 	"github.com/mpyw/suve/internal/tui/dialogs"
 	"github.com/mpyw/suve/internal/tui/nav"
+	"github.com/mpyw/suve/internal/tui/styles"
 )
 
 // awsIdentityFixture is the deterministic identity used in AWS goldens so the
@@ -170,6 +171,52 @@ func TestUpdate_BusyDialogSuppressesDismiss(t *testing.T) {
 	idle.dialogs = []dialog{&fakeDialog{}}
 	idle = updateApp(t, idle, specialKey(tea.KeyEscape))
 	assert.Empty(t, idle.dialogs, "an idle dialog is dismissed by esc")
+}
+
+// TestUpdate_DirtyFormEscGuard pins the #790 guard end-to-end through the shell:
+// a create/edit form that has unsaved input owns Esc (the shell forwards it via
+// the EscInterceptor seam instead of bare-popping), so the first Esc arms a
+// discard confirmation (the dialog stays on the stack) and only the second
+// consecutive Esc closes it. A clean form still closes on the first Esc.
+func TestUpdate_DirtyFormEscGuard(t *testing.T) {
+	t.Parallel()
+
+	newModel := func() *App {
+		m := newApp(config{scope: provider.Scope{Provider: provider.ProviderAWS}, identity: awsIdentityFixture()})
+		ef, _ := dialogs.NewEntryForm(dialogs.EntryFormInput{
+			Ctx: t.Context(), Mutator: capMutator{cap: goldenCap("aws", "secret")},
+			Service: "secret", Styles: styles.New(),
+		})
+		m.dialogs = []dialog{dialogAdapter{m: ef}}
+		m = updateApp(t, m, tea.WindowSizeMsg{Width: goldenTermWidth, Height: goldenTermHeight})
+
+		return m
+	}
+
+	// Clean form: the first Esc pops it (via the CanceledMsg the dialog emits).
+	clean := newModel()
+	next, cmd := clean.Update(specialKey(tea.KeyEscape))
+	clean, ok := next.(*App)
+	require.True(t, ok)
+	require.NotNil(t, cmd, "a clean form emits CanceledMsg on esc")
+	clean = updateApp(t, clean, cmd())
+	assert.Empty(t, clean.dialogs, "esc closes a clean form")
+
+	// Dirty form: typing a character makes it dirty.
+	dirty := newModel()
+	dirty = updateApp(t, dirty, keyPress('x'))
+
+	// First Esc arms — the dialog stays on the stack (not bare-popped).
+	dirty = updateApp(t, dirty, specialKey(tea.KeyEscape))
+	require.Len(t, dirty.dialogs, 1, "first esc on a dirty form arms, does not close")
+
+	// Second consecutive Esc discards: the dialog emits CanceledMsg, which pops it.
+	next, cmd = dirty.Update(specialKey(tea.KeyEscape))
+	dirty, ok = next.(*App)
+	require.True(t, ok)
+	require.NotNil(t, cmd, "the second esc emits CanceledMsg")
+	dirty = updateApp(t, dirty, cmd())
+	assert.Empty(t, dirty.dialogs, "a second consecutive esc discards")
 }
 
 // TestUpdate_StagedCountBadge pins that a staged-count report updates the Staging

--- a/internal/tui/dialog_golden_test.go
+++ b/internal/tui/dialog_golden_test.go
@@ -379,7 +379,7 @@ func TestDialog_EntryFormMinSizeGolden(t *testing.T) { //nolint:paralleltest // 
 		Service: "secret", Styles: styles.New(),
 	})
 
-	dialogGoldenSize(t, newDialogHost(m, cmd), "esc: cancel", minGoldenWidth, minGoldenHeight)
+	dialogGoldenSize(t, newDialogHost(m, cmd), "cancel", minGoldenWidth, minGoldenHeight)
 }
 
 // TestDialog_ErrorLongMessageMinSizeGolden pins the #686 fix for a long error at

--- a/internal/tui/dialogs/dialogs.go
+++ b/internal/tui/dialogs/dialogs.go
@@ -11,6 +11,7 @@
 package dialogs
 
 import (
+	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 
 	"github.com/mpyw/suve/internal/tui/data"
@@ -21,6 +22,39 @@ const (
 	serviceParam  = "param"
 	serviceSecret = "secret"
 )
+
+// discardNotice is the inline warning a free-text form shows after the first Esc
+// on a dirty form (#790); a second consecutive Esc then discards.
+const discardNotice = "unsaved changes — press esc again to discard"
+
+// submitKey submits a create/edit/tag form from any field (#791): ctrl+s is the
+// portable fallback that works in every terminal, while shift+enter is the
+// enhanced-keyboard binding (indistinguishable from a plain Enter unless the
+// terminal's Kitty keyboard protocol is active). It is handled by the dialog
+// itself — not the embedded huh form, which can only submit from its last field —
+// so a multi-line Value textarea (where Enter now inserts a newline) can still be
+// submitted while focused.
+//
+//nolint:gochecknoglobals // immutable dialog-local binding
+var submitKey = key.NewBinding(key.WithKeys("ctrl+s", "shift+enter"))
+
+// escKey is the discard/cancel binding the shell forwards into a discard-guarded
+// form (see EscInterceptor) so the form itself decides whether to arm a discard
+// confirmation (dirty) or close immediately (clean).
+//
+//nolint:gochecknoglobals // immutable dialog-local binding
+var escKey = key.NewBinding(key.WithKeys("esc"))
+
+// EscInterceptor is an optional dialog capability. A free-text form that guards
+// against discarding unsaved input implements it so the shell forwards the Back
+// (Esc) key into the dialog's Update — where a dirty form arms a discard
+// confirmation (a second Esc then discards) — instead of bare-popping it. A
+// clean form returns CanceledMsg on the first Esc, so the shell closes it exactly
+// as before. The shell still suppresses Esc entirely while the dialog is Busy (a
+// mutation in flight is never interrupted).
+type EscInterceptor interface {
+	InterceptEsc() bool
+}
 
 // Model is a modal dialog embedded in the app shell's dialog stack. It mirrors
 // the app's page contract but returns its own concrete interface (the app adapts

--- a/internal/tui/dialogs/dialogs_test.go
+++ b/internal/tui/dialogs/dialogs_test.go
@@ -575,6 +575,150 @@ func TestEntryForm_ImmediateCreateUpsertVoicesUpdate(t *testing.T) {
 	assert.Equal(t, "Applied update.", msg.Status, "an upsert voices an update, not a create")
 }
 
+// TestEntryForm_EscDiscardGuard pins the #790 double-Esc guard: a clean form
+// closes on the first Esc; a dirty form arms a confirmation on the first Esc
+// (stays open, shows the notice) and discards only on the second consecutive Esc;
+// any keystroke between the two Escs re-arms so a later single Esc is safe.
+func TestEntryForm_EscDiscardGuard(t *testing.T) {
+	t.Parallel()
+
+	// Clean create form: the first Esc cancels immediately.
+	clean, _ := newCreateEntry(t, awsSecretCap())
+	_, cmd := clean.Update(keyEsc())
+	assert.True(t, isCanceled(cmd), "esc on a clean form cancels immediately")
+	assert.False(t, clean.armed)
+
+	// Dirty form: a typed value diverges from the empty seed.
+	dirty, _ := newCreateEntry(t, awsSecretCap())
+	dirty.value = "half-typed value"
+
+	// First Esc arms — no cancel, notice shown, stays open.
+	_, cmd = dirty.Update(keyEsc())
+	assert.True(t, dirty.armed, "first esc on a dirty form arms the discard")
+	assert.Equal(t, discardNotice, dirty.notice)
+	assert.False(t, isCanceled(cmd), "first esc on a dirty form does not cancel")
+
+	// Second consecutive Esc discards.
+	_, cmd = dirty.Update(keyEsc())
+	assert.True(t, isCanceled(cmd), "a second consecutive esc discards")
+}
+
+// TestEntryForm_EscArmResetsOnKeystroke pins that any key between the two Escs
+// resets the armed state, so a stray Esc after typing again does not discard.
+func TestEntryForm_EscArmResetsOnKeystroke(t *testing.T) {
+	t.Parallel()
+
+	d, _ := newCreateEntry(t, awsSecretCap())
+	d.value = "half-typed value"
+
+	_, _ = d.Update(keyEsc())
+	require.True(t, d.armed)
+
+	// A keystroke resets the armed state (and clears the discard notice).
+	_, _ = d.Update(keyMsg('x'))
+	assert.False(t, d.armed, "a keystroke resets the armed state")
+	assert.Empty(t, d.notice)
+
+	// So the next single Esc only re-arms, it does not discard.
+	_, cmd := d.Update(keyEsc())
+	assert.True(t, d.armed, "a later single esc re-arms")
+	assert.False(t, isCanceled(cmd), "the re-armed first esc does not discard")
+}
+
+// TestEntryForm_ValueEnterInsertsNewline pins the #791 core: Enter in the Value
+// textarea inserts a newline (does not submit or advance). An edit form focuses
+// the Value field first, so a single Enter lands there.
+func TestEntryForm_ValueEnterInsertsNewline(t *testing.T) {
+	t.Parallel()
+
+	d, _ := newEntry(t, awsSecretCap(), true) // edit: value is the first field
+	m, _ := d.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	d, ok := m.(*entryForm)
+	require.True(t, ok)
+	require.Equal(t, "value", focusedFieldKey(d), "the edit form focuses the Value field first")
+
+	m, _ = d.Update(keyEnter())
+	d, ok = m.(*entryForm)
+	require.True(t, ok)
+
+	assert.Contains(t, d.value, "\n", "Enter inserts a newline in the Value textarea")
+	assert.False(t, d.busy, "Enter in Value does not submit")
+}
+
+// TestEntryForm_SingleLineEnterAdvances pins that Enter on a single-line field
+// (name) neither inserts a newline nor submits — it stays huh's advance key.
+func TestEntryForm_SingleLineEnterAdvances(t *testing.T) {
+	t.Parallel()
+
+	mut := &fakeMutator{svcCap: awsSecretCap()}
+	m, _ := NewEntryForm(EntryFormInput{
+		Ctx: context.Background(), Mutator: mut, Service: "secret", Styles: styles.New(), Name: "the-name",
+	})
+	d, ok := m.(*entryForm)
+	require.True(t, ok)
+	require.Equal(t, "name", focusedFieldKey(d), "the create form focuses the Name field first")
+
+	m, _ = d.Update(keyEnter())
+	d, ok = m.(*entryForm)
+	require.True(t, ok)
+
+	assert.NotContains(t, d.name, "\n", "Enter on a single-line field inserts no newline")
+	assert.False(t, d.busy, "Enter on a single-line field does not submit")
+	assert.False(t, mut.createCalled, "Enter on a single-line field does not write")
+}
+
+// TestEntryForm_SubmitKeys pins the #791 submit bindings: both ctrl+s (portable)
+// and shift+enter (enhanced-keyboard) submit the form from any field — here the
+// Value textarea, where Enter now inserts a newline instead.
+func TestEntryForm_SubmitKeys(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		key  tea.KeyPressMsg
+	}{
+		{"ctrl+s", keyCtrlS()},
+		{"shift+enter", keyShiftEnter()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			d, mut := newEntry(t, awsSecretCap(), true) // edit, value focused
+			d.value = "some value"
+
+			m, cmd := d.Update(tc.key)
+			d, ok := m.(*entryForm)
+			require.True(t, ok)
+
+			require.NotNil(t, cmd, "the submit key emits the mutation command")
+			assert.True(t, d.busy, "the submit key sets the busy guard")
+
+			_ = cmd() // run the mutation against the recording mutator
+
+			assert.True(t, mut.updateCalled, "the submit key routes through the mutator")
+		})
+	}
+}
+
+// TestEntryForm_CtrlSValidatesRequiredName pins that a forced submit (ctrl+s /
+// shift+enter) still enforces the create name validation huh would show inline:
+// an empty required name blocks the submit with a footer error rather than
+// dead-ending on the provider write.
+func TestEntryForm_CtrlSValidatesRequiredName(t *testing.T) {
+	t.Parallel()
+
+	d, mut := newCreateEntry(t, awsSecretCap())
+	d.value = "some value" // name left empty
+
+	m, _ := d.Update(keyCtrlS())
+	d, ok := m.(*entryForm)
+	require.True(t, ok)
+
+	assert.False(t, d.busy, "an empty required name blocks the forced submit")
+	assert.False(t, mut.createCalled, "no write is attempted with an invalid name")
+	assert.Contains(t, d.err, "name is required")
+}
+
 // TestDeleteConfirm_ForceRecoveryGating pins that force/recovery rows appear only
 // for a service with those capabilities, and are mutually exclusive (forcing
 // hides the recovery row).
@@ -852,6 +996,97 @@ func TestTagForm_EmptyTagsHidesRemove(t *testing.T) {
 	assert.Empty(t, mut.tagKey, "no tag write is routed")
 }
 
+// TestTagForm_EscDiscardGuard pins the #790 guard on the tag form: a clean form
+// closes on the first Esc; a form with a typed Add key arms on the first Esc and
+// discards only on the second.
+func TestTagForm_EscDiscardGuard(t *testing.T) {
+	t.Parallel()
+
+	newTag := func() *tagForm {
+		m, _ := NewTagForm(TagInput{
+			Ctx: context.Background(), Mutator: &fakeMutator{svcCap: awsParamCap()},
+			Service: "param", Styles: styles.New(), Name: "/app/X",
+		})
+		d, ok := m.(*tagForm)
+		require.True(t, ok)
+
+		return d
+	}
+
+	// Clean form: the first Esc cancels immediately.
+	clean := newTag()
+	_, cmd := clean.Update(keyEsc())
+	assert.True(t, isCanceled(cmd), "esc on a clean tag form cancels immediately")
+
+	// Dirty form (a typed Add key): first Esc arms, second discards.
+	dirty := newTag()
+	dirty.tagKey = "env"
+
+	_, cmd = dirty.Update(keyEsc())
+	assert.True(t, dirty.armed, "first esc on a dirty tag form arms the discard")
+	assert.Equal(t, discardNotice, dirty.notice)
+	assert.False(t, isCanceled(cmd), "first esc on a dirty tag form does not cancel")
+
+	_, cmd = dirty.Update(keyEsc())
+	assert.True(t, isCanceled(cmd), "a second consecutive esc discards")
+}
+
+// TestTagForm_SubmitKeys pins the #791 submit bindings on the tag form: ctrl+s
+// and shift+enter submit from any field, and a forced submit still enforces the
+// Add key-required validation.
+func TestTagForm_SubmitKeys(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		key  tea.KeyPressMsg
+	}{
+		{"ctrl+s", keyCtrlS()},
+		{"shift+enter", keyShiftEnter()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mut := &fakeMutator{svcCap: awsParamCap()}
+			m, _ := NewTagForm(TagInput{
+				Ctx: context.Background(), Mutator: mut, Service: "param", Styles: styles.New(), Name: "/app/X",
+			})
+			d, ok := m.(*tagForm)
+			require.True(t, ok)
+
+			d.tagKey, d.tagValue = "env", "prod"
+
+			m, cmd := d.Update(tc.key)
+			d, ok = m.(*tagForm)
+			require.True(t, ok)
+
+			require.NotNil(t, cmd, "the submit key emits the mutation command")
+			assert.True(t, d.busy)
+
+			_ = cmd()
+
+			assert.True(t, mut.addTagCalled, "the submit key routes through AddTag")
+			assert.Equal(t, "env", mut.tagKey)
+		})
+	}
+
+	// A forced submit with an empty Add key is blocked with a footer error.
+	mut := &fakeMutator{svcCap: awsParamCap()}
+	m, _ := NewTagForm(TagInput{
+		Ctx: context.Background(), Mutator: mut, Service: "param", Styles: styles.New(), Name: "/app/X",
+	})
+	d, ok := m.(*tagForm)
+	require.True(t, ok)
+
+	m, _ = d.Update(keyCtrlS())
+	d, ok = m.(*tagForm)
+	require.True(t, ok)
+
+	assert.False(t, d.busy, "an empty required key blocks the forced submit")
+	assert.False(t, mut.addTagCalled, "no write is attempted with an empty key")
+	assert.Contains(t, d.err, "key is required")
+}
+
 // TestDeleteConfirm_ResultVoicing pins the delete status voicing, including the
 // auto-unstage case: deleting a staged create removes it (nothing left to
 // delete). The pure voicing is asserted, then routed through onResult to confirm
@@ -990,4 +1225,51 @@ func newDelete(t *testing.T, svcCap capability.ServiceCapability) *deleteConfirm
 // keyMsg builds a printable key press.
 func keyMsg(r rune) tea.KeyPressMsg {
 	return tea.KeyPressMsg{Code: r, Text: string(r)}
+}
+
+// keyEnter / keyShiftEnter / keyCtrlS / keyEsc build the newline/submit/discard
+// key presses the #790/#791 guards react to. shift+enter carries ModShift so its
+// String() is "shift+enter" (distinct from a plain Enter), mirroring what an
+// enhanced-keyboard terminal reports.
+func keyEnter() tea.KeyPressMsg      { return tea.KeyPressMsg{Code: tea.KeyEnter} }
+func keyShiftEnter() tea.KeyPressMsg { return tea.KeyPressMsg{Code: tea.KeyEnter, Mod: tea.ModShift} }
+func keyCtrlS() tea.KeyPressMsg      { return tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl} }
+func keyEsc() tea.KeyPressMsg        { return tea.KeyPressMsg{Code: tea.KeyEscape} }
+
+// focusedFieldKey reports the huh key of the currently focused field.
+func focusedFieldKey(d *entryForm) string {
+	f := d.form.GetFocusedField()
+	if f == nil {
+		return ""
+	}
+
+	return f.GetKey()
+}
+
+// newCreateEntry builds a create form with no seeded fields, so it starts clean
+// (every field empty) for the discard-guard tests.
+func newCreateEntry(t *testing.T, svcCap capability.ServiceCapability) (*entryForm, *fakeMutator) {
+	t.Helper()
+
+	mut := &fakeMutator{svcCap: svcCap}
+
+	m, _ := NewEntryForm(EntryFormInput{
+		Ctx: context.Background(), Mutator: mut, Service: svcCap.Service, Styles: styles.New(),
+	})
+
+	d, ok := m.(*entryForm)
+	require.True(t, ok)
+
+	return d, mut
+}
+
+// isCanceled reports whether running cmd yields a CanceledMsg (a nil cmd is not).
+func isCanceled(cmd tea.Cmd) bool {
+	if cmd == nil {
+		return false
+	}
+
+	_, ok := cmd().(CanceledMsg)
+
+	return ok
 }

--- a/internal/tui/dialogs/entryform.go
+++ b/internal/tui/dialogs/entryform.go
@@ -84,6 +84,19 @@ type entryForm struct {
 	description string
 	staged      bool
 
+	// initName/initNamespace/initValue/initDescription snapshot the seeded field
+	// values at construction so the discard guard (#790) can tell a DIRTY form
+	// (a free-text field changed from its seed) from a clean one. Only the
+	// text-bearing fields are tracked — the Type/Mode selects seed to sensible
+	// defaults and carry no typed data to lose.
+	initName        string
+	initNamespace   string
+	initValue       string
+	initDescription string
+	// armed records that a first Esc on a dirty form has shown the discard notice;
+	// a second consecutive Esc then discards. Any other key resets it.
+	armed bool
+
 	form *huh.Form
 
 	busy   bool
@@ -138,6 +151,11 @@ func NewEntryForm(in EntryFormInput) (Model, tea.Cmd) {
 		// immediate (the mode toggle is hidden). A staged-only surface forces
 		// staged regardless (its toggle is hidden too).
 		staged: svcCap.HasStaging || in.StagedOnly,
+		// Snapshot the seeded free-text values for the discard guard (#790).
+		initName:        in.Name,
+		initNamespace:   in.Namespace,
+		initValue:       in.Value,
+		initDescription: in.Description,
 	}
 
 	cmd := d.rebuildForm()
@@ -214,12 +232,29 @@ func (d *entryForm) rebuildForm() tea.Cmd {
 	d.form = huh.NewForm(huh.NewGroup(fields...)).
 		WithWidth(dialogContentWidth).
 		WithShowHelp(false).
-		WithShowErrors(true)
+		WithShowErrors(true).
+		WithKeyMap(formKeyMap())
 
 	// Init the (re)built form, then immediately cap its body to the known
 	// terminal size so a retry after an error — or the initial build once the
 	// size has been seeded — never renders at full natural height off-screen.
 	return tea.Batch(d.form.Init(), d.syncFormSize())
+}
+
+// formKeyMap is the huh keymap the create/edit form uses so the multi-line Value
+// textarea can hold newlines (#791): in a huh Text field Enter inserts a newline
+// (NewLine) instead of advancing or submitting, and Tab advances. Every other
+// (single-line) field keeps huh's defaults, so Enter still advances — and submits
+// from the last field. Form submit from ANY field is driven by the dialog itself
+// (ctrl+s / shift+enter, see submitKey), which is why the textarea never needs to
+// submit on Enter.
+func formKeyMap() *huh.KeyMap {
+	km := huh.NewDefaultKeyMap()
+	km.Text.NewLine = key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "new line"))
+	km.Text.Next = key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "next"))
+	km.Text.Submit = key.NewBinding(key.WithKeys("shift+enter"), key.WithHelp("shift+enter", "submit"))
+
+	return km
 }
 
 // syncFormSize re-caps the embedded form's scrollable body to the current
@@ -283,6 +318,18 @@ func (d *entryForm) Update(msg tea.Msg) (Model, tea.Cmd) {
 			return d, nil // double-submit guard: swallow input mid-operation
 		}
 
+		if key.Matches(msg, escKey) {
+			return d.handleEsc()
+		}
+
+		// Any other key resets the discard-armed state so a later single Esc
+		// re-arms (a stray Esc after typing does not silently discard).
+		d.disarm()
+
+		if key.Matches(msg, submitKey) {
+			return d.forceSubmit()
+		}
+
 		if key.Matches(msg, ctrlEKey) && d.valueFieldFocused() {
 			return d, d.openEditor()
 		}
@@ -293,6 +340,65 @@ func (d *entryForm) Update(msg tea.Msg) (Model, tea.Cmd) {
 	}
 
 	return d.forwardToForm(msg)
+}
+
+// InterceptEsc opts the form into the shell's discard guard (#790): the shell
+// forwards Esc into Update (see handleEsc) rather than bare-popping the dialog.
+func (*entryForm) InterceptEsc() bool { return true }
+
+// handleEsc implements the discard guard: on a DIRTY form the first Esc arms a
+// confirmation (shows the notice, stays open); a second consecutive Esc — or any
+// Esc on a clean/unchanged form — discards (CanceledMsg closes it).
+func (d *entryForm) handleEsc() (Model, tea.Cmd) {
+	if d.dirty() && !d.armed {
+		d.armed = true
+		d.notice = discardNotice
+
+		return d, d.syncFormSize()
+	}
+
+	return d, canceledCmd
+}
+
+// dirty reports whether any free-text field diverges from its seeded value — a
+// non-empty entry on create, or a changed value/description/etc. on edit.
+func (d *entryForm) dirty() bool {
+	return d.name != d.initName ||
+		d.namespace != d.initNamespace ||
+		d.value != d.initValue ||
+		d.description != d.initDescription
+}
+
+// disarm clears the discard-armed state (and its notice) after any non-Esc key,
+// so the two Escs must be consecutive.
+func (d *entryForm) disarm() {
+	if d.armed {
+		d.armed = false
+		d.notice = ""
+	}
+}
+
+// forceSubmit submits the form from any field (ctrl+s / shift+enter), so a
+// multi-line value — where Enter now inserts a newline instead of advancing —
+// can be submitted without tabbing to the last field. It re-runs the create name
+// validation huh would enforce inline, so an empty required name still stops the
+// submit (with a footer error) instead of dead-ending on the provider write. The
+// other bound values are already live (huh syncs each field's accessor on every
+// keystroke), so no field needs to be blurred first.
+func (d *entryForm) forceSubmit() (Model, tea.Cmd) {
+	if !d.edit {
+		if err := d.nameValidator()(d.name); err != nil {
+			d.err = err.Error()
+
+			return d, d.syncFormSize()
+		}
+	}
+
+	d.err = ""
+	d.notice = ""
+	d.busy = true
+
+	return d, d.submit()
 }
 
 // forwardToForm drives the embedded huh form and reacts to its completion.
@@ -487,7 +593,10 @@ func (d *entryForm) header() string {
 func (d *entryForm) footer() string {
 	parts := make([]string, 0, 3) //nolint:mnd // at most error + notice + hint
 
-	hint := d.styles.PageHint.Render(entryHint(d.valueFieldFocused()))
+	// Wrap the hint to the dialog's fixed content width so the (now longer, #791)
+	// key hint stays inside the box — folding to a second line at the minimum size
+	// — instead of overflowing the border, and the box keeps the form's width.
+	hint := d.styles.PageHint.Width(dialogContentWidth).Render(entryHint(d.valueFieldFocused()))
 	// Reserve the frame around the footer (title, spacer, the form's minimum body,
 	// the hint); the error then the notice each take what remains, so the form
 	// body never drops below minFormBody and the whole dialog fits.
@@ -509,14 +618,16 @@ func (d *entryForm) footer() string {
 	return strings.Join(parts, "\n")
 }
 
-// entryHint is the bottom hint line, adding the ctrl+e affordance while the
-// value field is focused.
+// entryHint is the bottom hint line. While the Value textarea is focused it
+// voices Enter = newline and the ctrl+e editor handoff; on the single-line
+// fields Enter advances. Submit is always ctrl+s (portable) or shift+enter
+// (needs an enhanced-keyboard terminal).
 func entryHint(onValue bool) string {
 	if onValue {
-		return "tab/↑↓: fields · ctrl+e: $EDITOR · enter: submit · esc: cancel"
+		return "tab/↑↓: fields · enter: newline · ctrl+s / shift+enter: submit · ctrl+e: $EDITOR · esc: cancel"
 	}
 
-	return "tab/↑↓: fields · enter: submit · esc: cancel"
+	return "tab/↑↓: fields · enter: next · ctrl+s / shift+enter: submit · esc: cancel"
 }
 
 // namespaceDisplay renders a namespace for the read-only edit note, showing the

--- a/internal/tui/dialogs/sizing_test.go
+++ b/internal/tui/dialogs/sizing_test.go
@@ -71,8 +71,11 @@ func TestEntryForm_TallFormFitsMinSize(t *testing.T) {
 		"the dialog body fits inside the frame, so the shell never clips it")
 	assert.LessOrEqual(t, maxLineWidth(view), minWidth-dialogChrome,
 		"no line overflows the dialog width at the minimum size")
-	assert.Contains(t, stripANSI(view), "enter: submit", "the submit hint stays on-screen")
-	assert.Contains(t, stripANSI(view), "esc: cancel", "the cancel hint stays on-screen")
+	// The longer #791 hint folds across two lines at the minimum size, so match the
+	// wrap-safe affordance tokens rather than a phrase that may straddle the break.
+	assert.Contains(t, flatten(view), "ctrl+s", "the submit hint stays on-screen")
+	assert.Contains(t, flatten(view), "submit", "the submit hint stays on-screen")
+	assert.Contains(t, flatten(view), "cancel", "the cancel hint stays on-screen")
 }
 
 // TestEntryForm_CompressesWhenTallerThanScreen pins that the min-size form is
@@ -193,7 +196,7 @@ func TestEntryForm_LongErrorStaysBounded(t *testing.T) {
 		"a long error keeps the whole form within the terminal height")
 	assert.LessOrEqual(t, maxLineWidth(view), minWidth-dialogChrome,
 		"the wrapped error never overflows the dialog width")
-	assert.Contains(t, stripANSI(view), "esc: cancel", "the submit/cancel hint stays on-screen under a long error")
+	assert.Contains(t, flatten(view), "cancel", "the submit/cancel hint stays on-screen under a long error")
 }
 
 // TestErrorDialog_LongMessageWrapsAndScrollsMinSize pins that a long

--- a/internal/tui/dialogs/tagform.go
+++ b/internal/tui/dialogs/tagform.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"strings"
 
+	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
 	huh "charm.land/huh/v2"
 	"charm.land/lipgloss/v2"
@@ -50,9 +51,19 @@ type tagForm struct {
 	// free-text Add input and the Remove select of existing tags.
 	builtRemove bool
 
-	form *huh.Form
-	busy bool
-	err  string
+	// initTagKey/initTagValue snapshot the seeded Add free-text fields so the
+	// discard guard (#790) can tell a dirty form from a clean one. The Remove
+	// select carries no typed data, so only the Add inputs are tracked.
+	initTagKey   string
+	initTagValue string
+	// armed records that a first Esc on a dirty form has shown the discard notice;
+	// a second consecutive Esc then discards. Any other key resets it.
+	armed bool
+
+	form   *huh.Form
+	busy   bool
+	err    string
+	notice string
 }
 
 // TagInput configures a tag dialog.
@@ -212,6 +223,18 @@ func (d *tagForm) Update(msg tea.Msg) (Model, tea.Cmd) {
 		if d.busy {
 			return d, nil // double-submit guard
 		}
+
+		if key.Matches(msg, escKey) {
+			return d.handleEsc()
+		}
+
+		// Any other key resets the discard-armed state so a later single Esc
+		// re-arms (a stray Esc after typing does not silently discard).
+		d.disarm()
+
+		if key.Matches(msg, submitKey) {
+			return d.forceSubmit()
+		}
 	}
 
 	if d.busy {
@@ -242,6 +265,59 @@ func (d *tagForm) Update(msg tea.Msg) (Model, tea.Cmd) {
 	}
 
 	return d, cmd
+}
+
+// InterceptEsc opts the form into the shell's discard guard (#790): the shell
+// forwards Esc into Update (see handleEsc) rather than bare-popping the dialog.
+func (*tagForm) InterceptEsc() bool { return true }
+
+// handleEsc implements the discard guard: on a DIRTY form (a typed Add key/value)
+// the first Esc arms a confirmation (shows the notice, stays open); a second
+// consecutive Esc — or any Esc on a clean form — discards.
+func (d *tagForm) handleEsc() (Model, tea.Cmd) {
+	if d.dirty() && !d.armed {
+		d.armed = true
+		d.notice = discardNotice
+
+		return d, d.syncFormSize()
+	}
+
+	return d, canceledCmd
+}
+
+// dirty reports whether the Add free-text fields diverge from empty. Only the Add
+// inputs carry typed data to lose; the Remove select is a pick from existing tags.
+func (d *tagForm) dirty() bool {
+	return d.tagKey != d.initTagKey || d.tagValue != d.initTagValue
+}
+
+// disarm clears the discard-armed state (and its notice) after any non-Esc key,
+// so the two Escs must be consecutive.
+func (d *tagForm) disarm() {
+	if d.armed {
+		d.armed = false
+		d.notice = ""
+	}
+}
+
+// forceSubmit submits the tag form from any field (ctrl+s / shift+enter). It
+// re-runs the Add key validation huh would enforce inline, so an empty required
+// key still stops the submit (with a footer error). Remove targets a key chosen
+// from the existing-tags select, which is always seeded, so it needs no check.
+func (d *tagForm) forceSubmit() (Model, tea.Cmd) {
+	if !d.remove {
+		if err := requiredField("key")(d.tagKey); err != nil {
+			d.err = err.Error()
+
+			return d, d.syncFormSize()
+		}
+	}
+
+	d.err = ""
+	d.notice = ""
+	d.busy = true
+
+	return d, d.submit()
 }
 
 func (d *tagForm) submit() tea.Cmd {
@@ -300,17 +376,27 @@ func (d *tagForm) header() string {
 	return d.fit(d.styles.PaneTitle.Render("Tag — " + clipName(d.name, d.namespace)))
 }
 
-// footer renders the pinned rows below the form: any active error (wrapped to the
-// dialog width and capped so the form keeps at least minFormBody rows) then the
-// key hint.
+// footer renders the pinned rows below the form: any active error and discard
+// notice (each wrapped to the dialog width and capped so the form keeps at least
+// minFormBody rows) then the key hint.
 func (d *tagForm) footer() string {
-	parts := make([]string, 0, 2) //nolint:mnd // at most error + hint
+	parts := make([]string, 0, 3) //nolint:mnd // at most error + notice + hint
 
-	hint := d.styles.PageHint.Render("tab/↑↓: fields · enter: submit · esc: cancel")
+	// Wrap the hint to the dialog's fixed content width so the (longer, #791) key
+	// hint folds to a second line at the minimum size instead of overflowing the
+	// border, and the box keeps the form's width.
+	hint := d.styles.PageHint.Width(dialogContentWidth).
+		Render("tab/↑↓: fields · enter: next · ctrl+s / shift+enter: submit · esc: cancel")
+	reserved := lipgloss.Height(d.header()) + titleSpacerRows + minFormBody + lipgloss.Height(hint)
 
 	if d.err != "" {
-		budget := d.errBudget(lipgloss.Height(d.header()) + titleSpacerRows + minFormBody + lipgloss.Height(hint))
-		parts = append(parts, d.wrapCapped(d.styles.ErrorText.Render(d.err), budget))
+		line := d.wrapCapped(d.styles.ErrorText.Render(d.err), d.errBudget(reserved))
+		parts = append(parts, line)
+		reserved += lipgloss.Height(line)
+	}
+
+	if d.notice != "" {
+		parts = append(parts, d.wrapCapped(d.styles.Banner.Render(d.notice), d.errBudget(reserved)))
 	}
 
 	parts = append(parts, hint)

--- a/internal/tui/dialogs_wire.go
+++ b/internal/tui/dialogs_wire.go
@@ -36,3 +36,17 @@ func (a dialogAdapter) DismissCmd() tea.Cmd {
 
 	return nil
 }
+
+// interceptEsc forwards the optional dialogs.EscInterceptor seam through the
+// adapter (mirroring DismissCmd): the app stores every dialog as a dialogAdapter,
+// so the shell's Back handler asserts the seam against the adapter, not the
+// wrapped dialog. Returns the wrapped dialog's decision when it implements
+// EscInterceptor (the create/edit/tag forms' discard guard, #790), else false so
+// the shell dismisses exactly as before.
+func (a dialogAdapter) interceptEsc() bool {
+	if d, ok := a.m.(dialogs.EscInterceptor); ok {
+		return d.InterceptEsc()
+	}
+
+	return false
+}

--- a/internal/tui/testdata/TestDialog_EntryFormAWSParamGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormAWSParamGolden.golden
@@ -20,5 +20,6 @@
 │                                                          │
 │    Mode                                                  │
 │    (•) Stage    ( ) Apply immediately                    │
-│  tab/↑↓: fields · enter: submit · esc: cancel            │
+│  tab/↑↓: fields · enter: next · ctrl+s / shift+enter:    │
+│  submit · esc: cancel                                    │
 ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_EntryFormAWSSecretGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormAWSSecretGolden.golden
@@ -15,5 +15,6 @@
 │                                                          │
 │    Mode                                                  │
 │    (•) Stage    ( ) Apply immediately                    │
-│  tab/↑↓: fields · enter: submit · esc: cancel            │
+│  tab/↑↓: fields · enter: next · ctrl+s / shift+enter:    │
+│  submit · esc: cancel                                    │
 ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_EntryFormAppConfigGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormAppConfigGolden.golden
@@ -15,5 +15,6 @@
 │                                                          │
 │    Mode                                                  │
 │    (•) Stage    ( ) Apply immediately                    │
-│  tab/↑↓: fields · enter: submit · esc: cancel            │
+│  tab/↑↓: fields · enter: next · ctrl+s / shift+enter:    │
+│  submit · esc: cancel                                    │
 ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_EntryFormMinSizeGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormMinSizeGolden.golden
@@ -11,6 +11,6 @@
 │                                                          │
 │                                                          │
 │    Description                                           │
-│    > (optional)                                          │
-│  tab/↑↓: fields · enter: submit · esc: cancel            │
+│  tab/↑↓: fields · enter: next · ctrl+s / shift+enter:    │
+│  submit · esc: cancel                                    │
 ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_EntryFormStagedOnlyGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormStagedOnlyGolden.golden
@@ -1,13 +1,14 @@
-╭──────────────────────────────────────────────────────────────────╮
-│  Edit /app/api/DATABASE_URL                                      │
-│                                                                  │
-│  ┃ Value                                                         │
-│  ┃ postgres://new                                                │
-│  ┃                                                               │
-│  ┃                                                               │
-│  ┃                                                               │
-│                                                                  │
-│    Description                                                   │
-│    > (optional)                                                  │
-│  tab/↑↓: fields · ctrl+e: $EDITOR · enter: submit · esc: cancel  │
-╰──────────────────────────────────────────────────────────────────╯
+╭──────────────────────────────────────────────────────────╮
+│  Edit /app/api/DATABASE_URL                              │
+│                                                          │
+│  ┃ Value                                                 │
+│  ┃ postgres://new                                        │
+│  ┃                                                       │
+│  ┃                                                       │
+│  ┃                                                       │
+│                                                          │
+│    Description                                           │
+│    > (optional)                                          │
+│  tab/↑↓: fields · enter: newline · ctrl+s /              │
+│  shift+enter: submit · ctrl+e: $EDITOR · esc: cancel     │
+╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_TagAWSParamGolden.golden
+++ b/internal/tui/testdata/TestDialog_TagAWSParamGolden.golden
@@ -12,5 +12,6 @@
 │                                                          │
 │    Mode                                                  │
 │    (•) Stage    ( ) Apply immediately                    │
-│  tab/↑↓: fields · enter: submit · esc: cancel            │
+│  tab/↑↓: fields · enter: next · ctrl+s / shift+enter:    │
+│  submit · esc: cancel                                    │
 ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_TagAddOnlyWhenNoTagsGolden.golden
+++ b/internal/tui/testdata/TestDialog_TagAddOnlyWhenNoTagsGolden.golden
@@ -12,5 +12,6 @@
 │                                                          │
 │    Mode                                                  │
 │    (•) Stage    ( ) Apply immediately                    │
-│  tab/↑↓: fields · enter: submit · esc: cancel            │
+│  tab/↑↓: fields · enter: next · ctrl+s / shift+enter:    │
+│  submit · esc: cancel                                    │
 ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_TagRemoveSelectGolden.golden
+++ b/internal/tui/testdata/TestDialog_TagRemoveSelectGolden.golden
@@ -10,5 +10,6 @@
 │                                                          │
 │    Mode                                                  │
 │    (•) Stage    ( ) Apply immediately                    │
-│  tab/↑↓: fields · enter: submit · esc: cancel            │
+│  tab/↑↓: fields · enter: next · ctrl+s / shift+enter:    │
+│  submit · esc: cancel                                    │
 ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_TagStagedOnlyGolden.golden
+++ b/internal/tui/testdata/TestDialog_TagStagedOnlyGolden.golden
@@ -9,5 +9,6 @@
 │                                                          │
 │    Value                                                 │
 │    > (add only)                                          │
-│  tab/↑↓: fields · enter: submit · esc: cancel            │
+│  tab/↑↓: fields · enter: next · ctrl+s / shift+enter:    │
+│  submit · esc: cancel                                    │
 ╰──────────────────────────────────────────────────────────╯


### PR DESCRIPTION
Closes #790
Closes #791

## #790 — Esc discard guard (double-Esc to confirm on a dirty form)

Previously a partially-typed create/edit/tag form was discarded silently on Esc. Now:

- **Dirty detection.** Each form snapshots its seeded free-text values at construction (`initName`/`initValue`/… on the entry form; `initTagKey`/`initTagValue` on the tag form). A form is DIRTY when a text field diverges from that snapshot — for create, any non-empty field; for edit, a change from the loaded value/description; for tag, a typed Add key/value. The Type/Mode/action selects (which seed to sensible defaults and carry no typed data) are intentionally not counted.
- **The shell forwards Esc.** Esc is intercepted by the app shell (`m.keys.Back`), not the huh form, so a new optional `EscInterceptor` seam lets the entry/tag forms own Esc: when present, the shell forwards Esc into the dialog's `Update` (via the `dialogAdapter`) instead of bare-popping it.
- **Guard behavior.** A CLEAN form returns `CanceledMsg` on the first Esc (closes exactly as before). A DIRTY form arms on the first Esc — shows the inline notice `unsaved changes — press esc again to discard` and stays open — and discards only on the second **consecutive** Esc. Any other key/edit resets the armed state, so a later single Esc re-arms. The existing busy-guard (no Esc mid-apply) is preserved: the shell already suppresses Esc while `Busy()`.

## #791 — Value newline (Enter) + Shift+Enter / Ctrl+S submit

The Value field is a `huh.NewText` textarea, but Enter used to submit so newlines couldn't be entered. Now:

- **Enter inserts a newline in the Value textarea.** A custom huh keymap sets `Text.NewLine = enter`, `Text.Next = tab`, and `Text.Submit = shift+enter` — the last two are required to remove `enter` from huh's advance/submit bindings so Enter on a (possibly last-position) Value field inserts a newline rather than advancing/submitting. Single-line fields (name/namespace/description) keep huh's defaults, so Enter still advances (and submits from the last field).
- **Submit from any field.** huh can only submit from its last field, so submit is handled in the dialog itself: **`ctrl+s`** (portable, works everywhere) and **`shift+enter`** both submit from any field, including while the Value textarea is focused. The forced-submit path re-runs the same required-field validation huh would show inline (create name / tag Add key), so an empty required field is still blocked with a footer error instead of dead-ending on the provider write. **`ctrl+e` ($EDITOR)** is retained.
- **Keyboard enhancements enabled.** `App.View` now sets `view.KeyboardEnhancements.ReportAlternateKeys = true`. Bubble Tea v2 always requests basic key **disambiguation** alongside this, which is what makes `shift+enter` distinct from `enter` in a Kitty-protocol terminal. **Caveat:** terminals without the enhanced keyboard protocol (e.g. macOS Terminal.app) collapse `shift+enter` to `enter` and cannot distinguish it — so `ctrl+s` is the portable submit and `shift+enter` is the enhanced-terminal convenience.
- **Hints.** The entry/tag hint lines are updated (`… enter: newline · ctrl+s / shift+enter: submit · ctrl+e: $EDITOR · esc: cancel`) and now wrap to the fixed dialog width so the longer hint folds to a second line at the minimum size instead of overflowing the border.

## Tests / goldens

- **Unit (dialogs):** clean-form Esc cancels; dirty-form first Esc arms + shows the notice + stays, second Esc cancels, a keystroke between resets; Enter in the Value field inserts `\n`; single-line Enter neither newlines nor submits; `ctrl+s` and `shift+enter` (simulated with `ModShift`) submit and route through the mutator; forced submit still enforces required-name/required-key validation. Same guard + submit coverage on the tag form.
- **Unit (app):** the dirty-form Esc guard end-to-end through the shell — a dirty form's first Esc keeps it on the stack, the second closes it; a clean form closes on the first Esc.
- **Goldens:** the changed hint line regenerated the affected entry/tag dialog goldens (settled-FinalModel harness). No value was unmasked (the only seeded value is the edit form's own editable input surface, shown before and after).
- `go build ./...`, `go test ./internal/tui/...` and `-race -count=2` pass; `golangci-lint run --allow-parallel-runners ./internal/tui/...` reports 0 issues in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)