### PR TITLE
fix(tui): real terminal cursor in the browser prefix/filter inputs

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -279,7 +279,7 @@ func (m *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case cursor.BlinkMsg:
 		// Swallow the embedded text inputs' virtual-cursor blink so the focused
 		// field's caret stays steadily rendered: the app draws the real terminal
-		// cursor at that caret (see App.View / dialogCursor), which it locates by the
+		// cursor at that caret (see App.View / screenCursor), which it locates by the
 		// field's steady virtual-cursor cell. Dropping the blink keeps that cell —
 		// and thus the caret position — present every frame instead of flickering
 		// off, and the real cursor still blinks natively (#765).
@@ -1077,10 +1077,12 @@ func (m *App) View() tea.View {
 	screen := m.render()
 	view.SetContent(screen)
 	// Set the real terminal cursor at the focused text field's caret so a visible
-	// caret is drawn there — the embedded huh form's virtual cursor alone does not
+	// caret is drawn there — a bubbles text input's virtual cursor alone does not
 	// surface one under AltScreen (#765). The caret is read from the composited
-	// screen we just built, so it tracks the field wherever the dialog is drawn.
-	view.Cursor = m.dialogCursor(screen)
+	// screen we just built, so it tracks the focused field wherever it is drawn: a
+	// dialog's input (create/edit/tag/restore) or a page's own (the browser's
+	// prefix/filter).
+	view.Cursor = m.screenCursor(screen)
 
 	return view
 }

--- a/internal/tui/cursor.go
+++ b/internal/tui/cursor.go
@@ -7,28 +7,26 @@ import (
 	"charm.land/lipgloss/v2"
 )
 
-// dialogCursor returns the real terminal cursor for the focused text field of an
-// open dialog, or nil when no dialog is open or none of its fields is a text
-// input. It takes the already-composited screen so the caret is read from the
-// exact frame the terminal will draw.
+// screenCursor returns the real terminal cursor for the focused text field
+// anywhere in the composited frame — an open dialog's field (create/edit/tag/
+// restore) OR a page's own input (the browser's prefix/filter) — or nil when no
+// text input is focused. It takes the already-composited screen so the caret is
+// read from the exact frame the terminal will draw.
 //
-// Why the app must drive the real cursor: the dialogs embed huh forms, whose
-// bubbles text inputs draw a *virtual* cursor (a reverse-video cell) into their
-// View string rather than exposing a caret position. That virtual cell does not
-// reliably surface a visible caret — it blinks itself off, and the app renders
-// under AltScreen with view.Cursor unset, which hides the real terminal cursor
-// entirely — so the user cannot see where they are typing (#765). huh v2 exposes
-// neither the caret position nor a real-cursor toggle, so the app instead locates
-// the caret directly in the composited screen: the focused text input paints a
-// steady reverse-video cell there (the app keeps it steady by swallowing the
-// blink; see App.Update), and nothing else in the TUI uses reverse video, so that
-// cell's screen position is the caret. Reading the final frame keeps the caret
-// correct regardless of where the dialog overlay is composited.
-func (m *App) dialogCursor(screen string) *tea.Cursor {
-	if len(m.dialogs) == 0 {
-		return nil
-	}
-
+// Why the app must drive the real cursor: the text fields are bubbles text inputs
+// (directly on a page, or embedded in a dialog's huh form), which draw a *virtual*
+// cursor (a reverse-video cell) into their View string rather than exposing a caret
+// position. That virtual cell does not reliably surface a visible caret — it blinks
+// itself off, and the app renders under AltScreen with view.Cursor unset, which
+// hides the real terminal cursor entirely — so the user cannot see where they are
+// typing (#765). Neither bubbles nor huh v2 exposes the caret position or a
+// real-cursor toggle, so the app instead locates the caret directly in the
+// composited screen: the focused text input paints a steady reverse-video cell
+// there (the app keeps it steady by swallowing the blink; see App.Update), and
+// nothing else in the TUI uses reverse video, so that cell's screen position is the
+// caret. Only one text input is ever focused at once (a dialog is modal, so the
+// page underneath is not in an edit field), so a single scan is unambiguous.
+func (m *App) screenCursor(screen string) *tea.Cursor {
 	col, row, ok := cursorCellPos(screen)
 	if !ok {
 		return nil

--- a/internal/tui/cursor_test.go
+++ b/internal/tui/cursor_test.go
@@ -197,6 +197,44 @@ func TestAppCursor_TagKey(t *testing.T) {
 	requireCaretOnScreen(t, m)
 }
 
+// TestAppCursor_BrowserFilter pins that a page's own text input — not just a
+// dialog field — gets the real terminal cursor: focusing the browser's filter and
+// typing draws the caret at the insertion point (#765 parity for page inputs).
+func TestAppCursor_BrowserFilter(t *testing.T) {
+	t.Parallel()
+
+	m := newApp(config{
+		scope:     provider.Scope{Provider: provider.ProviderAWS},
+		identity:  awsIdentityFixture(),
+		sourceFor: sourceForShape("param", awsParamSource(), nil),
+	})
+	m = updateApp(t, m, tea.WindowSizeMsg{Width: browserTermWidth, Height: browserTermHeight})
+
+	m = updateApp(t, m, typeKey('/')) // browser: focus the filter input
+	require.True(t, m.activePageCapturesInput(), "the filter input is focused")
+
+	m = updateApp(t, m, typeKey('a'))
+	requireCaretOnScreen(t, m)
+}
+
+// TestAppCursor_BrowserPrefix pins the same for the browser's prefix input.
+func TestAppCursor_BrowserPrefix(t *testing.T) {
+	t.Parallel()
+
+	m := newApp(config{
+		scope:     provider.Scope{Provider: provider.ProviderAWS},
+		identity:  awsIdentityFixture(),
+		sourceFor: sourceForShape("param", awsParamSource(), nil),
+	})
+	m = updateApp(t, m, tea.WindowSizeMsg{Width: browserTermWidth, Height: browserTermHeight})
+
+	m = updateApp(t, m, typeKey('p')) // browser: focus the prefix input
+	require.True(t, m.activePageCapturesInput(), "the prefix input is focused")
+
+	m = updateApp(t, m, typeKey('x'))
+	requireCaretOnScreen(t, m)
+}
+
 func TestAppCursor_NoneWhenNoTextField(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/pages/browser/view.go
+++ b/internal/tui/pages/browser/view.go
@@ -479,11 +479,21 @@ func fieldLine(st styles.Styles, label, value string, width int) string {
 	return clip(st.FieldLabel.Render(padded)+" "+value, width)
 }
 
-// fieldValue renders a header input's value, showing a placeholder and a cursor
-// when focused.
+// caretCell is the focused header input's caret: a single reverse-video cell. The
+// app's screenCursor locates the caret by the sole reverse-video cell in the
+// composited frame and draws the REAL terminal cursor there (the #765 caret the
+// dialogs already get), so the caret must be reverse video — a plain glyph would
+// render no real cursor. It is always painted while focused (no blink dependency),
+// so the cursor never flickers off.
+//
+//nolint:gochecknoglobals // immutable rendered caret cell
+var caretCell = lipgloss.NewStyle().Reverse(true).Render(" ")
+
+// fieldValue renders a header input's value, showing a placeholder when empty and
+// the reverse-video caret when focused.
 func fieldValue(value string, focused bool) string {
 	if focused {
-		return value + "▎"
+		return value + caretCell
 	}
 
 	if value == "" {


### PR DESCRIPTION
## Bug

In the browser, editing the **prefix** or **filter** field showed no real terminal cursor — only a static `▎` glyph. Unlike the dialog fields (which got the real caret in #765), the page inputs left the terminal cursor hidden under AltScreen.

## Root cause

The browser renders its header inputs by hand — `fieldValue` appended a literal `▎` — instead of a reverse-video cell. The app locates the caret by scanning the composited frame for the **sole reverse-video cell** and draws the real terminal cursor there; a plain glyph is invisible to that scan, and the dialog-only gate in `dialogCursor` meant page inputs were never even considered.

## Fix

- `fieldValue` paints the caret as a **reverse-video cell** (always while focused — no blink dependency), so it is picked up by the caret scan and shows a steady block plus the real blinking cursor.
- Generalize `dialogCursor` → `screenCursor`: drop the `len(m.dialogs)==0` gate so the real cursor is placed for **any** focused text input in the frame — a dialog field or a page's own. Only one input is ever focused at a time (a dialog is modal), so the single scan stays unambiguous.

The browser is the only page with text inputs, so this closes the gap everywhere (investigated: `grep` for page-level `textinput` finds only prefix/filter).

## Tests
- `TestAppCursor_BrowserFilter` / `TestAppCursor_BrowserPrefix` assert the real cursor lands on the drawn caret cell (same `requireCaretOnScreen` proof the dialog cursor tests use).

Gates: `mise test` ✅ · `mise lint` 0 issues ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)