### PR TITLE
ci(dist): retroactive npm publish, .github/releases, run-names, labeler fix

### DIFF
--- a/.github/scripts/npm-publish.sh
+++ b/.github/scripts/npm-publish.sh
@@ -6,14 +6,14 @@
 #   suve                  main package (bin shim + optionalDependencies)
 #   @mpyw/suve-<os>-<cpu> six platform packages, each shipping one prebuilt binary
 #
-# Reuses the archives already built in releases/ by the release workflow:
+# Reuses the archives already built in .github/releases/ by the release workflow:
 #   darwin / windows -> self-contained GUI build (binary: suve / suve.exe)
 #   linux            -> CLI/TUI-only static build; the release workflow already
 #                       renames suve-cli -> suve inside the archive, so the member
 #                       is "suve" even though the archive is named suve-cli_*.
 #
 # Usage: .github/scripts/npm-publish.sh <version-without-v> [--dry-run|--no-provenance]
-#   Requires: node, npm; releases/ populated. A real publish authenticates via
+#   Requires: node, npm; .github/releases/ populated. A real publish authenticates via
 #   whatever the environment provides (OIDC trusted publishing in CI); this
 #   script does not configure auth itself.
 #
@@ -33,7 +33,7 @@ esac
 # This script lives at .github/scripts/; the repo root is two levels up.
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 NPM_DIR="$REPO_ROOT/.github/npm"
-RELEASES="$REPO_ROOT/releases"
+RELEASES="$REPO_ROOT/.github/releases"
 LICENSE="$REPO_ROOT/LICENSE"
 
 # platform-dir | archive filename | member inside archive | destination binary

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -17,3 +17,6 @@ jobs:
           configuration-path: .github/issue-labeler.yml
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           include-title: 1
+          # Required by v3.4. Our config is the flat `label: [regex]` form, not
+          # the versioned-template form, so disable versioned regex.
+          enable-versioned-regex: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 
+# Show the target version and selected mode in the run title, e.g.
+# "Release v1.2.3 · Release Only NPM".
+run-name: "Release ${{ inputs.version }} · ${{ inputs.mode }}"
+
 on:
   workflow_dispatch:
     inputs:
