### PR TITLE
fix(tui): stabilize dialog-golden captures under CI load (#796)

### DIFF
--- a/internal/tui/entryform_interaction_test.go
+++ b/internal/tui/entryform_interaction_test.go
@@ -105,10 +105,20 @@ func TestTUI_EntryTabToOKSubmits(t *testing.T) {
 	tab()              // Value -> Description
 	typeStr("mydesc")
 	tab()   // Description -> [ OK ]
-	enter() // OK -> complete -> Stage/Apply popup
-	enter() // popup: commit (staged default)
+	enter() // OK -> complete -> Stage/Apply popup (async)
 
-	deadline := time.Now().Add(3 * time.Second)
+	// Enter on [ OK ] completes the huh form, but the form reaches StateCompleted
+	// through a nextField command roundtrip, so beginSubmit only opens the
+	// Stage/Apply popup a loop iteration later. Gate the commit Enter below on the
+	// popup being RENDERED — under CI load a blind Enter would otherwise arrive
+	// before the popup is up, be forwarded back into the completed form, and never
+	// reach the mutator (created stays false, #796 class). waitFor matches the
+	// vt-rendered screen, not the raw stream.
+	waitFor(t, tm, "Apply immediately")
+
+	tm.Send(tea.KeyPressMsg{Code: tea.KeyEnter}) // popup: commit (staged default)
+
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		if created, _, _, _ := mut.snapshot(); created {
 			break

--- a/internal/tui/staging_golden_test.go
+++ b/internal/tui/staging_golden_test.go
@@ -451,8 +451,12 @@ func TestStaging_ApplyResultsGolden(t *testing.T) { //nolint:paralleltest // gol
 		TargetLine: "aws", Title: "Apply staged changes — Param", EntryCount: 2, TagCount: 1, Styles: styles.New(),
 	})
 
-	// Focus Apply (row 1) and confirm to reach the results view.
-	golden.RequireEqual(t, captureDialogWithKeys(t, newDialogHost(d, nil), "Apply results",
+	// Focus Apply (row 1) and confirm to reach the results view. Gate on the
+	// unstage-warning line — the LAST block the results body renders (entries →
+	// tags → conflicts → unstage warnings) — not just the "Apply results" title,
+	// so a slow CI apply can never quit on a partially-rendered results frame
+	// (#796).
+	golden.RequireEqual(t, captureDialogWithKeys(t, newDialogHost(d, nil), "could not be unstaged",
 		keyDownMsg(), keyEnterMsg()))
 }
 

--- a/internal/tui/staging_golden_test.go
+++ b/internal/tui/staging_golden_test.go
@@ -401,9 +401,22 @@ func waitFor(t *testing.T, tm *teatest.TestModel, marker string) {
 
 	var buf bytes.Buffer
 
+	waitForInBuf(t, tm, &buf, marker)
+}
+
+// waitForInBuf is waitFor against a caller-owned buffer, so an interaction test
+// that gates on several successive markers (initial render → rebuild → popup)
+// keeps the full accumulated stream across gates. The vt replay must see the whole
+// stream from the capability-handshake preamble on; a fresh buffer per gate would
+// replay only the tail (cursor-positioned incremental cell-updates) onto a blank
+// grid and miss content drawn earlier. Draining into the SAME buffer keeps every
+// gate rendering the true current screen.
+func waitForInBuf(t *testing.T, tm *teatest.TestModel, buf *bytes.Buffer, marker string) {
+	t.Helper()
+
 	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
-		_, _ = io.Copy(&buf, tm.Output())
+		_, _ = io.Copy(buf, tm.Output())
 		if buf.Len() > 0 && strings.Contains(renderVisibleScreenSize(t, buf.Bytes(), waitRenderWidth, waitRenderHeight), marker) {
 			return
 		}

--- a/internal/tui/tagform_interaction_test.go
+++ b/internal/tui/tagform_interaction_test.go
@@ -90,18 +90,32 @@ func TestTUI_TagRemoveRoutesSelectedKey(t *testing.T) {
 
 	tm := teatest.NewTestModel(t, newDialogHost(m, cmd), teatest.WithInitialTermSize(goldenTermWidth, goldenTermHeight))
 
-	tm.Send(keyRightMsg()) // Add -> Remove
+	// Output-gated choreography (not blind sleeps): the Add->Remove toggle rebuilds
+	// the form through a command roundtrip, and each huh field transition and the
+	// completion->popup step also round-trip through the tea loop. Under CI load a
+	// rapid Enter would otherwise be swallowed against a half-built form or arrive
+	// before the popup is up (#796 class). One accumulating buffer keeps the full
+	// stream so every vt replay renders the true current screen.
+	var buf bytes.Buffer
 
-	// advance action -> select -> complete (opens the Stage/Apply popup) -> commit.
-	// A small pace between keys lets the async form rebuild (after the Add->Remove
-	// toggle) settle so a rapid Enter is not swallowed against a half-built form.
-	for range 4 {
-		tm.Send(keyEnterMsg())
-		time.Sleep(30 * time.Millisecond)
-	}
+	waitForInBuf(t, tm, &buf, "Action") // the initial (Add) form has rendered
+
+	tm.Send(keyRightMsg())                // Add -> Remove (rebuilds the form)
+	waitForInBuf(t, tm, &buf, "env=prod") // the Remove select rebuilt & rendered
+
+	// Two Enters complete the two-field Remove form (Action select -> existing-tags
+	// select -> complete). Each Enter drives exactly one field advance through huh's
+	// nextField command, so the count is timing-independent; then gate on the popup
+	// actually rendering before committing.
+	tm.Send(keyEnterMsg()) // Action -> the existing-tags select
+	tm.Send(keyEnterMsg()) // select -> complete -> Stage/Apply popup
+
+	waitForInBuf(t, tm, &buf, "Apply immediately")
+
+	tm.Send(keyEnterMsg()) // popup: commit (staged default)
 
 	// Wait for the submit to reach the mutator.
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
 	for time.Now().Before(deadline) {
 		if remove, _, _, _ := mut.snapshot(); remove {
 			break


### PR DESCRIPTION
## The flakes

Two independent CI flakes in the TUI suite, both the same root cause — a teatest/golden capture that quits or asserts before the async render it depends on has actually landed under parallel `-race` CI load (#796 item 1).

1. **`TestStaging_ApplyResultsGolden`** intermittently fails on the **required** `Unit Test` job (seen blocking #787 and #789): the dialog-golden capture quit on a partially-rendered results frame → golden mismatch.
2. **`TestTUI_EntryTabToOKSubmits`** (added in #804) failed on **both** `Unit Test` (linux) and `Platform Test (darwin)` on this PR's CI run, and on `Platform Test (linux)` for main's own post-#805 run (`25231b35`) — so **main is currently red from this flake** and this PR unbreaks it. The test drove keystrokes with fixed 25ms sleeps and never synchronized with the rendered state; the final popup-commit Enter must land on the Stage/Apply popup, but the form-complete → popup transition goes through huh's `nextField` command roundtrip, so under load the popup was not up yet when the Enter arrived, the write never reached the mutator, and all four asserts (`created`/value/description/staged) failed.

## The fix

1. **FinalModel timeout 3s → ~10s** — already landed in #797 (commit `92c48174`). `captureDialogWithKeysSize` and `settledAppScreen` both use `WithFinalTimeout(10*time.Second)`; no change needed here.

2. **Gate the apply-results capture on the results content, not just the title.** `TestStaging_ApplyResultsGolden` now waits for the unstage-warning line `"could not be unstaged"` — the LAST block the results body renders (`entries → tags → conflicts → unstage warnings`) — so a slow CI apply can never quit on a partially-rendered frame.

3. **De-flake the entry/tag interaction tests across their async seams.** Replace the blind-sleep choreography with output-gated synchronization on the vt-rendered screen (the same mechanic the golden helpers already use):
   - `TestTUI_EntryTabToOKSubmits` waits for the Stage/Apply popup (`"Apply immediately"`) to render before sending the commit Enter.
   - `TestTUI_TagRemoveRoutesSelectedKey` waits for the initial render, the `Add→Remove` rebuild (`"env=prod"`), then the popup, in turn.
   - Plain in-form focus moves stay as short sleeps.
   - New `waitForInBuf` helper: `waitFor` against a caller-owned buffer, so a test can gate on several successive markers while the vt replay keeps the full stream from the handshake preamble on (a fresh buffer per gate would replay only the tail and miss earlier content). `waitFor` now delegates to it.
   - Final `created`/`remove` poll deadline raised 3s → 10s.

## Verification

```
$ go test -race -count=20 -run 'TestTUI_EntryTabToOKSubmits|TestTUI_Tag|TestStaging_ApplyResultsGolden' ./internal/tui/...
ok  	github.com/mpyw/suve/internal/tui	16.251s
(also green under sustained CPU contention)

$ mise test
ok  	github.com/mpyw/suve/internal/tui	...        # full suite green

$ golangci-lint run --allow-parallel-runners ./internal/tui/...
0 issues.
```

Part of #796 (item 2 — the non-required gcloud/azure TUI e2e CI timeouts — is handled separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
