### PR TITLE
fix(tui): draw the browser prefix/filter caret at the cursor position

### DIFF
--- a/internal/tui/cursor_test.go
+++ b/internal/tui/cursor_test.go
@@ -236,6 +236,33 @@ func TestAppCursor_BrowserPrefix(t *testing.T) {
 	requireCaretOnScreen(t, m)
 }
 
+// TestAppCursor_BrowserFilterTracksArrows pins that the caret follows the input's
+// cursor position: after typing, ← moves the drawn caret (and the real terminal
+// cursor) one cell left instead of leaving it pinned to the end.
+func TestAppCursor_BrowserFilterTracksArrows(t *testing.T) {
+	t.Parallel()
+
+	m := newApp(config{
+		scope:     provider.Scope{Provider: provider.ProviderAWS},
+		identity:  awsIdentityFixture(),
+		sourceFor: sourceForShape("param", awsParamSource(), nil),
+	})
+	m = updateApp(t, m, tea.WindowSizeMsg{Width: browserTermWidth, Height: browserTermHeight})
+
+	m = updateApp(t, m, typeKey('/'))
+	for _, r := range "abc" {
+		m = updateApp(t, m, typeKey(r))
+	}
+
+	end := requireCaretOnScreen(t, m)
+
+	m = updateApp(t, m, tea.KeyPressMsg{Code: tea.KeyLeft})
+	left := requireCaretOnScreen(t, m)
+
+	assert.Equal(t, end.Y, left.Y, "← keeps the caret on the same row")
+	assert.Equal(t, end.X-1, left.X, "← moves the caret one cell left of the end")
+}
+
 func TestAppCursor_NoneWhenNoTextField(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/pages/browser/view.go
+++ b/internal/tui/pages/browser/view.go
@@ -76,9 +76,9 @@ func (m *Model) renderHeader(width int) (string, []headerSeg) {
 	}
 
 	pieces = append(pieces,
-		piece{m.styles.FieldLabel.Render("prefix: ") + fieldValue(m.prefix.Value(), m.focus == focusPrefix), regionPrefix},
+		piece{m.styles.FieldLabel.Render("prefix: ") + fieldValue(m.prefix.Value(), m.prefix.Position(), m.focus == focusPrefix), regionPrefix},
 		piece{headerSep, ""},
-		piece{m.styles.FieldLabel.Render("filter: ") + fieldValue(m.filter.Value(), m.focus == focusFilter), regionFilter},
+		piece{m.styles.FieldLabel.Render("filter: ") + fieldValue(m.filter.Value(), m.filter.Position(), m.focus == focusFilter), regionFilter},
 		piece{headerSep, ""},
 		piece{toggle(m.styles, "values", m.valuesOn), regionValues},
 	)
@@ -479,28 +479,39 @@ func fieldLine(st styles.Styles, label, value string, width int) string {
 	return clip(st.FieldLabel.Render(padded)+" "+value, width)
 }
 
-// caretCell is the focused header input's caret: a single reverse-video cell. The
+// caretStyle draws the focused header input's caret as a reverse-video cell. The
 // app's screenCursor locates the caret by the sole reverse-video cell in the
 // composited frame and draws the REAL terminal cursor there (the #765 caret the
 // dialogs already get), so the caret must be reverse video — a plain glyph would
 // render no real cursor. It is always painted while focused (no blink dependency),
 // so the cursor never flickers off.
 //
-//nolint:gochecknoglobals // immutable rendered caret cell
-var caretCell = lipgloss.NewStyle().Reverse(true).Render(" ")
+//nolint:gochecknoglobals // immutable caret style
+var caretStyle = lipgloss.NewStyle().Reverse(true)
 
-// fieldValue renders a header input's value, showing a placeholder when empty and
-// the reverse-video caret when focused.
-func fieldValue(value string, focused bool) string {
-	if focused {
-		return value + caretCell
+// fieldValue renders a header input's value, showing a placeholder when empty and,
+// when focused, the reverse-video caret AT the input's cursor position (pos, a rune
+// index) — reversing the character under the caret, or a trailing space when the
+// caret is past the end — so ←/→ movement within the text is reflected instead of
+// the caret being pinned to the end.
+func fieldValue(value string, pos int, focused bool) string {
+	if !focused {
+		if value == "" {
+			return "—"
+		}
+
+		return value
 	}
 
-	if value == "" {
-		return "—"
+	runes := []rune(value)
+	pos = max(0, min(pos, len(runes)))
+
+	before := string(runes[:pos])
+	if pos == len(runes) {
+		return before + caretStyle.Render(" ")
 	}
 
-	return value
+	return before + caretStyle.Render(string(runes[pos])) + string(runes[pos+1:])
 }
 
 // toggle renders an "name:on/off" toggle chip.


### PR DESCRIPTION
Follow-up to #802. The header inputs drew the caret pinned to the **end** of the value, so pressing ←/→ moved the underlying input cursor but not the visible caret (nor the real terminal cursor) — it stayed stuck at the end.

`fieldValue` now renders the reverse-video caret **at the input's cursor position** (`textinput.Position()`), reversing the character under the caret (or a trailing space when past the end), so horizontal movement is reflected.

Adds `TestAppCursor_BrowserFilterTracksArrows` (type, then ← moves the caret one cell left).

Gates: `mise test` ✅ · `mise lint` 0 issues ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)