### PR TITLE
docs(demo): record the TUI demo GIF via vhs (#703)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ A **Git-like CLI/TUI/GUI** for AWS Parameter Store / Secrets Manager, Google Clo
 </p>
 
 <p align="center">
+  <img src="demo/tui-demo.gif" alt="TUI Demo" width="800">
+</p>
+
+<p align="center">
   <img src="demo/gui-demo.gif" alt="GUI Demo" width="800">
 </p>
 

--- a/demo/tui-demo.gif
+++ b/demo/tui-demo.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:29ad87fb771ddd4d9207642ea738ae4efc825fcb9afb27602d2184c59162b2ca
+size 1534773

--- a/demo/tui-demo.tape
+++ b/demo/tui-demo.tape
@@ -1,0 +1,188 @@
+# TUI Demo Recording for suve
+# This tape reproduces the CLI/GUI demo scenario in the keyboard-driven TUI:
+# browse, stage (new / edit / tag add / tag remove / delete), review, apply all,
+# then verify — on AWS Parameter Store via LocalStack, over the /demo/* namespace.
+#
+# Recorded with VHS: https://github.com/charmbracelet/vhs
+# Run: ./demo/tui-record.sh   (seeds LocalStack, then runs `vhs demo/tui-demo.tape`)
+
+Output "demo/tui-demo.gif"
+
+Set FontSize 16
+Set Width 1400
+Set Height 800
+Set Theme "Dracula"
+Set Padding 20
+
+# Configure LocalStack endpoint (tui-record.sh rewrites the port when
+# SUVE_LOCALSTACK_EXTERNAL_PORT is set; SUVE_STAGING_KEY is inherited from it).
+Env AWS_ENDPOINT_URL "http://localhost:4566"
+Env AWS_ACCESS_KEY_ID "test"
+Env AWS_SECRET_ACCESS_KEY "test"
+Env AWS_DEFAULT_REGION "us-east-1"
+
+# Launch the TUI. With only LocalStack AWS env active, AWS is the sole active
+# provider, so `suve --tui` opens straight on the AWS Param tab.
+Type "suve --tui"
+Enter
+Sleep 4s
+
+# ===========================================================================
+# 1. Browse: reveal values in the list; the first entry (/demo/api/url) detail
+#    shows its value and the Version=v1 tag.
+# ===========================================================================
+Type "v"
+Sleep 3s
+
+# ===========================================================================
+# 2. Stage a NEW parameter: /demo/cache/ttl = 3600
+#    (n → Name → Type[String] → Value → [ OK ] → Stage)
+# ===========================================================================
+Type "n"
+Sleep 2s
+Type "/demo/cache/ttl"
+Sleep 1s
+Enter
+Sleep 800ms
+Enter
+Sleep 800ms
+Type "3600"
+Sleep 1.5s
+Tab
+Sleep 800ms
+Tab
+Sleep 800ms
+Enter
+Sleep 1.5s
+Enter
+Sleep 2.5s
+
+# ===========================================================================
+# 4. Stage an EDIT of /demo/api/url: value v1 -> v2
+#    (e → Type -> Value; backspace "1.example.com", type "2.example.com" → Stage)
+# ===========================================================================
+Type "e"
+Sleep 2s
+Enter
+Sleep 1s
+Backspace 13
+Sleep 1s
+Type "2.example.com"
+Sleep 1.5s
+Tab
+Sleep 800ms
+Tab
+Sleep 800ms
+Enter
+Sleep 1.5s
+Enter
+Sleep 2.5s
+
+# ===========================================================================
+# 5. Stage tag Env=Dev on /demo/api/url
+#    (t → Action[Add] → Key=Env → Value=Dev → Stage)
+# ===========================================================================
+Type "t"
+Sleep 2s
+Enter
+Sleep 800ms
+Type "Env"
+Sleep 800ms
+Enter
+Sleep 800ms
+Type "Dev"
+Sleep 1s
+Enter
+Sleep 1.5s
+Enter
+Sleep 2.5s
+
+# ===========================================================================
+# 6. Stage REMOVAL of the Version tag on /demo/api/url
+#    (t → Action[Remove] → Tag[Version=v1] → Stage)
+# ===========================================================================
+Type "t"
+Sleep 2s
+Right
+Sleep 1.5s
+Enter
+Sleep 1s
+Enter
+Sleep 1.5s
+Enter
+Sleep 2.5s
+
+# ===========================================================================
+# 7. Stage DELETION of /demo/legacy/endpoint
+#    (down to it → d → [ Delete ] → Stage)
+# ===========================================================================
+Down
+Sleep 800ms
+Down
+Sleep 1.5s
+Type "d"
+Sleep 2s
+Enter
+Sleep 1.5s
+Enter
+Sleep 2.5s
+
+# ===========================================================================
+# 8/3. Switch to the Staging tab; stage tag Env=Dev on the new /demo/cache/ttl
+#      (only reachable here — a not-yet-applied create is not in the browser
+#      list), then review the changes in both value and diff views.
+# ===========================================================================
+Type "3"
+Sleep 3s
+Down
+Sleep 1.5s
+Type "t"
+Sleep 2s
+Type "Env"
+Sleep 800ms
+Enter
+Sleep 800ms
+Type "Dev"
+Sleep 1s
+Enter
+Sleep 2.5s
+# Toggle to raw value view, then back to the remote-vs-staged diff view.
+Type "v"
+Sleep 3s
+Type "v"
+Sleep 2.5s
+
+# ===========================================================================
+# 9. Apply ALL staged changes (A → focus Apply → Enter), then show the results.
+# ===========================================================================
+Type "A"
+Sleep 2s
+Down
+Sleep 1s
+Enter
+Sleep 3.5s
+Enter
+Sleep 2s
+
+# ===========================================================================
+# 10. Back on the Param tab, verify the applied state with values revealed.
+#     (1 rebuilds/reloads the tab; /demo/api/url is auto-selected, now v2 with
+#      the Env=Dev tag and no Version tag; /demo/cache/ttl exists; legacy gone.)
+# ===========================================================================
+Type "1"
+Sleep 3s
+Type "v"
+Sleep 3s
+
+# ===========================================================================
+# 11. Show /demo/api/url's version history (enter focuses the history pane:
+#     per-version values, #2 = current v2, #1 = the old v1).
+# ===========================================================================
+Enter
+Sleep 3.5s
+
+# Quit cleanly from the browser.
+Escape
+Sleep 800ms
+Type "q"
+Sleep 1.5s

--- a/demo/tui-record.sh
+++ b/demo/tui-record.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# TUI Demo Recording Script for suve
+#
+# This script sets up demo data and records the TUI demo. It mirrors
+# cli-record.sh: the TUI is pure Go and records over the same vhs terminal path
+# as the CLI demo (no browser).
+# Requires: vhs (https://github.com/charmbracelet/vhs)
+#
+# Usage: ./demo/tui-record.sh
+#   Set SUVE_LOCALSTACK_EXTERNAL_PORT to a free port to avoid colliding with an
+#   already-running LocalStack (e.g. another checkout's), e.g.:
+#   SUVE_LOCALSTACK_EXTERNAL_PORT=4599 ./demo/tui-record.sh
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+cd "$PROJECT_DIR"
+
+# LocalStack configuration. SUVE_LOCALSTACK_EXTERNAL_PORT is exported so docker
+# compose (which interpolates it in compose.yaml) and the endpoint URL agree.
+export SUVE_LOCALSTACK_EXTERNAL_PORT="${SUVE_LOCALSTACK_EXTERNAL_PORT:-4566}"
+export AWS_ENDPOINT_URL="http://localhost:${SUVE_LOCALSTACK_EXTERNAL_PORT}"
+export AWS_ACCESS_KEY_ID="test"
+export AWS_SECRET_ACCESS_KEY="test"
+export AWS_DEFAULT_REGION="us-east-1"
+# Pin a deterministic staging data key so the staging steps never block on the
+# macOS keychain (matches `mise test` and scripts/seed.sh). The TUI staging store
+# reads it from the inherited environment.
+export SUVE_STAGING_KEY="${SUVE_STAGING_KEY:-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=}"
+
+# This demo owns the /demo/* namespace, kept deliberately separate from the
+# `mise run seed-*` fixtures (/suve-demo/*), so recording and manual seeding
+# never clobber each other.
+
+echo "=== Setting up demo environment ==="
+
+# Guard against colliding with a LocalStack this script did not start (e.g. a
+# sibling checkout's). If the chosen port is already bound, refuse rather than
+# tearing down containers we do not own — pick a free SUVE_LOCALSTACK_EXTERNAL_PORT.
+if [ "$SUVE_LOCALSTACK_EXTERNAL_PORT" = "4566" ] && lsof -nP -iTCP:4566 -sTCP:LISTEN >/dev/null 2>&1; then
+  echo "ERROR: port 4566 is already in use (another LocalStack may be running)." >&2
+  echo "Re-run with a free port, e.g.: SUVE_LOCALSTACK_EXTERNAL_PORT=4599 ./demo/tui-record.sh" >&2
+  exit 1
+fi
+
+# Always build the full GUI binary (bin/suve) so it matches the current bindings
+# and API arity — a stale or CLI-only binary can drift out of sync.
+echo "Building suve (GUI)..."
+mise build-gui
+
+# Reset LocalStack (clean slate). --profile "*" so the profile-gated localstack
+# service is actually torn down (a bare `down` leaves profiled services running).
+echo "Resetting LocalStack..."
+docker compose --profile "*" down -v
+docker compose --profile aws up -d
+echo "Waiting for LocalStack to be ready..."
+sleep 3
+
+# Clear staging
+echo "Clearing staging..."
+./bin/suve stage reset --all 2>/dev/null || true
+
+# Set up 3 existing parameters (identical to cli-record.sh):
+# - /demo/api/url        -> will be edited (v1 -> v2)
+# - /demo/legacy/endpoint -> will be deleted
+# - /demo/config          -> untouched
+echo "Creating demo parameters..."
+./bin/suve param create /demo/api/url "https://api-v1.example.com"
+./bin/suve param tag /demo/api/url Version=v1
+
+./bin/suve param create /demo/legacy/endpoint "https://old.example.com"
+
+./bin/suve param create /demo/config '{"timeout":30}'
+
+echo "Demo data ready:"
+./bin/suve param ls -R /demo
+
+echo ""
+echo "=== Recording TUI demo ==="
+# Create temp tape with correct endpoint URL (rewrites the default 4566 port).
+TEMP_TAPE=$(mktemp)
+sed "s|http://localhost:4566|$AWS_ENDPOINT_URL|g" demo/tui-demo.tape > "$TEMP_TAPE"
+PATH="$PROJECT_DIR/bin:$PATH" vhs "$TEMP_TAPE"
+rm -f "$TEMP_TAPE"
+
+echo ""
+echo "=== Done ==="
+ls -la demo/tui-demo.gif


### PR DESCRIPTION
Records the keyboard-driven TUI demo GIF and wires it into the README, next to the existing CLI and GUI demos.

## What's added

- `demo/tui-demo.tape` — the vhs tape (mirrors `cli-demo.tape`'s header: `Output demo/tui-demo.gif`, Dracula, Padding 20; 1400×800 so the two-pane browser + detail render un-truncated).
- `demo/tui-record.sh` — mirrors `cli-record.sh`: LocalStack env (with `SUVE_LOCALSTACK_EXTERNAL_PORT` override + a port-4566 collision guard so it never tears down a LocalStack it didn't start), pinned `SUVE_STAGING_KEY`, `mise build-gui`, compose reset, `stage reset --all`, seed the three params, then `vhs` with the endpoint-substituted temp tape.
- `demo/tui-demo.gif` — the recorded GIF, tracked via Git LFS (1,534,773 bytes ≈ 1.5 MB).
- `README.md` — `<img src="demo/tui-demo.gif" alt="TUI Demo" width="800">` placed between the CLI and GUI demos (CLI/TUI/GUI order).

## Scenario parity

Same operations as the CLI (`demo/cli-demo.tape`) and GUI (`demo/gui-demo.spec.ts`) demos, on AWS Parameter Store via LocalStack over `/demo/*`. Seed identical to `cli-record.sh`: `/demo/api/url` = `https://api-v1.example.com` (tag `Version=v1`), `/demo/legacy/endpoint` = `https://old.example.com`, `/demo/config` = `{"timeout":30}`.

| Scenario step | CLI | GUI | TUI (this PR) |
|---|---|---|---|
| Browse list + reveal values, show `/demo/api/url` (value + `Version=v1`) | `param ls -R --show` | Show Values + click | `v` values-on; auto-selected detail + history |
| Stage new `/demo/cache/ttl` = 3600 | `stage param add` | `+ New` form | `n` entry form (Name → String → Value → `[ OK ]` → Stage) |
| Stage tag `Env=Dev` on the new param | `stage param tag` | *(not shown)* | Staging tab → select create row → `t` (staged-only) |
| Stage edit `/demo/api/url` v1 → v2 | `stage param edit` | `Edit` form | `e` entry form (edit Value → Stage) |
| Stage tag `Env=Dev` on `/demo/api/url` | `stage param tag` | `+ Add` form | `t` → Action=Add → Key/Value → Stage |
| Stage removal of the `Version` tag | `stage param untag` | per-chip remove | `t` → Action=Remove → pick `Version=v1` → Stage |
| Stage deletion of `/demo/legacy/endpoint` | `stage param delete` | `Delete` | `d` → `[ Delete ]` → Stage |
| Review staged changes (+ diff) | `stage status` / `stage diff` | Staging view + Diff/Value | Staging tab, diff **and** value views |
| Apply all | `stage apply --yes` | `Apply All` | `A` → focus Apply → Enter → results |
| Verify applied state | `param ls -R --show` | Refresh + Show Values | `1` reloads the tab; values-on |
| Version history (per-version values) | `param log -p` | History | `enter` focuses the history pane |

Ordering note: the "tag the new param" step is done from the **Staging tab**, because a not-yet-applied create is not in the browser list (its detail cannot load, so the browser `t` is a no-op there) — the same reason the GUI demo omits it. Everything else is one contiguous browser flow, then Staging tab → apply → verify. No scenario step was dropped.

## Per-frame verification

Recorded with `./demo/tui-record.sh` (on `SUVE_LOCALSTACK_EXTERNAL_PORT=4599`), then `ffmpeg -i demo/tui-demo.gif frames/frame-%04d.png` and read the key frames. 91.5 s, 1400×800.

- [x] Launch + `v`: two-pane browser, `/demo/api/url` value `https://api-v1.example.com`, `Version=v1` tag, Type String, history #1.
- [x] New form: Name `/demo/cache/ttl`, Type String, Value `3600`, focus reaches `[ OK ]`; Stage/Apply popup (Stage default) → "Staged create.", `Staging(1)`.
- [x] Edit form: Value seeded, backspaced to `https://api-v`, retyped to `https://api-v2.example.com`; Stage → "Staged update.", staged banner on the detail.
- [x] Tag add: Action=Add, Key `Env`, Value `Dev` → "Staged tag add.", `Staging(3)`.
- [x] Tag remove: Action=Remove, Tag select seeded `Version=v1` → committed.
- [x] Delete: "Delete parameter /demo/legacy/endpoint", `[ Delete ]` → "Staged delete.".
- [x] Staging tab: all changes visible — update (v1→v2), create (3600), delete, `+Env=Dev`, `−Version (was v1)`, and after the staging-tab tag `+Env=Dev` on `/demo/cache/ttl`.
- [x] Value view and diff view both shown.
- [x] Apply results: ✓ updated `/demo/api/url`, ✓ created `/demo/cache/ttl`, ✓ deleted `/demo/legacy/endpoint`, ✓ tags on both.
- [x] Verify (Param tab, values-on): `/demo/api/url` = `https://api-v2.example.com`, Version 2, tag `Env=Dev` (no `Version`), `/demo/cache/ttl` = `3600`, `/demo/legacy/endpoint` gone.
- [x] History: `#2` (v2, current) and `#1` (v1) with per-version values; `enter` focuses the history pane.
- [x] Clean quit (`q`) back to the shell.

`demo/tui-demo.gif` is committed as a Git LFS pointer (`git lfs ls-files` lists it; the staged blob is the `version https://git-lfs.github.com/spec/v1` pointer text).

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)
