### PR TITLE
chore(gui): measure Svelte frontend coverage via Playwright V8 → gui-frontend codecov flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -475,8 +475,27 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
+      # V8 coverage is identical across OSes, so collect + upload it once on
+      # ubuntu (COVERAGE=1 turns on the monocart pipeline; see
+      # tests/fixtures/coverage.ts). Other OSes run the plain suite.
+      - name: Run Playwright tests (with coverage)
+        if: matrix.os == 'ubuntu-latest'
+        run: COVERAGE=1 npm test
+
       - name: Run Playwright tests
+        if: matrix.os != 'ubuntu-latest'
         run: npm test
+
+      - name: Upload frontend coverage to Codecov
+        if: matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: ./internal/gui/frontend/coverage/lcov.info
+          flags: gui-frontend
+          name: codecov-suve-gui-frontend
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        continue-on-error: true
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,10 @@ Thumbs.db
 /internal/gui/frontend/playwright-report/
 /internal/gui/frontend/playwright/.cache/
 
+# Frontend JS/TS coverage (monocart V8 output + its shared cache); only written
+# when COVERAGE=1, never committed.
+/internal/gui/frontend/coverage/
+
 # Demo recording artifacts
 *.webm
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -5,8 +5,8 @@ coverage:
   status:
     project:
       default:
-        # 2 (unit + e2e) + 3 (platform: linux, darwin, windows) + 1 (gui)
-        after_n_builds: 6
+        # 2 (unit + e2e) + 3 (platform: linux, darwin, windows) + 1 (gui) + 1 (gui-frontend)
+        after_n_builds: 7
     patch:
       default:
-        after_n_builds: 6
+        after_n_builds: 7

--- a/internal/gui/frontend/package-lock.json
+++ b/internal/gui/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@playwright/test": "^1.57.0",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
         "@tsconfig/svelte": "^5.0.4",
+        "monocart-coverage-reports": "^2.12.12",
         "svelte": "^5.56.4",
         "svelte-check": "^4.0.0",
         "tslib": "^2.6.3",
@@ -690,6 +691,32 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-loose": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/acorn-loose/-/acorn-loose-8.5.2.tgz",
+      "integrity": "sha512-PPvV6g8UGMGgjrMu+n/f9E/tCSkNQ2Y97eFvuVdJfG11+xdIeDcLyNdC8SHcrHbRqkfwLASdplyR6B6sKM1U4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.15.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/aria-query": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
@@ -736,6 +763,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/console-grid": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/console-grid/-/console-grid-2.2.4.tgz",
+      "integrity": "sha512-OLjCRTiHhOpTRo9lQp/2FgJDyq5uQHwkEmVJulEnQ6JVf27oKKzXHZnNOv/e72V4++UdMZCrDWtvXW5sx4lyQg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -760,6 +804,13 @@
       "version": "5.8.1",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
       "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eight-colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/eight-colors/-/eight-colors-1.3.3.tgz",
+      "integrity": "sha512-4B54S2Qi4pJjeHmCbDIsveQZWQ/TSSQng4ixYJ9/SYHHpeS5nYK0pzcHvWzWUfRsvJQjwoIENhAwqg59thQceg==",
       "dev": true,
       "license": "MIT"
     },
@@ -806,6 +857,22 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-4.0.3.tgz",
+      "integrity": "sha512-yeXZaNbCBGaT9giTpLPBdtedzjwhlJBUoL/R4BVQU5mn0TQXOHwVIl1Q2DMuBIdNno4ktA1abZ7dQFVxD6uHxw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -821,6 +888,23 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-reference": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
@@ -829,6 +913,45 @@
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
+      }
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lightningcss": {
@@ -1111,6 +1234,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lz-utils": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/lz-utils/-/lz-utils-2.1.1.tgz",
+      "integrity": "sha512-d3Thjos0PSJQAoyMj6vipSSrtrRHS7DImqUNR8x9NW3+zQIftPIbMJAWhi5nPdg5Q9zHz6lxtN8kp/VdMlhi/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1120,6 +1250,53 @@
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/monocart-coverage-reports": {
+      "version": "2.12.12",
+      "resolved": "https://registry.npmjs.org/monocart-coverage-reports/-/monocart-coverage-reports-2.12.12.tgz",
+      "integrity": "sha512-d9FdUr2dn58Crweon0IE0zVi8r/i4vLvfvb2G7eL5vL5LfrxCB2X6F6qzuiwV6RioA4zbAI//7CYi6LjCvN3zA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-loose": "^8.5.2",
+        "acorn-walk": "^8.3.5",
+        "commander": "^14.0.3",
+        "console-grid": "^2.2.4",
+        "eight-colors": "^1.3.3",
+        "foreground-child": "^4.0.3",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "lz-utils": "^2.1.1",
+        "monocart-locator": "^1.0.3"
+      },
+      "bin": {
+        "mcr": "lib/cli.js"
+      }
+    },
+    "node_modules/monocart-locator": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/monocart-locator/-/monocart-locator-1.0.3.tgz",
+      "integrity": "sha512-pe29W2XAoA1WQmZZqxXoP7s06ZEXUhcb81086v68cqjk1HnVL7Q/iU/WJnnetxjPcLqwb4qG8vaSGUOMQU602g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -1306,6 +1483,32 @@
         "node": ">=6"
       }
     },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1314,6 +1517,19 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/svelte": {

