### PR TITLE
test(staging/store/file/internal): keyprovider corrupted-key detection and crypt reject branches

### DIFF
--- a/internal/staging/store/file/internal/crypt/crypt_internal_test.go
+++ b/internal/staging/store/file/internal/crypt/crypt_internal_test.go
@@ -189,6 +189,72 @@ func TestDecrypt_GCMError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to create GCM")
 }
 
+//nolint:paralleltest // Test modifies global randReader and newCipherFunc state.
+func TestEncryptWithKey_CipherError(t *testing.T) {
+	// Save originals and restore after test
+	originalRand := randReader
+	originalCipher := newCipherFunc
+
+	defer func() {
+		randReader = originalRand
+		newCipherFunc = originalCipher
+	}()
+
+	// Use real random for the nonce so the failure is attributable to the cipher.
+	randReader = rand.Reader
+
+	// Inject cipher error
+	newCipherFunc = func(_ []byte) (cipher.Block, error) {
+		return nil, errors.New("cipher creation failed")
+	}
+
+	_, err := EncryptWithKey([]byte("test data"), make([]byte, RawKeyLen))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create cipher")
+}
+
+//nolint:paralleltest // Test modifies global randReader state.
+func TestEncryptWithKey_NonceError(t *testing.T) {
+	// Save original and restore after test
+	original := randReader
+
+	defer func() { randReader = original }()
+
+	// Inject an error reader that fails immediately (no salt is read in the
+	// raw-key path, so the first read is the nonce).
+	randReader = &errorReader{
+		bytesToRead: 0,
+		err:         errors.New("random source unavailable"),
+	}
+
+	_, err := EncryptWithKey([]byte("test data"), make([]byte, RawKeyLen))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to generate nonce")
+}
+
+//nolint:paralleltest // Test modifies global newCipherFunc state.
+func TestDecryptWithKey_CipherError(t *testing.T) {
+	// First encrypt some data normally with a valid key.
+	key := make([]byte, RawKeyLen)
+
+	encrypted, err := EncryptWithKey([]byte("test data"), key)
+	require.NoError(t, err)
+
+	// Save original and restore after test
+	originalCipher := newCipherFunc
+
+	defer func() { newCipherFunc = originalCipher }()
+
+	// Inject cipher error
+	newCipherFunc = func(_ []byte) (cipher.Block, error) {
+		return nil, errors.New("cipher creation failed")
+	}
+
+	_, err = DecryptWithKey(encrypted, key)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to create cipher")
+}
+
 //nolint:paralleltest // Test modifies global newCipherFunc and newGCMFunc state.
 func TestSetCipherFuncs_AndReset(t *testing.T) {
 	// Test that SetCipherFuncs and ResetCipherFuncs work correctly

--- a/internal/staging/store/file/internal/crypt/crypt_test.go
+++ b/internal/staging/store/file/internal/crypt/crypt_test.go
@@ -304,6 +304,19 @@ func TestDecryptWithKey_InvalidKeyLength(t *testing.T) {
 	assert.ErrorIs(t, err, crypt.ErrInvalidKeyLength)
 }
 
+func TestDecryptWithKey_TruncatedData(t *testing.T) {
+	t.Parallel()
+
+	// A valid raw-key (v2) header followed by fewer than the minimum
+	// nonce(12) + authTag(16) trailing bytes must be rejected as ErrInvalidFormat
+	// before any decryption is attempted.
+	data := append([]byte(crypt.MagicHeader), crypt.VersionRawKey)
+	data = append(data, make([]byte, 5)...) // far below header + nonce + tag
+
+	_, err := crypt.DecryptWithKey(data, make([]byte, crypt.RawKeyLen))
+	assert.ErrorIs(t, err, crypt.ErrInvalidFormat)
+}
+
 func TestDecryptWithKey_WrongKey(t *testing.T) {
 	t.Parallel()
 

--- a/internal/staging/store/file/internal/keyprovider/keyprovider_test.go
+++ b/internal/staging/store/file/internal/keyprovider/keyprovider_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"testing"
+	"testing/iotest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -17,11 +18,13 @@ func withHooks(t *testing.T, fn func()) {
 	origLookup := lookupEnvFunc
 	origGet := keyringGetFunc
 	origSet := keyringSetFunc
+	origRand := randReader
 
 	t.Cleanup(func() {
 		lookupEnvFunc = origLookup
 		keyringGetFunc = origGet
 		keyringSetFunc = origSet
+		randReader = origRand
 	})
 
 	fn()
@@ -213,4 +216,55 @@ func TestResolve_CorruptStoredKey_Surfaced(t *testing.T) {
 		var kcErr *KeychainUnavailableError
 		require.ErrorAs(t, err, &kcErr)
 	})
+}
+
+// TestResolve_StoredKeyWrongLength_Surfaced: a stored key that decodes cleanly
+// but is not exactly 32 bytes is a hard error, never a silent plaintext
+// downgrade — a wrong-length key could not decrypt existing working state.
+//
+//nolint:paralleltest // overrides package-level hook vars.
+func TestResolve_StoredKeyWrongLength_Surfaced(t *testing.T) {
+	withHooks(t, func() {
+		lookupEnvFunc = func(string) (string, bool) { return "", false }
+		// Valid base64 that decodes to 31 bytes, one short of keyLen.
+		keyringGetFunc = func(string, string) (string, error) {
+			return base64.StdEncoding.EncodeToString(make([]byte, keyLen-1)), nil
+		}
+
+		_, _, _, err := Resolve()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "wrong length")
+
+		var kcErr *KeychainUnavailableError
+		require.ErrorAs(t, err, &kcErr)
+	})
+}
+
+// TestMint_RandReaderError: a failure of the random source surfaces from Mint
+// as an error rather than producing a short or predictable key.
+//
+//nolint:paralleltest // overrides package-level hook vars.
+func TestMint_RandReaderError(t *testing.T) {
+	withHooks(t, func() {
+		randReader = iotest.ErrReader(errors.New("random source unavailable"))
+
+		_, err := Mint()
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to generate data key")
+	})
+}
+
+// TestKeychainUnavailableError_UnwrapAndError verifies the wrapped cause is
+// retrievable via errors.Unwrap/errors.Is and that Error names both the
+// wrapper and the underlying cause.
+func TestKeychainUnavailableError_UnwrapAndError(t *testing.T) {
+	t.Parallel()
+
+	cause := errors.New("dbus unreachable")
+	err := &KeychainUnavailableError{Err: cause}
+
+	assert.Equal(t, cause, err.Unwrap())
+	require.ErrorIs(t, err, cause)
+	assert.Contains(t, err.Error(), "OS keychain unavailable")
+	assert.Contains(t, err.Error(), "dbus unreachable")
 }


### PR DESCRIPTION
Closes #822

Adds unit tests for the remaining crypto-correctness / key-loss-safety branches in the file staging store's `keyprovider` and `crypt` packages, using the existing test hooks and crafted byte slices.

## Verification

`go build ./...` — clean.

`golangci-lint run --allow-parallel-runners ./internal/staging/store/file/...`:
```
0 issues.
```

`SUVE_STAGING_KEY=... go test ./internal/staging/store/file/...`:
```
ok  github.com/mpyw/suve/internal/staging/store/file                          1.566s
ok  github.com/mpyw/suve/internal/staging/store/file/internal/crypt           1.028s
ok  github.com/mpyw/suve/internal/staging/store/file/internal/keyprovider     0.225s
```

Coverage (`go test -cover`):
```
keyprovider  89.2% -> 100.0%
crypt        94.1% ->  98.0%
```

The two blocks still uncovered in `crypt` (`crypt.go:192` in `DecryptWithAAD`, `crypt.go:280` in `DecryptWithKey`) are the `len(data) < headerLen` guards that sit directly after `IsEncrypted()`; since `IsEncrypted()` already returns false for any `len < headerLen`, those guards are unreachable defensive code and cannot be exercised without altering source.