### PR TITLE
test(cli/gcloud): cover presenter JSON/oneline paths and diff presenter (+ aws secret diff JSON)

### DIFF
--- a/internal/cli/commands/aws/secret/log_test.go
+++ b/internal/cli/commands/aws/secret/log_test.go
@@ -1,0 +1,104 @@
+package secret_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	awssecret "github.com/mpyw/suve/internal/cli/commands/aws/secret"
+	genericlog "github.com/mpyw/suve/internal/cli/commands/generic/log"
+	"github.com/mpyw/suve/internal/cli/output"
+	"github.com/mpyw/suve/internal/domain"
+	"github.com/mpyw/suve/internal/provider"
+	"github.com/mpyw/suve/internal/provider/providermock"
+)
+
+// logStore builds a mock reader over a two-version secret history, mapping each
+// resolved "#<id>" back to its stored value.
+func logStore() *providermock.Store {
+	created := time.Date(2024, 5, 6, 7, 8, 9, 0, time.UTC)
+
+	return &providermock.Store{
+		HistoryFunc: func(_ context.Context, _ string) ([]domain.Version, error) {
+			return []domain.Version{
+				{ID: "new-version-id-long", StagingLabels: []string{"AWSCURRENT"}, Created: &created},
+				{ID: "old-version-id-long", StagingLabels: []string{"AWSPREVIOUS"}, Created: &created},
+			}, nil
+		},
+		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+			return provider.NewVersionRef(spec[1:]), nil
+		},
+		GetFunc: func(_ context.Context, _ string, ref provider.VersionRef) (*domain.Entry, error) {
+			return &domain.Entry{Value: "value-" + ref.ID()}, nil
+		},
+	}
+}
+
+func runLog(
+	t *testing.T, presenter genericlog.Presenter, opts genericlog.Options,
+) string {
+	t.Helper()
+
+	var stdout, stderr bytes.Buffer
+
+	r := &genericlog.Runner{Presenter: presenter, Options: opts, Stdout: &stdout, Stderr: &stderr}
+	require.NoError(t, r.Run(t.Context()))
+
+	return stdout.String()
+}
+
+// TestLogPresenter_RenderValueNoop drives the default (non-patch) log render,
+// which calls RenderHeader followed by RenderValue for each version. Secrets
+// Manager's RenderValue is a deliberate no-op (no default value preview), so
+// the rendered output carries the version headers but never the stored values.
+func TestLogPresenter_RenderValueNoop(t *testing.T) {
+	t.Parallel()
+
+	presenter := awssecret.NewLogPresenter(logStore(), genericlog.Request{Name: "my-secret"})
+	out := runLog(t, presenter, genericlog.Options{})
+
+	// Truncated version IDs appear in the headers.
+	assert.Contains(t, out, "Version new-vers")
+	assert.Contains(t, out, "AWSCURRENT")
+	assert.Contains(t, out, "AWSPREVIOUS")
+	// RenderValue is a no-op: the stored values never leak into the log output.
+	assert.NotContains(t, out, "value-new-version-id-long")
+	assert.NotContains(t, out, "value-old-version-id-long")
+}
+
+// TestLogPresenter_Oneline exercises the compact one-line render path.
+func TestLogPresenter_Oneline(t *testing.T) {
+	t.Parallel()
+
+	presenter := awssecret.NewLogPresenter(logStore(), genericlog.Request{Name: "my-secret"})
+	out := runLog(t, presenter, genericlog.Options{Oneline: true})
+
+	assert.Contains(t, out, "AWSCURRENT")
+	assert.Contains(t, out, "AWSPREVIOUS")
+}
+
+// TestLogPresenter_JSON exercises the JSON render path, asserting per-version
+// IDs, stages, and values.
+func TestLogPresenter_JSON(t *testing.T) {
+	t.Parallel()
+
+	presenter := awssecret.NewLogPresenter(logStore(), genericlog.Request{Name: "my-secret"})
+	out := runLog(t, presenter, genericlog.Options{Output: output.FormatJSON})
+
+	var items []struct {
+		VersionID string   `json:"versionId"`
+		Stages    []string `json:"stages"`
+		Value     *string  `json:"value"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &items))
+	require.Len(t, items, 2)
+	assert.Equal(t, "new-version-id-long", items[0].VersionID)
+	assert.Equal(t, []string{"AWSCURRENT"}, items[0].Stages)
+	require.NotNil(t, items[0].Value)
+	assert.Equal(t, "value-new-version-id-long", *items[0].Value)
+}

--- a/internal/cli/commands/gcloud/gcloud_test.go
+++ b/internal/cli/commands/gcloud/gcloud_test.go
@@ -3,16 +3,20 @@ package gcloud_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	appcli "github.com/mpyw/suve/internal/cli/commands"
 	"github.com/mpyw/suve/internal/cli/commands/gcloud"
+	genericdiff "github.com/mpyw/suve/internal/cli/commands/generic/diff"
 	genericlog "github.com/mpyw/suve/internal/cli/commands/generic/log"
+	"github.com/mpyw/suve/internal/cli/output"
 	"github.com/mpyw/suve/internal/domain"
 	"github.com/mpyw/suve/internal/provider"
 	"github.com/mpyw/suve/internal/provider/providermock"
@@ -232,6 +236,28 @@ func TestShowPresenter(t *testing.T) {
 	// No ARN or Stages fields for Google Cloud.
 	assert.NotContains(t, out, "ARN")
 	assert.NotContains(t, out, "Stages")
+
+	// RenderJSON emits the structured view over the same fetched entry.
+	var jsonBuf bytes.Buffer
+	require.NoError(t, presenter.RenderJSON(&jsonBuf, value))
+
+	var showOut struct {
+		Name        string            `json:"name"`
+		Version     string            `json:"version"`
+		State       string            `json:"state"`
+		Description string            `json:"description"`
+		Created     string            `json:"created"`
+		Labels      map[string]string `json:"labels"`
+		Value       string            `json:"value"`
+	}
+	require.NoError(t, json.Unmarshal(jsonBuf.Bytes(), &showOut))
+	assert.Equal(t, "my-secret", showOut.Name)
+	assert.Equal(t, "3", showOut.Version)
+	assert.Equal(t, "enabled", showOut.State)
+	assert.Equal(t, "app credentials", showOut.Description)
+	assert.Equal(t, "s3cr3t", showOut.Value)
+	assert.Equal(t, map[string]string{"env": "prod"}, showOut.Labels)
+	assert.NotEmpty(t, showOut.Created)
 }
 
 func TestLogPresenter(t *testing.T) {
@@ -270,6 +296,50 @@ func TestLogPresenter(t *testing.T) {
 	out := buf.String()
 	assert.Contains(t, out, "Version 2")
 	assert.Contains(t, out, "enabled")
+
+	// RenderValue is a no-op for Google Cloud log (no default value preview).
+	var valueBuf bytes.Buffer
+	presenter.RenderValue(&valueBuf, 0, 0)
+	assert.Empty(t, valueBuf.String())
+
+	// RenderOneline emits a compact per-version line with the state tag.
+	var onelineBuf bytes.Buffer
+	presenter.RenderOneline(&onelineBuf, 0, 0)
+	oneline := onelineBuf.String()
+	assert.Contains(t, oneline, "2")
+	assert.Contains(t, oneline, "enabled")
+
+	// RenderJSON serializes every version; the destroyed version surfaces its
+	// fetch error instead of a value.
+	var jsonBuf bytes.Buffer
+	require.NoError(t, presenter.RenderJSON(&jsonBuf))
+
+	var items []struct {
+		Version string  `json:"version"`
+		State   string  `json:"state"`
+		Created string  `json:"created"`
+		Value   *string `json:"value"`
+		Error   string  `json:"error"`
+	}
+	require.NoError(t, json.Unmarshal(jsonBuf.Bytes(), &items))
+	require.Len(t, items, 2)
+	assert.Equal(t, "2", items[0].Version)
+	assert.Equal(t, "enabled", items[0].State)
+	require.NotNil(t, items[0].Value)
+	assert.Equal(t, "v2", *items[0].Value)
+	assert.Empty(t, items[0].Error)
+	assert.Equal(t, "1", items[1].Version)
+	assert.Equal(t, "destroyed", items[1].State)
+	assert.Nil(t, items[1].Value)
+	assert.Contains(t, items[1].Error, "cannot access destroyed version")
+
+	// RenderPatch skips versions whose value is inaccessible: i=0 (v2) has a
+	// destroyed parent (v1), and i=1 (v1) is itself destroyed. Both branches
+	// return without emitting a diff.
+	var patchBuf, patchErrBuf bytes.Buffer
+	presenter.RenderPatch(&patchBuf, &patchErrBuf, 0, false, false)
+	presenter.RenderPatch(&patchBuf, &patchErrBuf, 1, false, false)
+	assert.Empty(t, patchBuf.String())
 }
 
 func TestLogPresenter_Patch(t *testing.T) {
@@ -309,4 +379,130 @@ func TestLogPresenter_Patch(t *testing.T) {
 	assert.Contains(t, out, "my-secret#2")
 	// The initial version renders its all-added creation diff (+v1).
 	assert.Contains(t, out, "+v1")
+}
+
+// diffVersionSpec builds a Google Cloud diff spec pinned to an integer version.
+func diffVersionSpec(v int64) *gcloudversion.Spec {
+	return &gcloudversion.Spec{Name: "my-secret", Absolute: gcloudversion.AbsoluteSpec{Version: lo.ToPtr(v)}}
+}
+
+// diffStore resolves each spec suffix ("#N") to a ref and returns the mapped
+// entry, matching the gcloud diff usecase's resolve-then-get flow.
+func diffStore(byRef map[string]*domain.Entry) *providermock.Store {
+	return &providermock.Store{
+		ResolveFunc: func(_ context.Context, _, spec string) (provider.VersionRef, error) {
+			return provider.NewVersionRef(spec), nil
+		},
+		GetFunc: func(_ context.Context, _ string, ref provider.VersionRef) (*domain.Entry, error) {
+			entry, ok := byRef[ref.ID()]
+			if !ok {
+				return nil, errors.New("version not found")
+			}
+
+			return entry, nil
+		},
+	}
+}
+
+func runDiff(
+	t *testing.T, presenter genericdiff.Presenter, opts genericdiff.Options,
+) (string, error) {
+	t.Helper()
+
+	var stdout, stderr bytes.Buffer
+
+	r := &genericdiff.Runner{Presenter: presenter, Options: opts, Stdout: &stdout, Stderr: &stderr}
+	err := r.Run(t.Context())
+
+	return stdout.String(), err
+}
+
+func TestDiffPresenter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("text diff between two versions", func(t *testing.T) {
+		t.Parallel()
+
+		store := diffStore(map[string]*domain.Entry{
+			"#1": {Name: "my-secret", Value: "old-value", Version: domain.Version{ID: "1"}},
+			"#2": {Name: "my-secret", Value: "new-value", Version: domain.Version{ID: "2"}},
+		})
+
+		presenter := gcloud.NewDiffPresenter(store, diffVersionSpec(1), diffVersionSpec(2))
+		out, err := runDiff(t, presenter, genericdiff.Options{})
+		require.NoError(t, err)
+		assert.Contains(t, out, "-old-value")
+		assert.Contains(t, out, "+new-value")
+		// Labels carry the Google Cloud "name#version" form.
+		assert.Contains(t, out, "my-secret#1")
+		assert.Contains(t, out, "my-secret#2")
+	})
+
+	t.Run("json output for differing versions", func(t *testing.T) {
+		t.Parallel()
+
+		store := diffStore(map[string]*domain.Entry{
+			"#1": {Name: "my-secret", Value: "old-value", Version: domain.Version{ID: "1"}},
+			"#2": {Name: "my-secret", Value: "new-value", Version: domain.Version{ID: "2"}},
+		})
+
+		presenter := gcloud.NewDiffPresenter(store, diffVersionSpec(1), diffVersionSpec(2))
+		out, err := runDiff(t, presenter, genericdiff.Options{Output: output.FormatJSON})
+		require.NoError(t, err)
+
+		var diffOut struct {
+			OldName    string `json:"oldName"`
+			OldVersion string `json:"oldVersion"`
+			OldValue   string `json:"oldValue"`
+			NewName    string `json:"newName"`
+			NewVersion string `json:"newVersion"`
+			NewValue   string `json:"newValue"`
+			Identical  bool   `json:"identical"`
+			Diff       string `json:"diff"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out), &diffOut))
+		assert.Equal(t, "my-secret", diffOut.OldName)
+		assert.Equal(t, "1", diffOut.OldVersion)
+		assert.Equal(t, "old-value", diffOut.OldValue)
+		assert.Equal(t, "my-secret", diffOut.NewName)
+		assert.Equal(t, "2", diffOut.NewVersion)
+		assert.Equal(t, "new-value", diffOut.NewValue)
+		assert.False(t, diffOut.Identical)
+		assert.NotEmpty(t, diffOut.Diff)
+	})
+
+	t.Run("fetch error propagates", func(t *testing.T) {
+		t.Parallel()
+
+		// Only version 2 is resolvable; fetching spec1 (#1) fails, so Fetch — and
+		// thus the whole run — returns the error.
+		store := diffStore(map[string]*domain.Entry{
+			"#2": {Name: "my-secret", Value: "new-value", Version: domain.Version{ID: "2"}},
+		})
+
+		presenter := gcloud.NewDiffPresenter(store, diffVersionSpec(1), diffVersionSpec(2))
+		_, err := runDiff(t, presenter, genericdiff.Options{})
+		require.Error(t, err)
+	})
+
+	t.Run("json output for identical versions", func(t *testing.T) {
+		t.Parallel()
+
+		store := diffStore(map[string]*domain.Entry{
+			"#1": {Name: "my-secret", Value: "same-value", Version: domain.Version{ID: "1"}},
+			"#2": {Name: "my-secret", Value: "same-value", Version: domain.Version{ID: "2"}},
+		})
+
+		presenter := gcloud.NewDiffPresenter(store, diffVersionSpec(1), diffVersionSpec(2))
+		out, err := runDiff(t, presenter, genericdiff.Options{Output: output.FormatJSON})
+		require.NoError(t, err)
+
+		var diffOut struct {
+			Identical bool   `json:"identical"`
+			Diff      string `json:"diff"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(out), &diffOut))
+		assert.True(t, diffOut.Identical)
+		assert.Empty(t, diffOut.Diff)
+	})
 }

--- a/internal/cli/commands/generic/diff/diff_test.go
+++ b/internal/cli/commands/generic/diff/diff_test.go
@@ -3,6 +3,7 @@ package diff_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
@@ -705,6 +706,56 @@ func TestRunSecret(t *testing.T) {
 				t.Helper()
 				assert.Contains(t, output, "-not json")
 				assert.Contains(t, output, "+also not json")
+			},
+		},
+		{
+			// --output=json serializes the full (untruncated) version IDs and the
+			// identical flag via aws/secret diffPresenter.RenderJSON.
+			name: "json output serializes version IDs (differing)",
+			opts: genericdiff.Options{Output: output.FormatJSON},
+			store: secretDiffStore(map[string]*domain.Entry{
+				":AWSPREVIOUS": {Name: "my-secret", Value: "old-secret", Version: domain.Version{ID: "prev-version-id-long"}},
+				":AWSCURRENT":  {Name: "my-secret", Value: "new-secret", Version: domain.Version{ID: "curr-version-id-long"}},
+			}, nil),
+			check: func(t *testing.T, out string) {
+				t.Helper()
+
+				var diffOut struct {
+					OldVersionID string `json:"oldVersionId"`
+					NewVersionID string `json:"newVersionId"`
+					Identical    bool   `json:"identical"`
+					Diff         string `json:"diff"`
+				}
+				require.NoError(t, json.Unmarshal([]byte(out), &diffOut))
+				assert.Equal(t, "prev-version-id-long", diffOut.OldVersionID)
+				assert.Equal(t, "curr-version-id-long", diffOut.NewVersionID)
+				assert.False(t, diffOut.Identical)
+				assert.NotEmpty(t, diffOut.Diff)
+			},
+		},
+		{
+			// Same content across two distinct versions: identical is true and the
+			// diff field is omitted, but both version IDs still serialize.
+			name: "json output serializes version IDs (identical)",
+			opts: genericdiff.Options{Output: output.FormatJSON},
+			store: secretDiffStore(map[string]*domain.Entry{
+				":AWSPREVIOUS": {Name: "my-secret", Value: "same-secret", Version: domain.Version{ID: "prev-version-id-long"}},
+				":AWSCURRENT":  {Name: "my-secret", Value: "same-secret", Version: domain.Version{ID: "curr-version-id-long"}},
+			}, nil),
+			check: func(t *testing.T, out string) {
+				t.Helper()
+
+				var diffOut struct {
+					OldVersionID string `json:"oldVersionId"`
+					NewVersionID string `json:"newVersionId"`
+					Identical    bool   `json:"identical"`
+					Diff         string `json:"diff"`
+				}
+				require.NoError(t, json.Unmarshal([]byte(out), &diffOut))
+				assert.Equal(t, "prev-version-id-long", diffOut.OldVersionID)
+				assert.Equal(t, "curr-version-id-long", diffOut.NewVersionID)
+				assert.True(t, diffOut.Identical)
+				assert.Empty(t, diffOut.Diff)
 			},
 		},
 	}


### PR DESCRIPTION
Closes #820.

Adds unit coverage for the pure `io.Writer` render paths in the Google Cloud presenters (uncovered by both unit and e2e), plus the AWS-core diff/log JSON gaps flagged in the issue.

- **gcloud/diff.go** — whole diff presenter (`NewDiffPresenter`/`Fetch` incl. error branch/`OldValue`/`NewValue`/`Labels`/`RenderJSON`) driven via `genericdiff.Runner` in text and JSON modes.
- **gcloud/log.go** — `RenderJSON`, `RenderOneline`, `RenderValue`, and the destroyed-version skip branches in `RenderPatch`.
- **gcloud/show.go** — `RenderJSON`.
- **aws/secret/diff.go** — two `TestRunSecret` JSON subtests asserting `oldVersionId`/`newVersionId`/`identical` (differing + identical values).
- **aws/secret/log.go** — new `log_test.go` driving `genericlog.Runner` to cover `RenderValue`/`RenderJSON`/`RenderOneline`.

## Verification

```
$ go build ./...
(ok)

$ go test ./internal/cli/commands/gcloud/... ./internal/cli/commands/generic/diff/... ./internal/cli/commands/aws/secret/...
ok  	.../internal/cli/commands/gcloud
ok  	.../internal/cli/commands/generic/diff
ok  	.../internal/cli/commands/aws/secret
ok  	.../internal/cli/commands/aws/secret/{create,delete,restore,update}

$ golangci-lint run --allow-parallel-runners ./internal/cli/commands/gcloud/... ./internal/cli/commands/generic/... ./internal/cli/commands/aws/secret/...
0 issues.
```

Unit coverage (before -> after):
- `internal/cli/commands/gcloud`  44.4% -> 60.3%
- `internal/cli/commands/aws/secret`  21.3% -> 44.7%
- `internal/cli/commands/generic/diff`  73.2% (unchanged; new secret JSON subtests exercise `aws/secret` code, confirmed via cross-package `-coverpkg`: `aws/secret/diff.go:63 RenderJSON` 100%)

Both `RenderValue` no-ops (`gcloud/log.go:126`, `aws/secret/log.go:137`) are empty-bodied (zero statements), so the cover tool reports them 0.0% regardless; the new tests still invoke them to assert the no-op behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)