### PR TITLE
feat(tui): Tab/OK submit, ctrl+o editor, multi-line Description

### DIFF
--- a/internal/tui/dialogs/dialogs_test.go
+++ b/internal/tui/dialogs/dialogs_test.go
@@ -777,6 +777,21 @@ func TestEntryForm_NameValidatorRequired(t *testing.T) {
 	require.NoError(t, d.nameValidator()("/app/X"), "a non-empty name passes")
 }
 
+// TestEntryFormTheme_OKButtonInvertsOnFocus pins that the "[ OK ]" button is
+// reverse-video only while focused: huh's single-affirmative Confirm always renders
+// the affirmative with the group's FocusedButton, so the focus cue must live in the
+// focused-vs-blurred button styles. Reverse (no hard-coded colors) reads in both
+// light and dark terminals.
+func TestEntryFormTheme_OKButtonInvertsOnFocus(t *testing.T) {
+	t.Parallel()
+
+	for _, dark := range []bool{true, false} {
+		s := entryFormTheme().Theme(dark)
+		assert.True(t, s.Focused.FocusedButton.GetReverse(), "the focused OK button inverts (dark=%v)", dark)
+		assert.False(t, s.Blurred.FocusedButton.GetReverse(), "the blurred OK button is plain (dark=%v)", dark)
+	}
+}
+
 // TestFormKeyMap_MultilineBindings pins the multi-line field key contract: Enter
 // inserts a newline (never next/submit), Tab advances to the next field, and the
 // field never submits on its own — the form is completed from the "[ OK ]" button,

--- a/internal/tui/dialogs/dialogs_test.go
+++ b/internal/tui/dialogs/dialogs_test.go
@@ -777,21 +777,20 @@ func TestEntryForm_NameValidatorRequired(t *testing.T) {
 	require.NoError(t, d.nameValidator()("/app/X"), "a non-empty name passes")
 }
 
-// TestFormKeyMap_ValueDoneBindings pins the Value textarea's key contract: Enter
-// inserts a newline (so it cannot double as next/submit), while ctrl+s ("done")
-// confirms the value — advancing to the next field (Next) and, on the last field,
-// completing the form (Submit). This is what stops ctrl+s from skipping the field
-// below the value (e.g. Description).
-func TestFormKeyMap_ValueDoneBindings(t *testing.T) {
+// TestFormKeyMap_MultilineBindings pins the multi-line field key contract: Enter
+// inserts a newline (never next/submit), Tab advances to the next field, and the
+// field never submits on its own — the form is completed from the "[ OK ]" button,
+// so a multi-line field is never the last field and its Submit is disabled.
+func TestFormKeyMap_MultilineBindings(t *testing.T) {
 	t.Parallel()
 
 	km := formKeyMap()
-	ctrlS := tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl}
+	tab := tea.KeyPressMsg{Code: tea.KeyTab}
 
 	assert.True(t, key.Matches(keyEnter(), km.Text.NewLine), "enter inserts a newline")
-	assert.False(t, key.Matches(keyEnter(), km.Text.Submit), "enter never submits the textarea")
-	assert.True(t, key.Matches(ctrlS, km.Text.Next), "ctrl+s advances to the next field")
-	assert.True(t, key.Matches(ctrlS, km.Text.Submit), "ctrl+s completes the form from the last field")
+	assert.True(t, key.Matches(tab, km.Text.Next), "tab advances to the next field")
+	assert.False(t, key.Matches(keyEnter(), km.Text.Next), "enter does not advance (it inserts a newline)")
+	assert.False(t, key.Matches(keyEnter(), km.Text.Submit), "a multi-line field never submits on enter")
 }
 
 // TestDeleteConfirm_ForceRecoveryGating pins that force/recovery rows appear only

