### PR TITLE
test(usecase/gcloud,azure): cover with-value list fetch, delete/update previews, and error paths

### DIFF
--- a/internal/usecase/azure/azure_test.go
+++ b/internal/usecase/azure/azure_test.go
@@ -245,3 +245,292 @@ func TestListUseCase_SortsNames(t *testing.T) {
 
 	assert.Equal(t, []string{"alpha", "bravo", "charlie"}, names)
 }
+
+// TestListUseCase_WithValue exercises the --with-value parallel fetch path
+// (Execute + buildOutput + fetchValues): every name's value is fetched, and a
+// per-name Get failure is surfaced on that entry's Error field.
+func TestListUseCase_WithValue(t *testing.T) {
+	t.Parallel()
+
+	store := &providermock.Store{
+		ListFunc: func(_ context.Context) ([]string, error) {
+			return []string{"alpha", "bravo"}, nil
+		},
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			if name == "bravo" {
+				return nil, assert.AnError
+			}
+
+			return &domain.Entry{Name: name, Value: "val-" + name}, nil
+		},
+	}
+
+	uc := &azure.ListUseCase{Reader: store}
+	out, err := uc.Execute(t.Context(), azure.ListInput{WithValue: true})
+	require.NoError(t, err)
+	require.Len(t, out.Entries, 2)
+
+	byName := lo.SliceToMap(out.Entries, func(e azure.ListEntry) (string, azure.ListEntry) {
+		return e.Name, e
+	})
+
+	require.NotNil(t, byName["alpha"].Value)
+	assert.Equal(t, "val-alpha", *byName["alpha"].Value)
+	require.NoError(t, byName["alpha"].Error)
+
+	assert.Nil(t, byName["bravo"].Value)
+	require.ErrorIs(t, byName["bravo"].Error, assert.AnError)
+}
+
+// TestListUseCase_Error asserts a List failure is wrapped and propagated.
+func TestListUseCase_Error(t *testing.T) {
+	t.Parallel()
+
+	store := &providermock.Store{
+		ListFunc: func(_ context.Context) ([]string, error) {
+			return nil, assert.AnError
+		},
+	}
+
+	uc := &azure.ListUseCase{Reader: store}
+	_, err := uc.Execute(t.Context(), azure.ListInput{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list entries")
+}
+
+// TestListUseCase_InvalidFilter asserts a bad regex is a usage error.
+func TestListUseCase_InvalidFilter(t *testing.T) {
+	t.Parallel()
+
+	uc := &azure.ListUseCase{Reader: &providermock.Store{}}
+	_, err := uc.Execute(t.Context(), azure.ListInput{Filter: "["})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid filter regex")
+}
+
+func TestDeleteUseCase_GetCurrentValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		getErr    error
+		wantValue string
+		wantErr   error
+	}{
+		{name: "found", wantValue: "current"},
+		{name: "not found yields empty", getErr: provider.ErrNotFound},
+		{name: "other error propagates", getErr: assert.AnError, wantErr: assert.AnError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := &providermock.Store{
+				GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+					if tt.getErr != nil {
+						return nil, tt.getErr
+					}
+
+					return &domain.Entry{Name: name, Value: "current"}, nil
+				},
+			}
+
+			uc := &azure.DeleteUseCase{Store: store}
+			val, err := uc.GetCurrentValue(t.Context(), "my-entry")
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantValue, val)
+		})
+	}
+}
+
+func TestDeleteUseCase_Execute(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		var deleted string
+
+		store := &providermock.Store{
+			DeleteFunc: func(_ context.Context, name string, _ ...provider.DeleteOption) error {
+				deleted = name
+
+				return nil
+			},
+		}
+
+		uc := &azure.DeleteUseCase{Store: store}
+		out, err := uc.Execute(t.Context(), azure.DeleteInput{Name: "my-entry"})
+		require.NoError(t, err)
+		assert.Equal(t, "my-entry", out.Name)
+		assert.Equal(t, "my-entry", deleted)
+	})
+
+	t.Run("error is wrapped", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			DeleteFunc: func(_ context.Context, _ string, _ ...provider.DeleteOption) error {
+				return assert.AnError
+			},
+		}
+
+		uc := &azure.DeleteUseCase{Store: store}
+		_, err := uc.Execute(t.Context(), azure.DeleteInput{Name: "my-entry"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to delete entry")
+	})
+}
+
+// TestRestoreUseCase_Execute covers the Key Vault soft-delete recovery path
+// (delete.go RestoreUseCase.Execute), both success and wrapped-error.
+func TestRestoreUseCase_Execute(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		var restored string
+
+		store := &providermock.Store{
+			RestoreFunc: func(_ context.Context, name string) error {
+				restored = name
+
+				return nil
+			},
+		}
+
+		uc := &azure.RestoreUseCase{Restorer: store}
+		out, err := uc.Execute(t.Context(), azure.RestoreInput{Name: "my-entry"})
+		require.NoError(t, err)
+		assert.Equal(t, "my-entry", out.Name)
+		assert.Equal(t, "my-entry", restored)
+	})
+
+	t.Run("error is wrapped", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			RestoreFunc: func(_ context.Context, _ string) error {
+				return assert.AnError
+			},
+		}
+
+		uc := &azure.RestoreUseCase{Restorer: store}
+		_, err := uc.Execute(t.Context(), azure.RestoreInput{Name: "my-entry"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to restore entry")
+	})
+}
+
+func TestUpdateUseCase_GetCurrentValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		getErr    error
+		wantValue string
+		wantErr   error
+	}{
+		{name: "found", wantValue: "current"},
+		{name: "not found yields empty", getErr: provider.ErrNotFound},
+		{name: "other error propagates", getErr: assert.AnError, wantErr: assert.AnError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := &providermock.Store{
+				GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+					if tt.getErr != nil {
+						return nil, tt.getErr
+					}
+
+					return &domain.Entry{Name: name, Value: "current"}, nil
+				},
+			}
+
+			uc := &azure.UpdateUseCase{Store: store}
+			val, err := uc.GetCurrentValue(t.Context(), "my-entry")
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantValue, val)
+		})
+	}
+}
+
+// TestUpdateUseCase_Execute covers the success path plus the non-not-found read
+// failure and Put failure branches (the not-found branch is TestUpdateUseCase_NotFound).
+func TestUpdateUseCase_Execute(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		var gotType domain.ValueType
+
+		store := &providermock.Store{
+			GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+				return &domain.Entry{Name: name, Value: "old"}, nil
+			},
+			PutFunc: func(_ context.Context, _, _ string, valueType domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
+				gotType = valueType
+
+				return domain.Version{ID: "abc"}, nil
+			},
+		}
+
+		uc := &azure.UpdateUseCase{Store: store}
+		out, err := uc.Execute(t.Context(), azure.UpdateInput{Name: "my-entry", Value: "v", ValueType: domain.ValueTypeSecret})
+		require.NoError(t, err)
+		assert.Equal(t, "abc", out.Version)
+		assert.Equal(t, domain.ValueTypeSecret, gotType)
+	})
+
+	t.Run("read failure propagates unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) {
+				return nil, assert.AnError
+			},
+		}
+
+		uc := &azure.UpdateUseCase{Store: store}
+		_, err := uc.Execute(t.Context(), azure.UpdateInput{Name: "my-entry", Value: "v", ValueType: domain.ValueTypePlaintext})
+		require.ErrorIs(t, err, assert.AnError)
+	})
+
+	t.Run("put failure is wrapped", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+				return &domain.Entry{Name: name, Value: "old"}, nil
+			},
+			PutFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
+				return domain.Version{}, assert.AnError
+			},
+		}
+
+		uc := &azure.UpdateUseCase{Store: store}
+		_, err := uc.Execute(t.Context(), azure.UpdateInput{Name: "my-entry", Value: "v", ValueType: domain.ValueTypePlaintext})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to update entry")
+	})
+}

