### PR TITLE
test(gui): cover param bindings (Show/Log/Diff/Delete/AddTag/RemoveTag) and provider detection

### DIFF
--- a/internal/gui/param_internal_test.go
+++ b/internal/gui/param_internal_test.go
@@ -5,6 +5,7 @@ package gui
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,6 +23,33 @@ type fakeFactory struct{ store provider.Store }
 
 func (f fakeFactory) Store(context.Context, provider.Scope, provider.Kind) (provider.Store, error) {
 	return f.store, nil
+}
+
+// recordingFactory is a fakeFactory that also captures the scope it was asked to
+// build a store for, so a test can assert how a binding threaded the App
+// Configuration namespace into the resolved scope (paramStoreForNamespace).
+type recordingFactory struct {
+	store    provider.Store
+	gotScope provider.Scope
+}
+
+func (f *recordingFactory) Store(_ context.Context, sc provider.Scope, _ provider.Kind) (provider.Store, error) {
+	f.gotScope = sc
+
+	return f.store, nil
+}
+
+// installParamStore swaps the package-global registry for one whose sole factory
+// serves store for provider p, restoring the original on cleanup. It centralizes
+// the registry override the binding tests share.
+func installParamStore(t *testing.T, p provider.Provider, factory provider.Factory) {
+	t.Helper()
+
+	orig := registry
+	registry = provider.NewRegistry()
+	registry.Register(p, factory)
+
+	t.Cleanup(func() { registry = orig })
 }
 
 // fakeNamespaceLister is a minimal appConfigNamespaceLister for testing the
@@ -327,4 +355,252 @@ func TestParamNamespaceHelpers(t *testing.T) {
 		eff := app.effectiveParamScope("dev")
 		assert.Empty(t, eff.AppConfigNamespace)
 	})