--- a/internal/gui/frontend/package.json
+++ b/internal/gui/frontend/package.json
@@ -22,6 +22,7 @@
     "@playwright/test": "^1.57.0",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",
     "@tsconfig/svelte": "^5.0.4",
+    "monocart-coverage-reports": "^2.12.12",
     "svelte": "^5.56.4",
     "svelte-check": "^4.0.0",
     "tslib": "^2.6.3",

--- a/internal/gui/frontend/playwright.config.ts
+++ b/internal/gui/frontend/playwright.config.ts
@@ -5,6 +5,11 @@ const BASE_URL = `http://localhost:${PORT}`;
 
 export default defineConfig({
   testDir: './tests',
+  // Coverage lifecycle (no-op unless COVERAGE=1): clean monocart's shared V8
+  // cache before the run, then merge every worker's collected coverage into
+  // lcov after it. The per-test collection lives in tests/fixtures/coverage.ts.
+  globalSetup: './tests/coverage/global-setup.ts',
+  globalTeardown: './tests/coverage/global-teardown.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/internal/gui/frontend/tests/accessibility.spec.ts
+++ b/internal/gui/frontend/tests/accessibility.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   waitForItemList,

--- a/internal/gui/frontend/tests/app.spec.ts
+++ b/internal/gui/frontend/tests/app.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import { setupWailsMocks, type MockState, createAWSIdentityState, createNoAWSIdentityState } from './fixtures/wails-mock';
 
 test.describe('App Navigation', () => {

--- a/internal/gui/frontend/tests/coverage/config.ts
+++ b/internal/gui/frontend/tests/coverage/config.ts
@@ -1,0 +1,38 @@
+// Shared monocart-coverage-reports options, used by both the Playwright
+// global setup/teardown (cache clean + report generate) and the per-test
+// fixture that feeds V8 coverage into the shared cache.
+//
+// Coverage is collected only when COVERAGE=1 (see the fixture and the global
+// hooks); a normal `npm test` run never touches monocart.
+//
+// Mapping V8 coverage back to the app's own sources needs two adjustments for
+// a Vite dev server:
+//   * entryFilter keeps only the app modules Vite serves under `/src/` — this
+//     drops the Svelte runtime (node_modules/.vite/deps/*, whose own source
+//     maps resolve to `svelte/src/**`), @vite/client, Vite chunks, clsx, the
+//     generated wailsjs bindings, and the extracted CSS — before unpacking.
+//   * sourcePath rebuilds the real repo-relative path. Vite dev source maps
+//     unpack each module to a bare basename (e.g. `Modal.svelte`), losing its
+//     directory; since each dev entry is 1:1 with its source, the entry URL
+//     (info.distFile) carries the true `src/**` path.
+export const coverageOptions = {
+  name: 'GUI Frontend Coverage',
+  outputDir: './coverage',
+  reports: ['lcovonly'],
+  entryFilter: (entry: { url: string }) => {
+    const url = entry.url;
+    if (!url.includes('/src/')) {
+      return false;
+    }
+    // Drop stylesheets and Svelte's extracted <style> blocks; only .svelte/.ts
+    // logic is meaningful line coverage.
+    return !/\.css(\?|$)|type=style|lang\.css/.test(url);
+  },
+  sourcePath: (filePath: string, info: { distFile?: string }) => {
+    const dist = info?.distFile ?? filePath;
+    const match = dist.match(/src\/.+$/);
+    const resolved = match ? match[0] : filePath;
+    // Strip any Vite query string (?t=..., ?svelte&...).
+    return resolved.replace(/[?].*$/, '');
+  },
+};

--- a/internal/gui/frontend/tests/coverage/global-setup.ts
+++ b/internal/gui/frontend/tests/coverage/global-setup.ts
@@ -1,0 +1,12 @@
+import { CoverageReport } from 'monocart-coverage-reports';
+import { coverageOptions } from './config';
+
+// Playwright globalSetup: clear monocart's shared V8 cache before the run so a
+// previous run's coverage can't leak into this one. No-op unless COVERAGE=1.
+export default async function globalSetup() {
+  if (process.env.COVERAGE !== '1') {
+    return;
+  }
+  const report = new CoverageReport(coverageOptions);
+  report.cleanCache();
+}

--- a/internal/gui/frontend/tests/coverage/global-teardown.ts
+++ b/internal/gui/frontend/tests/coverage/global-teardown.ts
@@ -1,0 +1,15 @@
+import { CoverageReport } from 'monocart-coverage-reports';
+import { coverageOptions } from './config';
+
+// Playwright globalTeardown: merge every worker's cached V8 coverage into the
+// configured reports (lcov.info under outputDir). Playwright runs each worker in
+// its own process, so the per-test fixture's `add()` calls write to monocart's
+// shared on-disk cache; this single `generate()` merges them. No-op unless
+// COVERAGE=1.
+export default async function globalTeardown() {
+  if (process.env.COVERAGE !== '1') {
+    return;
+  }
+  const report = new CoverageReport(coverageOptions);
+  await report.generate();
+}

--- a/internal/gui/frontend/tests/description-display.spec.ts
+++ b/internal/gui/frontend/tests/description-display.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   waitForItemList,

--- a/internal/gui/frontend/tests/description-input.spec.ts
+++ b/internal/gui/frontend/tests/description-input.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   waitForItemList,

--- a/internal/gui/frontend/tests/e2e-workflows.spec.ts
+++ b/internal/gui/frontend/tests/e2e-workflows.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   waitForItemList,

--- a/internal/gui/frontend/tests/edge-cases.spec.ts
+++ b/internal/gui/frontend/tests/edge-cases.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createErrorState,

--- a/internal/gui/frontend/tests/filter-search.spec.ts
+++ b/internal/gui/frontend/tests/filter-search.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createFilterTestState,

--- a/internal/gui/frontend/tests/fixtures/coverage.ts
+++ b/internal/gui/frontend/tests/fixtures/coverage.ts
@@ -1,0 +1,29 @@
+import { CoverageReport } from 'monocart-coverage-reports';
+import { test as base, expect, type Page } from '@playwright/test';
+import { coverageOptions } from '../coverage/config';
+
+// Every spec imports `test`/`expect` from here rather than from
+// `@playwright/test`, so a single shared fixture wraps the `page` for the whole
+// suite. When COVERAGE=1 (and only on Chromium, since V8 coverage via CDP is
+// Chromium-only), the wrapped `page` collects JS coverage across the test and
+// hands it to monocart's shared cache; a plain `npm test` run is unaffected.
+const COLLECT = process.env.COVERAGE === '1';
+
+export const test = base.extend({
+  page: async ({ page, browserName }, use) => {
+    const collect = COLLECT && browserName === 'chromium';
+    if (collect) {
+      await page.coverage.startJSCoverage({ resetOnNavigation: false });
+    }
+
+    await use(page);
+
+    if (collect) {
+      const coverage = await page.coverage.stopJSCoverage();
+      const report = new CoverageReport(coverageOptions);
+      await report.add(coverage);
+    }
+  },
+});
+
+export { expect, type Page };

--- a/internal/gui/frontend/tests/keyboard-focus.spec.ts
+++ b/internal/gui/frontend/tests/keyboard-focus.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   waitForItemList,

--- a/internal/gui/frontend/tests/keyvault-restore.spec.ts
+++ b/internal/gui/frontend/tests/keyvault-restore.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from './fixtures/coverage';
 import { setupWailsMocks, createAzureState, navigateTo } from './fixtures/wails-mock';
 
 // Azure Key Vault soft-deletes secrets like AWS Secrets Manager, so the GUI must

--- a/internal/gui/frontend/tests/keyvault-version-tags.spec.ts
+++ b/internal/gui/frontend/tests/keyvault-version-tags.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from './fixtures/coverage';
 import { setupWailsMocks, createAzureState, navigateTo } from './fixtures/wails-mock';
 
 // Azure Key Vault scopes tags PER VERSION (each version has its own tags). The

--- a/internal/gui/frontend/tests/launch-context.spec.ts
+++ b/internal/gui/frontend/tests/launch-context.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createAzureState,

--- a/internal/gui/frontend/tests/multi-provider-staging.spec.ts
+++ b/internal/gui/frontend/tests/multi-provider-staging.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createGoogleCloudState,

--- a/internal/gui/frontend/tests/namespace-create.spec.ts
+++ b/internal/gui/frontend/tests/namespace-create.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createAzureNamespaceState,

--- a/internal/gui/frontend/tests/namespace-detail.spec.ts
+++ b/internal/gui/frontend/tests/namespace-detail.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createAzureState,

--- a/internal/gui/frontend/tests/namespace-filter.spec.ts
+++ b/internal/gui/frontend/tests/namespace-filter.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createAzureNamespaceState,

--- a/internal/gui/frontend/tests/param.spec.ts
+++ b/internal/gui/frontend/tests/param.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   type MockState,

--- a/internal/gui/frontend/tests/provider-selection.spec.ts
+++ b/internal/gui/frontend/tests/provider-selection.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createGoogleCloudState,

--- a/internal/gui/frontend/tests/scope-form.spec.ts
+++ b/internal/gui/frontend/tests/scope-form.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createAzureState,

--- a/internal/gui/frontend/tests/secret-service-mask.spec.ts
+++ b/internal/gui/frontend/tests/secret-service-mask.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createSecretStagedState,

--- a/internal/gui/frontend/tests/secret.spec.ts
+++ b/internal/gui/frontend/tests/secret.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   type MockState,

--- a/internal/gui/frontend/tests/securestring-diff.spec.ts
+++ b/internal/gui/frontend/tests/securestring-diff.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createParam,

--- a/internal/gui/frontend/tests/staging-advanced.spec.ts
+++ b/internal/gui/frontend/tests/staging-advanced.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   waitForItemList,

--- a/internal/gui/frontend/tests/staging-apply-all.spec.ts
+++ b/internal/gui/frontend/tests/staging-apply-all.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createStagedValue,

--- a/internal/gui/frontend/tests/staging-apply-partial-failure.spec.ts
+++ b/internal/gui/frontend/tests/staging-apply-partial-failure.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createStagedValue,

--- a/internal/gui/frontend/tests/staging-apply-unstage-warning.spec.ts
+++ b/internal/gui/frontend/tests/staging-apply-unstage-warning.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createStagedValue,

--- a/internal/gui/frontend/tests/staging-export-import.spec.ts
+++ b/internal/gui/frontend/tests/staging-export-import.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from './fixtures/coverage';
 import {
   setupWailsMocks,
   navigateTo,

--- a/internal/gui/frontend/tests/staging-namespace.spec.ts
+++ b/internal/gui/frontend/tests/staging-namespace.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createAzureNamespaceState,

--- a/internal/gui/frontend/tests/staging-reset-all.spec.ts
+++ b/internal/gui/frontend/tests/staging-reset-all.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createStagedValue,

--- a/internal/gui/frontend/tests/staging-scroll.spec.ts
+++ b/internal/gui/frontend/tests/staging-scroll.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test';
+import { test, expect, type Page } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createParamStagedState,

--- a/internal/gui/frontend/tests/staging.spec.ts
+++ b/internal/gui/frontend/tests/staging.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   type MockState,

--- a/internal/gui/frontend/tests/stress-robustness.spec.ts
+++ b/internal/gui/frontend/tests/stress-robustness.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   waitForItemList,

--- a/internal/gui/frontend/tests/tags-terminology.spec.ts
+++ b/internal/gui/frontend/tests/tags-terminology.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createGoogleCloudState,

--- a/internal/gui/frontend/tests/ui-interaction.spec.ts
+++ b/internal/gui/frontend/tests/ui-interaction.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createFilterTestState,

--- a/internal/gui/frontend/tests/version-history.spec.ts
+++ b/internal/gui/frontend/tests/version-history.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   createVersionHistoryState,

--- a/internal/gui/frontend/tests/viewport.spec.ts
+++ b/internal/gui/frontend/tests/viewport.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import {
   setupWailsMocks,
   waitForItemList,

--- a/internal/gui/frontend/tests/wails-mock-providers.spec.ts
+++ b/internal/gui/frontend/tests/wails-mock-providers.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from './fixtures/coverage';
 import { setupWailsMocks } from './fixtures/wails-mock';
 
 // Infrastructure test (not a feature spec): it exercises the provider-aware


### PR DESCRIPTION
Closes #830

Implements **Option A** from the issue's recommendation: collect V8 coverage during the existing Playwright suite, aggregate it with `monocart-coverage-reports` into lcov, and upload it to Codecov under a new `gui-frontend` flag (kept separate from the Go-only `gui` flag so the Go percentages stay comparable).

## Mechanism

- **Shared fixture** (`tests/fixtures/coverage.ts`): a single `test`/`expect` re-export that wraps the `page` fixture. Every spec now imports `test`/`expect` from here instead of `@playwright/test`, so the whole suite is covered by one fixture (no competing `test` import). Gated so it only collects when `COVERAGE=1` **and** `browserName === 'chromium'` (V8/CDP coverage is Chromium-only): `page.coverage.startJSCoverage({ resetOnNavigation: false })` before the test, `stopJSCoverage()` + `new CoverageReport(coverageOptions).add(...)` after. A plain `npm test` run is a pure pass-through.
- **Lifecycle** (`playwright.config.ts` `globalSetup`/`globalTeardown`): clean monocart's shared cache before the run, then `generate()` once after. Playwright runs workers in separate processes, so each worker's `add()` writes to monocart's shared on-disk cache and the single `generate()` merges them. Both hooks are no-ops unless `COVERAGE=1`.
- **Config** (`tests/coverage/config.ts`): `reports: ['lcovonly']` → `coverage/lcov.info`. Because this runs against the Vite **dev** server, two adjustments map coverage back to the app's own sources:
  - `entryFilter` keeps only modules Vite serves under `/src/`, dropping the Svelte runtime (`node_modules/.vite/deps/*`, whose source maps resolve to `svelte/src/**`), `@vite/client`, Vite chunks, `clsx`, the generated `wailsjs` bindings, and extracted CSS **before** unpacking.
  - `sourcePath` rebuilds the real repo-relative path: Vite dev source maps unpack each module to a bare basename (e.g. `Modal.svelte`), losing its directory; since each dev entry is 1:1 with its source, the entry URL (`info.distFile`) carries the true `src/**` path.
- **CI** (`.github/workflows/test.yml` `gui-test`): coverage is identical across OSes, so it's collected once — `COVERAGE=1 npm test` on `ubuntu-latest` only (other OSes run the plain suite), then a single `codecov/codecov-action` upload (same pinned SHA as the other jobs) with `flags: gui-frontend`, `files: ./internal/gui/frontend/coverage/lcov.info`, `continue-on-error: true` (best-effort, matching the repo policy).
- **codecov.yml**: `after_n_builds` 6 → 7 (project + patch) to account for the new upload.
- Generated coverage output (`/internal/gui/frontend/coverage/`) is gitignored.

Follow-up (out of scope, as the issue notes): Option B (vitest unit tests for pure store/lib logic) once this baseline exists.

## Verification

Validated locally (Node 24, Chromium). Source maps mapped correctly to `.svelte` and `.ts` — the lcov `SF:` paths are real repo-relative `src/**` files, not bundled Vite chunks, with zero `node_modules`/runtime leakage.

**Plain `npm test` (baseline unchanged, no coverage side effects):** the full local run (chromium + firefox + webkit, 1521 tests) shows `1519 passed`. The only 2 failures are pre-existing WebKit-only flakes (`filter-search` show-values toggle — passes on retry; `keyboard-focus` Tab navigation — still fails with the original `@playwright/test` import, i.e. with the coverage fixture fully bypassed, proving it is not caused by this change). CI runs Chromium-only, where the suite is fully green. A clean plain run creates **no** `coverage/` directory.

**`COVERAGE=1` Chromium run (CI path):**
```
507 passed (1.5m)
EXIT=0
```
produces `internal/gui/frontend/coverage/lcov.info`.

**lcov `SF:` sample (19 entries: 15 `.svelte` + 5 `.ts`, 0 noise):**
```
SF:src/App.svelte
SF:src/lib/DiffDisplay.svelte
SF:src/lib/Modal.svelte
SF:src/lib/ParamView.svelte
SF:src/lib/PassphraseModal.svelte
SF:src/lib/SecretView.svelte
SF:src/lib/Sidebar.svelte
SF:src/lib/StagingBanner.svelte
SF:src/lib/StagingSection.svelte
SF:src/lib/StagingView.svelte
SF:src/lib/TagList.svelte
SF:src/lib/icons/CloseIcon.svelte
SF:src/lib/icons/EyeIcon.svelte
SF:src/lib/icons/EyeOffIcon.svelte
SF:src/lib/diff-utils.ts
SF:src/lib/retry.ts
SF:src/lib/useDiffMode.svelte.ts
SF:src/lib/viewUtils.ts
SF:src/main.ts
```
with real line data, e.g. `src/lib/diff-utils.ts` → `FNF:2 FNH:2 LF:43 LH:36`.

**`npm run ci` (biome + svelte-check):** passes (0 errors; the pre-existing `baseUrl` deprecation warning is unrelated).

**`go build ./...`:** unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)