### PR TITLE
docs(readme): build the GUI with `mise build-gui`

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,12 +189,11 @@ mise build-cli
 # Binary: bin/suve
 ```
 
-**CLI/TUI + GUI** (requires [Wails CLI](https://wails.io/) and [Node.js](https://nodejs.org/)):
+**CLI/TUI + GUI** (requires [Node.js](https://nodejs.org/) for the frontend build):
 
 ```bash
-go install github.com/wailsapp/wails/v2/cmd/wails@latest
-cd gui && wails build -tags production -skipbindings
-# Binary: gui/build/bin/gui
+mise build-gui
+# Binary: bin/suve  (run `suve --gui`)
 ```
 
 **Build dependencies for GUI:**
@@ -218,10 +217,10 @@ Linux requires GTK3 and WebKit2GTK:
 | Fedora 40+ | `sudo dnf install gtk3-devel webkit2gtk4.1-devel` |
 | Arch Linux | `sudo pacman -S gtk3 webkit2gtk-4.1` |
 
-For **webkit2gtk-4.1** (Ubuntu 24.04+, Fedora 40+, Arch Linux), use the `webkit2_41` build tag:
+For **webkit2gtk-4.1** (Ubuntu 24.04+, Fedora 40+, Arch Linux), add the `webkit2_41` build tag via `SUVE_GUI_TAGS`:
 
 ```bash
-cd gui && wails build -tags production,webkit2_41 -skipbindings
+SUVE_GUI_TAGS=production,webkit2_41 mise build-gui
 ```
 
 </details>


### PR DESCRIPTION
## Summary

The **Building from source** GUI instructions were stale. They told users to install the Wails CLI and run the raw build:

```bash
go install github.com/wailsapp/wails/v2/cmd/wails@latest
cd gui && wails build -tags production -skipbindings
# Binary: gui/build/bin/gui
```

That is no longer how the binary is produced. `mise build-gui` builds the embedded frontend and compiles the single `bin/suve` (CLI+GUI) via `go build` — the Wails CLI is only needed for `wails dev` / `mise generate-gui-bindings`, not for building.

## Changes

- Replace the GUI build snippet with `mise build-gui` (output: `bin/suve`, run `suve --gui`).
- Replace the webkit2gtk-4.1 snippet with `SUVE_GUI_TAGS=production,webkit2_41 mise build-gui` (the env override the task documents).
- Drop the stale **Wails CLI** prerequisite from the section header; **Node.js** is still required (the task runs `npm install && npm run build`).

Verified against `mise.toml` (`[tasks.build-gui]`): it runs the frontend build then `CGO_ENABLED=1 go build -tags "${SUVE_GUI_TAGS:-production}" -o bin/suve ./cmd/suve` — no `wails` invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)