### PR TITLE
fix(tui): free Ctrl+E for end-of-line in the entry form (stop launching nano)

### DIFF
--- a/e2e/aws_tui_test.go
+++ b/e2e/aws_tui_test.go
@@ -260,3 +260,11 @@ func TestTUIAWS_StageApply(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, stagedVal, stdout, "the TUI apply wrote the staged value to the emulator")
 }
+
+// NOTE: the entry-form Ctrl+E / Ctrl+A key fix is covered at the unit layer
+// (internal/tui/dialogs: TestFormKeyMap_MultilineBindings and
+// TestEntryForm_ValueReadlineMotions), where the huh form's Update is synchronous.
+// A teatest e2e cannot drive it reliably: teatest.Send is asynchronous, so a Tab
+// that changes field focus races the keystrokes typed immediately after it (the
+// first char lands in the previous field), which is why the TUI e2e suite drives
+// browser navigation and pre-seeded staging — never multi-field form typing.

--- a/internal/tui/dialogs/dialogs_test.go
+++ b/internal/tui/dialogs/dialogs_test.go
@@ -666,6 +666,41 @@ func TestEntryForm_ValueEnterInsertsNewline(t *testing.T) {
 	assert.False(t, d.busy, "Enter in Value does not submit")
 }
 
+// TestEntryForm_ValueReadlineMotions pins the entry-form key fix at the layer the
+// bug lived: driving the real huh form + bubbles textarea, Ctrl+A and Ctrl+E are
+// readline start/end-of-line motions owned by the textarea — Ctrl+E is NOT huh's
+// built-in "open editor" binding (which would launch its default nano). From the
+// seeded "old" value, Ctrl+A then "X" prepends and Ctrl+E then "Y" appends,
+// yielding "XoldY"; Ctrl+E also leaves the form editable rather than busy on an
+// editor handoff. Before the fix, Ctrl+E did not move the caret (it opened the
+// editor), so "Y" landed after "X" as "XYold" — a clean regression signal.
+func TestEntryForm_ValueReadlineMotions(t *testing.T) {
+	t.Parallel()
+
+	d, _ := newEntry(t, awsSecretCap(), true) // edit: Value ("old") is the first field
+	m, _ := d.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	d, ok := m.(*entryForm)
+	require.True(t, ok)
+	require.Equal(t, "value", focusedFieldKey(d), "the edit form focuses the Value field first")
+	require.Equal(t, "old", d.value)
+
+	// Ctrl+A → line start, prepend "X"; Ctrl+E → line end, append "Y".
+	for _, msg := range []tea.KeyPressMsg{
+		{Code: 'a', Mod: tea.ModCtrl},
+		keyMsg('X'),
+		{Code: 'e', Mod: tea.ModCtrl},
+		keyMsg('Y'),
+	} {
+		m, _ = d.Update(msg)
+		d, ok = m.(*entryForm)
+		require.True(t, ok)
+	}
+
+	assert.Equal(t, "XoldY", d.value,
+		"Ctrl+A moved to line start and Ctrl+E to line end (not huh's editor)")
+	assert.False(t, d.busy, "Ctrl+E did not hand off to an external editor")
+}
+
 // TestEntryForm_SingleLineEnterAdvances pins that Enter on a single-line field
 // (name) neither inserts a newline nor submits — it stays huh's advance key.
 func TestEntryForm_SingleLineEnterAdvances(t *testing.T) {
@@ -802,10 +837,17 @@ func TestFormKeyMap_MultilineBindings(t *testing.T) {
 	km := formKeyMap()
 	tab := tea.KeyPressMsg{Code: tea.KeyTab}
 
+	ctrlJ := tea.KeyPressMsg{Code: 'j', Mod: tea.ModCtrl}
+	ctrlE := tea.KeyPressMsg{Code: 'e', Mod: tea.ModCtrl}
+
 	assert.True(t, key.Matches(keyEnter(), km.Text.NewLine), "enter inserts a newline")
+	assert.True(t, key.Matches(ctrlJ, km.Text.NewLine), "ctrl+j inserts a newline")
 	assert.True(t, key.Matches(tab, km.Text.Next), "tab advances to the next field")
 	assert.False(t, key.Matches(keyEnter(), km.Text.Next), "enter does not advance (it inserts a newline)")
 	assert.False(t, key.Matches(keyEnter(), km.Text.Submit), "a multi-line field never submits on enter")
+	// ctrl+e must NOT trigger huh's built-in editor: the binding is disabled so the
+	// key falls through to the textarea as readline end-of-line (not launch nano).
+	assert.False(t, key.Matches(ctrlE, km.Text.Editor), "ctrl+e does not open huh's built-in editor")
 }
 
 // TestDeleteConfirm_ForceRecoveryGating pins that force/recovery rows appear only

--- a/internal/tui/dialogs/entryform.go
+++ b/internal/tui/dialogs/entryform.go
@@ -284,11 +284,18 @@ func (d *entryForm) rebuildForm() tea.Cmd {
 // the caret motions ctrl+a/ctrl+e now stay with the text input.)
 func formKeyMap() *huh.KeyMap {
 	km := huh.NewDefaultKeyMap()
-	km.Text.NewLine = key.NewBinding(key.WithKeys("enter"), key.WithHelp("enter", "new line"))
+	km.Text.NewLine = key.NewBinding(key.WithKeys("enter", "ctrl+j"), key.WithHelp("enter", "new line"))
 	km.Text.Next = key.NewBinding(key.WithKeys("tab"), key.WithHelp("tab", "next"))
 	// A multi-line field is never the last field (the OK button is), so its Submit
 	// never fires; disable it so Enter there only ever inserts a newline.
 	km.Text.Submit = key.NewBinding(key.WithDisabled())
+	// Disable huh's built-in ctrl+e "open editor" binding. huh only disables it via
+	// Text.KeyBinds() (the help path), which never runs while WithShowHelp(false),
+	// so ExternalEditor(false) alone leaves ctrl+e live — it would launch huh's
+	// default "nano" and shadow the textarea's ctrl+e (readline end-of-line). We own
+	// the $EDITOR handoff on ctrl+o (see editorKey), so ctrl+e is freed to reach the
+	// textarea as end-of-line.
+	km.Text.Editor = key.NewBinding(key.WithDisabled())
 
 	return km
 }


### PR DESCRIPTION
## Summary

In the create/edit dialog's multi-line **Value** / **Description** textareas, **Ctrl+E** launched huh's built-in external editor — defaulting to `nano` when `$EDITOR` is unset — instead of moving the caret to end-of-line, shadowing the readline motion users expect. This PR frees Ctrl+E for end-of-line and restores Ctrl+J as a newline key.

## Root cause

The form fields are `huh.NewText()` backed by a bubbles `textarea`. huh binds **ctrl+e** to its "open editor" action (`TextKeyMap.Editor`), and only *disables* that binding inside `Text.KeyBinds()` — the **help-rendering** path:

```go
// huh/v2 field_text.go
func (t *Text) KeyBinds() []key.Binding {
    t.keymap.Editor.SetEnabled(t.externalEditor) // only place the disable happens
    ...
}
```

`KeyBinds()` runs only when help is shown (`group.go`: `if g.showHelp && ...`). This form uses `WithShowHelp(false)`, so `KeyBinds()` **never runs** — `ExternalEditor(false)` never takes effect, the `ctrl+e` binding stays live, and it intercepts the key in `Update` before it reaches the textarea. The launched editor is huh's `defaultEditor = "nano"`.

Ctrl+A worked because huh has no `ctrl+a` binding, so it already fell through to the textarea's `LineStart`.

## Fix

Disable huh's `Text.Editor` binding directly in the form keymap, independent of the help path:

```go
km.Text.Editor = key.NewBinding(key.WithDisabled())
```

- **Ctrl+E** now falls through to the textarea as **end-of-line**.
- The app's own `$EDITOR` handoff stays on **Ctrl+O** (`editorKey`); `ExternalEditor(false)` is kept so both paths agree on "disabled".
- Also restored **Ctrl+J** as a newline key alongside Enter (it had been dropped when `NewLine` was narrowed to `"enter"` only). Note Ctrl+M is CR — indistinguishable from Enter at the terminal — so it is covered by the `enter` binding.

Full readline audit of the multi-line field: after this change the only keys huh intercepts before the textarea are **Tab / Shift+Tab** (field navigation, intended). Every readline editing key (Ctrl+A/E/F/B/K/U/W/D/H/T/V, Alt+F/B/D/</>, Ctrl+P/N, …) reaches the textarea. Single-line Name/Namespace fields were never affected (huh's `AcceptSuggestion=ctrl+e` is disabled when no suggestions are set).

## Testing

- `mise test` — green.
- `mise lint` — the changed packages report **0 issues** (`internal/tui/dialogs`, `e2e`). *(There are 3 pre-existing lint findings in `e2e/gcloud_*` unrelated to this PR.)*
- `mise build-gui` — builds.

New coverage:
- `TestFormKeyMap_MultilineBindings` — keymap contract: `ctrl+j` inserts a newline; `ctrl+e` does **not** open huh's editor.
- `TestEntryForm_ValueReadlineMotions` — drives the **real huh form + bubbles textarea**: from `"old"`, Ctrl+A + `"X"` prepends and Ctrl+E + `"Y"` appends → `"XoldY"` (before the fix Ctrl+E did not move the caret, giving `"XYold"`). Deterministic because the dialog's `Update` is synchronous.

A teatest e2e cannot drive this reliably — `teatest.Send` is asynchronous, so a `Tab` that changes field focus races the keystrokes typed right after it (the first char lands in the previous field). That matches the existing TUI e2e suite, which drives browser navigation and pre-seeded staging rather than multi-field form typing; a `NOTE` in `e2e/aws_tui_test.go` records the rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)