### PR TITLE
fix(dist): scope the main npm package as @mpyw/suve

### DIFF
--- a/.github/npm/suve/README.md
+++ b/.github/npm/suve/README.md
@@ -5,10 +5,13 @@
 ## Install
 
 ```bash
-npm install -g suve
+npm install -g @mpyw/suve
 # or run without installing
-npx suve --version
+npx @mpyw/suve --version
 ```
+
+After install the command is just `suve` (the package name is scoped, the
+binary is not).
 
 The right prebuilt binary for your platform is installed automatically as an
 optional dependency (`@mpyw/suve-<os>-<cpu>`). No build step, no network fetch

--- a/.github/npm/suve/lib/resolve.mjs
+++ b/.github/npm/suve/lib/resolve.mjs
@@ -47,7 +47,7 @@ export function resolveBinary(platform = process.platform, arch = process.arch) 
       `suve: the platform package "${pkg}" is not installed.\n` +
         `This usually means npm skipped optionalDependencies (for example with ` +
         `--no-optional, or --ignore-scripts on an incompatible host).\n` +
-        `Reinstall to fetch it: npm install suve`
+        `Reinstall to fetch it: npm install @mpyw/suve`
     );
   }
 }

--- a/.github/npm/suve/package.json
+++ b/.github/npm/suve/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "suve",
+  "name": "@mpyw/suve",
   "version": "0.0.0",
   "description": "Git-like CLI/TUI/GUI for multi-cloud secret and parameter management across AWS, Google Cloud, and Azure",
   "license": "MIT",

--- a/README.md
+++ b/README.md
@@ -103,17 +103,17 @@ scoop bucket add mpyw https://github.com/mpyw/scoop-bucket.git
 scoop install suve
 ```
 
-### Using [npm](https://www.npmjs.com/package/suve) (macOS/Linux/Windows)
+### Using [npm](https://www.npmjs.com/package/@mpyw/suve) (macOS/Linux/Windows)
 
 ```bash
 # Global install
-npm install -g suve
+npm install -g @mpyw/suve
 
 # Or run without installing
-npx suve --version
+npx @mpyw/suve --version
 ```
 
-The right prebuilt binary is pulled in automatically as a platform-specific optional dependency (`@mpyw/suve-<os>-<cpu>`) — no build step or install-time download. macOS/Windows get the self-contained GUI build; Linux gets the dependency-free CLI/TUI-only static build, so **`--gui` is not available via npm on Linux** (use a package manager or the `.deb`/`.rpm` for the desktop GUI). The `--tui` works on every platform.
+The installed command is just `suve` (only the package name is scoped). The right prebuilt binary is pulled in automatically as a platform-specific optional dependency (`@mpyw/suve-<os>-<cpu>`) — no build step or install-time download. macOS/Windows get the self-contained GUI build; Linux gets the dependency-free CLI/TUI-only static build, so **`--gui` is not available via npm on Linux** (use a package manager or the `.deb`/`.rpm` for the desktop GUI). The `--tui` works on every platform.
 
 <details>
 <summary>Linux (.deb / .rpm)</summary>


### PR DESCRIPTION
## Why

During the local bootstrap publish, the 6 platform packages published fine but the main **unscoped** `suve` package was rejected by the npm registry:

> 403 Forbidden - PUT https://registry.npmjs.org/suve - Package name too similar to existing packages save,serve,sade,sane,scule,use,uvu,vue; try renaming your package to '@mpyw/suve'

npm's spam-prevention blocks the unscoped name. Fix per npm's own suggestion: scope the main package to **`@mpyw/suve`** (consistent with the `@mpyw/suve-*` platform packages).

## What changes

- `.github/npm/suve/package.json`: `name` `suve` → `@mpyw/suve`.
- Install docs (root README + npm README) and the `resolve.mjs` reinstall hint use `@mpyw/suve`.
- **The `bin` is still `suve`**, so the installed command is unchanged — only `npm install`/`npx` use the scoped name (`npm i -g @mpyw/suve`, `npx @mpyw/suve`).

## Verification

- `node --test` (.github/npm/suve): 8/8 pass.
- `check-naming.sh`: OK.
- The 6 platform packages already published at 1.6.0 are unaffected; only the main package name changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)