### PR TITLE
fix(detect): auto-select AWS from ambient-credential env vars (CloudShell, ECS, IRSA)

### DIFF
--- a/internal/provider/detect/detect.go
+++ b/internal/provider/detect/detect.go
@@ -1,20 +1,31 @@
 // Package detect resolves which cloud provider should back the flat `param` /
 // `secret` command aliases (and, later, the GUI's initial provider selection),
 // based purely on environment variables. It performs no network calls and no
-// credential-chain resolution, so it is safe to run on every process start.
+// credential-chain resolution, so it is safe to run on every process start
+// (including on the shell-completion path, where speed matters).
 //
 // The rules (per service, param and secret decided independently):
 //
-//   - A provider is "active via env" when its address/identity env var is set:
-//     AWS     — AWS_ACCESS_KEY_ID | AWS_VAULT | AWS_PROFILE (both services)
-//     GoogleCloud     — GOOGLE_CLOUD_PROJECT (secret only)
-//     Azure   — AZURE_KEYVAULT_NAME (secret) / AZURE_APPCONFIG_NAME (param)
+//   - A provider is "active via env" when one of its address/identity/ambient
+//     env vars is set:
+//     AWS — AWS_ACCESS_KEY_ID | AWS_VAULT | AWS_PROFILE, or an ambient-credential
+//     marker set by AWS-managed compute: AWS_CONTAINER_CREDENTIALS_FULL_URI
+//     (CloudShell, App Runner, EKS Pod Identity), AWS_CONTAINER_CREDENTIALS_RELATIVE_URI
+//     (ECS), or AWS_WEB_IDENTITY_TOKEN_FILE (IRSA / EKS). This is what makes the
+//     flat aliases work in AWS CloudShell, where none of the classic vars are set.
+//     GoogleCloud — GOOGLE_CLOUD_PROJECT (secret only)
+//     Azure — AZURE_KEYVAULT_NAME (secret) / AZURE_APPCONFIG_NAME (param)
 //   - A flat alias is exposed for a service only when exactly ONE provider is
 //     active for it. Zero or two-plus active means no alias — the user must use
 //     the explicit group (e.g. `suve aws secret`). There is no priority order.
 //   - AWS-only final fallback: when NO provider is active via env for any
 //     service, AWS is accepted via ~/.aws/credentials so the common "plain AWS"
 //     setup keeps working. If that file is absent too, nothing is aliased.