--- a/internal/tui/dialogs/entryform.go
+++ b/internal/tui/dialogs/entryform.go
@@ -263,7 +263,8 @@ func (d *entryForm) rebuildForm() tea.Cmd {
 		WithWidth(dialogContentWidth).
 		WithShowHelp(false).
 		WithShowErrors(true).
-		WithKeyMap(formKeyMap())
+		WithKeyMap(formKeyMap()).
+		WithTheme(entryFormTheme())
 
 	// Init the (re)built form, then immediately cap its body to the known
 	// terminal size so a retry after an error — or the initial build once the
@@ -288,6 +289,25 @@ func formKeyMap() *huh.KeyMap {
 	km.Text.Submit = key.NewBinding(key.WithDisabled())
 
 	return km
+}
+
+// entryFormTheme is huh's default (Charm) theme with only the "[ OK ]" button
+// restyled so it inverts ONLY while focused. huh's single-affirmative Confirm
+// always renders the affirmative with the field group's FocusedButton, and the
+// default theme copies Blurred = Focused, so the button never changed on focus (you
+// could not tell it was selected). Overriding the focused button to reverse-video
+// and the blurred one to plain gives the single-button form a clear focus cue. It
+// uses Reverse (no hard-coded colors), so it swaps whatever fg/bg is in effect and
+// reads well in both light and dark terminals; ThemeCharm(isDark) still supplies
+// every other style, so the rest of the form is unchanged.
+func entryFormTheme() huh.Theme {
+	return huh.ThemeFunc(func(isDark bool) *huh.Styles {
+		s := huh.ThemeCharm(isDark)
+		s.Focused.FocusedButton = lipgloss.NewStyle().Reverse(true).Padding(0, 1)
+		s.Blurred.FocusedButton = lipgloss.NewStyle().Padding(0, 1)
+
+		return s
+	})
 }
 
 // syncFormSize re-caps the embedded form's scrollable body to the current
@@ -712,10 +732,10 @@ func (d *entryForm) footer() string {
 // fields Enter also advances.
 func entryHint(onMultiline bool) string {
 	if onMultiline {
-		return "tab: fields · enter: newline · ctrl+o: $EDITOR · [OK]: submit · esc: cancel"
+		return "tab/shift+tab: fields · enter: newline · ctrl+o: $EDITOR · esc: cancel"
 	}
 
-	return "tab: fields · enter: next · [OK]: submit · esc: cancel"
+	return "tab/shift+tab: fields · enter: next · esc: cancel"
 }
 
 // namespaceDisplay renders a namespace for the read-only edit note, showing the

--- a/internal/tui/dialogs/entryform.go
+++ b/internal/tui/dialogs/entryform.go
@@ -48,10 +48,21 @@ type editorFinishedMsg struct {
 	err     error
 }
 
-// ctrlEKey is the value-field $EDITOR handoff binding.
+// Field keys for the two multi-line fields, shared by rebuildForm and the $EDITOR
+// handoff so it knows which field it is editing.
+const (
+	fieldKeyValue       = "value"
+	fieldKeyDescription = "description"
+)
+
+// editorKey is the value-field $EDITOR handoff binding. It is ctrl+o ("open"), not
+// ctrl+e: bubbles text inputs bind ctrl+e to end-of-line (readline), so ctrl+e here
+// would shadow that motion inside the Value textarea; ctrl+o is unbound by the text
+// input and is a portable control character (unlike ctrl+. and friends, which only
+// enhanced-keyboard terminals report).
 //
 //nolint:gochecknoglobals // immutable dialog-local binding
-var ctrlEKey = key.NewBinding(key.WithKeys("ctrl+e"))
+var editorKey = key.NewBinding(key.WithKeys("ctrl+o"))
 
 // entryForm is the create/edit dialog. It embeds a huh form (name, type,
 // namespace, value, description, mode) as a model and adds a $EDITOR handoff on
@@ -98,6 +109,16 @@ type entryForm struct {
 	armed bool
 
 	form *huh.Form
+	// confirmOK backs the final "[ OK ]" submit button (a single-affirmative huh
+	// Confirm): the user tabs to it and presses Enter to complete the form, so a
+	// multi-line Value/Description (where Enter inserts a newline) has an explicit,
+	// visible way out. The bool itself is inert — the single OK button always
+	// completes; Esc cancels.
+	confirmOK bool
+	// editorField records which multi-line field ("value"/"description") the $EDITOR
+	// handoff is editing, so onEditorFinished writes the returned buffer back to the
+	// right one.
+	editorField string
 
 	// confirming/confirm drive the Stage/Apply popup shown before the write
 	// commits (replacing the old inline Mode toggle). While confirming is true the
@@ -217,21 +238,26 @@ func (d *entryForm) rebuildForm() tea.Cmd {
 			Options(huh.NewOptions(paramtype.Options()...)...).Value(&d.valueType))
 	}
 
-	fields = append(fields, huh.NewText().Key("value").Title("Value").Lines(4). //nolint:mnd // value textarea height
-											ExternalEditor(false).Value(&d.value))
+	fields = append(fields, huh.NewText().Key(fieldKeyValue).Title("Value").Lines(4). //nolint:mnd // value textarea height
+												ExternalEditor(false).Value(&d.value))
 
-	// Description is AWS-only: the gcloud, Azure Key Vault, and App Configuration
-	// writers ignore it (and the GUI never offers it), so it is shown only for a
-	// service that honors it.
+	// Description is a free-text field the AWS (Parameter Store + Secrets Manager)
+	// and Google Cloud (stored as the description annotation) writers honor; Azure
+	// has no description concept, so it is shown only for a service that supports it.
+	// It is multi-line like Value (both back onto free-text that accepts newlines),
+	// with the same ctrl+o $EDITOR handoff.
 	if d.svcCap.HasDescription {
-		fields = append(fields, huh.NewInput().Key("description").Title("Description").
-			Placeholder("(optional)").Value(&d.description))
+		fields = append(fields, huh.NewText().Key(fieldKeyDescription).Title("Description").Lines(3). //nolint:mnd // description textarea height
+														ExternalEditor(false).Placeholder("(optional)").Value(&d.description))
 	}
 
-	// The Stage/Apply choice is no longer an inline field: it is the mode-confirm
-	// popup opened on submit (see beginSubmit), so the choice is always an explicit,
-	// visible step. The popup is skipped when there is no genuine choice (a service
-	// without staging, or a staged-only surface — both submit directly).
+	// The final "[ OK ]" button completes the form. With multi-line Value/Description
+	// fields (Enter inserts a newline), Tab walks to this button and Enter submits —
+	// an explicit, visible way out that does not collide with in-field newlines. A
+	// single-affirmative Confirm renders just the button; Esc still cancels. The
+	// Stage/Apply choice is the mode-confirm popup opened after completion (see
+	// beginSubmit), not an inline field.
+	fields = append(fields, huh.NewConfirm().Key("ok").Affirmative("OK").Negative("").Value(&d.confirmOK))
 
 	d.form = huh.NewForm(huh.NewGroup(fields...)).
 		WithWidth(dialogContentWidth).
@@ -246,19 +272,20 @@ func (d *entryForm) rebuildForm() tea.Cmd {
 }
 
 // formKeyMap is the huh keymap the create/edit form uses so the multi-line Value
-// textarea can hold newlines (#791): in a huh Text field Enter inserts a newline
-// (NewLine), so it cannot double as "next field". Instead ctrl+s (and Tab) confirm
-// the value and advance to the next field — or, on the last field, complete the
-// form — via huh's own field navigation (Next fires on a non-last field, Submit on
-// the last one; ctrl+s is bound to both). This is why ctrl+s no longer needs to be
-// a dialog-level force-submit: confirming the value simply advances to the field
-// below (e.g. Description) instead of skipping it. Every single-line field keeps
-// huh's defaults, so Enter advances there and completes the form from the last one.
+// and Description fields can hold newlines (#791): in a huh Text field Enter inserts
+// a newline (NewLine), so it cannot double as "next field". Tab advances between
+// fields, and the form is completed from the final "[ OK ]" button (Enter) — never
+// from a text field, so a multi-line field's Submit is disabled and Enter there only
+// ever inserts a newline. Every single-line field keeps huh's defaults, so Enter
+// advances there. (No dialog-level submit key: ctrl+s was terminal XOFF and is gone;
+// the caret motions ctrl+a/ctrl+e now stay with the text input.)
 func formKeyMap() *huh.KeyMap {
 	km := huh.NewDefaultKeyMap()
 	km.Text.NewLine = key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "new line"))
-	km.Text.Next = key.NewBinding(key.WithKeys("tab", "ctrl+s"), key.WithHelp("ctrl+s", "done"))
-	km.Text.Submit = key.NewBinding(key.WithKeys("ctrl+s"), key.WithHelp("ctrl+s", "done"))
+	km.Text.Next = key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "next"))
+	// A multi-line field is never the last field (the OK button is), so its Submit
+	// never fires; disable it so Enter there only ever inserts a newline.
+	km.Text.Submit = key.NewBinding(key.WithDisabled())
 
 	return km
 }
