### PR TITLE
docs(readme): add a `--description` column to the metadata terminology table

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ A **Git-like CLI/TUI/GUI** for AWS Parameter Store / Secrets Manager, Google Clo
 
 suve uses AWS-friendly terms and maps each backend's native concept onto three axes. Mind two naming traps: Google Cloud "labels" are suve **tags** (key=value metadata), and Azure App Configuration's "label" is suve's **namespace** (an identity axis, `--namespace`/`--ns`) — neither is the other.
 
-| Backend | suve **tag** (`tag`/`untag`) | suve **`:LABEL`** (version selector) | suve **namespace** (`--namespace`) |
-|---|---|---|---|
-| AWS Parameter Store | resource tags | — | — |
-| AWS Secrets Manager | resource tags | version staging labels (`AWSCURRENT` / `AWSPREVIOUS` / custom) | — |
-| Google Cloud Secret Manager | resource **labels** | — | — |
-| Azure Key Vault | tags on a specific version | — | — |
-| Azure App Configuration | tags on a specific version | — | **label** — the `(key, label)` composite address (unset = empty string, or `dev` / `prd` / …) |
+| Backend | suve **tag**<br>(`tag`/`untag`) | suve **`:LABEL`**<br>(version selector) | suve **description**<br>(`--description`) | suve **namespace**<br>(`--namespace`) |
+|---|---|---|---|---|
+| AWS Parameter Store | resource tags | — | resource description | — |
+| AWS Secrets Manager | resource tags | version staging labels (`AWSCURRENT` / `AWSPREVIOUS` / custom) | resource description | — |
+| Google Cloud Secret Manager | resource **labels** | — | resource **annotation: `description=...`** | — |
+| Azure Key Vault | tags on a specific version | — | — | — |
+| Azure App Configuration | tags on a specific version | — | — | **label** — the `(key, label)` composite address (unset = empty string, or `dev` / `prd` / …) |
 
 All key=value metadata is unified as **tags**; suve adds no per-provider command or flag aliases. For the App Configuration label axis, see [Namespaces](#namespaces).
 


### PR DESCRIPTION
## Summary

The **Metadata terminology** table mapped each backend's `tag`, `:LABEL` (version selector), and `namespace` concept, but left out the free-text **description** that most backends support. This adds a `suve --description` column so the table covers every metadata concept suve maps.

## New column

| Backend | `--description` maps to |
|---|---|
| AWS Parameter Store | resource description |
| AWS Secrets Manager | resource description |
| Google Cloud Secret Manager | the `description=...` secret **annotation** |
| Azure Key Vault | — (unsupported) |
| Azure App Configuration | — (unsupported) |

Verified against the implementation:
- `--description` flag exists on AWS param/secret `create`/`update`, Google Cloud `create`/`update`, and `stage add`/`stage edit`.
- `HasDescription` is `true` for AWS Param, AWS Secret, and Google Cloud Secret Manager; unset (false) for Azure Key Vault and App Configuration (`internal/capability/capability.go`).
- Google Cloud stores the description under the secret annotation key `"description"` (`internal/provider/gcloud/secret/secret.go`, `descriptionAnnotation`).

## Notes

- Existing cell content is unchanged; only the new column and `<br>` header line-breaks (to keep the now-five-column table readable) were added.
- Dashes normalized to `—` for the "not applicable" cells, consistent with the rest of the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)