### PR TITLE
test(provider/aws): secret version-ref resolution edges and param/secret error mapping

### DIFF
--- a/internal/provider/aws/param/param_internal_test.go
+++ b/internal/provider/aws/param/param_internal_test.go
@@ -1,0 +1,58 @@
+package param
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mpyw/suve/internal/domain"
+)
+
+// mapTypeToDomain / mapDomainToType are pure package-private enum maps. The
+// emulator only ever round-trips String/SecureString/StringList, so the default
+// (unknown-enum) fallbacks never fire in e2e; the tables below cover every arm.
+
+func TestMapTypeToDomain(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   types.ParameterType
+		want domain.ValueType
+	}{
+		{name: "secure string", in: types.ParameterTypeSecureString, want: domain.ValueTypeSecret},
+		{name: "string list", in: types.ParameterTypeStringList, want: domain.ValueTypeList},
+		{name: "string", in: types.ParameterTypeString, want: domain.ValueTypePlaintext},
+		{name: "unknown falls back to plaintext", in: types.ParameterType("bogus"), want: domain.ValueTypePlaintext},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, mapTypeToDomain(tt.in))
+		})
+	}
+}
+
+func TestMapDomainToType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   domain.ValueType
+		want types.ParameterType
+	}{
+		{name: "secret", in: domain.ValueTypeSecret, want: types.ParameterTypeSecureString},
+		{name: "list", in: domain.ValueTypeList, want: types.ParameterTypeStringList},
+		{name: "plaintext", in: domain.ValueTypePlaintext, want: types.ParameterTypeString},
+		{name: "unknown falls back to string", in: domain.ValueType("bogus"), want: types.ParameterTypeString},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, mapDomainToType(tt.in))
+		})
+	}
+}

--- a/internal/provider/aws/param/param_test.go
+++ b/internal/provider/aws/param/param_test.go
@@ -408,6 +408,39 @@ func TestDelete(t *testing.T) {
 	assert.Equal(t, "/my/param", gotName)
 }
 
