### PR TITLE
fix(tui): repaint on scroll in browser cloud shells to fix corruption

### DIFF
--- a/internal/tui/components/entrylist.go
+++ b/internal/tui/components/entrylist.go
@@ -93,30 +93,45 @@ func (l *EntryList) SelectedRow() (ListRow, bool) {
 }
 
 // Move changes the selection by delta, clamping at the ends, and keeps the
-// selection visible.
-func (l *EntryList) Move(delta int) {
+// selection visible. It reports whether the viewport actually scrolled (the
+// offset changed), so callers can force a full repaint only when a scroll-region
+// optimization would otherwise fire (see internal/tui/termquirk).
+func (l *EntryList) Move(delta int) bool {
 	if len(l.rows) == 0 {
-		return
+		return false
 	}
 
+	before := l.offset
 	l.selected = clamp(l.selected+delta, 0, len(l.rows)-1)
 	l.ensureVisible()
+
+	return l.offset != before
 }
 
-// SelectIndex selects a specific index (clamped) and keeps it visible.
-func (l *EntryList) SelectIndex(i int) {
+// SelectIndex selects a specific index (clamped) and keeps it visible. It reports
+// whether the offset changed (a click on a partially-visible row scrolls it fully
+// into view), so callers can force a full repaint only then (see termquirk).
+func (l *EntryList) SelectIndex(i int) bool {
 	if len(l.rows) == 0 {
-		return
+		return false
 	}
 
+	before := l.offset
 	l.selected = clamp(i, 0, len(l.rows)-1)
 	l.ensureVisible()
+
+	return l.offset != before
 }
 
 // Scroll moves the viewport by delta rows without moving the selection (wheel
-// scrolling), clamped so it never scrolls past the ends.
-func (l *EntryList) Scroll(delta int) {
+// scrolling), clamped so it never scrolls past the ends. It reports whether the
+// offset actually changed (false when already clamped at an end), so callers can
+// force a full repaint only on a real scroll (see internal/tui/termquirk).
+func (l *EntryList) Scroll(delta int) bool {
+	before := l.offset
 	l.offset = clamp(l.offset+delta, 0, l.maxOffset())
+
+	return l.offset != before
 }
 
 // RowAtLine maps a 0-based content line (relative to the list body, i.e. below

--- a/internal/tui/components/historytable.go
+++ b/internal/tui/components/historytable.go
@@ -104,29 +104,45 @@ func (t *HistoryTable) Selected() int {
 	return t.selected
 }
 
-// Move changes the selection by delta, clamped, keeping it visible.
-func (t *HistoryTable) Move(delta int) {
+// Move changes the selection by delta, clamped, keeping it visible. It reports
+// whether the viewport actually scrolled (the offset changed), so callers can
+// force a full repaint only when a scroll-region optimization would otherwise
+// fire (see internal/tui/termquirk).
+func (t *HistoryTable) Move(delta int) bool {
 	if len(t.rows) == 0 {
-		return
+		return false
 	}
 
+	before := t.offset
 	t.selected = clamp(t.selected+delta, 0, len(t.rows)-1)
 	t.ensureVisible()
+
+	return t.offset != before
 }
 
-// SelectIndex selects a specific row index (clamped).
-func (t *HistoryTable) SelectIndex(i int) {
+// SelectIndex selects a specific row index (clamped). It reports whether the
+// offset changed (a click on a partially-visible row scrolls it fully into view),
+// so callers can force a full repaint only then (see termquirk).
+func (t *HistoryTable) SelectIndex(i int) bool {
 	if len(t.rows) == 0 {
-		return
+		return false
 	}
 
+	before := t.offset
 	t.selected = clamp(i, 0, len(t.rows)-1)
 	t.ensureVisible()
+
+	return t.offset != before
 }
 
-// Scroll wheel-scrolls without moving the selection.
-func (t *HistoryTable) Scroll(delta int) {
+// Scroll wheel-scrolls without moving the selection. It reports whether the
+// offset actually changed (false when already clamped at an end), so callers can
+// force a full repaint only on a real scroll (see internal/tui/termquirk).
+func (t *HistoryTable) Scroll(delta int) bool {
+	before := t.offset
 	t.offset = clamp(t.offset+delta, 0, t.maxOffset())
+
+	return t.offset != before
 }
 
 // SetCompare toggles compare mode; leaving it clears the picks.

--- a/internal/tui/components/scroll_report_internal_test.go
+++ b/internal/tui/components/scroll_report_internal_test.go
@@ -1,0 +1,165 @@
+package components
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mpyw/suve/internal/tui/styles"
+)
+
+// singleLineRows builds n single-line rows (no preview) with distinct names.
+func singleLineRows(n int) []ListRow {
+	rows := make([]ListRow, n)
+	for i := range rows {
+		rows[i] = ListRow{Name: "/k/" + string(rune('A'+i))}
+	}
+
+	return rows
+}
+
+// TestEntryListMoveReportsScroll pins that Move returns exactly whether the
+// viewport scrolled (the offset changed): a full down-then-up sweep of a list
+// taller than the window must include both scrolling moves (true) and in-window
+// moves (false), and the return value must agree with the offset delta on every
+// step — the signal callers use to force a full repaint only on scroll.
+func TestEntryListMoveReportsScroll(t *testing.T) {
+	t.Parallel()
+
+	l := NewEntryList(styles.New())
+	l.SetRows(singleLineRows(12), false)
+	l.SetSize(40, 4)
+
+	deltas := []int{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1}
+
+	sawScroll, sawNoScroll := false, false
+
+	for _, delta := range deltas {
+		before := l.offset
+		scrolled := l.Move(delta)
+
+		assert.Equal(t, l.offset != before, scrolled, "Move must report whether the offset changed")
+
+		if scrolled {
+			sawScroll = true
+		} else {
+			sawNoScroll = true
+		}
+	}
+
+	assert.True(t, sawScroll, "a sweep past the window must scroll at least once")
+	assert.True(t, sawNoScroll, "a sweep must include in-window moves that do not scroll")
+}
+
+// TestEntryListMoveEmptyNoScroll pins that Move on an empty list never reports a
+// scroll (there is nothing to move or repaint).
+func TestEntryListMoveEmptyNoScroll(t *testing.T) {
+	t.Parallel()
+
+	l := NewEntryList(styles.New())
+	l.SetSize(40, 4)
+
+	assert.False(t, l.Move(1), "empty list must not report a scroll")
+	assert.False(t, l.Move(-1), "empty list must not report a scroll")
+}
+
+// TestHistoryTableMoveReportsScroll mirrors the EntryList contract for the
+// version-history table.
+func TestHistoryTableMoveReportsScroll(t *testing.T) {
+	t.Parallel()
+
+	tbl := NewHistoryTable(styles.New())
+	tbl.SetRows(valuedRows(12))
+	tbl.SetSize(60, 4)
+
+	deltas := []int{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1}
+
+	sawScroll, sawNoScroll := false, false
+
+	for _, delta := range deltas {
+		before := tbl.offset
+		scrolled := tbl.Move(delta)
+
+		assert.Equal(t, tbl.offset != before, scrolled, "Move must report whether the offset changed")
+
+		if scrolled {
+			sawScroll = true
+		} else {
+			sawNoScroll = true
+		}
+	}
+
+	assert.True(t, sawScroll, "a sweep past the window must scroll at least once")
+	assert.True(t, sawNoScroll, "a sweep must include in-window moves that do not scroll")
+}
+
+// TestHistoryTableMoveEmptyNoScroll pins the empty-table case.
+func TestHistoryTableMoveEmptyNoScroll(t *testing.T) {
+	t.Parallel()
+
+	tbl := NewHistoryTable(styles.New())
+	tbl.SetSize(60, 4)
+
+	assert.False(t, tbl.Move(1), "empty table must not report a scroll")
+	assert.False(t, tbl.Move(-1), "empty table must not report a scroll")
+}
+
+// TestEntryListScrollReportsChange pins that wheel Scroll reports whether the
+// offset changed: a downward scroll from the top scrolls (true), and a scroll
+// already clamped at an end reports no change (false) so callers skip the
+// repaint.
+func TestEntryListScrollReportsChange(t *testing.T) {
+	t.Parallel()
+
+	l := NewEntryList(styles.New())
+	l.SetRows(singleLineRows(12), false)
+	l.SetSize(40, 4)
+
+	assert.False(t, l.Scroll(-1), "already at top: scrolling up does not change the offset")
+	assert.True(t, l.Scroll(1), "scrolling down from the top moves the offset")
+
+	// Scroll far past the bottom, then a further down-scroll is a no-op.
+	l.Scroll(100)
+	assert.False(t, l.Scroll(1), "already at the bottom: scrolling down does not change the offset")
+}
+
+// TestHistoryTableScrollReportsChange mirrors the EntryList wheel-scroll contract.
+func TestHistoryTableScrollReportsChange(t *testing.T) {
+	t.Parallel()
+
+	tbl := NewHistoryTable(styles.New())
+	tbl.SetRows(valuedRows(12))
+	tbl.SetSize(60, 4)
+
+	assert.False(t, tbl.Scroll(-1), "already at top: scrolling up does not change the offset")
+	assert.True(t, tbl.Scroll(1), "scrolling down from the top moves the offset")
+
+	tbl.Scroll(100)
+	assert.False(t, tbl.Scroll(1), "already at the bottom: scrolling down does not change the offset")
+}
+
+// TestEntryListSelectIndexReportsScroll pins that a click-select reports whether
+// it scrolled a partially-visible row into view: selecting the already-visible
+// row 0 does not scroll (false), selecting the last row does (true).
+func TestEntryListSelectIndexReportsScroll(t *testing.T) {
+	t.Parallel()
+
+	l := NewEntryList(styles.New())
+	l.SetRows(singleLineRows(12), false)
+	l.SetSize(40, 4)
+
+	assert.False(t, l.SelectIndex(0), "selecting the already-visible top row does not scroll")
+	assert.True(t, l.SelectIndex(11), "selecting the last row scrolls it into view")
+}
+
+// TestHistoryTableSelectIndexReportsScroll mirrors the click-select contract.
+func TestHistoryTableSelectIndexReportsScroll(t *testing.T) {
+	t.Parallel()
+
+	tbl := NewHistoryTable(styles.New())
+	tbl.SetRows(valuedRows(12))
+	tbl.SetSize(60, 4)
+
+	assert.False(t, tbl.SelectIndex(0), "selecting the already-visible top row does not scroll")
+	assert.True(t, tbl.SelectIndex(11), "selecting the last row scrolls it into view")
+}

--- a/internal/tui/components/valuepane.go
+++ b/internal/tui/components/valuepane.go
@@ -74,12 +74,17 @@ func (p *ValuePane) Masked() bool { return p.masked }
 func (p *ValuePane) RawValue() string { return p.raw }
 
 // Update forwards a message (e.g. a wheel event) to the viewport for scrolling.
-func (p *ValuePane) Update(msg tea.Msg) tea.Cmd {
+// It also reports whether the viewport's scroll offset actually changed, so the
+// owning page can force a full repaint only on a real scroll (see
+// internal/tui/termquirk).
+func (p *ValuePane) Update(msg tea.Msg) (tea.Cmd, bool) {
+	before := p.vp.YOffset()
+
 	var cmd tea.Cmd
 
 	p.vp, cmd = p.vp.Update(msg)
 
-	return cmd
+	return cmd, p.vp.YOffset() != before
 }
 
 // HintSuffix is the "(x to reveal)" hint shown next to the Value label for a

--- a/internal/tui/dialogs/apply.go
+++ b/internal/tui/dialogs/apply.go
@@ -155,11 +155,7 @@ func (d *applyDialog) Update(msg tea.Msg) (Model, tea.Cmd) {
 		return d, nil
 	case tea.MouseWheelMsg:
 		// Wheel scrolls the results body (the confirm phase has nothing to scroll).
-		var cmd tea.Cmd
-
-		d.vp, cmd = d.vp.Update(msg)
-
-		return d, cmd
+		return d, scrollViewport(&d.vp, msg)
 	case tea.MouseClickMsg:
 		return d.handleClick(msg)
 	case tea.KeyPressMsg:
@@ -217,11 +213,7 @@ func (d *applyDialog) handleKey(msg tea.KeyPressMsg) (Model, tea.Cmd) {
 
 		// Any other key scrolls the results body (↑↓/j/k, pgup/pgdn, etc.); Esc is
 		// intercepted by the shell before it reaches here, so it still closes.
-		var cmd tea.Cmd
-
-		d.vp, cmd = d.vp.Update(msg)
-
-		return d, cmd
+		return d, scrollViewport(&d.vp, msg)
 	}
 
 	return d.handleConfirmKey(msg)

--- a/internal/tui/dialogs/errordialog.go
+++ b/internal/tui/dialogs/errordialog.go
@@ -61,11 +61,7 @@ func (d *errorDialog) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 		return d, nil
 	case tea.MouseWheelMsg:
-		var cmd tea.Cmd
-
-		d.vp, cmd = d.vp.Update(msg)
-
-		return d, cmd
+		return d, scrollViewport(&d.vp, msg)
 	case tea.MouseClickMsg:
 		if id, _, _, ok := d.hits.At(msg.X, msg.Y); ok && id == regionClose {
 			return d, canceledCmd
@@ -79,11 +75,7 @@ func (d *errorDialog) Update(msg tea.Msg) (Model, tea.Cmd) {
 
 		// Any other key scrolls the message body (↑↓/j/k, pgup/pgdn, etc.); Esc is
 		// intercepted by the shell before it reaches here, so it still closes.
-		var cmd tea.Cmd
-
-		d.vp, cmd = d.vp.Update(msg)
-
-		return d, cmd
+		return d, scrollViewport(&d.vp, msg)
 	}
 
 	return d, nil

--- a/internal/tui/dialogs/scrollrepaint.go
+++ b/internal/tui/dialogs/scrollrepaint.go
@@ -1,0 +1,28 @@
+package dialogs
+
+import (
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/mpyw/suve/internal/tui/termquirk"
+)
+
+// scrollViewport forwards msg to a dialog's scrollable viewport and, when its
+// scroll offset actually changes on a terminal that mishandles Bubble Tea's
+// scroll-region optimization (CloudShell), forces a full repaint so the scroll
+// renders cleanly (see internal/tui/termquirk).
+//
+// The viewport scrolls synchronously inside Update, so the offset delta is known
+// immediately and the ClearScreen batch renders the already-scrolled model. huh
+// forms are deliberately NOT handled here: they defer focus movement through an
+// async NextField/PrevField command, so a batched ClearScreen would race the
+// scroll — that is tracked as a separate follow-up.
+func scrollViewport(vp *viewport.Model, msg tea.Msg) tea.Cmd {
+	before := vp.YOffset()
+
+	var cmd tea.Cmd
+
+	*vp, cmd = vp.Update(msg)
+
+	return termquirk.RepaintOnScroll(vp.YOffset() != before, cmd)
+}

--- a/internal/tui/dialogs/scrollrepaint_test.go
+++ b/internal/tui/dialogs/scrollrepaint_test.go
@@ -1,0 +1,70 @@
+//nolint:testpackage // white-box: exercises the unexported repaint helpers
+package dialogs
+
+import (
+	"reflect"
+	"testing"
+
+	"charm.land/bubbles/v2/viewport"
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+)
+
+//nolint:gochecknoglobals // test-only type sentinel
+var clearScreenType = reflect.TypeOf(tea.ClearScreen())
+
+func drain(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+
+	msg := cmd()
+	if msg == nil {
+		return nil
+	}
+
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var out []tea.Msg
+		for _, c := range batch {
+			out = append(out, drain(c)...)
+		}
+
+		return out
+	}
+
+	return []tea.Msg{msg}
+}
+
+func hasClearScreen(cmd tea.Cmd) bool {
+	for _, m := range drain(cmd) {
+		if reflect.TypeOf(m) == clearScreenType {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestScrollViewportGatesOnOffsetChange pins that a dialog viewport repaint fires
+// only when the offset actually changes on an affected terminal.
+func TestScrollViewportGatesOnOffsetChange(t *testing.T) {
+	t.Setenv("CLOUD_SHELL", "")
+	t.Setenv("AZUREPS_HOST_ENVIRONMENT", "")
+	t.Setenv("SUVE_TUI_FULL_REPAINT", "")
+	t.Setenv("AWS_EXECUTION_ENV", "CloudShell")
+
+	vp := viewport.New()
+	vp.SetWidth(20)
+	vp.SetHeight(3)
+	vp.SetContent("l0\nl1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\nl9")
+
+	// Already at the top: scrolling up does not move the offset -> no repaint.
+	assert.Equal(t, 0, vp.YOffset())
+	assert.False(t, hasClearScreen(scrollViewport(&vp, tea.KeyPressMsg{Code: tea.KeyPgUp})),
+		"a no-op scroll at the top must not repaint")
+
+	// Page-down from the top changes the offset -> repaint.
+	assert.True(t, hasClearScreen(scrollViewport(&vp, tea.KeyPressMsg{Code: tea.KeyPgDown})),
+		"scrolling from the top must force a repaint in CloudShell")
+	assert.Positive(t, vp.YOffset(), "sanity: the viewport actually scrolled")
+}

--- a/internal/tui/pages/browser/mouse.go
+++ b/internal/tui/pages/browser/mouse.go
@@ -2,6 +2,8 @@ package browser
 
 import (
 	tea "charm.land/bubbletea/v2"
+
+	"github.com/mpyw/suve/internal/tui/termquirk"
 )
 
 // handleMouseClick resolves a left click against the last-rendered hit map and
@@ -37,9 +39,9 @@ func (m *Model) handleMouseClick(msg tea.MouseClickMsg) (*Model, tea.Cmd) {
 	case regionList:
 		if idx, rowOK := m.list.RowAtLine(dy); rowOK {
 			m.focus = focusList
-			m.list.SelectIndex(idx)
+			scrolled := m.list.SelectIndex(idx)
 
-			return m, m.selectionCmd()
+			return m, termquirk.RepaintOnScroll(scrolled, m.selectionCmd())
 		}
 	case regionHistory:
 		if idx, rowOK := m.history.RowAtLine(dy); rowOK {
@@ -69,19 +71,19 @@ func (m *Model) handleMouseClick(msg tea.MouseClickMsg) (*Model, tea.Cmd) {
 // keyboard space-pick / enter-diff flow, reducing to the same nav.OpenDiff.
 func (m *Model) clickHistoryRow(idx int) tea.Cmd {
 	m.focus = focusHistory
-	m.history.SelectIndex(idx)
+	scrolled := m.history.SelectIndex(idx)
 
 	if !m.history.Compare() {
-		return nil
+		return termquirk.RepaintOnScroll(scrolled, nil)
 	}
 
 	m.history.TogglePick()
 
 	if _, _, ok := m.history.PickedVersions(); ok {
-		return m.openDiff()
+		return termquirk.RepaintOnScroll(scrolled, m.openDiff())
 	}
 
-	return nil
+	return termquirk.RepaintOnScroll(scrolled, nil)
 }
 
 // handleMouseMotion resizes the list while a divider drag is in progress: the
@@ -117,11 +119,13 @@ func (m *Model) handleMouseWheel(msg tea.MouseWheelMsg) (*Model, tea.Cmd) {
 
 	switch id {
 	case regionList:
-		m.list.Scroll(delta)
+		return m, termquirk.RepaintOnScroll(m.list.Scroll(delta), nil)
 	case regionHistory:
-		m.history.Scroll(delta)
+		return m, termquirk.RepaintOnScroll(m.history.Scroll(delta), nil)
 	case regionDetail, regionValueLabel:
-		return m, m.valuePane.Update(msg)
+		cmd, scrolled := m.valuePane.Update(msg)
+
+		return m, termquirk.RepaintOnScroll(scrolled, cmd)
 	}
 
 	return m, nil

--- a/internal/tui/pages/browser/update.go
+++ b/internal/tui/pages/browser/update.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mpyw/suve/internal/provider/azure/appconfig/aznamespace"
 	"github.com/mpyw/suve/internal/tui/data"
 	"github.com/mpyw/suve/internal/tui/nav"
+	"github.com/mpyw/suve/internal/tui/termquirk"
 )
 
 // Update handles forwarded messages. It returns itself as the page (the app
@@ -547,17 +548,17 @@ func (m *Model) handleNavKey(msg tea.KeyPressMsg) (*Model, tea.Cmd) {
 }
 
 // move shifts the focused widget's selection; moving the list reloads the
-// selection's detail/history.
+// selection's detail/history. When the move scrolls the viewport on a terminal
+// that mishandles Bubble Tea's scroll-region optimization (CloudShell), a full
+// repaint is forced so the scroll renders cleanly (see internal/tui/termquirk).
 func (m *Model) move(delta int) tea.Cmd {
 	if m.focus == focusHistory {
-		m.history.Move(delta)
-
-		return nil
+		return termquirk.RepaintOnScroll(m.history.Move(delta), nil)
 	}
 
-	m.list.Move(delta)
+	scrolled := m.list.Move(delta)
 
-	return m.selectionCmd()
+	return termquirk.RepaintOnScroll(scrolled, m.selectionCmd())
 }
 
 // onSelect: from the list it moves focus into the history; from the history in

--- a/internal/tui/pages/diff/diff.go
+++ b/internal/tui/pages/diff/diff.go
@@ -29,6 +29,7 @@ import (
 	"github.com/mpyw/suve/internal/tui/keys"
 	"github.com/mpyw/suve/internal/tui/nav"
 	"github.com/mpyw/suve/internal/tui/styles"
+	"github.com/mpyw/suve/internal/tui/termquirk"
 )
 
 // scrollKey is a help-only binding advertising viewport scrolling (the diff
@@ -177,14 +178,24 @@ func (m *Model) Update(msg tea.Msg) (*Model, tea.Cmd) {
 	case tea.KeyPressMsg:
 		return m.handleKey(msg)
 	case tea.MouseWheelMsg:
-		var cmd tea.Cmd
-
-		m.vp, cmd = m.vp.Update(msg)
-
-		return m, cmd
+		return m, m.scrollViewport(msg)
 	default:
 		return m, nil
 	}
+}
+
+// scrollViewport forwards msg to the diff viewport and, when the viewport's
+// scroll offset actually changes on a terminal that mishandles Bubble Tea's
+// scroll-region optimization (CloudShell), forces a full repaint so the scroll
+// renders cleanly (see internal/tui/termquirk).
+func (m *Model) scrollViewport(msg tea.Msg) tea.Cmd {
+	before := m.vp.YOffset()
+
+	var cmd tea.Cmd
+
+	m.vp, cmd = m.vp.Update(msg)
+
+	return termquirk.RepaintOnScroll(m.vp.YOffset() != before, cmd)
 }
 
 // handleKey handles the page-local keys (mask toggle, back) and forwards the
@@ -205,11 +216,7 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) (*Model, tea.Cmd) {
 		return m, nil
 	}
 
-	var cmd tea.Cmd
-
-	m.vp, cmd = m.vp.Update(msg)
-
-	return m, cmd
+	return m, m.scrollViewport(msg)
 }
 
 // HelpKeyMap reports the diff page's context-aware bindings for the help bar:

--- a/internal/tui/pages/staging/mouse.go
+++ b/internal/tui/pages/staging/mouse.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+
+	"github.com/mpyw/suve/internal/tui/termquirk"
 )
 
 // handleMouseClick resolves a left click against the last-rendered hit map and
@@ -86,7 +88,10 @@ func (m *Model) handleMouseWheel(msg tea.MouseWheelMsg) (*Model, tea.Cmd) {
 	m.scroll += delta
 	m.scrollToSelection = false // an explicit scroll is not overridden by the selection
 
-	return m, nil
+	// The staging scroll offset (m.scroll) is clamped later at view time in
+	// clampScroll, so an actual-change signal is not available here; force the
+	// repaint on any wheel when the terminal needs it (see termquirk).
+	return m, termquirk.RepaintOnScroll(true, nil)
 }
 
 // wheelDelta maps a wheel button to a row delta (down positive, up negative).

--- a/internal/tui/pages/staging/update.go
+++ b/internal/tui/pages/staging/update.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mpyw/suve/internal/tui/components"
 	"github.com/mpyw/suve/internal/tui/data"
 	"github.com/mpyw/suve/internal/tui/nav"
+	"github.com/mpyw/suve/internal/tui/termquirk"
 )
 
 // Update handles forwarded messages. It returns itself as the page (the app
@@ -99,11 +100,11 @@ func (m *Model) handleKey(msg tea.KeyPressMsg) (*Model, tea.Cmd) {
 	case key.Matches(msg, m.keys.Up):
 		m.moveSelection(-1)
 
-		return m, nil
+		return m, termquirk.RepaintOnScroll(true, nil)
 	case key.Matches(msg, m.keys.Down):
 		m.moveSelection(1)
 
-		return m, nil
+		return m, termquirk.RepaintOnScroll(true, nil)
 	case key.Matches(msg, viewKey):
 		return m, m.toggleView()
 	case key.Matches(msg, m.keys.Select):

--- a/internal/tui/termquirk/termquirk.go
+++ b/internal/tui/termquirk/termquirk.go
@@ -1,0 +1,73 @@
+// Package termquirk detects terminal environments that need rendering
+// workarounds in the TUI, and provides the repaint helper those workarounds use.
+package termquirk
+
+import (
+	"os"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// ScrollNeedsFullRepaint reports whether the current terminal mishandles Bubble
+// Tea v2's scroll-region optimization and therefore needs scrolling to force a
+// full repaint (tea.ClearScreen) instead.
+//
+// When a rendered block shifts vertically (any scroll — up/down keys, PgUp/PgDn,
+// mouse wheel, a viewport moving), Bubble Tea's cell renderer emits scroll-region
+// control sequences (ESC[…r + SU/SD/IL/DL/ReverseIndex) rather than rewriting
+// cells. AWS CloudShell's browser terminal (xterm.js) negotiates synchronized
+// output and scroll regions differently from a native terminal emulator, so
+// those targeted writes land on the wrong rows and corrupt the display — while a
+// resize (which forces a full repaint) clears it cleanly. Native terminals
+// (Terminal.app, iTerm2, kitty, …) handle the optimization correctly, so they
+// stay on the fast path untouched.
+//
+// True when running in a known browser-based cloud shell, or when
+// SUVE_TUI_FULL_REPAINT is set to a non-empty value — an escape hatch for other
+// affected browser terminals (Cloud9, Gitpod, Coder, …).
+//
+// Detection is by environment variable, never by TERM / terminal type: browser
+// terminals (xterm.js, hterm, …) all report TERM=xterm-256color, identical to a
+// native xterm/Terminal.app, so a TERM-based check would wrongly force the slow
+// path on native terminals — the very case that must stay untouched. Each cloud
+// shell instead exports a distinctive marker:
+//   - AWS CloudShell        — AWS_EXECUTION_ENV=CloudShell
+//   - Google Cloud Shell    — CLOUD_SHELL=true
+//   - Azure Cloud Shell     — AZUREPS_HOST_ENVIRONMENT=cloud-shell/<ver>
+func ScrollNeedsFullRepaint() bool {
+	return os.Getenv("SUVE_TUI_FULL_REPAINT") != "" || inCloudShell()
+}
+
+// inCloudShell reports whether the process is running inside a known
+// browser-based cloud shell, detected purely from its distinctive env markers.
+func inCloudShell() bool {
+	switch {
+	case os.Getenv("AWS_EXECUTION_ENV") == "CloudShell": // AWS CloudShell
+		return true
+	case os.Getenv("CLOUD_SHELL") == "true": // Google Cloud Shell
+		return true
+	case strings.HasPrefix(os.Getenv("AZUREPS_HOST_ENVIRONMENT"), "cloud-shell"): // Azure Cloud Shell
+		return true
+	default:
+		return false
+	}
+}
+
+// RepaintOnScroll batches a tea.ClearScreen ahead of cmd when a scroll happened
+// and the terminal needs a full repaint to avoid the scroll-region corruption;
+// otherwise it returns cmd untouched (the fast path). cmd may be nil.
+//
+// Pass scrolled=false to skip the repaint when the viewport did not actually move
+// (e.g. an in-window selection change, or a wheel clamped at an end), so a full
+// repaint is paid only when a scroll-region optimization would otherwise fire.
+// Callers that cannot cheaply tell whether the offset changed (a scroll offset
+// computed later at view time) pass scrolled=true to repaint on every scroll
+// input.
+func RepaintOnScroll(scrolled bool, cmd tea.Cmd) tea.Cmd {
+	if scrolled && ScrollNeedsFullRepaint() {
+		return tea.Batch(tea.ClearScreen, cmd)
+	}
+
+	return cmd
+}

--- a/internal/tui/termquirk/termquirk_test.go
+++ b/internal/tui/termquirk/termquirk_test.go
@@ -1,0 +1,145 @@
+package termquirk_test
+
+import (
+	"reflect"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/mpyw/suve/internal/tui/termquirk"
+)
+
+func TestScrollNeedsFullRepaint(t *testing.T) {
+	tests := []struct {
+		name      string
+		awsExec   string // AWS_EXECUTION_ENV
+		gcpShell  string // CLOUD_SHELL
+		azureHost string // AZUREPS_HOST_ENVIRONMENT
+		override  string // SUVE_TUI_FULL_REPAINT
+		want      bool
+	}{
+		{name: "native terminal (nothing set)", want: false},
+		{name: "some other AWS execution env (Lambda)", awsExec: "AWS_Lambda_go1.x", want: false},
+		{name: "AWS CloudShell", awsExec: "CloudShell", want: true},
+		{name: "Google Cloud Shell", gcpShell: "true", want: true},
+		{name: "CLOUD_SHELL set to something else -> not detected", gcpShell: "1", want: false},
+		{name: "Azure Cloud Shell", azureHost: "cloud-shell/1.0", want: true},
+		{name: "Azure host env unrelated -> not detected", azureHost: "AzureAutomation/1.0", want: false},
+		{name: "override forces it on for other browser terminals", override: "1", want: true},
+		{name: "override wins even on a native terminal", override: "true", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Not parallel: t.Setenv mutates process env.
+			t.Setenv("AWS_EXECUTION_ENV", tt.awsExec)
+			t.Setenv("CLOUD_SHELL", tt.gcpShell)
+			t.Setenv("AZUREPS_HOST_ENVIRONMENT", tt.azureHost)
+			t.Setenv("SUVE_TUI_FULL_REPAINT", tt.override)
+
+			assert.Equal(t, tt.want, termquirk.ScrollNeedsFullRepaint())
+		})
+	}
+}
+
+// drain runs cmd (recursing into batches) and returns every leaf message.
+func drain(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+
+	msg := cmd()
+	if msg == nil {
+		return nil
+	}
+
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var out []tea.Msg
+		for _, c := range batch {
+			out = append(out, drain(c)...)
+		}
+
+		return out
+	}
+
+	return []tea.Msg{msg}
+}
+
+// clearScreenType is the reflected type of tea's (unexported) clear-screen
+// message, obtained from a known tea.ClearScreen() invocation.
+//
+//nolint:gochecknoglobals // test-only type sentinel
+var clearScreenType = reflect.TypeOf(tea.ClearScreen())
+
+func containsClearScreen(msgs []tea.Msg) bool {
+	for _, m := range msgs {
+		if reflect.TypeOf(m) == clearScreenType {
+			return true
+		}
+	}
+
+	return false
+}
+
+func containsMsg(msgs []tea.Msg, want any) bool {
+	for _, m := range msgs {
+		if m == want {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestRepaintOnScroll(t *testing.T) {
+	sentinel := tea.Cmd(func() tea.Msg { return "sentinel" })
+
+	tests := []struct {
+		name       string
+		scrolled   bool
+		cloudShell bool
+		wantClear  bool
+	}{
+		{name: "no scroll, native terminal -> passthrough", scrolled: false, cloudShell: false},
+		{name: "no scroll, CloudShell -> passthrough (nothing to repaint)", scrolled: false, cloudShell: true},
+		{name: "scroll, native terminal -> keep optimized path", scrolled: true, cloudShell: false},
+		{name: "scroll, CloudShell -> force full repaint", scrolled: true, cloudShell: true, wantClear: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Not parallel: t.Setenv mutates process env (read by termquirk).
+			t.Setenv("CLOUD_SHELL", "")
+			t.Setenv("AZUREPS_HOST_ENVIRONMENT", "")
+			t.Setenv("SUVE_TUI_FULL_REPAINT", "")
+
+			if tt.cloudShell {
+				t.Setenv("AWS_EXECUTION_ENV", "CloudShell")
+			} else {
+				t.Setenv("AWS_EXECUTION_ENV", "")
+			}
+
+			msgs := drain(termquirk.RepaintOnScroll(tt.scrolled, sentinel))
+
+			assert.Equal(t, tt.wantClear, containsClearScreen(msgs),
+				"a full repaint must be forced only when a scroll happened on an affected terminal")
+			assert.True(t, containsMsg(msgs, "sentinel"),
+				"the wrapped command must always survive")
+		})
+	}
+}
+
+// TestRepaintOnScrollNilCmd pins that a nil cmd yields a bare ClearScreen (no
+// panic) on an affected terminal, and nil on the fast path.
+func TestRepaintOnScrollNilCmd(t *testing.T) {
+	t.Setenv("CLOUD_SHELL", "")
+	t.Setenv("AZUREPS_HOST_ENVIRONMENT", "")
+	t.Setenv("SUVE_TUI_FULL_REPAINT", "")
+
+	t.Setenv("AWS_EXECUTION_ENV", "CloudShell")
+	assert.True(t, containsClearScreen(drain(termquirk.RepaintOnScroll(true, nil))))
+
+	t.Setenv("AWS_EXECUTION_ENV", "")
+	assert.Nil(t, termquirk.RepaintOnScroll(true, nil), "native terminal keeps the fast path (nil cmd)")
+}


### PR DESCRIPTION
## Problem

In **AWS CloudShell**'s browser terminal (xterm.js) the TUI corrupts when scrolling — up/down keys, mouse wheel, or clicking a partly-visible row. Bubble Tea v2's cell renderer applies a hard **scroll-region optimization** on any vertical block shift (`ESC[…r` + `SU`/`SD`/`IL`/`DL`/`ReverseIndex`), and browser terminals negotiate scroll regions / synchronized output differently from a native emulator, so the targeted writes land on the wrong rows. A terminal **resize** (full repaint) clears it cleanly — which is exactly the fix applied here, on scroll. There is no Bubble Tea option to disable the optimization.

Native terminals (Terminal.app, iTerm2, …) handle it correctly and must stay untouched.

## Fix — `internal/tui/termquirk`

- **`ScrollNeedsFullRepaint()`** detects browser cloud shells **by env var**, never by `TERM`:
  - AWS CloudShell — `AWS_EXECUTION_ENV=CloudShell`
  - Google Cloud Shell — `CLOUD_SHELL=true`
  - Azure Cloud Shell — `AZUREPS_HOST_ENVIRONMENT=cloud-shell/…`
  - `SUVE_TUI_FULL_REPAINT` — escape hatch for other browser terminals (Cloud9, Gitpod, …)

  (A `TERM` check is impossible: browser terminals report `TERM=xterm-256color`, identical to a native xterm — gating on it would wrongly slow down native terminals.)
- **`RepaintOnScroll(scrolled, cmd)`** batches `tea.ClearScreen` only when the viewport **actually scrolled** *and* the terminal needs it — so native terminals keep the optimized path and in-window selection moves stay flicker-free.

## Surfaces gated

Every **synchronous** scroll surface (offset mutated in-place during `Update`, so the batched repaint renders the already-scrolled frame — no async race):

- Browser list & history — `Move`/`Scroll`/`SelectIndex` now report whether the offset changed → keys, wheel, and click-select
- Browser value pane & the diff page — viewport `YOffset` delta
- Apply / error dialogs — viewport `YOffset` delta
- Staging up/down + wheel — unconditional (its offset is computed later at view time in `clampScroll`)

This mirrors the existing `tea.ClearScreen` workarounds in `staging` `toggleView` and `deleteconfirm`.

## Deliberately deferred (follow-up)

**huh forms** (entry/restore/tag) defer focus movement through an async `NextField`/`PrevField` command, so a batched `ClearScreen` would race the scroll; they also navigate selects with typeable keys (`j`/`k`/`g`). Doing them correctly needs `tea.Sequence` + a typing-aware repaint — tracked separately rather than shipping racy/incomplete gating here.

## Verification
- `mise test` — pass (new tests: `termquirk` detection + `RepaintOnScroll`; component `Move`/`Scroll`/`SelectIndex` bool; dialog `scrollViewport`)
- `mise lint` — clean (only pre-existing `e2e/gcloud_*` debt on `main`)
- Reviewed by Codex `gpt-5.6-sol`: no blocking or major issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)