+}
+
+// TestParamShow_MapsEntry covers the ParamShow binding: it resolves + gets via
+// the param.ShowUseCase and mirrors every field onto the DTO, including
+// Type/Secret from the domain value type (SecureString ⇒ secret) and the
+// formatted LastModified/tags (#702).
+//
+//nolint:paralleltest // overrides the package-global registry.
+func TestParamShow_MapsEntry(t *testing.T) {
+	modified := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	store := &providermock.Store{
+		ResolveFunc: func(context.Context, string, string) (provider.VersionRef, error) {
+			return provider.VersionRef{}, nil
+		},
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{
+				Name:        name,
+				Value:       "sekret",
+				Version:     domain.Version{ID: "3"},
+				Type:        domain.ValueTypeSecret,
+				Description: "the description",
+				Modified:    &modified,
+				Tags:        []domain.Tag{{Key: "env", Value: "prod"}},
+			}, nil
+		},
+	}
+
+	installParamStore(t, provider.ProviderAWS, fakeFactory{store: store})
+
+	app := &App{ctx: t.Context(), scope: provider.Scope{Provider: provider.ProviderAWS}}
+
+	res, err := app.ParamShow("/my/secure", "")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/my/secure", res.Name)
+	assert.Equal(t, "sekret", res.Value)
+	assert.Equal(t, int64(3), res.Version)
+	assert.Equal(t, paramtype.SecureString, res.Type)
+	assert.True(t, res.Secret, "a SecureString param must be flagged secret")
+	assert.Equal(t, "the description", res.Description)
+	assert.NotEmpty(t, res.LastModified, "a known modification time must be formatted")
+	require.Len(t, res.Tags, 1)
+	assert.Equal(t, ParamShowTag{Key: "env", Value: "prod"}, res.Tags[0])
+}
+
+// TestParamLog_MapsVersions covers the ParamLog binding: it walks the history
+// via param.LogUseCase and mirrors each version's Type/Secret and the IsCurrent
+// flag (the highest version) onto the DTO.
+//
+//nolint:paralleltest // overrides the package-global registry.
+func TestParamLog_MapsVersions(t *testing.T) {
+	store := &providermock.Store{
+		HistoryFunc: func(context.Context, string) ([]domain.Version, error) {
+			return []domain.Version{{ID: "2"}, {ID: "1"}}, nil
+		},
+		ResolveFunc: func(context.Context, string, string) (provider.VersionRef, error) {
+			return provider.VersionRef{}, nil
+		},
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			// Return a secret value so Type/Secret mapping is exercised.
+			return &domain.Entry{Name: name, Value: "v", Type: domain.ValueTypeSecret}, nil
+		},
+	}
+
+	installParamStore(t, provider.ProviderAWS, fakeFactory{store: store})
+
+	app := &App{ctx: t.Context(), scope: provider.Scope{Provider: provider.ProviderAWS}}
+
+	res, err := app.ParamLog("/my/secure", 0, "")
+	require.NoError(t, err)
+	assert.Equal(t, "/my/secure", res.Name)
+	require.Len(t, res.Entries, 2)
+
+	// History is newest-first, so version 2 leads and is the current one.
+	assert.Equal(t, int64(2), res.Entries[0].Version)
+	assert.True(t, res.Entries[0].IsCurrent, "the highest version is current")
+	assert.Equal(t, paramtype.SecureString, res.Entries[0].Type)
+	assert.True(t, res.Entries[0].Secret, "a SecureString version must be flagged secret")
+
+	assert.Equal(t, int64(1), res.Entries[1].Version)
+	assert.False(t, res.Entries[1].IsCurrent, "an older version is not current")
+}
+
+// TestParamDiff_SetsSecretMaskForSecureString is the risk branch (#702): the
+// diff DTO's Secret flag must be true when EITHER side is a SecureString, so the
+// diff view masks both sides; it stays false when both sides are plaintext.
+//
+//nolint:paralleltest // overrides the package-global registry.
+func TestParamDiff_SetsSecretMaskForSecureString(t *testing.T) {
+	newStore := func(t1, t2 domain.ValueType) *providermock.Store {
+		return &providermock.Store{
+			ResolveFunc: func(context.Context, string, string) (provider.VersionRef, error) {
+				return provider.VersionRef{}, nil
+			},
+			GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+				if name == "/a" {
+					return &domain.Entry{Name: name, Value: "old", Type: t1}, nil
+				}
+
+				return &domain.Entry{Name: name, Value: "new", Type: t2}, nil
+			},
+		}
+	}
+
+	t.Run("secure side masks both", func(t *testing.T) {
+		installParamStore(t, provider.ProviderAWS,
+			fakeFactory{store: newStore(domain.ValueTypePlaintext, domain.ValueTypeSecret)})
+
+		app := &App{ctx: t.Context(), scope: provider.Scope{Provider: provider.ProviderAWS}}
+
+		res, err := app.ParamDiff("/a", "/b", "")
+		require.NoError(t, err)
+		assert.Equal(t, "/a", res.OldName)
+		assert.Equal(t, "/b", res.NewName)
+		assert.Equal(t, "old", res.OldValue)
+		assert.Equal(t, "new", res.NewValue)
+		assert.True(t, res.Secret, "a SecureString on either side must set the mask flag")
+	})
+
+	t.Run("plaintext both sides is not masked", func(t *testing.T) {
+		installParamStore(t, provider.ProviderAWS,
+			fakeFactory{store: newStore(domain.ValueTypePlaintext, domain.ValueTypePlaintext)})
+
+		app := &App{ctx: t.Context(), scope: provider.Scope{Provider: provider.ProviderAWS}}
+
+		res, err := app.ParamDiff("/a", "/b", "")
+		require.NoError(t, err)
+		assert.False(t, res.Secret, "two plaintext params must not set the mask flag")
+	})
+}
+
+// TestParamDelete covers the ParamDelete binding: it drives param.DeleteUseCase
+// and returns the deleted name.
+//
+//nolint:paralleltest // overrides the package-global registry.
+func TestParamDelete(t *testing.T) {
+	var gotName string
+
+	store := &providermock.Store{
+		DeleteFunc: func(_ context.Context, name string, _ ...provider.DeleteOption) error {
+			gotName = name
+
+			return nil
+		},
+	}
+
+	installParamStore(t, provider.ProviderAWS, fakeFactory{store: store})
+
+	app := &App{ctx: t.Context(), scope: provider.Scope{Provider: provider.ProviderAWS}}
+
+	res, err := app.ParamDelete("/my/param", "")
+	require.NoError(t, err)
+	assert.Equal(t, "/my/param", res.Name)
+	assert.Equal(t, "/my/param", gotName, "the delete must reach the provider writer")
+}
+
+// TestParamAddTag covers the ParamAddTag binding: it forwards a single key/value
+// as the Add map of param.TagUseCase.
+//
+//nolint:paralleltest // overrides the package-global registry.
+func TestParamAddTag(t *testing.T) {
+	var gotName string
+
+	var gotAdd map[string]string
+
+	store := &providermock.Store{
+		TagFunc: func(_ context.Context, name string, add map[string]string) error {
+			gotName = name
+			gotAdd = add
+
+			return nil
+		},
+	}
+
+	installParamStore(t, provider.ProviderAWS, fakeFactory{store: store})
+
+	app := &App{ctx: t.Context(), scope: provider.Scope{Provider: provider.ProviderAWS}}
+
+	require.NoError(t, app.ParamAddTag("/my/param", "env", "prod", ""))
+	assert.Equal(t, "/my/param", gotName)
+	assert.Equal(t, map[string]string{"env": "prod"}, gotAdd)
+}
+
+// TestParamRemoveTag covers the ParamRemoveTag binding: it forwards the key as
+// the Remove list of param.TagUseCase.
+//
+//nolint:paralleltest // overrides the package-global registry.
+func TestParamRemoveTag(t *testing.T) {
+	var gotName string
+
+	var gotKeys []string
+
+	store := &providermock.Store{
+		UntagFunc: func(_ context.Context, name string, keys []string) error {
+			gotName = name
+			gotKeys = keys
+
+			return nil
+		},
+	}
+
+	installParamStore(t, provider.ProviderAWS, fakeFactory{store: store})
+
+	app := &App{ctx: t.Context(), scope: provider.Scope{Provider: provider.ProviderAWS}}
+
+	require.NoError(t, app.ParamRemoveTag("/my/param", "env", ""))
+	assert.Equal(t, "/my/param", gotName)
+	assert.Equal(t, []string{"env"}, gotKeys)
+}
+
+// TestParamShow_AppConfigNamespaceThreadsThroughStore covers the App
+// Configuration namespace axis shared by every param binding: the namespace
+// argument must be threaded through paramStoreForNamespace onto the resolved
+// store's scope (the label axis), so a namespaced setting is read under its own
+// namespace rather than the shared read scope's. It also asserts the App
+// Configuration value maps to a non-secret "String" via paramtype.Display.
+//
+//nolint:paralleltest // overrides the package-global registry.
+func TestParamShow_AppConfigNamespaceThreadsThroughStore(t *testing.T) {
+	store := &providermock.Store{
+		ResolveFunc: func(context.Context, string, string) (provider.VersionRef, error) {
+			return provider.VersionRef{}, nil
+		},
+		GetFunc: func(_ context.Context, name string, _ provider.VersionRef) (*domain.Entry, error) {
+			// App Configuration values are always plaintext.
+			return &domain.Entry{Name: name, Value: "v", Type: domain.ValueTypePlaintext}, nil
+		},
+	}
+
+	factory := &recordingFactory{store: store}
+	installParamStore(t, provider.ProviderAzure, factory)
+
+	app := &App{
+		ctx:   t.Context(),
+		scope: provider.Scope{Provider: provider.ProviderAzure, StoreName: "store"},
+	}
+
+	res, err := app.ParamShow("app/config", "dev")
+	require.NoError(t, err)
+
+	assert.Equal(t, "dev", factory.gotScope.AppConfigNamespace,
+		"the entry's namespace must be threaded onto the resolved store scope")
+	assert.Equal(t, "store", factory.gotScope.StoreName, "the read scope's store name is preserved")
+
+	assert.False(t, res.Secret, "App Configuration values are never secrets")
+	assert.Equal(t, paramtype.Display(domain.ValueTypePlaintext), res.Type)
+	assert.Equal(t, paramtype.String, res.Type)
 }