+// TestDelete_NotFoundMapsSentinel guards the ParameterNotFound→ErrNotFound
+// mapping so callers can treat a missing parameter idempotently.
+func TestDelete_NotFoundMapsSentinel(t *testing.T) {
+	t.Parallel()
+
+	store := param.New(&mockClient{
+		deleteParameter: func(*ssm.DeleteParameterInput) (*ssm.DeleteParameterOutput, error) {
+			return nil, &types.ParameterNotFound{Message: aws.String("nope")}
+		},
+	})
+
+	err := store.Delete(t.Context(), "/missing")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, provider.ErrNotFound)
+}
+
+// TestDelete_GenericErrorWrapped covers the non-NotFound delete error path: it
+// is wrapped (not mapped to the sentinel) so callers do not treat it as absent.
+func TestDelete_GenericErrorWrapped(t *testing.T) {
+	t.Parallel()
+
+	store := param.New(&mockClient{
+		deleteParameter: func(*ssm.DeleteParameterInput) (*ssm.DeleteParameterOutput, error) {
+			return nil, assert.AnError
+		},
+	})
+
+	err := store.Delete(t.Context(), "/my/param")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, provider.ErrNotFound)
+	assert.Contains(t, err.Error(), "failed to delete parameter")
+}
+
 func TestTagAndUntag(t *testing.T) {
 	t.Parallel()
 
@@ -437,6 +470,65 @@ func TestTagAndUntag(t *testing.T) {
 	require.NoError(t, store.Untag(t.Context(), "/my/param", []string{"env"}))
 	require.NotNil(t, removeIn)
 	assert.Equal(t, []string{"env"}, removeIn.TagKeys)
+}
+
+// TestTag_EmptyIsNoop / TestUntag_EmptyIsNoop cover the early-return guards:
+// with nothing to add/remove the adapter must not call AWS.
+func TestTag_EmptyIsNoop(t *testing.T) {
+	t.Parallel()
+
+	store := param.New(&mockClient{
+		addTags: func(*ssm.AddTagsToResourceInput) (*ssm.AddTagsToResourceOutput, error) {
+			t.Fatal("AddTagsToResource must not be called for an empty tag set")
+
+			return &ssm.AddTagsToResourceOutput{}, nil
+		},
+	})
+
+	require.NoError(t, store.Tag(t.Context(), "/my/param", nil))
+}
+
+func TestUntag_EmptyIsNoop(t *testing.T) {
+	t.Parallel()
+
+	store := param.New(&mockClient{
+		removeTags: func(*ssm.RemoveTagsFromResourceInput) (*ssm.RemoveTagsFromResourceOutput, error) {
+			t.Fatal("RemoveTagsFromResource must not be called for an empty key set")
+
+			return &ssm.RemoveTagsFromResourceOutput{}, nil
+		},
+	})
+
+	require.NoError(t, store.Untag(t.Context(), "/my/param", nil))
+}
+
+// TestTag_ErrorWrapped / TestUntag_ErrorWrapped cover the AWS-error branches.
+func TestTag_ErrorWrapped(t *testing.T) {
+	t.Parallel()
+
+	store := param.New(&mockClient{
+		addTags: func(*ssm.AddTagsToResourceInput) (*ssm.AddTagsToResourceOutput, error) {
+			return nil, assert.AnError
+		},
+	})
+
+	err := store.Tag(t.Context(), "/my/param", map[string]string{"env": "prod"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to add tags")
+}
+
+func TestUntag_ErrorWrapped(t *testing.T) {
+	t.Parallel()
+
+	store := param.New(&mockClient{
+		removeTags: func(*ssm.RemoveTagsFromResourceInput) (*ssm.RemoveTagsFromResourceOutput, error) {
+			return nil, assert.AnError
+		},
+	})
+
+	err := store.Untag(t.Context(), "/my/param", []string{"env"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to remove tags")
 }
 
 func TestCreate_NewReturnsVersion(t *testing.T) {

--- a/internal/provider/aws/secret/secret_internal_test.go
+++ b/internal/provider/aws/secret/secret_internal_test.go
@@ -1,0 +1,165 @@
+package secret
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/version/awssecretversion"
+)
+
+// baseIndex and sortNewestFirst are pure package-private helpers over the raw
+// SDK version-list type. The localstack emulator always returns well-formed,
+// timestamped, labeled versions, so the not-found and nil-CreatedDate branches
+// never fire in e2e; they are exercised here with crafted lists.
+
+// baseList is a newest-first list: id-3 is AWSCURRENT, id-2 AWSPREVIOUS, id-1
+// deprecated (unlabeled).
+func baseList() []types.SecretVersionsListEntry {
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	return []types.SecretVersionsListEntry{
+		{VersionId: aws.String("id-3"), CreatedDate: aws.Time(base.Add(2 * time.Hour)), VersionStages: []string{"AWSCURRENT"}},
+		{VersionId: aws.String("id-2"), CreatedDate: aws.Time(base.Add(time.Hour)), VersionStages: []string{"AWSPREVIOUS"}},
+		{VersionId: aws.String("id-1"), CreatedDate: aws.Time(base), VersionStages: []string{}},
+	}
+}
+
+func TestBaseIndex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		abs     awssecretversion.AbsoluteSpec
+		wantIdx int
+		wantErr string
+	}{
+		{
+			name:    "id found",
+			abs:     awssecretversion.AbsoluteSpec{ID: aws.String("id-2")},
+			wantIdx: 1,
+		},
+		{
+			name:    "id not found",
+			abs:     awssecretversion.AbsoluteSpec{ID: aws.String("nope")},
+			wantErr: "version ID not found: nope",
+		},
+		{
+			name:    "label found",
+			abs:     awssecretversion.AbsoluteSpec{Label: aws.String("AWSPREVIOUS")},
+			wantIdx: 1,
+		},
+		{
+			name:    "label not found",
+			abs:     awssecretversion.AbsoluteSpec{Label: aws.String("NOSUCHLABEL")},
+			wantErr: "version label not found: NOSUCHLABEL",
+		},
+		{
+			name:    "no spec anchors at AWSCURRENT",
+			abs:     awssecretversion.AbsoluteSpec{},
+			wantIdx: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			idx, err := baseIndex(baseList(), tt.abs)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.EqualError(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantIdx, idx)
+		})
+	}
+}
+
+// TestBaseIndex_NoSpecFallsBackToZero covers the default branch when no version
+// carries AWSCURRENT: the anchor falls back to index 0.
+func TestBaseIndex_NoSpecFallsBackToZero(t *testing.T) {
+	t.Parallel()
+
+	list := []types.SecretVersionsListEntry{
+		{VersionId: aws.String("id-2"), VersionStages: []string{"AWSPREVIOUS"}},
+		{VersionId: aws.String("id-1"), VersionStages: []string{}},
+	}
+
+	idx, err := baseIndex(list, awssecretversion.AbsoluteSpec{})
+	require.NoError(t, err)
+	assert.Equal(t, 0, idx)
+}
+
+func TestSortNewestFirst(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		input []types.SecretVersionsListEntry
+		want  []string // expected VersionId order
+	}{
+		{
+			name: "distinct timestamps newest first",
+			input: []types.SecretVersionsListEntry{
+				{VersionId: aws.String("old"), CreatedDate: aws.Time(base)},
+				{VersionId: aws.String("new"), CreatedDate: aws.Time(base.Add(time.Hour))},
+			},
+			want: []string{"new", "old"},
+		},
+		{
+			name: "equal timestamps tie-break by version-id descending",
+			input: []types.SecretVersionsListEntry{
+				{VersionId: aws.String("aaa"), CreatedDate: aws.Time(base)},
+				{VersionId: aws.String("bbb"), CreatedDate: aws.Time(base)},
+			},
+			want: []string{"bbb", "aaa"},
+		},
+		{
+			name: "both nil CreatedDate tie-break by version-id descending",
+			input: []types.SecretVersionsListEntry{
+				{VersionId: aws.String("aaa")},
+				{VersionId: aws.String("bbb")},
+			},
+			want: []string{"bbb", "aaa"},
+		},
+		{
+			name: "nil CreatedDate sorts after a dated version",
+			input: []types.SecretVersionsListEntry{
+				{VersionId: aws.String("undated")},
+				{VersionId: aws.String("dated"), CreatedDate: aws.Time(base)},
+			},
+			want: []string{"dated", "undated"},
+		},
+		{
+			name: "dated version sorts before a nil-CreatedDate one",
+			input: []types.SecretVersionsListEntry{
+				{VersionId: aws.String("dated"), CreatedDate: aws.Time(base)},
+				{VersionId: aws.String("undated")},
+			},
+			want: []string{"dated", "undated"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sortNewestFirst(tt.input)
+			got := lo.Map(tt.input, func(v types.SecretVersionsListEntry, _ int) string {
+				return aws.ToString(v.VersionId)
+			})
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/provider/aws/secret/secret_test.go
+++ b/internal/provider/aws/secret/secret_test.go
@@ -533,6 +533,49 @@ func TestDelete_RecoveryWindow(t *testing.T) {
 	assert.Nil(t, in.ForceDeleteWithoutRecovery)
 }
 
+// TestDelete_NotFoundMapsSentinel guards the ResourceNotFound→ErrNotFound
+// mapping on the delete path so callers can treat a missing secret idempotently.
+func TestDelete_NotFoundMapsSentinel(t *testing.T) {
+	t.Parallel()
+
+	store := secret.New(&mockClient{
+		deleteSec: func(*secretsmanager.DeleteSecretInput) (*secretsmanager.DeleteSecretOutput, error) {
+			return nil, &types.ResourceNotFoundException{Message: aws.String("nope")}
+		},
+	})
+
+	err := store.Delete(t.Context(), "missing-secret")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, provider.ErrNotFound)
+}
+
+// TestPut_UpdatesWhenExistsAppliesKMSKey covers applyUpdateOptions: a KMSKeyID
+// WriteOption must fold onto the UpdateSecretInput when Put updates an existing
+// secret (the create path already covers applyCreateOptions).
+func TestPut_UpdatesWhenExistsAppliesKMSKey(t *testing.T) {
+	t.Parallel()
+
+	var updateIn *secretsmanager.UpdateSecretInput
+
+	store := secret.New(&mockClient{
+		create: func(*secretsmanager.CreateSecretInput) (*secretsmanager.CreateSecretOutput, error) {
+			return nil, &types.ResourceExistsException{Message: aws.String("exists")}
+		},
+		updateSec: func(in *secretsmanager.UpdateSecretInput) (*secretsmanager.UpdateSecretOutput, error) {
+			updateIn = in
+
+			return &secretsmanager.UpdateSecretOutput{VersionId: aws.String("ver-2")}, nil
+		},
+	})
+
+	_, err := store.Put(t.Context(), "my-secret", "val", domain.ValueTypeSecret, "",
+		secret.KMSKeyID{Value: "alias/my-key"},
+	)
+	require.NoError(t, err)
+	require.NotNil(t, updateIn)
+	assert.Equal(t, "alias/my-key", aws.ToString(updateIn.KmsKeyId))
+}
+
 func TestGet_PopulatesExtraARN(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #823

Adds unit coverage for AWS param/secret adapter branches the localstack emulator never triggers (version-resolution edges and error-mapping paths).

## What's covered
- **aws/secret** (in-package pure-function tests): `baseIndex` version-ID / staging-label not-found errors and the no-spec AWSCURRENT-fallback; `sortNewestFirst` nil-`CreatedDate` tie-breaks (both-nil, each-nil-side) plus the equal-timestamp version-id tie-break.
- **aws/secret** (external): `Delete` `ResourceNotFound`→`ErrNotFound`; `applyUpdateOptions` KMS key folding on the Put-updates-existing path.
- **aws/param** (in-package): `mapTypeToDomain` / `mapDomainToType` enum tables including the unknown-value fallbacks.
- **aws/param** (external): `Delete` `ParameterNotFound`→`ErrNotFound` plus a generic-error-wrap guard; `Tag`/`Untag` empty-noop and AWS-error branches.

No production code changed.

## Verification
```
$ go build ./...
(ok)

$ go test ./internal/provider/aws/...
ok  github.com/mpyw/suve/internal/provider/aws
ok  github.com/mpyw/suve/internal/provider/aws/infra
ok  github.com/mpyw/suve/internal/provider/aws/param
ok  github.com/mpyw/suve/internal/provider/aws/secret

$ golangci-lint run --allow-parallel-runners ./internal/provider/aws/...
0 issues.

# coverage (statement %)
                 before   after
aws/secret       81.6%    89.3%
aws/param        85.1%    92.9%
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)