### PR TITLE
test(cli/azure): cover param/secret presenter JSON+oneline paths and the App Configuration diff presenter

### DIFF
--- a/internal/cli/commands/azure/param/param_test.go
+++ b/internal/cli/commands/azure/param/param_test.go
@@ -3,19 +3,23 @@ package param_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	appcli "github.com/mpyw/suve/internal/cli/commands"
 	"github.com/mpyw/suve/internal/cli/commands/azure/param"
+	genericdiff "github.com/mpyw/suve/internal/cli/commands/generic/diff"
 	genericlog "github.com/mpyw/suve/internal/cli/commands/generic/log"
 	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/azure/appconfig"
 	"github.com/mpyw/suve/internal/provider/providermock"
+	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/usecase/azure"
 	"github.com/mpyw/suve/internal/version/azureappconfigversion"
 )
@@ -358,4 +362,125 @@ func TestListRunner_NonAppConfigNoColumn(t *testing.T) {
 	}
 	require.NoError(t, r.Run(t.Context(), param.ListOptions{}))
 	assert.Equal(t, "k1\nk2\n", buf.String())
+}
+
+// TestShowPresenter_RenderJSON covers the App Configuration show presenter's
+// JSON path: name/value plus the optional "modified" timestamp and the tags map.
+func TestShowPresenter_RenderJSON(t *testing.T) {
+	t.Parallel()
+
+	modified := time.Date(2024, 5, 6, 7, 8, 9, 0, time.UTC)
+
+	store := &providermock.Store{
+		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+			assert.Empty(t, spec)
+
+			return provider.VersionRef{}, nil
+		},
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{
+				Name:    name,
+				Value:   "30",
+				Type:    domain.ValueTypePlaintext,
+				Version: domain.Version{Created: &modified}, // unversioned, but carries a modified time
+				Tags:    []domain.Tag{{Key: "env", Value: "prod"}},
+			}, nil
+		},
+	}
+
+	spec, err := azureappconfigversion.Parse("app/timeout")
+	require.NoError(t, err)
+
+	presenter := param.NewShowPresenter(store, spec)
+	require.NoError(t, presenter.Fetch(t.Context()))
+
+	var buf, errBuf bytes.Buffer
+
+	value := presenter.Value(false, &errBuf)
+	require.NoError(t, presenter.RenderJSON(&buf, value))
+
+	var out struct {
+		Name     string            `json:"name"`
+		Modified string            `json:"modified"`
+		Tags     map[string]string `json:"tags"`
+		Value    string            `json:"value"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out))
+	assert.Equal(t, "app/timeout", out.Name)
+	assert.Equal(t, "30", out.Value)
+	assert.Equal(t, timeutil.FormatRFC3339(modified), out.Modified)
+	assert.Equal(t, map[string]string{"env": "prod"}, out.Tags)
+}
+
+// TestDiffPresenter_RenderJSON drives the App Configuration diff presenter end to
+// end through the generic Runner with --output=json, covering NewDiffPresenter,
+// Fetch, OldValue/NewValue, Labels, and RenderJSON. App Configuration is
+// unversioned, so diff compares two distinct keys with an empty suffix.
+func TestDiffPresenter_RenderJSON(t *testing.T) {
+	t.Parallel()
+
+	values := map[string]string{"key-a": "alpha", "key-b": "beta"}
+
+	store := &providermock.Store{
+		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+			assert.Empty(t, spec) // App Configuration is unversioned.
+
+			return provider.VersionRef{}, nil
+		},
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{Name: name, Value: values[name]}, nil
+		},
+	}
+
+	spec1, err := azureappconfigversion.Parse("key-a")
+	require.NoError(t, err)
+	spec2, err := azureappconfigversion.Parse("key-b")
+	require.NoError(t, err)
+
+	presenter := param.NewDiffPresenter(store, spec1, spec2)
+
+	var stdout, stderr bytes.Buffer
+
+	r := &genericdiff.Runner{
+		Presenter: presenter,
+		Options:   genericdiff.Options{Output: output.FormatJSON},
+		Stdout:    &stdout,
+		Stderr:    &stderr,
+	}
+	require.NoError(t, r.Run(t.Context()))
+
+	var out struct {
+		OldName   string `json:"oldName"`
+		OldValue  string `json:"oldValue"`
+		NewName   string `json:"newName"`
+		NewValue  string `json:"newValue"`
+		Identical bool   `json:"identical"`
+	}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &out))
+	assert.Equal(t, "key-a", out.OldName)
+	assert.Equal(t, "alpha", out.OldValue)
+	assert.Equal(t, "key-b", out.NewName)
+	assert.Equal(t, "beta", out.NewValue)
+	assert.False(t, out.Identical)
+}
+
+// TestLogPresenter_RenderStubs covers the App Configuration log presenter's
+// render stubs. App Configuration has no version history, so these methods only
+// exist to satisfy the genericlog.Presenter interface and must be safe no-ops.
+func TestLogPresenter_RenderStubs(t *testing.T) {
+	t.Parallel()
+
+	presenter := param.NewLogPresenter(&providermock.Store{}, genericlog.Request{Name: "my-key"})
+
+	var buf, errBuf bytes.Buffer
+
+	assert.Equal(t, 0, presenter.Len())
+	require.NoError(t, presenter.RenderJSON(&buf))
+	presenter.RenderOneline(&buf, 0, 0)
+	presenter.RenderHeader(&buf, 0)
+	presenter.RenderValue(&buf, 0, 0)
+	presenter.RenderPatch(&buf, &errBuf, 0, false, false)
+
+	assert.Empty(t, buf.String())
+	assert.Empty(t, errBuf.String())
 }

--- a/internal/cli/commands/azure/secret/secret_test.go
+++ b/internal/cli/commands/azure/secret/secret_test.go
@@ -3,7 +3,10 @@ package secret_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,10 +15,13 @@ import (
 
 	appcli "github.com/mpyw/suve/internal/cli/commands"
 	"github.com/mpyw/suve/internal/cli/commands/azure/secret"
+	genericdiff "github.com/mpyw/suve/internal/cli/commands/generic/diff"
 	genericlog "github.com/mpyw/suve/internal/cli/commands/generic/log"
+	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/providermock"
+	"github.com/mpyw/suve/internal/timeutil"
 	"github.com/mpyw/suve/internal/usecase/azure"
 	"github.com/mpyw/suve/internal/version/azurekvversion"
 )
@@ -236,4 +242,250 @@ func TestLogPresenter_Patch(t *testing.T) {
 	assert.Contains(t, out, "my-secret#2")
 	// The initial version renders its all-added creation diff (+v1).
 	assert.Contains(t, out, "+v1")
+}
+
+// TestShowPresenter_RenderJSON covers the Key Vault show presenter's JSON path:
+// name/version/state/created plus the tags map and value.
+func TestShowPresenter_RenderJSON(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2024, 5, 6, 7, 8, 9, 0, time.UTC)
+
+	store := &providermock.Store{
+		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+			assert.Empty(t, spec)
+
+			return provider.VersionRef{}, nil
+		},
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{
+				Name:    name,
+				Value:   "s3cr3t",
+				Type:    domain.ValueTypeSecret,
+				Version: domain.Version{ID: "abc123", State: "enabled", Created: &created},
+				Tags:    []domain.Tag{{Key: "env", Value: "prod"}},
+			}, nil
+		},
+	}
+
+	spec, err := azurekvversion.Parse("my-secret")
+	require.NoError(t, err)
+
+	presenter := secret.NewShowPresenter(store, spec)
+	require.NoError(t, presenter.Fetch(t.Context()))
+
+	var buf, errBuf bytes.Buffer
+
+	value := presenter.Value(false, &errBuf)
+	require.NoError(t, presenter.RenderJSON(&buf, value))
+
+	var out struct {
+		Name    string            `json:"name"`
+		Version string            `json:"version"`
+		State   string            `json:"state"`
+		Created string            `json:"created"`
+		Tags    map[string]string `json:"tags"`
+		Value   string            `json:"value"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &out))
+	assert.Equal(t, "my-secret", out.Name)
+	assert.Equal(t, "abc123", out.Version)
+	assert.Equal(t, "enabled", out.State)
+	assert.Equal(t, timeutil.FormatRFC3339(created), out.Created)
+	assert.Equal(t, "s3cr3t", out.Value)
+	assert.Equal(t, map[string]string{"env": "prod"}, out.Tags)
+}
+
+// TestDiffPresenter_RenderJSON drives the Key Vault diff presenter end to end
+// through the generic Runner with --output=json, covering NewDiffPresenter,
+// Fetch, OldValue/NewValue, Labels, and RenderJSON.
+func TestDiffPresenter_RenderJSON(t *testing.T) {
+	t.Parallel()
+
+	values := map[string]string{"abc": "old-val", "def": "new-val"}
+
+	store := &providermock.Store{
+		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+			return provider.NewVersionRef(strings.TrimPrefix(spec, "#")), nil
+		},
+		GetFunc: func(_ context.Context, name string, ref provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{
+				Name:    name,
+				Value:   values[ref.ID()],
+				Version: domain.Version{ID: ref.ID()},
+			}, nil
+		},
+	}
+
+	spec1, err := azurekvversion.Parse("my-secret#abc")
+	require.NoError(t, err)
+	spec2, err := azurekvversion.Parse("my-secret#def")
+	require.NoError(t, err)
+
+	presenter := secret.NewDiffPresenter(store, spec1, spec2)
+
+	var stdout, stderr bytes.Buffer
+
+	r := &genericdiff.Runner{
+		Presenter: presenter,
+		Options:   genericdiff.Options{Output: output.FormatJSON},
+		Stdout:    &stdout,
+		Stderr:    &stderr,
+	}
+	require.NoError(t, r.Run(t.Context()))
+
+	var out struct {
+		OldName    string `json:"oldName"`
+		OldVersion string `json:"oldVersion"`
+		OldValue   string `json:"oldValue"`
+		NewName    string `json:"newName"`
+		NewVersion string `json:"newVersion"`
+		NewValue   string `json:"newValue"`
+		Identical  bool   `json:"identical"`
+	}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &out))
+	assert.Equal(t, "my-secret", out.OldName)
+	assert.Equal(t, "abc", out.OldVersion)
+	assert.Equal(t, "old-val", out.OldValue)
+	assert.Equal(t, "my-secret", out.NewName)
+	assert.Equal(t, "def", out.NewVersion)
+	assert.Equal(t, "new-val", out.NewValue)
+	assert.False(t, out.Identical)
+}
+
+// logStore builds a Key Vault log store from a newest-first version history.
+// A version listed in errVersions has its value fetch fail (mirroring a disabled
+// version, whose value is inaccessible).
+func logStore(history []domain.Version, errVersions ...string) *providermock.Store {
+	return &providermock.Store{
+		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
+			return history, nil
+		},
+		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+			return provider.NewVersionRef(strings.TrimPrefix(spec, "#")), nil
+		},
+		GetFunc: func(_ context.Context, _ string, ref provider.VersionRef) (*domain.Entry, error) {
+			if slices.Contains(errVersions, ref.ID()) {
+				return nil, errors.New("disabled version has no accessible value")
+			}
+
+			return &domain.Entry{Value: "v-" + ref.ID()}, nil
+		},
+	}
+}
+
+// TestLogPresenter_RenderJSON covers the JSON path, including both the value
+// branch (enabled versions) and the error branch (disabled versions) plus tags.
+func TestLogPresenter_RenderJSON(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2024, 5, 6, 7, 8, 9, 0, time.UTC)
+
+	store := logStore([]domain.Version{
+		{ID: "new", State: "enabled", Created: &created, Tags: []domain.Tag{{Key: "env", Value: "prod"}}},
+		{ID: "old", State: "disabled", Created: &created},
+	}, "old")
+
+	presenter := secret.NewLogPresenter(store, genericlog.Request{Name: "my-secret"})
+	require.NoError(t, presenter.Fetch(t.Context()))
+
+	var buf bytes.Buffer
+	require.NoError(t, presenter.RenderJSON(&buf))
+
+	var items []struct {
+		Version string            `json:"version"`
+		State   string            `json:"state"`
+		Created string            `json:"created"`
+		Value   *string           `json:"value"`
+		Tags    map[string]string `json:"tags"`
+		Error   string            `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &items))
+	require.Len(t, items, 2)
+
+	assert.Equal(t, "new", items[0].Version)
+	assert.Equal(t, "enabled", items[0].State)
+	require.NotNil(t, items[0].Value)
+	assert.Equal(t, "v-new", *items[0].Value)
+	assert.Equal(t, map[string]string{"env": "prod"}, items[0].Tags)
+	assert.Empty(t, items[0].Error)
+
+	assert.Equal(t, "old", items[1].Version)
+	assert.Nil(t, items[1].Value)
+	assert.Contains(t, items[1].Error, "disabled version")
+}
+
+// TestLogPresenter_RenderOneline covers the compact one-line format, including
+// the state annotation and the formatted date.
+func TestLogPresenter_RenderOneline(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2024, 5, 6, 7, 8, 9, 0, time.UTC)
+
+	store := logStore([]domain.Version{
+		{ID: "new", State: "enabled", Created: &created},
+	})
+
+	presenter := secret.NewLogPresenter(store, genericlog.Request{Name: "my-secret"})
+	require.NoError(t, presenter.Fetch(t.Context()))
+
+	var buf bytes.Buffer
+	presenter.RenderOneline(&buf, 0, 0)
+	// RenderValue is a documented no-op; call it to confirm it stays silent.
+	presenter.RenderValue(&buf, 0, 0)
+
+	out := buf.String()
+	assert.Contains(t, out, "new")
+	assert.Contains(t, out, "enabled")
+	assert.Contains(t, out, "2024-05-06")
+}
+
+// TestLogPresenter_PatchSkips covers the three RenderPatch skip branches:
+//   - the newest entry is disabled, so its value is missing (log.go:154);
+//   - the parent entry is disabled, so the old value is missing (log.go:180);
+//   - the oldest shown entry is not the initial version because the window was
+//     cut by --number, so no all-added creation diff is emitted (log.go:165).
+func TestLogPresenter_PatchSkips(t *testing.T) {
+	t.Parallel()
+
+	t.Run("disabled newest and disabled parent are skipped", func(t *testing.T) {
+		t.Parallel()
+
+		// History: new (enabled) -> old (disabled). Both branches are exercised:
+		// i=0 has a disabled parent (old); i=1 is itself disabled.
+		store := logStore([]domain.Version{
+			{ID: "new", State: "enabled"},
+			{ID: "old", State: "disabled"},
+		}, "old")
+
+		presenter := secret.NewLogPresenter(store, genericlog.Request{Name: "my-secret"})
+		require.NoError(t, presenter.Fetch(t.Context()))
+
+		var buf, errBuf bytes.Buffer
+
+		presenter.RenderPatch(&buf, &errBuf, 0, false, false) // parent "old" is disabled -> skip
+		presenter.RenderPatch(&buf, &errBuf, 1, false, false) // "old" itself is disabled -> skip
+
+		assert.Empty(t, buf.String())
+	})
+
+	t.Run("windowed oldest is not the initial version", func(t *testing.T) {
+		t.Parallel()
+
+		// Full history has two versions but --number=1 shows only the newest, so
+		// the oldest shown version is not the genuine initial: no creation diff.
+		store := logStore([]domain.Version{
+			{ID: "new", State: "enabled"},
+			{ID: "old", State: "enabled"},
+		})
+
+		presenter := secret.NewLogPresenter(store, genericlog.Request{Name: "my-secret", MaxResults: 1})
+		require.NoError(t, presenter.Fetch(t.Context()))
+		require.Equal(t, 1, presenter.Len())
+
+		var buf, errBuf bytes.Buffer
+		presenter.RenderPatch(&buf, &errBuf, 0, false, false)
+
+		assert.Empty(t, buf.String())
+	})
 }


### PR DESCRIPTION
Closes #819

Adds unit coverage for the Azure param/secret presenter paths that were untouched by both unit and e2e (e2e never runs `--output=json` / `--oneline` for Azure). Each test uses `providermock.Store` and renders into a `bytes.Buffer`, then `json.Unmarshal`s the output and asserts fields; diff presenters are driven end to end through `genericdiff.Runner` with `Options{Output: output.FormatJSON}`.

Covered:
- `azure/param`: `show.RenderJSON`; the entire App Configuration diff presenter (`NewDiffPresenter`/`Fetch`/`OldValue`/`NewValue`/`Labels`/`RenderJSON`); the log render stubs.
- `azure/secret`: `show.RenderJSON`; the Key Vault diff presenter via the Runner; `log.RenderJSON` (value + error branches), `RenderOneline`, and the three `RenderPatch` skip branches (disabled newest → `log.go:154`, disabled parent → `log.go:180`, windowed non-initial oldest with `InitialIncluded=false` → `log.go:165`).

## Verification

Gates run in the worktree (not `mise lint`):

```
$ go build ./...
(ok)

$ go test ./internal/cli/commands/azure/...
?   	github.com/mpyw/suve/internal/cli/commands/azure	[no test files]
ok  	github.com/mpyw/suve/internal/cli/commands/azure/param
ok  	github.com/mpyw/suve/internal/cli/commands/azure/secret

$ golangci-lint run --allow-parallel-runners ./internal/cli/commands/azure/...
0 issues.
```

Coverage delta (`go test -cover ./internal/cli/commands/azure/...`):

```
                         before     after
azure/param              45.8%   →   54.6%
azure/secret             37.6%   →   54.9%
```

Per-function confirmation of the targeted presenters (`go tool cover -func`): `param/diff.go` and `secret/diff.go` `NewDiffPresenter`/`OldValue`/`NewValue`/`Labels`/`RenderJSON` all 100%; `show.RenderJSON` 100% both packages; `secret/log.go` `RenderJSON` 100%, `RenderOneline` 100%, `RenderPatch` 92.3% (all skip branches hit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)