--- a/internal/gui/providers_internal_test.go
+++ b/internal/gui/providers_internal_test.go
@@ -3,11 +3,32 @@
 package gui
 
 import (
+	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/detect"
 )
+
+// clearDetectEnv makes provider detection hermetic: it blanks every env var the
+// resolver reads and points the AWS shared-credentials path at a non-existent
+// file, so the ~/.aws/credentials fallback stays off regardless of the ambient
+// machine. A subtest then sets only the vars its case needs.
+func clearDetectEnv(t *testing.T) {
+	t.Helper()
+
+	for _, k := range []string{
+		"AWS_ACCESS_KEY_ID", "AWS_VAULT", "AWS_PROFILE",
+		"GOOGLE_CLOUD_PROJECT", "AZURE_KEYVAULT_NAME", "AZURE_APPCONFIG_NAME",
+	} {
+		t.Setenv(k, "")
+	}
+
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "no-such-credentials"))
+}
 
 func TestUniqueActiveProvider(t *testing.T) {
 	t.Parallel()
@@ -68,4 +89,133 @@ func TestUniqueActiveProvider(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestDetectProviders covers the DetectProviders binding (and providerStrings):
+// it projects detect.Resolve over the ambient env into the frontend DTO — the
+// uniquely-active provider per service (empty when 0 or 2+ are active) plus the
+// full active sets, in the resolver's stable order.
+func TestDetectProviders(t *testing.T) {
+	const (
+		aws    = "aws"
+		gcloud = "googlecloud"
+		az     = "azure"
+	)
+
+	tests := []struct {
+		name string
+		env  map[string]string
+		want DetectResult
+	}{
+		{
+			name: "aws via env: param+secret+stage all aws",
+			env:  map[string]string{"AWS_ACCESS_KEY_ID": "AKIA"},
+			want: DetectResult{
+				Param: aws, Secret: aws, Stage: aws,
+				ParamActive: []string{aws}, SecretActive: []string{aws}, StageActive: []string{aws},
+			},
+		},
+		{
+			name: "google cloud: secret+stage only (no param store)",
+			env:  map[string]string{"GOOGLE_CLOUD_PROJECT": "proj"},
+			want: DetectResult{
+				Secret: gcloud, Stage: gcloud,
+				ParamActive: []string{}, SecretActive: []string{gcloud}, StageActive: []string{gcloud},
+			},
+		},
+		{
+			name: "azure app config: param+stage only (no key vault)",
+			env:  map[string]string{"AZURE_APPCONFIG_NAME": "store"},
+			want: DetectResult{
+				Param: az, Stage: az,
+				ParamActive: []string{az}, SecretActive: []string{}, StageActive: []string{az},
+			},
+		},
+		{
+			name: "two param providers -> ambiguous param, unique secret stays aws",
+			env:  map[string]string{"AWS_ACCESS_KEY_ID": "AKIA", "AZURE_APPCONFIG_NAME": "store"},
+			want: DetectResult{
+				Param: "", Secret: aws, Stage: "",
+				ParamActive: []string{aws, az}, SecretActive: []string{aws}, StageActive: []string{aws, az},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearDetectEnv(t)
+
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			app := &App{}
+			got := app.DetectProviders()
+			require.NotNil(t, got)
+			assert.Equal(t, &tt.want, got)
+		})
+	}
+}
+
+// TestInitialProviderFromEnv covers the standalone env-derived initial provider:
+// the sole provider active across services, or "" when zero or two-plus are
+// active (the frontend then shows the selector).
+func TestInitialProviderFromEnv(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want provider.Provider
+	}{
+		{
+			name: "nothing active -> empty",
+			env:  nil,
+			want: "",
+		},
+		{
+			name: "single provider (google cloud) -> that provider",
+			env:  map[string]string{"GOOGLE_CLOUD_PROJECT": "proj"},
+			want: provider.ProviderGoogleCloud,
+		},
+		{
+			name: "aws across both services -> aws",
+			env:  map[string]string{"AWS_ACCESS_KEY_ID": "AKIA"},
+			want: provider.ProviderAWS,
+		},
+		{
+			name: "two distinct providers -> empty (ambiguous)",
+			env:  map[string]string{"AWS_ACCESS_KEY_ID": "AKIA", "GOOGLE_CLOUD_PROJECT": "proj"},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearDetectEnv(t)
+
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+
+			assert.Equal(t, tt.want, InitialProviderFromEnv())
+		})
+	}
+}
+
+func TestProviderStrings(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		[]string{"aws", "azure"},
+		providerStrings([]provider.Provider{provider.ProviderAWS, provider.ProviderAzure}))
+	assert.Empty(t, providerStrings(nil))
+}
+
+// TestApp_InitialProvider covers the launch-provider accessor: the provider the
+// GUI was launched with, surfaced verbatim for the frontend's initial selection
+// (empty when no explicit provider was chosen).
+func TestApp_InitialProvider(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "azure", (&App{initialProvider: provider.ProviderAzure}).InitialProvider())
+	assert.Empty(t, (&App{}).InitialProvider())
 }


