### PR TITLE
test(cli): cover passphrase prompt mismatch/cancel branches and valueinput/editor edges

### DIFF
--- a/internal/cli/commands/internal/valueinput_test.go
+++ b/internal/cli/commands/internal/valueinput_test.go
@@ -4,14 +4,48 @@ import (
 	"context"
 	"errors"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v3"
 
 	cliinternal "github.com/mpyw/suve/internal/cli/commands/internal"
 )
+
+// errReader fails on the first Read, standing in for a stdin whose read errors.
+type errReader struct{ err error }
+
+func (r errReader) Read([]byte) (int, error) { return 0, r.err }
+
+func TestStdin(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns the reader injected via cmd.Root().Reader", func(t *testing.T) {
+		t.Parallel()
+
+		r := strings.NewReader("injected")
+		cmd := &cli.Command{Reader: r}
+		assert.Same(t, r, cliinternal.Stdin(cmd))
+	})
+
+	t.Run("falls back to os.Stdin when no reader is set", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Same(t, os.Stdin, cliinternal.Stdin(&cli.Command{}))
+	})
+}
+
+func TestValueStdinFlag(t *testing.T) {
+	t.Parallel()
+
+	f, ok := cliinternal.ValueStdinFlag().(*cli.BoolFlag)
+	require.True(t, ok)
+	assert.Equal(t, cliinternal.FlagValueStdin, f.Name)
+	assert.NotEmpty(t, f.Usage)
+}
 
 func TestResolveValue_FromStdin(t *testing.T) {
 	t.Parallel()
@@ -81,6 +115,20 @@ func TestResolveValue_FromStdin(t *testing.T) {
 		rest, rerr := io.ReadAll(reader)
 		require.NoError(t, rerr)
 		assert.Equal(t, "sk-12345\n", string(rest))
+	})
+
+	t.Run("surfaces a stdin read error", func(t *testing.T) {
+		t.Parallel()
+
+		sentinel := errors.New("read boom")
+
+		_, proceed, err := cliinternal.ResolveValue(t.Context(), cliinternal.ValueSource{
+			FromStdin: true,
+			Stdin:     errReader{err: sentinel},
+		})
+		require.ErrorIs(t, err, sentinel)
+		assert.False(t, proceed)
+		assert.Contains(t, err.Error(), "failed to read value from stdin")
 	})
 
 	t.Run("reads stdin when confirmation is skipped via --yes", func(t *testing.T) {

--- a/internal/cli/passphrase/passphrase_test.go
+++ b/internal/cli/passphrase/passphrase_test.go
@@ -2,6 +2,7 @@ package passphrase_test
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
@@ -139,6 +140,105 @@ func TestPrompter_WarnNonTTY(t *testing.T) {
 	p.WarnNonTTY()
 	assert.Contains(t, stderr.String(), "Non-interactive mode")
 	assert.Contains(t, stderr.String(), "plain text")
+}
+
+// errReader fails on the first Read, standing in for a stdin whose read errors
+// (something other than EOF), so the non-TTY read paths surface the failure.
+type errReader struct{ err error }
+
+func (r errReader) Read([]byte) (int, error) { return 0, r.err }
+
+// dataThenErrReader yields data once, then fails on the next Read. It lets a
+// prompt's first read succeed and its second read (the confirmation) error.
+type dataThenErrReader struct {
+	data []byte
+	err  error
+	done bool
+}
+
+func (r *dataThenErrReader) Read(p []byte) (int, error) {
+	if r.done {
+		return 0, r.err
+	}
+
+	r.done = true
+
+	return copy(p, r.data), nil
+}
+
+func TestPrompter_PromptForEncrypt_EmptyConfirmReadError(t *testing.T) {
+	t.Parallel()
+
+	// Empty passphrase reaches confirmPlainText; the reader is then at EOF, so
+	// the confirmation ReadString errors and the prompt treats it as a decline.
+	p := &passphrase.Prompter{
+		Stdin:  strings.NewReader("\n"),
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+
+	_, err := p.PromptForEncrypt()
+	assert.ErrorIs(t, err, passphrase.ErrCancelled)
+}
+
+func TestPrompter_PromptForEncrypt_ReadError(t *testing.T) {
+	t.Parallel()
+
+	p := &passphrase.Prompter{
+		Stdin:  errReader{err: errors.New("boom")},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+
+	_, err := p.PromptForEncrypt()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read passphrase")
+}
+
+func TestPrompter_PromptForEncrypt_ConfirmReadError(t *testing.T) {
+	t.Parallel()
+
+	// The first read yields a non-empty passphrase; the confirmation read then
+	// errors, so the prompt reports a confirmation-read failure.
+	p := &passphrase.Prompter{
+		Stdin:  &dataThenErrReader{data: []byte("secret\n"), err: errors.New("boom")},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+
+	_, err := p.PromptForEncrypt()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read confirmation")
+}
+
+func TestPrompter_PromptForDecrypt_ReadError(t *testing.T) {
+	t.Parallel()
+
+	p := &passphrase.Prompter{
+		Stdin:  errReader{err: errors.New("boom")},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+
+	_, err := p.PromptForDecrypt()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to read passphrase")
+}
+
+func TestPrompter_ReadFromStdin_ReadError(t *testing.T) {
+	t.Parallel()
+
+	// A non-EOF read error must propagate rather than be swallowed as empty.
+	sentinel := errors.New("boom")
+
+	p := &passphrase.Prompter{
+		Stdin:  errReader{err: sentinel},
+		Stdout: &bytes.Buffer{},
+		Stderr: &bytes.Buffer{},
+	}
+
+	_, err := p.ReadFromStdin()
+	assert.ErrorIs(t, err, sentinel)
 }
 
 func TestPrompter_ReadFromStdin(t *testing.T) {


### PR DESCRIPTION
Closes #824

Adds unit tests for the non-PTY-reachable error and helper branches in `internal/cli/passphrase` and `internal/cli/commands/internal/valueinput.go`. (The mismatch, empty→decline, CRLF, editor-exec, and ResolveValue editor-fallback/conflict cases the issue cites were already covered on `main`; baseline 78.4% already reflected them. This PR fills the remaining coverable gaps — reader-error edges and the `Stdin`/`ValueStdinFlag` helpers.)

## Verification

Gates run in the worktree (`mise lint` intentionally not run per parallel-worktree lock):

```
$ go build ./...
BUILD OK

$ go test ./internal/cli/passphrase/... ./internal/cli/commands/internal/... ./internal/cli/editor/...
ok  github.com/mpyw/suve/internal/cli/passphrase
ok  github.com/mpyw/suve/internal/cli/commands/internal
ok  github.com/mpyw/suve/internal/cli/editor

$ golangci-lint run --allow-parallel-runners ./internal/cli/passphrase/... ./internal/cli/commands/internal/... ./internal/cli/editor/...
0 issues.
```

Coverage delta (package statement coverage):

| Package | Before | After |
| --- | --- | --- |
| `internal/cli/passphrase` | 78.4% | 90.2% |
| `internal/cli/commands/internal` | 28.7% | 33.0% |
| `internal/cli/editor` | 84.6% | 84.6% (unchanged) |

`valueinput.go` per-function after: `Stdin` 100%, `ValueStdinFlag` 100%, `ResolveValue` 86.4%→90.9%.

Remaining uncovered blocks are PTY-only and left to e2e as the issue directs: `passphrase.readPassword` true-TTY `term.ReadPassword` branch (and its `bufReader` init), the `ResolveValue` `os.Stdin` fallback, and the interactive `editor.Open` assignment. `editor.go` is unchanged — its `Open` exec path is already covered on `main`; the only remaining gaps are I/O-failure-injection paths (CreateTemp/Write/Close/ReadFile) outside this issue's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)