### PR TITLE
test(tui): raise golden finish-wait timeout 3s→10s to stop the apply-results flake (#796)

### DIFF
--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -570,7 +570,7 @@ func requireShellGolden(t *testing.T, m *App) {
 	tm := teatest.NewTestModel(t, m, teatest.WithInitialTermSize(goldenTermWidth, goldenTermHeight))
 
 	tm.Send(keyPress('q'))
-	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
+	tm.WaitFinished(t, teatest.WithFinalTimeout(10*time.Second))
 
 	out, err := io.ReadAll(tm.FinalOutput(t))
 	require.NoError(t, err)

--- a/internal/tui/browser_golden_test.go
+++ b/internal/tui/browser_golden_test.go
@@ -66,7 +66,7 @@ func captureUntil(t *testing.T, model tea.Model, marker string, width, height in
 func settledScreen(t *testing.T, tm *teatest.TestModel, width, height int) string {
 	t.Helper()
 
-	fm := tm.FinalModel(t, teatest.WithFinalTimeout(3*time.Second))
+	fm := tm.FinalModel(t, teatest.WithFinalTimeout(10*time.Second))
 
 	vm, ok := fm.(interface{ View() tea.View })
 	require.True(t, ok, "final model must render a tea.View")

--- a/internal/tui/dialog_golden_test.go
+++ b/internal/tui/dialog_golden_test.go
@@ -153,7 +153,7 @@ func captureDialogWithKeysSize(t *testing.T, host *dialogHost, marker string, w,
 
 	tm.Send(hostQuitMsg{})
 
-	fm := tm.FinalModel(t, teatest.WithFinalTimeout(3*time.Second))
+	fm := tm.FinalModel(t, teatest.WithFinalTimeout(10*time.Second))
 
 	final, ok := fm.(*dialogHost)
 	require.True(t, ok, "final model must be *dialogHost")

--- a/internal/tui/staging_golden_test.go
+++ b/internal/tui/staging_golden_test.go
@@ -368,7 +368,7 @@ func captureStaging(t *testing.T, m *App, marker string, valueView bool) string 
 func settledAppScreen(t *testing.T, tm *teatest.TestModel) string {
 	t.Helper()
 
-	fm := tm.FinalModel(t, teatest.WithFinalTimeout(3*time.Second))
+	fm := tm.FinalModel(t, teatest.WithFinalTimeout(10*time.Second))
 
 	app, ok := fm.(*App)
 	require.True(t, ok, "final model must be *App")

--- a/internal/tui/tagform_interaction_test.go
+++ b/internal/tui/tagform_interaction_test.go
@@ -113,7 +113,7 @@ func TestTUI_TagRemoveRoutesSelectedKey(t *testing.T) {
 	assert.True(t, staged, "the untag routes staged by default")
 
 	tm.Send(hostQuitMsg{})
-	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
+	tm.WaitFinished(t, teatest.WithFinalTimeout(10*time.Second))
 }
 
 // TestTUI_TagEmptyNeverOffersRemove drives the tag dialog for an entry with NO
@@ -154,5 +154,5 @@ func TestTUI_TagEmptyNeverOffersRemove(t *testing.T) {
 	assert.NotContains(t, out, "Remove tag", "the action toggle never reaches Remove")
 
 	tm.Send(hostQuitMsg{})
-	tm.WaitFinished(t, teatest.WithFinalTimeout(3*time.Second))
+	tm.WaitFinished(t, teatest.WithFinalTimeout(10*time.Second))
 }


### PR DESCRIPTION
The required `Unit Test` job intermittently failed on `TestStaging_ApplyResultsGolden` (and siblings): under parallel `-race` CI load the teatest `FinalModel`/`WaitFinished` 'program finished' wait timed out at 3s → partial capture → golden mismatch. The happy path finishes fast, so a bigger ceiling only adds headroom under load. Bumps all six finish-waits to 10s. No golden/render change. Addresses the required-gate half of #796 (the non-required gcloud/azure e2e CI timing is tracked separately with #786/#794 deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)