### PR TITLE
chore(coverage): exclude untestable runtime glue from codecov (cmd/suve, Wails/TUI bootstrap, OS dialogs, STS)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,16 @@ coverage:
     patch:
       default:
         after_n_builds: 6
+
+# Untestable runtime glue: entrypoints and desktop/window bootstrap that can only
+# run against a live terminal, a live Wails window, or the OS — no injectable seam.
+# Excluded so they don't drag the denominator. (Function-level exclusions such as
+# GUI PickExport/ImportPath, GetAWSIdentity, and the TUI run.go Run/awsIdentityFetcher
+# are not expressible here — those files also hold tested code — and are left as an
+# optional refactor.)
+ignore:
+  - "cmd/suve/main.go"
+  - "internal/gui/run.go"
+  - "internal/gui/run_darwin.go"
+  - "internal/gui/run_linux.go"
+  - "internal/gui/run_windows.go"


### PR DESCRIPTION
Closes #829.

Adds a codecov `ignore:` list for runtime glue that can only run against a live terminal, a live Wails window, or the OS — code with no injectable seam that permanently sits at 0% and drags the denominator.

## Excluded (whole-file, verified glue-only)
- `cmd/suve/main.go` — process entrypoint
- `internal/gui/run.go` — `wails.Run` desktop bootstrap (only `Run`)
- `internal/gui/run_darwin.go` / `run_linux.go` / `run_windows.go` — `applyPlatformOptions` window wiring

## Deliberately NOT excluded
codecov `ignore` is path-based, not function-based, so these could not be excluded without also dropping tested code in the same file:
- GUI `PickExportPath`/`PickImportPath` (`internal/gui/staging.go` — file has tested bindings)
- GUI `GetAWSIdentity` (`internal/gui/app.go` — file is heavily tested)
- TUI `run.go` `Run`/`awsIdentityFetcher` (file also holds `newModel`/`ensureResolvable`, which are testable)

These are left as an optional future refactor (e.g. inject an identity resolver) rather than dishonestly excluding their whole files.

## Verification
- YAML structure validated; `ignore` is a top-level key per codecov schema.
- No code changes; CI coverage upload unaffected other than the excluded paths leaving the denominator.