### PR TITLE
fix(tui): repaint huh forms on scroll in browser cloud shells

### DIFF
--- a/internal/tui/dialogs/entryform.go
+++ b/internal/tui/dialogs/entryform.go
@@ -515,7 +515,7 @@ func (d *entryForm) forwardToForm(msg tea.Msg) (Model, tea.Cmd) {
 	case huh.StateNormal:
 	}
 
-	return d, cmd
+	return d, repaintFormScroll(d.form, msg, cmd)
 }
 
 // multilineFieldKey returns the key of the focused multi-line field ("value" or

--- a/internal/tui/dialogs/restore.go
+++ b/internal/tui/dialogs/restore.go
@@ -127,7 +127,7 @@ func (d *restoreForm) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case huh.StateNormal:
 	}
 
-	return d, cmd
+	return d, repaintFormScroll(d.form, msg, cmd)
 }
 
 func (d *restoreForm) submit() tea.Cmd {

--- a/internal/tui/dialogs/scrollrepaint.go
+++ b/internal/tui/dialogs/scrollrepaint.go
@@ -1,8 +1,10 @@
 package dialogs
 
 import (
+	"charm.land/bubbles/v2/key"
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
+	huh "charm.land/huh/v2"
 
 	"github.com/mpyw/suve/internal/tui/termquirk"
 )
@@ -13,10 +15,7 @@ import (
 // renders cleanly (see internal/tui/termquirk).
 //
 // The viewport scrolls synchronously inside Update, so the offset delta is known
-// immediately and the ClearScreen batch renders the already-scrolled model. huh
-// forms are deliberately NOT handled here: they defer focus movement through an
-// async NextField/PrevField command, so a batched ClearScreen would race the
-// scroll — that is tracked as a separate follow-up.
+// immediately and the ClearScreen batch renders the already-scrolled model.
 func scrollViewport(vp *viewport.Model, msg tea.Msg) tea.Cmd {
 	before := vp.YOffset()
 
@@ -25,4 +24,45 @@ func scrollViewport(vp *viewport.Model, msg tea.Msg) tea.Cmd {
 	*vp, cmd = vp.Update(msg)
 
 	return termquirk.RepaintOnScroll(vp.YOffset() != before, cmd)
+}
+
+// formFocusKeys are the keys that move focus between fields in a huh form (as
+// opposed to editing text inside a single-line field). Only these can scroll a
+// form whose focused field is a single-line Input.
+//
+//nolint:gochecknoglobals // immutable key set, mirrors the other dialog bindings
+var formFocusKeys = key.NewBinding(key.WithKeys("tab", "shift+tab", "up", "down", "enter"))
+
+// repaintFormScroll forces a full repaint after a key that may scroll a huh
+// form's internal viewport, on a terminal that mishandles the scroll-region
+// optimization (see termquirk); on native terminals it returns cmd untouched.
+//
+// Unlike the synchronous surfaces, huh moves focus through an async
+// NextField/PrevField command, so the scroll happens in a later update. It
+// therefore uses tea.Sequence (not tea.Batch): the messages are emitted in order
+// and processed FIFO, so the ClearScreen lands AFTER the scroll has settled.
+//
+// To avoid repainting on every keystroke, a single-line Input (where typing
+// cannot scroll) repaints only on focus-move keys; every other field kind — a
+// multi-line Text that wraps, or a Select/MultiSelect navigated with j/k/g etc. —
+// repaints on any key, since there the "typing vs. navigation" distinction does
+// not hold.
+func repaintFormScroll(form *huh.Form, msg tea.Msg, cmd tea.Cmd) tea.Cmd {
+	kp, ok := msg.(tea.KeyPressMsg)
+	if !ok || !termquirk.ScrollNeedsFullRepaint() || !formKeyMayScroll(form, kp) {
+		return cmd
+	}
+
+	return tea.Sequence(cmd, tea.ClearScreen)
+}
+
+// formKeyMayScroll reports whether kp could scroll the form's internal viewport,
+// given the focused field kind. A single-line Input scrolls only when focus
+// moves off-screen (formFocusKeys); any other field may scroll on any key.
+func formKeyMayScroll(form *huh.Form, kp tea.KeyPressMsg) bool {
+	if _, isSingleLine := form.GetFocusedField().(*huh.Input); isSingleLine {
+		return key.Matches(kp, formFocusKeys)
+	}
+
+	return true
 }

--- a/internal/tui/dialogs/scrollrepaint_test.go
+++ b/internal/tui/dialogs/scrollrepaint_test.go
@@ -7,6 +7,7 @@ import (
 
 	"charm.land/bubbles/v2/viewport"
 	tea "charm.land/bubbletea/v2"
+	huh "charm.land/huh/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -67,4 +68,52 @@ func TestScrollViewportGatesOnOffsetChange(t *testing.T) {
 	assert.True(t, hasClearScreen(scrollViewport(&vp, tea.KeyPressMsg{Code: tea.KeyPgDown})),
 		"scrolling from the top must force a repaint in CloudShell")
 	assert.Positive(t, vp.YOffset(), "sanity: the viewport actually scrolled")
+}
+
+// TestFormKeyMayScroll pins the field-type-aware decision: a single-line Input
+// scrolls only when focus moves (so typing never repaints), while a multi-line
+// Text may scroll on any key.
+func TestFormKeyMayScroll(t *testing.T) {
+	t.Parallel()
+
+	inputForm := huh.NewForm(huh.NewGroup(huh.NewInput().Key("name")))
+	inputForm.Init()
+
+	textForm := huh.NewForm(huh.NewGroup(huh.NewText().Key("body")))
+	textForm.Init()
+
+	tab := tea.KeyPressMsg{Code: tea.KeyTab}
+	typing := tea.KeyPressMsg{Code: 'a', Text: "a"}
+
+	assert.True(t, formKeyMayScroll(inputForm, tab), "Input: a focus-move key can scroll")
+	assert.False(t, formKeyMayScroll(inputForm, typing), "Input: typing cannot scroll")
+	assert.True(t, formKeyMayScroll(textForm, tab), "Text: focus-move key can scroll")
+	assert.True(t, formKeyMayScroll(textForm, typing), "Text: typing can wrap-scroll")
+}
+
+// TestRepaintFormScroll pins the gating + ordering: on an affected terminal a
+// scroll-capable key forces a repaint (via tea.Sequence, so it lands after the
+// async focus move), while typing in an Input, a non-key message, or a native
+// terminal do not.
+func TestRepaintFormScroll(t *testing.T) {
+	t.Setenv("CLOUD_SHELL", "")
+	t.Setenv("AZUREPS_HOST_ENVIRONMENT", "")
+	t.Setenv("SUVE_TUI_FULL_REPAINT", "")
+
+	form := huh.NewForm(huh.NewGroup(huh.NewInput().Key("name")))
+	form.Init()
+
+	tab := tea.KeyPressMsg{Code: tea.KeyTab}
+	typing := tea.KeyPressMsg{Code: 'a', Text: "a"}
+
+	// Native terminal: never repaints, even on a focus-move key.
+	t.Setenv("AWS_EXECUTION_ENV", "")
+	assert.False(t, hasClearScreen(repaintFormScroll(form, tab, nil)), "native terminal: no repaint")
+
+	// CloudShell: focus-move key on an Input repaints; typing does not.
+	t.Setenv("AWS_EXECUTION_ENV", "CloudShell")
+	assert.True(t, hasClearScreen(repaintFormScroll(form, tab, nil)), "CloudShell: focus-move key repaints")
+	assert.False(t, hasClearScreen(repaintFormScroll(form, typing, nil)), "CloudShell: Input typing does not repaint")
+	assert.False(t, hasClearScreen(repaintFormScroll(form, tea.WindowSizeMsg{Width: 1, Height: 1}, nil)),
+		"CloudShell: a non-key message does not repaint")
 }

--- a/internal/tui/dialogs/tagform.go
+++ b/internal/tui/dialogs/tagform.go
@@ -279,7 +279,7 @@ func (d *tagForm) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case huh.StateNormal:
 	}
 
-	return d, cmd
+	return d, repaintFormScroll(d.form, msg, cmd)
 }
 
 // InterceptEsc opts the form into the shell's discard guard (#790): the shell


### PR DESCRIPTION
Closes #860. Completes the browser-cloud-shell scroll-corruption fix from #859, which deliberately left the huh forms (create/edit, restore, tag) out.

## Problem

When a form is taller than its area, huh scrolls its internal viewport as focus moves. In a browser cloud shell (CloudShell etc.) that triggers the same Bubble Tea scroll-region optimization that corrupts the display everywhere else. #859 couldn't reuse its approach because huh moves focus through an **async** `NextField`/`PrevField` command, so batching `tea.ClearScreen` alongside it would race the scroll.

## Fix — field-type-aware repaint

- **Ordering:** use `tea.Sequence(cmd, tea.ClearScreen)` instead of `tea.Batch`. The messages are emitted in order and processed FIFO, so the repaint lands *after* the async focus move has scrolled the viewport.
- **Flicker control:** repaint on every keystroke in a form would flicker while typing. Instead, decide per focused field kind (`form.GetFocusedField()`):
  - single-line **`Input`** (name, tag key) → typing can't scroll, so repaint only on focus-move keys (`tab`/`shift+tab`/`up`/`down`/`enter`) — **typing stays flicker-free**
  - multi-line **`Text`** (value/description, wraps) and **`Select`/`MultiSelect`** (navigated with `j`/`k`/`g` etc.) → repaint on any key
- **Gated** behind `termquirk.ScrollNeedsFullRepaint()`, so native terminals keep the optimized path untouched (zero behavior change off cloud shells).

## Notes
- Removes the "huh forms deliberately not handled" caveat from `scrollrepaint.go` and the README known-limitation note is now obsolete — I'll follow up on the README once this lands (or fold it into #861 if it hasn't merged).
- The Stage/Apply submit path (`StateCompleted`) is untouched — only the `StateNormal` navigation return is wrapped.

## Verification
- `mise test` — pass · `mise lint` — clean (only pre-existing `e2e/gcloud_*` debt on `main`)
- New tests: `TestFormKeyMayScroll` (Input vs Text decision) and `TestRepaintFormScroll` (native = no repaint; CloudShell Input focus-key = repaint, typing = none, non-key = none). Golden TUI tests run without a cloud-shell env, so form behavior there is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)