@@ -449,7 +453,7 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           VERSION="${VERSION#v}"
-          mkdir -p releases
+          mkdir -p .github/releases
 
           # All builds use goreleaser format: dist/{id}_{goos}_{goarch}/
           for dir in dist/*/; do
@@ -505,18 +509,18 @@ jobs:
               # github backend) get "Permission denied".
               chmod +x "$staging/${dst_binary}.exe"
               cp README.md LICENSE "$staging/"
-              (cd "$staging" && zip -r "../releases/${archive_name}" .)
+              (cd "$staging" && zip -r "../.github/releases/${archive_name}" .)
             else
               cp "$dir/${src_binary}" "$staging/${dst_binary}"
               # Restore the executable bit (see note above).
               chmod +x "$staging/${dst_binary}"
               cp README.md LICENSE "$staging/"
-              tar -czvf "releases/${archive_name}" -C "$staging" .
+              tar -czvf ".github/releases/${archive_name}" -C "$staging" .
             fi
             rm -rf "$staging"
           done
 
-          ls -la releases/
+          ls -la .github/releases/
 
       - name: Create Linux packages (.deb, .rpm)
         env:
@@ -546,8 +550,8 @@ jobs:
             cp "${cli_dir}/suve-cli" ./suve-cli
 
             echo "=== Generating suve-cli packages for ${arch} ==="
-            nfpm pkg --config .github/templates/nfpm.yaml --packager deb --target "releases/suve-cli_${VERSION}-1_${deb_arch}.deb"
-            nfpm pkg --config .github/templates/nfpm.yaml --packager rpm --target "releases/suve-cli-${VERSION}-1.${rpm_arch}.rpm"
+            nfpm pkg --config .github/templates/nfpm.yaml --packager deb --target ".github/releases/suve-cli_${VERSION}-1_${deb_arch}.deb"
+            nfpm pkg --config .github/templates/nfpm.yaml --packager rpm --target ".github/releases/suve-cli-${VERSION}-1.${rpm_arch}.rpm"
             rm ./suve-cli
 
             # --- GUI package (webkit2gtk-4.0) ---
@@ -565,8 +569,8 @@ jobs:
             cp "${gui_dir}/suve" ./suve
 
             echo "=== Generating suve packages for ${arch} (webkit2gtk-4.0) ==="
-            nfpm pkg --config .github/templates/nfpm-gui.yaml --packager deb --target "releases/suve_${VERSION}-1_${deb_arch}.deb"
-            nfpm pkg --config .github/templates/nfpm-gui.yaml --packager rpm --target "releases/suve-${VERSION}-1.${rpm_arch}.rpm"
+            nfpm pkg --config .github/templates/nfpm-gui.yaml --packager deb --target ".github/releases/suve_${VERSION}-1_${deb_arch}.deb"
+            nfpm pkg --config .github/templates/nfpm-gui.yaml --packager rpm --target ".github/releases/suve-${VERSION}-1.${rpm_arch}.rpm"
             rm ./suve
 
             # --- GUI package (webkit2gtk-4.1) ---
@@ -582,19 +586,19 @@ jobs:
             cp "${gui41_dir}/suve" ./suve
 
             echo "=== Generating suve_webkit2_41 packages for ${arch} (webkit2gtk-4.1) ==="
-            nfpm pkg --config .github/templates/nfpm-gui.yaml --packager deb --target "releases/suve_webkit2_41_${VERSION}-1_${deb_arch}.deb"
-            nfpm pkg --config .github/templates/nfpm-gui.yaml --packager rpm --target "releases/suve_webkit2_41-${VERSION}-1.${rpm_arch}.rpm"
+            nfpm pkg --config .github/templates/nfpm-gui.yaml --packager deb --target ".github/releases/suve_webkit2_41_${VERSION}-1_${deb_arch}.deb"
+            nfpm pkg --config .github/templates/nfpm-gui.yaml --packager rpm --target ".github/releases/suve_webkit2_41-${VERSION}-1.${rpm_arch}.rpm"
             rm ./suve
           done
 
           echo "=== Generated packages ==="
-          ls -la releases/*.deb releases/*.rpm
+          ls -la .github/releases/*.deb .github/releases/*.rpm
 
           echo "=== Installing verification tools ==="
           sudo apt-get update && sudo apt-get install -y lintian rpm rpmlint
 
           echo "=== Verifying .deb packages ==="
-          for deb_pkg in releases/*.deb; do
+          for deb_pkg in .github/releases/*.deb; do
             echo "--- ${deb_pkg} ---"
             dpkg-deb -I "${deb_pkg}"
             echo "--- lintian ${deb_pkg} ---"
@@ -604,7 +608,7 @@ jobs:
           done
 
           echo "=== Verifying .rpm packages ==="
-          for rpm_pkg in releases/*.rpm; do
+          for rpm_pkg in .github/releases/*.rpm; do
             echo "--- ${rpm_pkg} ---"
             rpm -qip "${rpm_pkg}"
             echo "--- rpmlint ${rpm_pkg} ---"
@@ -613,7 +617,7 @@ jobs:
 
       - name: Generate checksums
         run: |
-          cd releases
+          cd .github/releases
           sha256sum *.tar.gz *.zip *.deb *.rpm > checksums.txt
           cat checksums.txt
 
@@ -641,7 +645,7 @@ jobs:
           gh release create "$TAG" \
             --title "$TAG" \
             --notes "$FINAL_BODY" \
-            releases/*
+            .github/releases/*
 
       - name: Update Homebrew formulas
         if: ${{ inputs.mode != 'Release Only NPM' }}
@@ -655,12 +659,12 @@ jobs:
           fi
 
           export VERSION="${TAG#v}"
-          export SHA256_DARWIN_AMD64=$(grep "suve_.*_darwin_amd64.tar.gz" releases/checksums.txt | cut -d' ' -f1)
-          export SHA256_DARWIN_ARM64=$(grep "suve_.*_darwin_arm64.tar.gz" releases/checksums.txt | cut -d' ' -f1)
-          export SHA256_LINUX_AMD64=$(grep -E "suve_[0-9.]+_linux_amd64\.tar\.gz$" releases/checksums.txt | cut -d' ' -f1)
-          export SHA256_LINUX_ARM64=$(grep -E "suve_[0-9.]+_linux_arm64\.tar\.gz$" releases/checksums.txt | cut -d' ' -f1)
-          export SHA256_LINUX_CLI_AMD64=$(grep "suve-cli_.*_linux_amd64.tar.gz" releases/checksums.txt | cut -d' ' -f1)
-          export SHA256_LINUX_CLI_ARM64=$(grep "suve-cli_.*_linux_arm64.tar.gz" releases/checksums.txt | cut -d' ' -f1)
+          export SHA256_DARWIN_AMD64=$(grep "suve_.*_darwin_amd64.tar.gz" .github/releases/checksums.txt | cut -d' ' -f1)
+          export SHA256_DARWIN_ARM64=$(grep "suve_.*_darwin_arm64.tar.gz" .github/releases/checksums.txt | cut -d' ' -f1)
+          export SHA256_LINUX_AMD64=$(grep -E "suve_[0-9.]+_linux_amd64\.tar\.gz$" .github/releases/checksums.txt | cut -d' ' -f1)
+          export SHA256_LINUX_ARM64=$(grep -E "suve_[0-9.]+_linux_arm64\.tar\.gz$" .github/releases/checksums.txt | cut -d' ' -f1)
+          export SHA256_LINUX_CLI_AMD64=$(grep "suve-cli_.*_linux_amd64.tar.gz" .github/releases/checksums.txt | cut -d' ' -f1)
+          export SHA256_LINUX_CLI_ARM64=$(grep "suve-cli_.*_linux_arm64.tar.gz" .github/releases/checksums.txt | cut -d' ' -f1)
 
           # Generate both formulas
           envsubst < .github/templates/homebrew-formula.rb > suve.rb
@@ -690,12 +694,12 @@ jobs:
           fi
 
           export VERSION="${TAG#v}"
-          export SHA256_WINDOWS_AMD64=$(grep "windows_amd64.zip" releases/checksums.txt | cut -d' ' -f1)
-          export SHA256_WINDOWS_ARM64=$(grep "windows_arm64.zip" releases/checksums.txt | cut -d' ' -f1)
+          export SHA256_WINDOWS_AMD64=$(grep "windows_amd64.zip" .github/releases/checksums.txt | cut -d' ' -f1)
+          export SHA256_WINDOWS_ARM64=$(grep "windows_arm64.zip" .github/releases/checksums.txt | cut -d' ' -f1)
 
           if [[ -z "$SHA256_WINDOWS_AMD64" || -z "$SHA256_WINDOWS_ARM64" ]]; then
             echo "Error: Could not find SHA256 checksums for Windows builds"
-            cat releases/checksums.txt
+            cat .github/releases/checksums.txt
             exit 1
           fi
 
@@ -710,6 +714,19 @@ jobs:
           git add suve.json
           git commit -m "Update suve to ${VERSION}"
           git push
+
+      - name: Restore npm tooling from the workflow ref
+        if: ${{ inputs.mode != 'Release Without NPM' }}
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          # The build/release steps operate on inputs.version (the tag). A tag
+          # created before npm support lacks .github/npm and the publish script,
+          # so overlay them from the ref this workflow runs on (github.sha =
+          # current main). This lets an older tag be published to npm using the
+          # current tooling with that tag's freshly built binaries.
+          git fetch --no-tags --depth=1 origin "$SHA"
+          git checkout "$SHA" -- .github/scripts/npm-publish.sh .github/npm
 
       - name: Set up Node.js (npm publish)
         if: ${{ inputs.mode != 'Release Without NPM' }}

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,5 +1,8 @@
 name: Tag
 
+# Show the target version in the run title, e.g. "Tag v1.2.3".
+run-name: "Tag ${{ inputs.version }}"
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -1,5 +1,9 @@
 name: Tag and Release
 
+# Show the target version in the run title, e.g. "Tag and Release v1.2.3".
+# This flow always releases everything (mode: Release All below).
+run-name: "Tag and Release ${{ inputs.version }}"
+
 on:
   workflow_dispatch:
     inputs:

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ Thumbs.db
 /internal/gui/frontend/dist/
 /cover.html
 
+# Release workflow staging dir (archives assembled at release time)
+/.github/releases/
+
 # Windows icon resources (generated during build)
 /cmd/suve/versioninfo.json
 /cmd/suve/appicon.ico


### PR DESCRIPTION
Batched CI/release-workflow improvements.

## Retroactive npm publish for older tags
`release.yml` checks out `inputs.version` (the tag). A tag created before npm support lacks `.github/npm` and `.github/scripts/npm-publish.sh`, so `Release Only NPM` on such a tag died with `npm-publish.sh: No such file or directory`. Now a step overlays that tooling from the workflow ref (`github.sha` = current main) right before publishing, so an older tag is published to npm using the **current** tooling with **that tag's** freshly built binaries. (`.github/templates/*` for nfpm/homebrew/scoop already exist on those tags.)

## Move staging dir `releases/` → `.github/releases/`
All archive/checksum/nfpm/gh-release steps and `npm-publish.sh`'s `RELEASES` now use `.github/releases/`; added to `.gitignore`. GitHub URL/API paths (`releases/download`, `releases/generate-notes`) are deliberately untouched.

## Run titles show version + mode
`run-name` added to:
- Release → `Release <version> · <mode>`
- Tag → `Tag <version>`
- Tag and Release → `Tag and Release <version>`

## issue-labeler fix
`github/issue-labeler@v3.4` requires `enable-versioned-regex`; it was unset, failing every run with `Input required and not supplied: enable-versioned-regex`. Set to `0` (our config is the flat `label: [regex]` form).

## Verification
- All four workflow YAMLs parse.
- `npm-publish.sh` `bash -n` OK; end-to-end dry-run against `.github/releases/` extracts all 6 binaries and completes.
- `node --test` (.github/npm/suve): 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)