### PR TITLE
docs(readme): sync the TUI guide keymap with the current bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,23 +718,28 @@ Keymap (the in-app `?` toggles full help, which is the source of truth):
 | Browser | `p` / `/` | edit prefix / filter |
 | Browser | `v` | toggle value display |
 | Browser | `r` | recursive toggle / refresh |
+| Browser | `[` / `]` | narrow / widen the list pane |
 | Browser | `L` | load more (paged secrets) |
 | Browser | `x` | reveal a masked value |
-| Browser / Diff | `J` | pretty-print a JSON value (parity with `--parse-json`) |
 | Browser | `c`, `space`, `enter` | compare mode: toggle, pick a version, open diff |
 | Browser | `space` | pick namespace (App Configuration) |
-| Browser | `S` | jump to the Staging tab |
 | Browser | `n` / `e` / `d` / `t` / `R` | new / edit / delete / tag / restore |
+| Compare / Diff | `↑`/`↓` | scroll the diff |
+| Compare / Diff | `s` | toggle side-by-side / unified layout |
+| Compare / Diff | `x` | hide / show a secret diff's values |
 | Staging | `v` | toggle diff / value view |
-| Staging | `e` / `u` / `t` | edit staged / unstage (entry + tags) / add staged tag |
-| Staging | `x` | reveal the selected row's masked value |
+| Staging | `e` / `u` / `t` | edit staged / unstage (entry + tags) / add or remove staged tags |
+| Staging | `x` | reveal / hide the selected row's value |
 | Staging | `enter` | open the full-diff detail |
 | Staging | `a` / `A` | apply this section / apply all |
 | Staging | `r` / `R` | reset this section / reset all |
 | Staging | `ctrl+r` | refresh |
-| Dialogs | `ctrl+e` | open the value in `$EDITOR` (create/edit) |
+| Dialogs (create / edit) | `tab` / `shift+tab` | move between fields |
+| Dialogs (create / edit) | `enter` | next field; inserts a newline in the multi-line Value / Description; submits on the `[ OK ]` button |
+| Dialogs (create / edit) | `ctrl+o` | open the Value or Description in `$EDITOR` |
+| Dialogs | `esc` | cancel (press twice to discard an edited form) |
 
-Mutations are **staged by default** (an "Apply immediately" toggle is offered where the backend supports staging); operation markers and unsupported controls follow each backend's capabilities. Rendering honors `NO_COLOR` and degrades gracefully on narrow terminals.
+JSON values are always pretty-printed automatically (parity with `--parse-json`), so there is no format toggle. Mutations are **staged by default** where the backend supports staging: completing a create, edit, or delete opens a **Stage / Apply** confirmation popup (`←`/`→` choose, `enter` confirms, `esc` returns to the form); on a backend without staging the write is always immediate. Operation markers and unsupported controls follow each backend's capabilities. Rendering honors `NO_COLOR` and degrades gracefully on narrow terminals.
 
 ### Feature support
 


### PR DESCRIPTION
## Summary

The README **TUI mode** keymap table had drifted from the implementation after the recent TUI UX changes (#795, #798, #804, #805). This rebuilds every row from the actual bindings and the rendered help goldens (the source of truth), and fixes the surrounding prose. Docs-only.

## Row-by-row before / after + evidence

| Row (before) | Problem | After | Evidence |
|---|---|---|---|
| `Browser / Diff` · `J` · pretty-print a JSON value | No such key exists; JSON is pretty-printed **automatically** | row removed; prose note added | `internal/tui/pages/browser/view.go:363` ("always pretty-printed (GUI parity, #732), so there is no format toggle hint"); no `J` binding anywhere in `internal/tui/` |
| `Browser` · `S` · jump to the Staging tab | No `S` binding; tab switching is `1`/`2`/`3` or tab | row removed | no `WithKeys("S")` in the browser; `internal/tui/pages/browser/update.go` `handleActionKey` has no such case |
| `Dialogs` · `ctrl+e` · open the value in `$EDITOR` | Binding is `ctrl+o` (ctrl+e shadows readline end-of-line in the Value textarea); also covers Description | `ctrl+o` · open the Value or Description in `$EDITOR` | `internal/tui/dialogs/entryform.go:65` (`editorKey = ctrl+o`), `:390` handler, `:517-529` multiline field = value/description |
| — (no dialog nav rows) | The tab/enter/`[ OK ]` submit model (#804/#805) was undocumented | added `tab`/`shift+tab` fields, `enter` newline/next + `[ OK ]` submit, `esc` cancel (double-esc discard) | `entryform.go:285-294` `formKeyMap` (enter=newline, tab=next, submit disabled), `:262` `[ OK ]` Confirm button, `:735-741` `entryHint`, `:409-418` double-esc discard guard (#790) |
| prose: "an 'Apply immediately' toggle is offered" | #798 replaced the inline mode toggle with a **Stage / Apply** popup shown after form completion | prose describes the Stage/Apply confirmation popup (`←`/`→` choose, `enter` confirm, `esc` back) | `entryform.go:443-457` `beginSubmit`, `internal/tui/dialogs/confirm.go` `modeConfirm` (`:51-64` keys, `:75` hint) |
| — (missing) | `[`/`]` list-resize and the Compare/Diff keys were absent | added `[`/`]` narrow/widen; added Compare/Diff group (scroll, `s` side-by-side, `x` hide/show) | browser `narrowKey`/`widenKey` `internal/tui/pages/browser/browser.go:96-97`; diff `scrollKey`/`layoutKey`/`maskKey` `internal/tui/pages/diff/diff.go:38,46,53` |

### Verified already correct (unchanged)

- Global: `?` help, `q`/`ctrl+c` quit, `tab`/`shift+tab`, `1`/`2`/`3`, `↑/k`,`↓/j`, `enter`, `esc`, `y` copy-stays-masked — `internal/tui/keys/keys.go:63-113`; copy-mask note `internal/tui/pages/browser/update.go:704-721` (#689).
- Browser: `p`/`/`, `v`, `r`, `L`, `x`, `c`/`space`/`enter` compare, `space` namespace, `n`/`e`/`d`/`t`/`R` — `internal/tui/pages/browser/browser.go:83-104`, `update.go` `handleActionKey`, `help.go`.
- Staging: `v`, `e`/`u`/`t`, `x`, `enter`, `a`/`A`, `r`/`R`, `ctrl+r` — `internal/tui/pages/staging/staging.go:48-65` (tweaked wording: `t` = add/remove tags, `x` = reveal/hide to match the view-aware binding in `help.go`).

Cross-checked against the rendered full-help golden `internal/tui/testdata/TestBrowser_FullHelpGolden.golden` and the dialog goldens (`TestDialog_EntryFormAWSParamGolden`, `TestDialog_DeleteConfirmModePopupGolden`).

`docs/{aws,gcloud,azure}.md` only link to this section for the keymap — no keybindings to fix there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)