### PR TITLE
docs(readme): label build variants CLI/TUI (the TUI ships in every build)

### DIFF
--- a/.claude/skills/refresh-demo-gifs/SKILL.md
+++ b/.claude/skills/refresh-demo-gifs/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: refresh-demo-gifs
-description: Use when re-recording the CLI or GUI demo GIFs after a UI change or a user-visible CLI output change. Covers the record scripts, robust Playwright selectors, output-drift triggers, frame verification, and Git LFS.
+description: Use when re-recording the CLI, TUI, or GUI demo GIFs after a UI change or a user-visible output change. Covers the record scripts, robust Playwright selectors, output-drift triggers, frame verification, and Git LFS.
 ---
 
 # Refreshing the demo GIFs
 
-Two demos are recorded and committed as GIFs (PRs #619, #618, #61):
+The demos are recorded and committed as GIFs (PRs #619, #618, #61):
 
 - **CLI demo**: `demo/cli-demo.tape` recorded via `./demo/cli-record.sh` (vhs).
+- **TUI demo**: `demo/tui-demo.tape` recorded via `./demo/tui-record.sh` (vhs, same
+  terminal-recording path as the CLI demo — the TUI is pure Go, no browser).
 - **GUI demo**: `demo/gui-demo.spec.ts` recorded via `./demo/gui-record.sh`
   (Playwright-driven).
 

--- a/.github/templates/release-notes-downloads.md
+++ b/.github/templates/release-notes-downloads.md
@@ -37,7 +37,7 @@
 | x86_64 | [suve_${VERSION}_linux_amd64_webkit2_41.tar.gz](${BASE_URL}/suve_${VERSION}_linux_amd64_webkit2_41.tar.gz) | [suve_webkit2_41_${VERSION}-1_amd64.deb](${BASE_URL}/suve_webkit2_41_${VERSION}-1_amd64.deb) | [suve_webkit2_41-${VERSION}-1.x86_64.rpm](${BASE_URL}/suve_webkit2_41-${VERSION}-1.x86_64.rpm) |
 | ARM64 | [suve_${VERSION}_linux_arm64_webkit2_41.tar.gz](${BASE_URL}/suve_${VERSION}_linux_arm64_webkit2_41.tar.gz) | [suve_webkit2_41_${VERSION}-1_arm64.deb](${BASE_URL}/suve_webkit2_41_${VERSION}-1_arm64.deb) | [suve_webkit2_41-${VERSION}-1.aarch64.rpm](${BASE_URL}/suve_webkit2_41-${VERSION}-1.aarch64.rpm) |
 
-### Linux CLI-only (no dependencies)
+### Linux CLI/TUI-only (no dependencies)
 
 | Architecture | Tarball | Debian/Ubuntu | RHEL/Fedora |
 |--------------|---------|---------------|-------------|

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Load the matching skill under `.claude/skills/` before non-trivial work; each ho
 - **add-provider-adapter** — adding a cloud adapter (or a new service under one): the `Store` interface, SDK confinement, error mapping, version parsing, CLI/registry wiring, staging.
 - **add-e2e-emulator** — wiring an emulator-backed e2e seam: env gate, `compose.test.yaml` service, `mise e2e-<provider>` task, closed-network CI job, coverage upload.
 - **gui-change** — changing `internal/gui/**`: bindings-regenerate-then-rebuild rule, capability-driven UI, server-side guards, async-load checklist.
-- **refresh-demo-gifs** — re-recording CLI/GUI demo GIFs: record scripts, robust selectors, output-drift triggers, frame verification, Git LFS.
+- **refresh-demo-gifs** — re-recording CLI/TUI/GUI demo GIFs: record scripts, robust selectors, output-drift triggers, frame verification, Git LFS.
 - **bug-audit-epic** — running a codebase- or subsystem-wide bug audit: parallel investigators, adversarial verification, severity-grouped epic with linked sub-issues.
 - **bug-fix-pr** — turning one filed bug into a fix PR: reproduce, fix at the cited site, add regression tests at every layer, run gates.
 - **feature-epic-breakdown** — planning a multi-PR feature or cross-cutting refactor as a layer-ordered epic with standalone sub-issues.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A **Git-like CLI/TUI/GUI** for AWS Parameter Store / Secrets Manager, Google Clo
 - **Colored diff output**: Easy-to-read unified diff format
 - **Multi-cloud**: [AWS SSM Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) / [Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html), [Google Cloud Secret Manager](https://cloud.google.com/secret-manager/docs), and [Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/) / [App Configuration](https://learn.microsoft.com/en-us/azure/azure-app-configuration/)
 - **Secure staging**: Working staging state is encrypted at rest with a data key stored in the OS keychain (override with `SUVE_STAGING_KEY`). When no key is available (no keychain backend and no `SUVE_STAGING_KEY`), an interactive session falls back to plaintext with a warning, while a non-interactive one refuses to write unencrypted unless `SUVE_STAGING_ALLOW_PLAINTEXT` is set. Exported snapshot files carry a separately passphrase-encrypted payload ([Argon2](https://en.wikipedia.org/wiki/Argon2) + [AES-GCM](https://en.wikipedia.org/wiki/Galois/Counter_Mode); an empty passphrase writes plaintext).
-- **TUI mode**: Keyboard-driven terminal UI via `--tui` flag (built with [Bubble Tea](https://github.com/charmbracelet/bubbletea)); ships in every build, including the dependency-free CLI-only one
+- **TUI mode**: Keyboard-driven terminal UI via `--tui` flag (built with [Bubble Tea](https://github.com/charmbracelet/bubbletea)); ships in every build, including the dependency-free CLI/TUI-only one
 - **GUI mode**: Desktop application via `--gui` flag (built with [Wails](https://wails.io/))
 
 ### Metadata terminology
@@ -51,17 +51,17 @@ All key=value metadata is unified as **tags**; suve adds no per-provider command
 ## Installation
 
 > [!NOTE]
-> On Linux, `suve` requires GTK3 and WebKit2GTK for GUI support. Use the CLI-only version if you only need CLI functionality. The keyboard-driven **TUI (`--tui`) is pure Go and ships in every build**, including the CLI-only one — only the desktop **GUI (`--gui`)** needs the GTK3/WebKit2GTK dependencies.
+> On Linux, `suve` requires GTK3 and WebKit2GTK for GUI support. Use the CLI/TUI-only version if you don't need the desktop GUI. The keyboard-driven **TUI (`--tui`) is pure Go and ships in every build**, including the CLI/TUI-only one — only the desktop **GUI (`--gui`)** needs the GTK3/WebKit2GTK dependencies.
 
 ### Using [mise](https://mise.jdx.dev/) (macOS/Linux/Windows)
 
 suve is installable directly from GitHub Releases via mise's `github` backend — no extra registry required:
 
 ```bash
-# Full version (CLI + GUI)
+# Full version (CLI/TUI + GUI)
 mise use -g "github:mpyw/suve"
 
-# CLI-only version (no GUI dependencies, recommended for Linux. Not available on macOS/Windows)
+# CLI/TUI-only version (no GUI dependencies, recommended for Linux. Not available on macOS/Windows)
 mise use -g "github:mpyw/suve[matching=cli]"
 ```
 
@@ -80,15 +80,15 @@ suve is available in the [standard aqua registry](https://github.com/aquaproj/aq
 aqua g -i mpyw/suve
 ```
 
-The registry picks the right asset per platform automatically: the self-contained GUI build on macOS/Windows, and the dependency-free CLI-only static build on Linux (supported from v1.6.1).
+The registry picks the right asset per platform automatically: the self-contained GUI build on macOS/Windows, and the dependency-free CLI/TUI-only static build on Linux (supported from v1.6.1).
 
 ### Using [Homebrew](https://brew.sh/) (macOS/Linux)
 
 ```bash
-# Full version (CLI + GUI)
+# Full version (CLI/TUI + GUI)
 brew install mpyw/tap/suve
 
-# CLI-only version (no GUI dependencies, recommended for Linux)
+# CLI/TUI-only version (no GUI dependencies, recommended for Linux)
 brew install mpyw/tap/suve-cli
 ```
 
@@ -111,11 +111,11 @@ export VERSION=0.0.0
 export ARCH=amd64  # or arm64
 export WEBKIT_SUFFIX=""  # use "_webkit2_41" for Ubuntu 24.04+
 
-# CLI-only (recommended, no GUI dependencies)
+# CLI/TUI-only (recommended, no GUI dependencies)
 curl -LO "https://github.com/mpyw/suve/releases/download/v${VERSION}/suve-cli_${VERSION}-1_${ARCH}.deb"
 sudo dpkg -i "suve-cli_${VERSION}-1_${ARCH}.deb"
 
-# Full version (CLI + GUI, requires GTK3 and WebKit2GTK)
+# Full version (CLI/TUI + GUI, requires GTK3 and WebKit2GTK)
 curl -LO "https://github.com/mpyw/suve/releases/download/v${VERSION}/suve${WEBKIT_SUFFIX}_${VERSION}-1_${ARCH}.deb"
 sudo dpkg -i "suve${WEBKIT_SUFFIX}_${VERSION}-1_${ARCH}.deb"
 ```
@@ -129,11 +129,11 @@ export VERSION=0.0.0
 export ARCH=x86_64  # or aarch64
 export WEBKIT_SUFFIX=""  # use "_webkit2_41" for Fedora 40+
 
-# CLI-only (recommended, no GUI dependencies)
+# CLI/TUI-only (recommended, no GUI dependencies)
 curl -LO "https://github.com/mpyw/suve/releases/download/v${VERSION}/suve-cli-${VERSION}-1.${ARCH}.rpm"
 sudo rpm -i "suve-cli-${VERSION}-1.${ARCH}.rpm"
 
-# Full version (CLI + GUI, requires GTK3 and WebKit2GTK)
+# Full version (CLI/TUI + GUI, requires GTK3 and WebKit2GTK)
 curl -LO "https://github.com/mpyw/suve/releases/download/v${VERSION}/suve${WEBKIT_SUFFIX}-${VERSION}-1.${ARCH}.rpm"
 sudo rpm -i "suve${WEBKIT_SUFFIX}-${VERSION}-1.${ARCH}.rpm"
 ```
@@ -143,18 +143,18 @@ sudo rpm -i "suve${WEBKIT_SUFFIX}-${VERSION}-1.${ARCH}.rpm"
 </details>
 
 <details>
-<summary>Using <code>go install</code> (CLI only)</summary>
+<summary>Using <code>go install</code> (CLI/TUI only)</summary>
 
 ```bash
 go install github.com/mpyw/suve/cmd/suve@latest
 ```
 
-**Note:** `go install` builds CLI only. GUI requires pre-built assets that are not included in the Go module. For GUI support, use a [package manager](#installation) or [build from source](#building-from-source).
+**Note:** `go install` builds the CLI/TUI only. The desktop GUI requires pre-built assets that are not included in the Go module. For GUI support, use a [package manager](#installation) or [build from source](#building-from-source).
 
 </details>
 
 <details>
-<summary>Using <code>go tool</code> (CLI only, Go 1.25+)</summary>
+<summary>Using <code>go tool</code> (CLI/TUI only, Go 1.25+)</summary>
 
 ```bash
 # Add to go.mod as a tool dependency
@@ -178,14 +178,14 @@ git clone https://github.com/mpyw/suve.git
 cd suve
 ```
 
-**CLI only:**
+**CLI/TUI only:**
 
 ```bash
 mise build-cli
 # Binary: bin/suve
 ```
 
-**CLI + GUI** (requires [Wails CLI](https://wails.io/) and [Node.js](https://nodejs.org/)):
+**CLI/TUI + GUI** (requires [Wails CLI](https://wails.io/) and [Node.js](https://nodejs.org/)):
 
 ```bash
 go install github.com/wailsapp/wails/v2/cmd/wails@latest


### PR DESCRIPTION
The keyboard-driven **TUI (`--tui`)** is pure Go and ships in **every** build, including the dependency-free "CLI-only" one — only the desktop **GUI (`--gui`)** needs GTK3/WebKit2GTK. So the install/build variant labels that read `CLI + GUI` / `CLI-only` understated what the minimal build actually contains.

Relabel the human-facing variant names to **`CLI/TUI + GUI`** / **`CLI/TUI-only`** across the install and build sections:

- mise, aqua, Homebrew, `.deb`/`.rpm`, `go install` / `go tool`, and build-from-source
- prose in the install NOTE and the aqua asset-selection line

Unchanged: the aqua/brew package names, the `matching=cli` selector, release asset names — only the labels. Lines where the TUI is the *subject* (e.g. "the same staging store as the CLI/GUI") already read correctly and are left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)