+//
+// Deliberately NOT detected: an EC2 instance profile with no credentials env var
+// and no shared file delivers credentials only through IMDS, which has no env
+// marker and would require a network probe. Running suve from a bare EC2 host is
+// rare; there the explicit `suve aws ...` group still works.
 package detect
 
 import (
@@ -88,7 +99,12 @@ func Resolve(env Environment) Result {
 
 	awsEnv := getenv("AWS_ACCESS_KEY_ID") != "" ||
 		getenv("AWS_VAULT") != "" ||
-		getenv("AWS_PROFILE") != ""
+		getenv("AWS_PROFILE") != "" ||
+		// Ambient credentials from AWS-managed compute (no classic env var):
+		// CloudShell / App Runner / EKS Pod Identity, ECS, and IRSA / EKS.
+		getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI") != "" ||
+		getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") != "" ||
+		getenv("AWS_WEB_IDENTITY_TOKEN_FILE") != ""
 	gcloudSecret := getenv("GOOGLE_CLOUD_PROJECT") != ""
 	azureSecret := getenv("AZURE_KEYVAULT_NAME") != ""
 	azureParam := getenv("AZURE_APPCONFIG_NAME") != ""

--- a/internal/provider/detect/detect_test.go
+++ b/internal/provider/detect/detect_test.go
@@ -41,6 +41,42 @@ func TestResolve(t *testing.T) {
 			// no aliases at all
 		},
 		{
+			name: "AWS_CONTAINER_CREDENTIALS_FULL_URI set (CloudShell/App Runner/EKS) -> AWS both, no fallback",
+			//nolint:gosec // G101: AWS env var name + placeholder URL, not a real credential
+			vars:          map[string]string{"AWS_CONTAINER_CREDENTIALS_FULL_URI": "http://localhost:1338/..."},
+			credsExist:    true, // must be ignored: env is active
+			wantParam:     aws,
+			wantSecret:    aws,
+			wantParamSet:  []provider.Provider{aws},
+			wantSecretSet: []provider.Provider{aws},
+		},
+		{
+			name:          "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI set (ECS) -> AWS both",
+			vars:          map[string]string{"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "/v2/credentials/abc"},
+			wantParam:     aws,
+			wantSecret:    aws,
+			wantParamSet:  []provider.Provider{aws},
+			wantSecretSet: []provider.Provider{aws},
+		},
+		{
+			name: "AWS_WEB_IDENTITY_TOKEN_FILE set (IRSA/EKS) -> AWS both",
+			//nolint:gosec // G101: AWS env var name + placeholder path, not a real credential
+			vars:          map[string]string{"AWS_WEB_IDENTITY_TOKEN_FILE": "/var/run/secrets/token"},
+			wantParam:     aws,
+			wantSecret:    aws,
+			wantParamSet:  []provider.Provider{aws},
+			wantSecretSet: []provider.Provider{aws},
+		},
+		{
+			name: "AWS container creds + GoogleCloud -> secret ambiguous, param=AWS (ambient AWS is a real env signal)",
+			//nolint:gosec // G101: AWS env var name + placeholder URL, not a real credential
+			vars:          map[string]string{"AWS_CONTAINER_CREDENTIALS_FULL_URI": "http://localhost:1338/...", "GOOGLE_CLOUD_PROJECT": "p"},
+			wantParam:     aws,
+			wantSecret:    "",
+			wantParamSet:  []provider.Provider{aws},
+			wantSecretSet: []provider.Provider{aws, gcloud},
+		},
+		{
 			name:           "nothing set, credentials file present -> AWS fallback for both",
 			vars:           nil,
 			credsExist:     true,


### PR DESCRIPTION
## Problem

In **AWS CloudShell** the flat `param`/`secret`/`stage` command aliases weren't offered, so `suve param ...` failed and users had to fall back to the explicit `suve aws ...` group. Provider auto-detection only recognized AWS from `AWS_ACCESS_KEY_ID` / `AWS_VAULT` / `AWS_PROFILE` or a `~/.aws/credentials` file — none of which CloudShell sets (it delivers credentials through the container-credentials endpoint).

## Fix

Detect AWS from the **ambient-credential environment variables** that AWS-managed compute exports, keeping detection **fully offline** (no network, no credential-chain resolution — so shell completion stays instant):

| Env var | Environment |
|---|---|
| `AWS_CONTAINER_CREDENTIALS_FULL_URI` | CloudShell, App Runner, EKS Pod Identity |
| `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` | ECS |
| `AWS_WEB_IDENTITY_TOKEN_FILE` | IRSA / EKS |

These join the existing `AWS_ACCESS_KEY_ID` / `AWS_VAULT` / `AWS_PROFILE` signals as "AWS active via env", so CloudShell now auto-selects AWS and the flat aliases (and their completions) work.

### Why env vars, not a credential-chain probe
An earlier iteration probed the live AWS credential chain, but that meant a network/timeout on the startup path (and awkward shell-completion behavior). Every browser cloud shell / managed-compute environment that matters already exports a distinctive env var, so a pure env check is faster, side-effect-free, and completion-safe.

### Out of scope (intentional)
A bare **EC2 instance profile** delivers credentials only through IMDS, which sets no env marker; detecting it would require a network probe on every startup. Running suve from a bare EC2 host is rare — there the explicit `suve aws ...` group still works.

## Verification
- `mise test` — pass · `mise lint` — clean (only pre-existing `e2e/gcloud_*` debt on `main`)
- New `detect_test.go` cases for `FULL_URI` (CloudShell), `RELATIVE_URI` (ECS), `WEB_IDENTITY_TOKEN_FILE` (IRSA), and ambiguity with another provider.
- Reviewed by Codex `gpt-5.6-sol`.

_(Branch name `fix/aws-detect-credential-chain` predates the pivot from the probe approach.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