--- a/internal/usecase/gcloud/gcloud_test.go
+++ b/internal/usecase/gcloud/gcloud_test.go
@@ -2,6 +2,7 @@ package gcloud_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -215,4 +216,449 @@ func TestListUseCase_SortsNames(t *testing.T) {
 	}
 
 	assert.Equal(t, []string{"alpha", "bravo", "charlie"}, names)
+}
+
+// TestListUseCase_WithValue exercises the --with-value parallel fetch path
+// (buildOutput + fetchValues): every name's current value is fetched, and a
+// per-name Get failure is surfaced on that entry's Error field rather than
+// aborting the whole listing.
+func TestListUseCase_WithValue(t *testing.T) {
+	t.Parallel()
+
+	store := &providermock.Store{
+		ListFunc: func(_ context.Context) ([]string, error) {
+			return []string{"alpha", "bravo"}, nil
+		},
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			if name == "bravo" {
+				return nil, assert.AnError
+			}
+
+			return &domain.Entry{Name: name, Value: "val-" + name}, nil
+		},
+	}
+
+	uc := &gcloud.ListUseCase{Reader: store}
+	out, err := uc.Execute(t.Context(), gcloud.ListInput{WithValue: true})
+	require.NoError(t, err)
+	require.Len(t, out.Entries, 2)
+
+	byName := lo.SliceToMap(out.Entries, func(e gcloud.ListEntry) (string, gcloud.ListEntry) {
+		return e.Name, e
+	})
+
+	require.NotNil(t, byName["alpha"].Value)
+	assert.Equal(t, "val-alpha", *byName["alpha"].Value)
+	require.NoError(t, byName["alpha"].Error)
+
+	assert.Nil(t, byName["bravo"].Value)
+	require.ErrorIs(t, byName["bravo"].Error, assert.AnError)
+}
+
+// TestListUseCase_Error asserts a List failure is wrapped and propagated.
+func TestListUseCase_Error(t *testing.T) {
+	t.Parallel()
+
+	store := &providermock.Store{
+		ListFunc: func(_ context.Context) ([]string, error) {
+			return nil, assert.AnError
+		},
+	}
+
+	uc := &gcloud.ListUseCase{Reader: store}
+	_, err := uc.Execute(t.Context(), gcloud.ListInput{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list secrets")
+}
+
+// TestListUseCase_InvalidFilter asserts a bad regex is a usage error.
+func TestListUseCase_InvalidFilter(t *testing.T) {
+	t.Parallel()
+
+	uc := &gcloud.ListUseCase{Reader: &providermock.Store{}}
+	_, err := uc.Execute(t.Context(), gcloud.ListInput{Filter: "["})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid filter regex")
+}
+
+func TestDeleteUseCase_GetCurrentValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		getErr    error
+		wantValue string
+		wantErr   error
+	}{
+		{name: "found", wantValue: "current"},
+		{name: "not found yields empty", getErr: provider.ErrNotFound},
+		{name: "other error propagates", getErr: assert.AnError, wantErr: assert.AnError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := &providermock.Store{
+				GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+					if tt.getErr != nil {
+						return nil, tt.getErr
+					}
+
+					return &domain.Entry{Name: name, Value: "current"}, nil
+				},
+			}
+
+			uc := &gcloud.DeleteUseCase{Store: store}
+			val, err := uc.GetCurrentValue(t.Context(), "my-secret")
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantValue, val)
+		})
+	}
+}
+
+func TestDeleteUseCase_Execute(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		var deleted string
+
+		store := &providermock.Store{
+			DeleteFunc: func(_ context.Context, name string, _ ...provider.DeleteOption) error {
+				deleted = name
+
+				return nil
+			},
+		}
+
+		uc := &gcloud.DeleteUseCase{Store: store}
+		out, err := uc.Execute(t.Context(), gcloud.DeleteInput{Name: "my-secret"})
+		require.NoError(t, err)
+		assert.Equal(t, "my-secret", out.Name)
+		assert.Equal(t, "my-secret", deleted)
+	})
+
+	t.Run("error is wrapped", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			DeleteFunc: func(_ context.Context, _ string, _ ...provider.DeleteOption) error {
+				return assert.AnError
+			},
+		}
+
+		uc := &gcloud.DeleteUseCase{Store: store}
+		_, err := uc.Execute(t.Context(), gcloud.DeleteInput{Name: "my-secret"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to delete secret")
+	})
+}
+
+func TestUpdateUseCase_GetCurrentValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		getErr    error
+		wantValue string
+		wantErr   error
+	}{
+		{name: "found", wantValue: "current"},
+		{name: "not found yields empty", getErr: provider.ErrNotFound},
+		{name: "other error propagates", getErr: assert.AnError, wantErr: assert.AnError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := &providermock.Store{
+				GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+					if tt.getErr != nil {
+						return nil, tt.getErr
+					}
+
+					return &domain.Entry{Name: name, Value: "current"}, nil
+				},
+			}
+
+			uc := &gcloud.UpdateUseCase{Store: store}
+			val, err := uc.GetCurrentValue(t.Context(), "my-secret")
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantValue, val)
+		})
+	}
+}
+
+// TestUpdateUseCase_Execute_ErrorBranches covers the not-found, non-not-found
+// read failure, and Put failure branches of the update Execute path.
+func TestUpdateUseCase_Execute_ErrorBranches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("not found maps to ErrSecretNotFound", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) {
+				return nil, provider.ErrNotFound
+			},
+		}
+
+		uc := &gcloud.UpdateUseCase{Store: store}
+		_, err := uc.Execute(t.Context(), gcloud.UpdateInput{Name: "missing", Value: "v"})
+		require.ErrorIs(t, err, gcloud.ErrSecretNotFound)
+	})
+
+	t.Run("read failure propagates unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) {
+				return nil, assert.AnError
+			},
+		}
+
+		uc := &gcloud.UpdateUseCase{Store: store}
+		_, err := uc.Execute(t.Context(), gcloud.UpdateInput{Name: "my-secret", Value: "v"})
+		require.ErrorIs(t, err, assert.AnError)
+	})
+
+	t.Run("put failure is wrapped", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+				return &domain.Entry{Name: name, Value: "old"}, nil
+			},
+			PutFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
+				return domain.Version{}, assert.AnError
+			},
+		}
+
+		uc := &gcloud.UpdateUseCase{Store: store}
+		_, err := uc.Execute(t.Context(), gcloud.UpdateInput{Name: "my-secret", Value: "v"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to update secret")
+	})
+}
+
+// TestCreateUseCase_Error asserts a Create failure is wrapped.
+func TestCreateUseCase_Error(t *testing.T) {
+	t.Parallel()
+
+	store := &providermock.Store{
+		CreateFunc: func(_ context.Context, _, _ string, _ domain.ValueType, _ string, _ ...provider.WriteOption) (domain.Version, error) {
+			return domain.Version{}, provider.ErrAlreadyExists
+		},
+	}
+
+	uc := &gcloud.CreateUseCase{Writer: store}
+	_, err := uc.Execute(t.Context(), gcloud.CreateInput{Name: "my-secret", Value: "v"})
+	require.Error(t, err)
+	require.ErrorIs(t, err, provider.ErrAlreadyExists)
+	assert.Contains(t, err.Error(), "failed to create secret")
+}
+
+// TestShowUseCase_Errors covers the Resolve-error and Get-error branches.
+func TestShowUseCase_Errors(t *testing.T) {
+	t.Parallel()
+
+	spec, err := gcloudversion.Parse("my-secret#3")
+	require.NoError(t, err)
+
+	t.Run("resolve error", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			ResolveFunc: func(_ context.Context, _, _ string) (provider.VersionRef, error) {
+				return provider.VersionRef{}, assert.AnError
+			},
+		}
+
+		uc := &gcloud.ShowUseCase{Reader: store}
+		_, err := uc.Execute(t.Context(), gcloud.ShowInput{Spec: spec})
+		require.ErrorIs(t, err, assert.AnError)
+	})
+
+	t.Run("get error", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			ResolveFunc: func(_ context.Context, _, _ string) (provider.VersionRef, error) {
+				return provider.NewVersionRef("3"), nil
+			},
+			GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) {
+				return nil, assert.AnError
+			},
+		}
+
+		uc := &gcloud.ShowUseCase{Reader: store}
+		_, err := uc.Execute(t.Context(), gcloud.ShowInput{Spec: spec})
+		require.ErrorIs(t, err, assert.AnError)
+	})
+}
+
+// TestDiffUseCase_Errors covers a resolve failure on the first spec and a get
+// failure on the second.
+func TestDiffUseCase_Errors(t *testing.T) {
+	t.Parallel()
+
+	spec1, err := gcloudversion.Parse("my-secret#1")
+	require.NoError(t, err)
+
+	spec2, err := gcloudversion.Parse("my-secret")
+	require.NoError(t, err)
+
+	t.Run("resolve failure on first spec", func(t *testing.T) {
+		t.Parallel()
+
+		store := &providermock.Store{
+			ResolveFunc: func(_ context.Context, _, _ string) (provider.VersionRef, error) {
+				return provider.VersionRef{}, assert.AnError
+			},
+		}
+
+		uc := &gcloud.DiffUseCase{Reader: store}
+		_, err := uc.Execute(t.Context(), gcloud.DiffInput{Spec1: spec1, Spec2: spec2})
+		require.ErrorIs(t, err, assert.AnError)
+	})
+
+	t.Run("get failure on second spec", func(t *testing.T) {
+		t.Parallel()
+
+		sentinel := errors.New("boom on #2")
+		store := &providermock.Store{
+			ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+				return provider.NewVersionRef(strings.TrimPrefix(spec, "#")), nil
+			},
+			GetFunc: func(_ context.Context, name string, ref provider.VersionRef) (*domain.Entry, error) {
+				if ref.ID() == "" {
+					return nil, sentinel
+				}
+
+				return &domain.Entry{Name: name, Value: "v", Version: domain.Version{ID: ref.ID()}}, nil
+			},
+		}
+
+		uc := &gcloud.DiffUseCase{Reader: store}
+		_, err := uc.Execute(t.Context(), gcloud.DiffInput{Spec1: spec1, Spec2: spec2})
+		require.ErrorIs(t, err, sentinel)
+	})
+}
+
+// TestLogUseCase_PerVersionFetchError asserts a resolve/get failure for a single
+// version is recorded on that entry's Error field, not fatal to the listing.
+func TestLogUseCase_PerVersionFetchError(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	versions := []domain.Version{
+		{ID: "2", State: "enabled", Created: &now},
+		{ID: "1", State: "destroyed", Created: lo.ToPtr(now.Add(-time.Hour))},
+	}
+
+	resolveErr := errors.New("cannot resolve destroyed")
+
+	store := &providermock.Store{
+		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
+			return versions, nil
+		},
+		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+			if spec == "#1" {
+				return provider.VersionRef{}, resolveErr
+			}
+
+			return provider.NewVersionRef(strings.TrimPrefix(spec, "#")), nil
+		},
+		GetFunc: func(_ context.Context, name string, ref provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{Name: name, Value: "val" + ref.ID(), Version: domain.Version{ID: ref.ID()}}, nil
+		},
+	}
+
+	uc := &gcloud.LogUseCase{Reader: store}
+	out, err := uc.Execute(t.Context(), gcloud.LogInput{Name: "my-secret"})
+	require.NoError(t, err)
+	require.Len(t, out.Entries, 2)
+	assert.True(t, out.InitialIncluded)
+
+	assert.Equal(t, "val2", out.Entries[0].Value)
+	require.NoError(t, out.Entries[0].Error)
+
+	assert.Empty(t, out.Entries[1].Value)
+	require.ErrorIs(t, out.Entries[1].Error, resolveErr)
+}
+
+// TestLogUseCase_GetError asserts a Get failure (as opposed to Resolve) on a
+// version is likewise recorded per-entry.
+func TestLogUseCase_GetError(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	store := &providermock.Store{
+		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
+			return []domain.Version{{ID: "1", Created: &now}}, nil
+		},
+		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+			return provider.NewVersionRef(strings.TrimPrefix(spec, "#")), nil
+		},
+		GetFunc: func(_ context.Context, _ string, _ provider.VersionRef) (*domain.Entry, error) {
+			return nil, assert.AnError
+		},
+	}
+
+	uc := &gcloud.LogUseCase{Reader: store}
+	out, err := uc.Execute(t.Context(), gcloud.LogInput{Name: "my-secret"})
+	require.NoError(t, err)
+	require.Len(t, out.Entries, 1)
+	require.ErrorIs(t, out.Entries[0].Error, assert.AnError)
+}
+
+// TestLogUseCase_EmptyHistory covers the early return when the secret has no
+// versions.
+func TestLogUseCase_EmptyHistory(t *testing.T) {
+	t.Parallel()
+
+	store := &providermock.Store{
+		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
+			return nil, nil
+		},
+	}
+
+	uc := &gcloud.LogUseCase{Reader: store}
+	out, err := uc.Execute(t.Context(), gcloud.LogInput{Name: "my-secret"})
+	require.NoError(t, err)
+	assert.Empty(t, out.Entries)
+	assert.False(t, out.InitialIncluded)
+}
+
+// TestLogUseCase_HistoryError asserts a History failure is wrapped.
+func TestLogUseCase_HistoryError(t *testing.T) {
+	t.Parallel()
+
+	store := &providermock.Store{
+		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
+			return nil, assert.AnError
+		},
+	}
+
+	uc := &gcloud.LogUseCase{Reader: store}
+	_, err := uc.Execute(t.Context(), gcloud.LogInput{Name: "my-secret"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to list secret versions")
 }


### PR DESCRIPTION
Closes #818

Extend the gcloud/azure use-case tests to cover the provider-specific presentation layer that e2e never reaches: the `--with-value` parallel value fetch (`buildOutput`/`fetchValues`), `GetCurrentValue` delete/update previews for both clouds, the Key Vault restore path, and the `Execute` error branches (not-found mapping, propagated read failures, wrapped write/list failures).

## Verification

Gates run in the worktree (not `mise lint` — it deadlocks across parallel worktrees):

```
$ go build ./...
(ok)

$ SUVE_STAGING_KEY=… go test ./internal/usecase/...
ok  	github.com/mpyw/suve/internal/usecase/azure
ok  	github.com/mpyw/suve/internal/usecase/gcloud
ok  	github.com/mpyw/suve/internal/usecase/param
ok  	github.com/mpyw/suve/internal/usecase/secret
ok  	github.com/mpyw/suve/internal/usecase/staging

$ golangci-lint run --allow-parallel-runners ./internal/usecase/...
0 issues.
```

Coverage delta (`go test -cover ./internal/usecase/gcloud/... ./internal/usecase/azure/...`):

| package | before | after |
| --- | --- | --- |
| internal/usecase/gcloud | 51.9% | 94.1% |
| internal/usecase/azure  | 53.0% | 86.8% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)