### PR TITLE
test(tui): de-flake teatest waits by matching the vt-rendered screen

### DIFF
--- a/e2e/aws_tui_test.go
+++ b/e2e/aws_tui_test.go
@@ -4,7 +4,7 @@
 package e2e_test
 
 import (
-	"bytes"
+	"strings"
 	"testing"
 	"time"
 
@@ -73,21 +73,26 @@ func newTUIModel(t *testing.T, service string) tea.Model {
 // keyRune builds a printable key press (matches the tui package's own helper).
 func keyRune(r rune) tea.KeyPressMsg { return tea.KeyPressMsg{Code: r, Text: string(r)} }
 
-// waitForScreen gates on marker appearing in the live output stream since the
-// last read, so navigation keys are only sent once the awaited async frame has
-// rendered.
+// waitForScreen gates on marker appearing in the RENDERED visible screen, so
+// navigation keys are only sent once the awaited async frame has rendered. It
+// renders the accumulated output through a cell-grid emulator rather than matching
+// the raw stream: CI emits incremental cell-updates that can split a marker across
+// cursor-positioned writes, so a raw bytes.Contains misses text the user plainly
+// sees (the same flake the internal/tui waitFor fixes).
 func waitForScreen(t *testing.T, tm *teatest.TestModel, marker string) {
 	t.Helper()
 
 	teatest.WaitFor(t, tm.Output(), func(b []byte) bool {
-		return bytes.Contains(b, []byte(marker))
+		return strings.Contains(renderTUIScreen(t, b), marker)
 	}, teatest.WithDuration(tuiWaitTimeout), teatest.WithCheckInterval(50*time.Millisecond))
 }
 
-// finalScreen quits the program and returns the settled final model's full
-// screen content. Rendering the settled View — not the live diff-frame stream —
-// is what makes the assertion deterministic (the tui package's golden harness
-// uses the same discipline for the same reason).
+// finalScreen quits the program and returns the settled final model's screen,
+// rendered through the cell-grid emulator so the returned string is the plain
+// visible screen (no interspersed styling that could split a marker mid-phrase).
+// Rendering the settled View — not the live diff-frame stream — is what makes the
+// assertion deterministic (the tui package's golden harness uses the same
+// discipline for the same reason).
 func finalScreen(t *testing.T, tm *teatest.TestModel) string {
 	t.Helper()
 
@@ -98,7 +103,7 @@ func finalScreen(t *testing.T, tm *teatest.TestModel) string {
 	vm, ok := fm.(interface{ View() tea.View })
 	require.True(t, ok, "final model must render a tea.View")
 
-	return vm.View().Content
+	return renderTUIScreen(t, []byte(vm.View().Content))
 }
 
 // TestTUIAWS_ParamBrowse seeds two SSM parameters and drives the TUI param

--- a/e2e/tui_render_test.go
+++ b/e2e/tui_render_test.go
@@ -1,0 +1,74 @@
+//go:build e2e
+
+package e2e_test
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/vt"
+)
+
+// renderE2EWidth/renderE2EHeight size the emulator the TUI e2e helpers render
+// into. They are larger than the tests' real terminal (120×34) so replaying a
+// stream drawn for that size never re-wraps a marker across lines: content is
+// placed at the columns it was drawn to and the extra blank columns/rows are
+// trimmed.
+const (
+	renderE2EWidth  = 240
+	renderE2EHeight = 80
+)
+
+// renderTUIScreen replays a captured teatest byte stream (or a settled model's
+// View().Content) through a cell-grid virtual terminal and returns the VISIBLE
+// SCREEN: rows joined by newline, trailing spaces and trailing blank rows trimmed.
+//
+// This mirrors the internal/tui golden harness (renderVisibleScreenSize) and
+// exists for the same reason: teatest captures the terminal's whole capability
+// handshake and CI emits incremental cell-updates, so a marker can be split across
+// cursor-positioned writes and the drawing bytes differ from a local run even when
+// the drawn frame is identical. A cell-grid emulator applies the drawing commands
+// and ignores the invisible probes, so matching against its screen captures exactly
+// what a user sees and is environment-independent.
+func renderTUIScreen(tb testing.TB, raw []byte) string {
+	tb.Helper()
+
+	e := vt.NewEmulator(renderE2EWidth, renderE2EHeight)
+
+	// Drain the emulator's reply pipe: capability queries make it write a response
+	// that would otherwise block forever with no reader. The responses touch no
+	// cell, so discarding them never perturbs the rendered screen.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		_, _ = io.Copy(io.Discard, e)
+	}()
+
+	// LNM (ESC[20h): a bare line feed also returns to column 0, matching how Bubble
+	// Tea stacks the top chrome rows with bare LFs.
+	_, _ = e.WriteString("\x1b[20h")
+
+	// Drop the alt-screen exit (ESC[?1049l): the captured stream ends by leaving the
+	// alt screen on quit, which would return to the blank primary buffer; without
+	// this the visible screen would be empty. (A settled View().Content contains no
+	// such sequence, so this is a harmless no-op there.)
+	_, _ = e.Write(bytes.ReplaceAll(raw, []byte("\x1b[?1049l"), nil))
+
+	screen := strings.TrimRight(e.String(), "\n")
+
+	// Shut down without racing the drain goroutine: closing the reply pipe makes the
+	// in-flight Read return EOF, so the goroutine has exited by the time <-done
+	// returns; only then is it safe to Close the emulator with no reader in flight.
+	if c, ok := e.InputPipe().(io.Closer); ok {
+		_ = c.Close()
+	}
+
+	<-done
+
+	_ = e.Close()
+
+	return screen
+}

--- a/internal/tui/staging_golden_test.go
+++ b/internal/tui/staging_golden_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -376,25 +377,41 @@ func settledAppScreen(t *testing.T, tm *teatest.TestModel) string {
 	return renderVisibleScreenSize(t, []byte(app.View().Content), browserTermWidth, browserTermHeight)
 }
 
-// waitFor drains the live output until marker appears (or the deadline). It only
-// gates on the async load having rendered; the golden is taken from the settled
-// FinalModel, not from this stream.
+// waitRenderWidth/waitRenderHeight size the emulator waitFor renders into. They
+// are deliberately larger than any test's real terminal (browser 120×34, dialogs
+// 100×30) so replaying a stream drawn for the smaller size never re-wraps a marker
+// across lines — content is placed at the columns it was drawn to, and the extra
+// blank columns/rows are trimmed. The golden itself is still captured at the real
+// size from the settled model.
+const (
+	waitRenderWidth  = 240
+	waitRenderHeight = 80
+)
+
+// waitFor drains the live output until marker appears in the RENDERED visible
+// screen (or the deadline). It matches against the vt-rendered screen — not the
+// raw output stream — because CI negotiates incremental cell-updates that can split
+// a marker across cursor-positioned writes (e.g. a redraw that keeps a shared
+// "Apply " prefix and rewrites only "results"), so a raw bytes.Contains misses text
+// the user plainly sees. Rendering through the same emulator the goldens use
+// rejoins the cells. It only gates on the async load having rendered; the golden is
+// taken from the settled FinalModel, not from this stream.
 func waitFor(t *testing.T, tm *teatest.TestModel, marker string) {
 	t.Helper()
 
 	var buf bytes.Buffer
 
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		_, _ = io.Copy(&buf, tm.Output())
-		if bytes.Contains(buf.Bytes(), []byte(marker)) {
+		if buf.Len() > 0 && strings.Contains(renderVisibleScreenSize(t, buf.Bytes(), waitRenderWidth, waitRenderHeight), marker) {
 			return
 		}
 
 		time.Sleep(20 * time.Millisecond)
 	}
 
-	require.Contains(t, buf.String(), marker, "content never rendered")
+	require.Contains(t, renderVisibleScreenSize(t, buf.Bytes(), waitRenderWidth, waitRenderHeight), marker, "content never rendered")
 }
 
 // TestStaging_ApplyConfirmGolden renders the apply confirmation dialog (target

--- a/internal/tui/tagform_interaction_test.go
+++ b/internal/tui/tagform_interaction_test.go
@@ -150,10 +150,12 @@ func TestTUI_TagEmptyNeverOffersRemove(t *testing.T) {
 	assert.False(t, add, "no tag write is submitted without a key")
 
 	// The dead-end note is never rendered, and the action never reaches Remove.
+	// Match against the vt-rendered screen (not the raw stream) so a marker split
+	// across incremental cell-updates cannot make a negative assertion pass falsely.
 	var buf bytes.Buffer
 
 	_, _ = io.Copy(&buf, tm.Output())
-	out := buf.String()
+	out := renderVisibleScreenSize(t, buf.Bytes(), waitRenderWidth, waitRenderHeight)
 	assert.NotContains(t, out, "(no tags to remove)", "the dead-end note is never shown")
 	assert.NotContains(t, out, "Remove tag", "the action toggle never reaches Remove")
 


### PR DESCRIPTION
## Problem

The teatest-driven TUI tests gate async renders by scanning the **raw output stream** for a marker (`bytes.Contains`). CI negotiates incremental cell-updates, so a redraw that preserves a shared prefix and rewrites only the tail — e.g. keeping `Apply ` and rewriting `results` — splits the marker across cursor-positioned writes. A raw match then misses text the user plainly sees, and the wait times out with `content never rendered`.

This is exactly what failed `TestStaging_ApplyResultsGolden` on #798's CI (the results view had fully rendered, down to `enter/esc: close`, but `Apply results` never appeared as a contiguous substring in the byte stream). Same latent flake sits under the AWS/gcloud/azure TUI e2e.

## Fix

Match against the **vt-rendered visible screen** — the same cell-grid emulator the goldens already use. Rendering rejoins the split cells and ignores the invisible capability probes, so the gate is environment-independent.

- **`internal/tui` `waitFor`** — render the accumulated stream through `renderVisibleScreenSize` into a generous 240×80 emulator (so a stream drawn for the smaller real terminal never re-wraps a marker across lines), and bump the deadline 5s→10s to match the finish-wait already raised in #797.
- **`e2e` `waitForScreen` / `finalScreen`** — render through a new `renderTUIScreen` helper (mirrors the internal/tui harness). `finalScreen` now returns the plain visible screen, so `assert.Contains` can't be defeated by styling interspersed mid-phrase.
- **tagform interaction** negative assertions render too, so a split marker can't make a `NotContains` pass falsely.

## Covers #786 / #794

The AWS, Google Cloud (#786), and Azure (#794) TUI e2e all drive through these **shared** `waitForScreen` / `finalScreen` helpers, so they inherit the fix — the pending PRs pick it up on rebase/merge with no per-PR change.

## Verification
- `internal/tui` suite green ×3 (incl. `TestStaging_ApplyResultsGolden`, `TestTUI_TagEmptyNeverOffersRemove`)
- `mise e2e-aws-tui` green against localstack (`ParamBrowse` / `SecretBrowse` / `StageApply`)
- `mise lint` 0 issues · `mise test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)