@@ -338,12 +365,9 @@ func (d *entryForm) Update(msg tea.Msg) (Model, tea.Cmd) {
 		// re-arms (a stray Esc after typing does not silently discard).
 		d.disarm()
 
-		if key.Matches(msg, ctrlEKey) && d.valueFieldFocused() {
+		if key.Matches(msg, editorKey) && d.multilineFieldKey() != "" {
 			return d, d.openEditor()
 		}
-		// ctrl+s is not handled here: it is a huh keymap binding on the Value field
-		// (confirm the value and advance/complete), so it flows through to the form
-		// below like any other field key.
 	}
 
 	if d.busy {
@@ -390,11 +414,10 @@ func (d *entryForm) disarm() {
 }
 
 // beginSubmit is the submit path, reached when the huh form completes (Enter on the
-// last single-line field, or ctrl+s on the last field / the Value textarea when it
-// is last). It opens the Stage/Apply popup when the service offers a genuine choice,
-// otherwise runs the write directly (a service without staging, or a staged-only
-// surface — both have a single fixed mode). huh has already validated every field
-// by the time the form completes, so no re-validation is needed here.
+// "[ OK ]" button). It opens the Stage/Apply popup when the service offers a genuine
+// choice, otherwise runs the write directly (a service without staging, or a
+// staged-only surface — both have a single fixed mode). huh has already validated
+// every field by the time the form completes, so no re-validation is needed here.
 func (d *entryForm) beginSubmit() (Model, tea.Cmd) {
 	d.err = ""
 	d.notice = ""
@@ -455,8 +478,8 @@ func (d *entryForm) forwardToForm(msg tea.Msg) (Model, tea.Cmd) {
 
 	switch d.form.State {
 	case huh.StateCompleted:
-		// Reaching the last single-line field and pressing Enter completes the huh
-		// form; route that through the same Stage/Apply popup as ctrl+s.
+		// Enter on the final "[ OK ]" button completes the form; route it through the
+		// Stage/Apply popup (or a direct write when there is no choice).
 		return d.beginSubmit()
 	case huh.StateAborted:
 		return d, canceledCmd
@@ -466,12 +489,21 @@ func (d *entryForm) forwardToForm(msg tea.Msg) (Model, tea.Cmd) {
 	return d, cmd
 }
 
-// valueFieldFocused reports whether the huh value textarea currently has focus,
-// so ctrl+e is intercepted only there.
-func (d *entryForm) valueFieldFocused() bool {
+// multilineFieldKey returns the key of the focused multi-line field ("value" or
+// "description"), or "" when neither is focused — so the ctrl+o $EDITOR handoff is
+// intercepted only on a multi-line field and knows which one to edit.
+func (d *entryForm) multilineFieldKey() string {
 	f := d.form.GetFocusedField()
+	if f == nil {
+		return ""
+	}
 
-	return f != nil && f.GetKey() == "value"
+	switch f.GetKey() {
+	case fieldKeyValue, fieldKeyDescription:
+		return f.GetKey()
+	default:
+		return ""
+	}
 }
 
 // submit runs the create/edit mutation off the update loop.
@@ -518,11 +550,12 @@ func (d *entryForm) onResult(msg mutationResultMsg) (Model, tea.Cmd) {
 	return d, doneCmd(d.service, status, d.staged)
 }
 
-// openEditor writes the current value to a temp file and hands off to the user's
-// editor. The editor command is built by the shared internal/cli/editor helper,
-// so the TUI and the CLI resolve VISUAL→EDITOR, honor a flag-bearing or
-// space-containing editor path, and pick the same OS fallback — they cannot
-// diverge.
+// openEditor writes the focused multi-line field's current text to a temp file and
+// hands off to the user's editor, recording which field (value/description) so the
+// result is folded back into the right one. The editor command is built by the
+// shared internal/cli/editor helper, so the TUI and the CLI resolve VISUAL→EDITOR,
+// honor a flag-bearing or space-containing editor path, and pick the same OS
+// fallback — they cannot diverge.
 func (d *entryForm) openEditor() tea.Cmd {
 	if !isTTY() {
 		d.notice = "editor needs a TTY."
@@ -530,7 +563,12 @@ func (d *entryForm) openEditor() tea.Cmd {
 		return d.syncFormSize()
 	}
 
+	d.editorField = d.multilineFieldKey()
+
 	buffer := d.value
+	if d.editorField == fieldKeyDescription {
+		buffer = d.description
+	}
 
 	tmp, err := os.CreateTemp("", "suve-tui-*.txt")
 	if err != nil {
@@ -566,10 +604,10 @@ func (d *entryForm) openEditor() tea.Cmd {
 	})
 }
 
-// onEditorFinished folds the editor buffer back into the value field: an
-// unchanged buffer is a no-op ("No changes made."), otherwise the new content
-// replaces the textarea's value and the form is rebuilt so the huh textarea
-// buffer re-syncs (mirroring every other path).
+// onEditorFinished folds the editor buffer back into the field it was launched from
+// (value/description): an unchanged buffer is a no-op ("No changes made."),
+// otherwise the new content replaces that field and the form is rebuilt so the huh
+// textarea buffer re-syncs (mirroring every other path).
 func (d *entryForm) onEditorFinished(msg editorFinishedMsg) (Model, tea.Cmd) {
 	if msg.err != nil {
 		d.notice = "editor error: " + msg.err.Error()
@@ -577,23 +615,28 @@ func (d *entryForm) onEditorFinished(msg editorFinishedMsg) (Model, tea.Cmd) {
 		return d, d.syncFormSize()
 	}
 
+	// before holds the pre-edit buffer that was written to the tmpfile.
+	before := &d.value
+	if d.editorField == fieldKeyDescription {
+		before = &d.description
+	}
+
 	// Most editors auto-append a trailing newline; normalize it away with the same
 	// round-trip-lossless rule the CLI uses, so an untouched round-trip is
-	// byte-identical to the seed value and correctly reported as a no-op (instead
-	// of silently mutating the value with a stray newline). d.value still holds the
-	// pre-edit buffer that was written to the tmpfile.
-	content := editor.Normalize(d.value, msg.content)
+	// byte-identical to the seed and correctly reported as a no-op (instead of
+	// silently mutating the field with a stray newline).
+	content := editor.Normalize(*before, msg.content)
 
-	if content == d.value {
+	if content == *before {
 		d.notice = "No changes made."
 
 		return d, d.syncFormSize()
 	}
 
-	d.value = content
+	*before = content
 	d.notice = "Loaded from editor."
 
-	// Rebuild so the huh textarea re-binds to the edited value (consistent with
+	// Rebuild so the huh textarea re-binds to the edited field (consistent with
 	// every other value-changing path; avoids a stale textarea buffer).
 	return d, d.rebuildForm()
 }
@@ -641,7 +684,7 @@ func (d *entryForm) footer() string {
 	// Wrap the hint to the dialog's fixed content width so the (now longer, #791)
 	// key hint stays inside the box — folding to a second line at the minimum size
 	// — instead of overflowing the border, and the box keeps the form's width.
-	hint := d.styles.PageHint.Width(dialogContentWidth).Render(entryHint(d.valueFieldFocused()))
+	hint := d.styles.PageHint.Width(dialogContentWidth).Render(entryHint(d.multilineFieldKey() != ""))
 	// Reserve the frame around the footer (title, spacer, the form's minimum body,
 	// the hint); the error then the notice each take what remains, so the form
 	// body never drops below minFormBody and the whole dialog fits.
@@ -663,16 +706,16 @@ func (d *entryForm) footer() string {
 	return strings.Join(parts, "\n")
 }
 
-// entryHint is the bottom hint line. While the Value textarea is focused Enter
-// inserts a newline, so ctrl+s ("done") confirms the value and advances to the next
-// field (or completes the form on the last field); ctrl+e hands off to $EDITOR. On
-// the single-line fields Enter advances and completes the form from the last one.
-func entryHint(onValue bool) string {
-	if onValue {
-		return "tab/↑↓: fields · enter: newline · ctrl+s: done · ctrl+e: $EDITOR · esc: cancel"
+// entryHint is the bottom hint line. On a multi-line field (Value/Description)
+// Enter inserts a newline and ctrl+o hands off to $EDITOR; Tab moves between fields
+// and the form is submitted from the "[ OK ]" button (Enter). On the single-line
+// fields Enter also advances.
+func entryHint(onMultiline bool) string {
+	if onMultiline {
+		return "tab: fields · enter: newline · ctrl+o: $EDITOR · [OK]: submit · esc: cancel"
 	}
 
-	return "tab/↑↓: fields · enter: next · esc: cancel"
+	return "tab: fields · enter: next · [OK]: submit · esc: cancel"
 }
 
 // namespaceDisplay renders a namespace for the read-only edit note, showing the

--- a/internal/tui/entryform_interaction_test.go
+++ b/internal/tui/entryform_interaction_test.go
@@ -19,9 +19,9 @@ import (
 
 // recordingEntryMutator records the create the entry dialog routes, so an
 // interaction test can assert the value AND the field below it (Description) both
-// reach the mutator — i.e. ctrl+s ("done") on the Value textarea advances to
-// Description instead of skipping it. Concurrency-safe: the tea program calls it
-// from its own goroutine while the test polls from another.
+// reach the mutator — i.e. Tab off the Value textarea reaches Description instead of
+// skipping it. Concurrency-safe: the tea program calls it from its own goroutine
+// while the test polls from another.
 type recordingEntryMutator struct {
 	cap capability.ServiceCapability
 
@@ -70,12 +70,12 @@ func (m *recordingEntryMutator) snapshot() (created bool, value, description str
 	return m.created, m.value, m.description, m.staged
 }
 
-// TestTUI_EntryCtrlSAdvancesToDescription drives a create through the real event
-// loop: on the Value textarea ctrl+s ("done") confirms the value and advances to
-// Description (rather than submitting the form and skipping it), so a Description
-// typed after ctrl+s reaches the write. The final Enter on Description completes the
-// form, and Enter in the Stage/Apply popup commits with the default (staged) mode.
-func TestTUI_EntryCtrlSAdvancesToDescription(t *testing.T) {
+// TestTUI_EntryTabToOKSubmits drives a create through the real event loop with the
+// Tab/OK model: Enter in the multi-line Value/Description inserts newlines, Tab walks
+// Value → Description → the "[ OK ]" button, Enter on OK completes the form, and
+// Enter in the Stage/Apply popup commits with the default (staged) mode. It proves a
+// multi-line Description typed after the Value is NOT skipped.
+func TestTUI_EntryTabToOKSubmits(t *testing.T) {
 	t.Parallel()
 
 	mut := &recordingEntryMutator{cap: capability.ServiceCapability{
@@ -96,14 +96,17 @@ func TestTUI_EntryCtrlSAdvancesToDescription(t *testing.T) {
 			send(tea.KeyPressMsg{Code: r, Text: string(r)})
 		}
 	}
+	tab := func() { send(tea.KeyPressMsg{Code: tea.KeyTab}) }
+	enter := func() { send(tea.KeyPressMsg{Code: tea.KeyEnter}) }
 
 	typeStr("myname")
-	send(tea.KeyPressMsg{Code: tea.KeyEnter}) // Name -> Value
-	typeStr("myvalue")
-	send(tea.KeyPressMsg{Code: 's', Mod: tea.ModCtrl}) // Value: confirm + advance -> Description
+	enter()            // Name (single-line) -> Value
+	typeStr("myvalue") // Enter here would be a newline, so Tab advances instead
+	tab()              // Value -> Description
 	typeStr("mydesc")
-	send(tea.KeyPressMsg{Code: tea.KeyEnter}) // Description (last) -> complete -> popup
-	send(tea.KeyPressMsg{Code: tea.KeyEnter}) // popup: commit (staged default)
+	tab()   // Description -> [ OK ]
+	enter() // OK -> complete -> Stage/Apply popup
+	enter() // popup: commit (staged default)
 
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
@@ -117,7 +120,7 @@ func TestTUI_EntryCtrlSAdvancesToDescription(t *testing.T) {
 	created, value, description, staged := mut.snapshot()
 	assert.True(t, created, "the create reaches the mutator")
 	assert.Equal(t, "myvalue", value, "the value is written")
-	assert.Equal(t, "mydesc", description, "the Description typed after ctrl+s is NOT skipped")
+	assert.Equal(t, "mydesc", description, "the multi-line Description is NOT skipped")
 	assert.True(t, staged, "the default popup choice stages the write")
 
 	tm.Send(hostQuitMsg{})

--- a/internal/tui/testdata/TestDialog_EntryFormAWSParamGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormAWSParamGolden.golden
@@ -20,6 +20,6 @@
 │                                                          │
 │                                                          │
 │                                                          │
-│      OK                                                  │
-│  tab: fields · enter: next · [OK]: submit · esc: cancel  │
+│     OK                                                   │
+│  tab/shift+tab: fields · enter: next · esc: cancel       │
 ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_EntryFormAWSParamGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormAWSParamGolden.golden
@@ -16,6 +16,10 @@
 │                                                          │
 │                                                          │
 │    Description                                           │
-│    > (optional)                                          │
-│  tab/↑↓: fields · enter: next · esc: cancel              │
+│    (optional)                                            │
+│                                                          │
+│                                                          │
+│                                                          │
+│      OK                                                  │
+│  tab: fields · enter: next · [OK]: submit · esc: cancel  │
 ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_EntryFormAWSSecretGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormAWSSecretGolden.golden
@@ -15,6 +15,6 @@
 │                                                          │
 │                                                          │
 │                                                          │
-│      OK                                                  │
-│  tab: fields · enter: next · [OK]: submit · esc: cancel  │
+│     OK                                                   │
+│  tab/shift+tab: fields · enter: next · esc: cancel       │
 ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_EntryFormAWSSecretGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormAWSSecretGolden.golden
@@ -11,6 +11,10 @@
 │                                                          │
 │                                                          │
 │    Description                                           │
-│    > (optional)                                          │
-│  tab/↑↓: fields · enter: next · esc: cancel              │
+│    (optional)                                            │
+│                                                          │
+│                                                          │
+│                                                          │
+│      OK                                                  │
+│  tab: fields · enter: next · [OK]: submit · esc: cancel  │
 ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_EntryFormAppConfigGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormAppConfigGolden.golden
@@ -13,6 +13,6 @@
 │                                                          │
 │                                                          │
 │                                                          │
-│      OK                                                  │
-│  tab: fields · enter: next · [OK]: submit · esc: cancel  │
+│     OK                                                   │
+│  tab/shift+tab: fields · enter: next · esc: cancel       │
 ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_EntryFormAppConfigGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormAppConfigGolden.golden
@@ -12,5 +12,7 @@
 │                                                          │
 │                                                          │
 │                                                          │
-│  tab/↑↓: fields · enter: next · esc: cancel              │
+│                                                          │
+│      OK                                                  │
+│  tab: fields · enter: next · [OK]: submit · esc: cancel  │
 ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_EntryFormMinSizeGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormMinSizeGolden.golden
@@ -11,6 +11,6 @@
 │                                                          │
 │                                                          │
 │    Description                                           │
-│    > (optional)                                          │
-│  tab/↑↓: fields · enter: next · esc: cancel              │
+│    (optional)                                            │
+│  tab: fields · enter: next · [OK]: submit · esc: cancel  │
 ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_EntryFormMinSizeGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormMinSizeGolden.golden
@@ -12,5 +12,5 @@
 │                                                          │
 │    Description                                           │
 │    (optional)                                            │
-│  tab: fields · enter: next · [OK]: submit · esc: cancel  │
+│  tab/shift+tab: fields · enter: next · esc: cancel       │
 ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_EntryFormStagedOnlyGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormStagedOnlyGolden.golden
@@ -12,7 +12,7 @@
 │                                                          │
 │                                                          │
 │                                                          │
-│      OK                                                  │
-│  tab: fields · enter: newline · ctrl+o: $EDITOR · [OK]:  │
-│  submit · esc: cancel                                    │
+│     OK                                                   │
+│  tab/shift+tab: fields · enter: newline · ctrl+o:        │
+│  $EDITOR · esc: cancel                                   │
 ╰──────────────────────────────────────────────────────────╯

--- a/internal/tui/testdata/TestDialog_EntryFormStagedOnlyGolden.golden
+++ b/internal/tui/testdata/TestDialog_EntryFormStagedOnlyGolden.golden
@@ -8,7 +8,11 @@
 │  ┃                                                       │
 │                                                          │
 │    Description                                           │
-│    > (optional)                                          │
-│  tab/↑↓: fields · enter: newline · ctrl+s: done ·        │
-│  ctrl+e: $EDITOR · esc: cancel                           │
+│    (optional)                                            │
+│                                                          │
+│                                                          │
+│                                                          │
+│      OK                                                  │
+│  tab: fields · enter: newline · ctrl+o: $EDITOR · [OK]:  │
+│  submit · esc: cancel                                    │
 ╰──────────────────────────────────────────────────────────╯


### PR DESCRIPTION
Reworks the create/edit form's key model around everyday readline habits and multi-line editing. Supersedes the short-lived ctrl+s "done" binding.

## Why
- **ctrl+s** is terminal **XOFF** (flow control) — it can freeze output in some terminals.
- **ctrl+e** ($EDITOR) shadowed bubbles' **end-of-line** motion inside the textarea, and the user relies on ctrl+a/ctrl+e daily.
- **Description** was single-line even though the backends accept newlines.

## Changes
- **Submit → Tab + `[ OK ]`**: Tab walks the fields; an explicit `[ OK ]` button (single-affirmative huh Confirm) completes the form on Enter, then the Stage/Apply popup opens (or a direct write when there's no choice). No more ctrl+s.
- **$EDITOR → ctrl+o** (was ctrl+e): ctrl+o is unbound by the text input and portable; ctrl+a/ctrl+e are back to line-start/line-end everywhere.
- **Description is now multi-line** like Value (free text that accepts newlines — AWS Parameter Store/Secrets Manager, and Google Cloud's description annotation), with the same ctrl+o $EDITOR handoff. `openEditor`/`onEditorFinished` fold the buffer back into whichever field launched it.
- Keyboard-only, consistent with the rest of the huh form (huh has no mouse support — confirmed).

## Tests
- `TestFormKeyMap_MultilineBindings` (Enter=newline, Tab=next, no field-level submit)
- `TestTUI_EntryTabToOKSubmits` — end-to-end: type name → Enter, value → Tab, description → Tab → `[ OK ]` Enter → Stage/Apply popup → Enter; asserts the multi-line Description is not skipped.
- Regenerated the entry-form goldens (multi-line Description + OK button + new hint).

Gates: `mise test` ✅ · `mise lint` 0 issues ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)