### PR DESCRIPTION
Closes #815

Adds unit coverage for the previously-untested `internal/gui` param bindings and provider-detection helpers, using the existing `providermock.Store` + package-global registry seam and `t.Setenv` env tables.

## Verification

`CGO_ENABLED=1 go build -tags production ./...` — passes.

`CGO_ENABLED=1 go test -tags production ./internal/gui/...`:
```
ok  	github.com/mpyw/suve/internal/gui	0.546s
```

`golangci-lint run --allow-parallel-runners --build-tags production ./internal/gui/...`:
```
0 issues.
```

Package coverage (`-cover`): **53.2% → 60.2%** (+7.0pp).

Per-function (before → after):
```
param.go:215  ParamShow               0.0% -> 80.0%
param.go:254  ParamLog                0.0% -> 76.9%
param.go:291  ParamDiff               0.0% -> 71.4%
param.go:403  ParamDelete             0.0% -> 75.0%
param.go:422  ParamAddTag             0.0% -> 80.0%
param.go:439  ParamRemoveTag          0.0% -> 80.0%
providers.go:33  DetectProviders        0.0% -> 100.0%
providers.go:50  InitialProviderFromEnv 0.0% -> 100.0%
providers.go:80  providerStrings        0.0% -> 100.0%
app.go:153    InitialProvider         0.0% -> 100.0%
```

Notable assertions:
- `ParamDiff` sets the `Secret` mask flag when either side is a SecureString and stays false for two plaintext params (#702 risk branch).
- An Azure App Configuration scope case threads the namespace through `paramStoreForNamespace` onto the resolved store scope and asserts `Secret`/`Type` via `paramtype.Display`.
- `DetectProviders` / `InitialProviderFromEnv` use hermetic `t.Setenv` tables (AWS credentials-file fallback pinned off).

Remaining uncovered lines in the param bindings are the error-return guards (parse-error / store-resolution / use-case failure branches); the happy paths and the risk branch are covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)