### PR TITLE
ci(pages): generate a GitHub Pages docs site from README + docs/

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -60,14 +60,32 @@ jobs:
 
       - name: Configure Pages
         # enablement: true turns Pages on (source = GitHub Actions) on the first run.
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
         with:
           enablement: true
 
+      # actions/upload-pages-artifact internally pins actions/upload-artifact by
+      # tag, which this repo's "actions must be pinned to a full SHA" policy
+      # rejects. So build the same github-pages artifact by hand: tar the site the
+      # way upload-pages-artifact does, then upload it with the repo's SHA-pinned
+      # upload-artifact. deploy-pages consumes the "github-pages" artifact.
+      - name: Archive the site as a Pages artifact
+        run: |
+          tar \
+            --dereference --hard-dereference \
+            --directory .site/out \
+            -cvf "$RUNNER_TEMP/artifact.tar" \
+            --exclude=.git \
+            --exclude=.github \
+            .
+
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          path: .site/out
+          name: github-pages
+          path: ${{ runner.temp }}/artifact.tar
+          retention-days: 1
+          if-no-files-found: error
 
   deploy:
     name: Deploy to GitHub Pages
@@ -81,4 +99,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,28 +8,33 @@ on:
     paths:
       - README.md
       - docs/**
+      - demo/**
+      - gui/build/appicon.png
       - mkdocs.yml
       - scripts/build_docs_site.py
+      - scripts/check_site_links.py
+      - scripts/test_docs_pipeline.py
       - scripts/docs-requirements.txt
       - .github/workflows/pages.yml
-  # Build (but don't deploy) on PRs that touch the site, to catch breakage early.
+  # Build + validate (no deploy) on PRs that touch the site, to catch breakage early.
   pull_request:
     paths:
       - README.md
       - docs/**
+      - demo/**
+      - gui/build/appicon.png
       - mkdocs.yml
       - scripts/build_docs_site.py
+      - scripts/check_site_links.py
+      - scripts/test_docs_pipeline.py
       - scripts/docs-requirements.txt
       - .github/workflows/pages.yml
   workflow_dispatch:
 
-# Least privilege: read the repo, write the Pages deployment via OIDC.
+# Least privilege by default; the deploy job opts into the Pages write scopes.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
-# One in-flight Pages deployment at a time; don't cancel a running deploy.
 concurrency:
   group: pages-${{ github.ref }}
   cancel-in-progress: false
@@ -39,8 +44,11 @@ env:
   DISABLE_MKDOCS_2_WARNING: "true"
 
 jobs:
-  build:
-    name: Build site
+  # Deterministic validation gate — runs on PRs and main, needs no Pages perms.
+  # It fails the build (no AI/human review) on any broken local link, missing
+  # anchor, output collision, missing asset, or unmapped README anchor.
+  validate:
+    name: Build & validate site
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -50,13 +58,51 @@ jobs:
           # fetch them so they ship in the site instead of as pointer files.
           lfs: true
 
+      - name: Set up docs toolchain
+        run: |
+          python3 -m venv .venv
+          .venv/bin/pip install --quiet --upgrade pip
+          .venv/bin/pip install --quiet -r scripts/docs-requirements.txt
+
+      - name: Unit-test the pipeline
+        run: .venv/bin/python scripts/test_docs_pipeline.py
+
+      - name: Assemble the site source (fails on broken/unmapped links, collisions, missing assets)
+        run: .venv/bin/python scripts/build_docs_site.py
+
+      - name: Build with MkDocs (strict — link/anchor/nav problems fail)
+        run: .venv/bin/mkdocs build --strict
+
+      - name: Validate rendered links, anchors and assets
+        run: .venv/bin/python scripts/check_site_links.py
+
+  # Deploy from main only; this is the sole job with the Pages write scopes.
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: validate
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          lfs: true
+
       - name: Build the site
         run: |
           python3 -m venv .venv
           .venv/bin/pip install --quiet --upgrade pip
           .venv/bin/pip install --quiet -r scripts/docs-requirements.txt
           .venv/bin/python scripts/build_docs_site.py
-          .venv/bin/mkdocs build
+          .venv/bin/mkdocs build --strict
+          .venv/bin/python scripts/check_site_links.py
 
       - name: Configure Pages
         # enablement: true turns Pages on (source = GitHub Actions) on the first run.
@@ -87,16 +133,6 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  deploy:
-    name: Deploy to GitHub Pages
-    needs: build
-    # PRs only validate the build; deploy from main (or a manual dispatch on main).
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
       - name: Deploy
         id: deployment
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -76,45 +76,14 @@ jobs:
       - name: Validate rendered links, anchors and assets
         run: .venv/bin/python scripts/check_site_links.py
 
-  # Deploy from main only; this is the sole job with the Pages write scopes.
-  deploy:
-    name: Deploy to GitHub Pages
-    needs: validate
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          lfs: true
-
-      - name: Build the site
-        run: |
-          python3 -m venv .venv
-          .venv/bin/pip install --quiet --upgrade pip
-          .venv/bin/pip install --quiet -r scripts/docs-requirements.txt
-          .venv/bin/python scripts/build_docs_site.py
-          .venv/bin/mkdocs build --strict
-          .venv/bin/python scripts/check_site_links.py
-
-      - name: Configure Pages
-        # enablement: true turns Pages on (source = GitHub Actions) on the first run.
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-        with:
-          enablement: true
-
+      # Package the VALIDATED output as the github-pages artifact here, so the
+      # privileged deploy job ships exactly what was validated (no rebuild).
       # actions/upload-pages-artifact internally pins actions/upload-artifact by
       # tag, which this repo's "actions must be pinned to a full SHA" policy
-      # rejects. So build the same github-pages artifact by hand: tar the site the
-      # way upload-pages-artifact does, then upload it with the repo's SHA-pinned
-      # upload-artifact. deploy-pages consumes the "github-pages" artifact.
+      # rejects — so tar the site the way upload-pages-artifact does and upload it
+      # with the repo's SHA-pinned upload-artifact under the name deploy-pages
+      # expects. (Harmless on PRs: the deploy job is skipped and the artifact
+      # expires.)
       - name: Archive the site as a Pages artifact
         run: |
           tar \
@@ -133,6 +102,28 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  # Deploy from main only; the sole job with the Pages write scopes. It deploys
+  # the artifact produced (and validated) by the validate job — it does not
+  # rebuild, so what ships is exactly what passed the gate.
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: validate
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Configure Pages
+        # enablement: true turns Pages on (source = GitHub Actions) on the first run.
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+        with:
+          enablement: true
+
       - name: Deploy
         id: deployment
+        # Consumes the "github-pages" artifact uploaded by the validate job.
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,84 @@
+name: Pages
+
+on:
+  push:
+    branches: [main]
+    # Only rebuild when something the site is generated from changes.
+    # (GitHub Actions does not support YAML anchors, so the list is repeated.)
+    paths:
+      - README.md
+      - docs/**
+      - mkdocs.yml
+      - scripts/build_docs_site.py
+      - scripts/docs-requirements.txt
+      - .github/workflows/pages.yml
+  # Build (but don't deploy) on PRs that touch the site, to catch breakage early.
+  pull_request:
+    paths:
+      - README.md
+      - docs/**
+      - mkdocs.yml
+      - scripts/build_docs_site.py
+      - scripts/docs-requirements.txt
+      - .github/workflows/pages.yml
+  workflow_dispatch:
+
+# Least privilege: read the repo, write the Pages deployment via OIDC.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# One in-flight Pages deployment at a time; don't cancel a running deploy.
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  # Silence the mkdocs-2/ProperDocs upgrade nag in the build log.
+  DISABLE_MKDOCS_2_WARNING: "true"
+
+jobs:
+  build:
+    name: Build site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Demo GIFs / the app icon embedded in the README are tracked in Git LFS;
+          # fetch them so they ship in the site instead of as pointer files.
+          lfs: true
+
+      - name: Build the site
+        run: |
+          python3 -m venv .venv
+          .venv/bin/pip install --quiet --upgrade pip
+          .venv/bin/pip install --quiet -r scripts/docs-requirements.txt
+          .venv/bin/python scripts/build_docs_site.py
+          .venv/bin/mkdocs build
+
+      - name: Configure Pages
+        # enablement: true turns Pages on (source = GitHub Actions) on the first run.
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        with:
+          enablement: true
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: .site/out
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    # PRs only validate the build; deploy from main (or a manual dispatch on main).
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ Thumbs.db
 /cmd/suve/appicon.ico
 /cmd/suve/resource_windows_amd64.syso
 /cmd/suve/resource_windows_arm64.syso
+
+# Generated GitHub Pages site (assembled source, build output, and local venv)
+/.site/

--- a/README.md
+++ b/README.md
@@ -927,8 +927,8 @@ Unversioned key-value store. `#`, `~`, and `:` are valid key characters — the 
 | [`suve azure param create`](docs/azure.md#suve-azure-param-create) | `--namespace`/`--ns` | Create a new key |
 | [`suve azure param update`](docs/azure.md#suve-azure-param-update) | `--namespace`/`--ns`<br>`--yes` | Update an existing key |
 | [`suve azure param delete`](docs/azure.md#suve-azure-param-delete) | `--namespace`/`--ns`<br>`--yes` | Delete a key |
-| [`suve azure param tag`](docs/azure.md#suve-azure-param-tag) | `--namespace`/`--ns` | Add or update tags (GET-merge-PUT) |
-| [`suve azure param untag`](docs/azure.md#suve-azure-param-untag) | `--namespace`/`--ns` | Remove tags |
+| [`suve azure param tag`](docs/azure.md#suve-azure-param-tag--untag) | `--namespace`/`--ns` | Add or update tags (GET-merge-PUT) |
+| [`suve azure param untag`](docs/azure.md#suve-azure-param-tag--untag) | `--namespace`/`--ns` | Remove tags |
 
 #### Namespaces
 

--- a/mise.toml
+++ b/mise.toml
@@ -399,13 +399,15 @@ depends = ["x11-setup"]
 run = "HOST_DISPLAY=host.docker.internal:0 docker compose --profile ubuntu-24 run --rm ubuntu-24"
 
 [tasks.docs-build]
-description = "Assemble and build the GitHub Pages site (MkDocs) into .site/out"
+description = "Assemble, strictly build, and link-check the GitHub Pages site into .site/out"
 run = '''
 python3 -m venv .site/venv
 .site/venv/bin/pip install --quiet --upgrade pip
 .site/venv/bin/pip install --quiet -r scripts/docs-requirements.txt
+.site/venv/bin/python scripts/test_docs_pipeline.py
 .site/venv/bin/python scripts/build_docs_site.py
-DISABLE_MKDOCS_2_WARNING=true .site/venv/bin/mkdocs build
+DISABLE_MKDOCS_2_WARNING=true .site/venv/bin/mkdocs build --strict
+.site/venv/bin/python scripts/check_site_links.py
 '''
 
 [tasks.docs-serve]
@@ -415,5 +417,14 @@ python3 -m venv .site/venv
 .site/venv/bin/pip install --quiet --upgrade pip
 .site/venv/bin/pip install --quiet -r scripts/docs-requirements.txt
 .site/venv/bin/python scripts/build_docs_site.py
-DISABLE_MKDOCS_2_WARNING=true .site/venv/bin/mkdocs serve
+DISABLE_MKDOCS_2_WARNING=true .site/venv/bin/mkdocs serve --strict
+'''
+
+[tasks.docs-test]
+description = "Unit-test the docs-site pipeline (splitter + link checker)"
+run = '''
+python3 -m venv .site/venv
+.site/venv/bin/pip install --quiet --upgrade pip
+.site/venv/bin/pip install --quiet -r scripts/docs-requirements.txt
+.site/venv/bin/python scripts/test_docs_pipeline.py
 '''

--- a/mise.toml
+++ b/mise.toml
@@ -397,3 +397,23 @@ run = "HOST_DISPLAY=host.docker.internal:0 docker compose --profile ubuntu-22 ru
 description = "Start the Ubuntu 24.04 desktop (webkit2gtk-4.1, requires XQuartz)"
 depends = ["x11-setup"]
 run = "HOST_DISPLAY=host.docker.internal:0 docker compose --profile ubuntu-24 run --rm ubuntu-24"
+
+[tasks.docs-build]
+description = "Assemble and build the GitHub Pages site (MkDocs) into .site/out"
+run = '''
+python3 -m venv .site/venv
+.site/venv/bin/pip install --quiet --upgrade pip
+.site/venv/bin/pip install --quiet -r scripts/docs-requirements.txt
+.site/venv/bin/python scripts/build_docs_site.py
+DISABLE_MKDOCS_2_WARNING=true .site/venv/bin/mkdocs build
+'''
+
+[tasks.docs-serve]
+description = "Assemble and serve the docs site locally at http://127.0.0.1:8000"
+run = '''
+python3 -m venv .site/venv
+.site/venv/bin/pip install --quiet --upgrade pip
+.site/venv/bin/pip install --quiet -r scripts/docs-requirements.txt
+.site/venv/bin/python scripts/build_docs_site.py
+DISABLE_MKDOCS_2_WARNING=true .site/venv/bin/mkdocs serve
+'''

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,22 @@ site_dir: .site/out
 exclude_docs: |
   SUMMARY.md
 
+# Promote every link/anchor/nav problem to a warning; the build runs with
+# --strict (see the Pages workflow and `mise docs-build`), which turns these
+# warnings into a non-zero exit — so a doc restructuring that breaks a Markdown
+# link or cross-page #anchor fails CI deterministically. Raw-HTML links/assets
+# (which MkDocs does not validate) are covered by scripts/check_site_links.py.
+validation:
+  nav:
+    omitted_files: warn
+    not_found: warn
+    absolute_links: warn
+  links:
+    not_found: warn
+    anchors: warn
+    absolute_links: warn
+    unrecognized_links: warn
+
 theme:
   name: material
   icon:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,60 @@
+site_name: suve
+site_description: Git-like CLI (and GUI/TUI) for multi-cloud secret and parameter management across AWS, Google Cloud, and Azure.
+site_url: https://mpyw.github.io/suve/
+repo_url: https://github.com/mpyw/suve
+repo_name: mpyw/suve
+
+# The source tree is assembled by scripts/build_docs_site.py (README split into
+# per-section pages + docs/*.md), and the built site goes to .site/out. Neither
+# directory is committed; both are produced fresh by `mise docs-build` / CI.
+docs_dir: .site/src
+site_dir: .site/out
+
+# literate-nav reads SUMMARY.md for the nav; keep it out of the built pages.
+exclude_docs: |
+  SUMMARY.md
+
+theme:
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.top
+    - navigation.footer
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+
+plugins:
+  - search
+  - literate-nav:
+      nav_file: SUMMARY.md
+
+markdown_extensions:
+  # GitHub-compatible heading slugs, so the README's existing #anchor links keep
+  # resolving after the split (scripts/build_docs_site.py uses the same slugifier).
+  - toc:
+      slugify: !!python/object/apply:pymdownx.slugs.slugify
+        kwds:
+          case: lower
+      permalink: true
+  - admonition
+  - attr_list
+  - md_in_html
+  - tables
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true

--- a/scripts/build_docs_site.py
+++ b/scripts/build_docs_site.py
@@ -2,16 +2,21 @@
 """Assemble the MkDocs source tree for the GitHub Pages site.
 
 The site is generated from the repo's existing Markdown — README.md plus
-docs/*.md — WITHOUT committing anything: this script writes a throwaway source
-tree under .site/src that `mkdocs build` (see mkdocs.yml) turns into .site/out.
+docs/**/*.md — WITHOUT committing anything: this writes a throwaway source tree
+under .site/src that `mkdocs build` (see mkdocs.yml) turns into .site/out.
 
 Because the README is large, it is split into one page per top-level `## `
 section (the content before the first section becomes the home page). Splitting
 would break the many intra-README anchor links (`#provider-selection`, …) and
 the docs' `../README.md#…` links, so an anchor→page map is built from every
-heading and used to rewrite those links to the page each section landed on. The
-heading slugs use the same GitHub-compatible slugifier MkDocs is configured with
-(pymdownx.slugs.slugify), so the rewritten anchors resolve.
+heading and used to rewrite those links to the page each section landed on.
+
+Fail-closed by design: anything that would silently produce a broken or wrong
+site — an unmapped anchor, a missing asset, an output-path collision, an empty
+page slug, or a Git-LFS pointer left un-materialised — is collected and makes the
+script exit non-zero, so CI catches doc-restructuring breakage deterministically
+(no AI/human review). The rendered HTML is validated separately by
+scripts/check_site_links.py after the build.
 
 Run via `mise docs-build` / `mise docs-serve`, or directly; it is idempotent.
 """
@@ -26,23 +31,21 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 SRC = REPO / ".site" / "src"
 
-# Local assets referenced (by relative path) from the README intro, copied into
-# the site so those links resolve. Each entry is a path relative to the repo root.
+# Local assets referenced (by relative path) from the README, copied into the
+# site so those links resolve. Each entry is a path relative to the repo root.
 ASSETS = ["demo", "gui/build/appicon.png"]
 
-# The docs/*.md pages, in nav order, as (source filename, nav title).
-DOC_PAGES = [
-    ("aws.md", "AWS commands"),
-    ("azure.md", "Azure commands"),
-    ("gcloud.md", "Google Cloud commands"),
-    ("staging-state-transitions.md", "Staging state transitions"),
-]
-
-FENCE_RE = re.compile(r"^\s*(```|~~~)")
+# A fenced code block opens with ``` or ~~~ (>=3), indented at most 3 spaces
+# (CommonMark), and closes with a marker of the SAME character and >= the opening
+# length, on a line that is only that marker (+ optional trailing text on open).
+FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})\s*(.*)$")
 H2_RE = re.compile(r"^## +(.*\S)\s*$")
 HEADING_RE = re.compile(r"^(#{1,6}) +(.*\S)\s*$")
 MD_LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")
 HTML_TAG_RE = re.compile(r"<[^>]+>")
+# Inline code spans: a run of N backticks, content, then N backticks. Used to
+# avoid rewriting links that live inside inline code.
+CODE_SPAN_RE = re.compile(r"(`+)(?:.*?)\1")
 # A <details> summary is not a heading, so MkDocs (and GitHub) give it no anchor.
 # We map its text and inject a matching id so #anchor links to it still resolve.
 SUMMARY_RE = re.compile(r"<summary(\s[^>]*)?>(.*?)</summary>", re.IGNORECASE)
@@ -68,6 +71,32 @@ def _load_slugify():
 _SLUGIFY = _load_slugify()
 
 
+class Fences:
+    """Tracks fenced-code state so headings/links inside code are ignored,
+    honoring the opening marker's character and length (mixed ```/~~~ safe)."""
+
+    def __init__(self) -> None:
+        self._char = ""
+        self._len = 0
+
+    def is_code(self, line: str) -> bool:
+        """Feed the next line; return True if it is a fence marker or inside a
+        fenced block (i.e. not ordinary prose)."""
+        m = FENCE_RE.match(line)
+        if not self._char:
+            if m:
+                self._char = m.group(1)[0]
+                self._len = len(m.group(1))
+                return True
+            return False
+        # Inside a fence: only a closing marker of the same char, >= the opening
+        # length, with nothing but the marker on the line, ends it.
+        if m and m.group(1)[0] == self._char and len(m.group(1)) >= self._len and not m.group(2).strip():
+            self._char = ""
+            self._len = 0
+        return True
+
+
 def heading_slug(raw: str) -> str:
     """Slug for a heading's raw Markdown text, mirroring how MkDocs slugifies the
     rendered heading: strip HTML tags, reduce Markdown links to their text, drop
@@ -82,7 +111,19 @@ def section_filename(title: str) -> str:
     return heading_slug(title) + ".md"
 
 
-def build_readme_pages(readme: str):
+def apply_outside_code(line: str, fn) -> str:
+    """Apply fn to the parts of line that are NOT inside inline code spans."""
+    out: list[str] = []
+    pos = 0
+    for m in CODE_SPAN_RE.finditer(line):
+        out.append(fn(line[pos : m.start()]))
+        out.append(m.group(0))  # inline code, left verbatim
+        pos = m.end()
+    out.append(fn(line[pos:]))
+    return "".join(out)
+
+
+def build_readme_pages(readme: str, err):
     """Split the README into (filename, title, body) pages at each `## ` heading,
     and build the anchor→filename map over every heading. The pre-first-section
     content is the home page (index.md)."""
@@ -93,33 +134,33 @@ def build_readme_pages(readme: str):
     current_name = "index.md"
     current_title = "Home"
     current_body: list[str] = []
-    in_fence = False
+    fences = Fences()
 
     def flush():
         pages.append((current_name, current_title, current_body))
 
     for line in lines:
-        if FENCE_RE.match(line):
-            in_fence = not in_fence
+        if fences.is_code(line):
             current_body.append(line)
             continue
 
-        if not in_fence:
-            m2 = H2_RE.match(line)
-            if m2:
-                flush()
-                current_title = m2.group(1)
-                current_name = section_filename(current_title)
-                current_body = [line]
-                anchor_page[heading_slug(current_title)] = current_name
-                continue
+        m2 = H2_RE.match(line)
+        if m2:
+            flush()
+            current_title = m2.group(1)
+            current_name = section_filename(current_title)
+            if current_name == ".md":
+                err(f"README section {current_title!r} slugifies to an empty page name")
+            current_body = [line]
+            anchor_page.setdefault(heading_slug(current_title), current_name)
+            continue
 
-            mh = HEADING_RE.match(line)
-            if mh:
-                anchor_page.setdefault(heading_slug(mh.group(2)), current_name)
+        mh = HEADING_RE.match(line)
+        if mh:
+            anchor_page.setdefault(heading_slug(mh.group(2)), current_name)
 
-            for ms in SUMMARY_RE.finditer(line):
-                anchor_page.setdefault(heading_slug(ms.group(2)), current_name)
+        for ms in SUMMARY_RE.finditer(line):
+            anchor_page.setdefault(heading_slug(ms.group(2)), current_name)
 
         current_body.append(line)
 
@@ -127,14 +168,14 @@ def build_readme_pages(readme: str):
     return pages, anchor_page
 
 
-def rewrite_links(body: str, anchor_page: dict[str, str], *, from_readme: bool, warn) -> str:
-    """Rewrite cross-page links so they survive the split. Links inside fenced code
-    are left untouched."""
+def rewrite_links(body: str, anchor_page: dict[str, str], *, from_readme: bool, err) -> str:
+    """Rewrite cross-page links so they survive the split. Links inside fenced or
+    inline code are left untouched; an unmapped anchor is a hard error."""
 
     def map_anchor(anchor: str, whole: str) -> str:
-        page = anchor_page.get(anchor)
+        page = anchor_page.get(anchor.lower())
         if page is None:
-            warn(f"unmapped anchor #{anchor} in {whole!r}")
+            err(f"unmapped anchor #{anchor} in {whole!r}")
             return whole
         return f"]({page}#{anchor})"
 
@@ -144,79 +185,128 @@ def rewrite_links(body: str, anchor_page: dict[str, str], *, from_readme: bool, 
             return m.group(0)
         return f'<summary{attrs} id="{heading_slug(inner)}">{inner}</summary>'
 
-    def rewrite_line(line: str) -> str:
+    def rewrite_prose(text: str) -> str:
         if from_readme:
             # README lives at the repo root; docs/ links become root-level siblings.
-            line = re.sub(r"\]\(docs/([^)]+)\)", r"](\1)", line)
+            text = re.sub(r"\]\(docs/([^)#]+)((?:#[^)]*)?)\)", r"](\1\2)", text)
             # Give each <details> summary an id so #anchor links to it resolve.
-            line = SUMMARY_RE.sub(add_summary_id, line)
+            text = SUMMARY_RE.sub(add_summary_id, text)
             # Same-README anchors now live on whichever split page carries them.
-            line = re.sub(r"\]\(#([\w-]+)\)", lambda m: map_anchor(m.group(1), m.group(0)), line)
+            text = re.sub(r"\]\(#([^)\s]+)\)", lambda m: map_anchor(m.group(1), m.group(0)), text)
         else:
-            # docs/*.md pages: rewrite their links back to the README.
-            line = re.sub(
-                r"\]\(\.\./README\.md#([\w-]+)\)",
+            # docs/*.md pages: rewrite their links back to the README, tolerating
+            # ../README.md, ./README.md, and README.md spellings.
+            text = re.sub(
+                r"\]\((?:\.\./|\./)?README\.md#([^)\s]+)\)",
                 lambda m: map_anchor(m.group(1), m.group(0)),
-                line,
+                text,
             )
-            line = re.sub(r"\]\(\.\./README\.md\)", "](index.md)", line)
-        return line
+            text = re.sub(r"\]\((?:\.\./|\./)?README\.md\)", "](index.md)", text)
+        return text
 
+    fences = Fences()
     out: list[str] = []
-    in_fence = False
     for line in body.splitlines(keepends=True):
-        if FENCE_RE.match(line):
-            in_fence = not in_fence
+        if fences.is_code(line):
             out.append(line)
             continue
-        out.append(line if in_fence else rewrite_line(line))
+        out.append(apply_outside_code(line, rewrite_prose))
     return "".join(out)
 
 
+def first_heading_title(text: str, fallback: str) -> str:
+    fences = Fences()
+    for line in text.splitlines(keepends=True):
+        if fences.is_code(line):
+            continue
+        mh = HEADING_RE.match(line)
+        if mh:
+            return HTML_TAG_RE.sub("", MD_LINK_RE.sub(r"\1", mh.group(2))).strip() or fallback
+    return fallback
+
+
+def discover_doc_pages(err) -> list[tuple[Path, str, str]]:
+    """Every docs/**/*.md, as (source path, flat output filename, nav title).
+    Flattening keeps README's `docs/X.md` links working as root-level `X.md`."""
+    docs_dir = REPO / "docs"
+    out: list[tuple[Path, str, str]] = []
+    for path in sorted(docs_dir.rglob("*.md")):
+        rel = path.relative_to(docs_dir)
+        if len(rel.parts) > 1:
+            err(f"nested docs file not supported (flatten it or extend the script): docs/{rel}")
+            continue
+        title = first_heading_title(path.read_text(encoding="utf-8"), rel.stem)
+        out.append((path, rel.name, title))
+    return out
+
+
+def is_lfs_pointer(path: Path) -> bool:
+    try:
+        with path.open("rb") as fh:
+            return fh.read(46).startswith(b"version https://git-lfs")
+    except OSError:
+        return False
+
+
 def main() -> int:
-    warnings: list[str] = []
-    warn = warnings.append
+    errors: list[str] = []
+    err = errors.append
+    claimed: dict[str, str] = {}  # output filename -> what claimed it (collision guard)
+
+    def claim(name: str, who: str) -> None:
+        if name in claimed:
+            err(f"output collision: {who} and {claimed[name]} both map to {name}")
+        else:
+            claimed[name] = who
 
     if SRC.exists():
         shutil.rmtree(SRC)
     SRC.mkdir(parents=True)
 
     readme = (REPO / "README.md").read_text(encoding="utf-8")
-    pages, anchor_page = build_readme_pages(readme)
-
-    # Home is always reachable even if the README ever loses its intro.
-    anchor_page.setdefault("", "index.md")
+    pages, anchor_page = build_readme_pages(readme, err)
+    anchor_page.setdefault("", "index.md")  # bare ../README.md -> home
 
     nav: list[tuple[str, str]] = []
     for name, title, body in pages:
-        text = rewrite_links("".join(body), anchor_page, from_readme=True, warn=warn)
+        claim(name, f"README section {title!r}")
+        text = rewrite_links("".join(body), anchor_page, from_readme=True, err=err)
         (SRC / name).write_text(text, encoding="utf-8")
         nav.append((name, "Home" if name == "index.md" else title))
 
-    for filename, title in DOC_PAGES:
-        body = (REPO / "docs" / filename).read_text(encoding="utf-8")
-        text = rewrite_links(body, anchor_page, from_readme=False, warn=warn)
-        (SRC / filename).write_text(text, encoding="utf-8")
-        nav.append((filename, title))
+    for path, name, title in discover_doc_pages(err):
+        claim(name, f"docs/{path.name}")
+        text = rewrite_links(path.read_text(encoding="utf-8"), anchor_page, from_readme=False, err=err)
+        (SRC / name).write_text(text, encoding="utf-8")
+        nav.append((name, title))
 
     for asset in ASSETS:
         src = REPO / asset
         dst = SRC / asset
         if src.is_dir():
             shutil.copytree(src, dst)
+            for f in src.rglob("*"):
+                if f.is_file() and is_lfs_pointer(f):
+                    err(f"asset is an un-materialised Git-LFS pointer: {f.relative_to(REPO)}")
         elif src.is_file():
             dst.parent.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src, dst)
+            if is_lfs_pointer(src):
+                err(f"asset is an un-materialised Git-LFS pointer: {asset}")
         else:
-            warn(f"asset not found: {asset}")
+            err(f"asset not found: {asset}")
 
     # literate-nav reads this SUMMARY.md for page order/titles.
     summary = "".join(f"- [{title}]({name})\n" for name, title in nav)
     (SRC / "SUMMARY.md").write_text(summary, encoding="utf-8")
 
-    print(f"assembled {len(pages)} README pages + {len(DOC_PAGES)} doc pages into {SRC.relative_to(REPO)}")
-    for w in warnings:
-        print(f"  warning: {w}", file=sys.stderr)
+    if errors:
+        print(f"build_docs_site: {len(errors)} error(s):", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    print(f"assembled {len(pages)} README pages + {len(nav) - len(pages)} doc pages into {SRC.relative_to(REPO)}")
     return 0
 
 

--- a/scripts/build_docs_site.py
+++ b/scripts/build_docs_site.py
@@ -49,6 +49,11 @@ CODE_SPAN_RE = re.compile(r"(`+)(?:.*?)\1")
 # A <details> summary is not a heading, so MkDocs (and GitHub) give it no anchor.
 # We map its text and inject a matching id so #anchor links to it still resolve.
 SUMMARY_RE = re.compile(r"<summary(\s[^>]*)?>(.*?)</summary>", re.IGNORECASE)
+# Reference-style link definition (`[label]: url`) and usage (`[text][label]`,
+# collapsed `[text][]`). Splitting the README can separate a usage from its
+# definition, which would silently render as plain text; we detect that.
+REF_DEF_RE = re.compile(r"^ {0,3}\[([^\]]+)\]:\s+\S")
+REF_USE_RE = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
 
 
 def _load_slugify():
@@ -78,8 +83,13 @@ class Fences:
     def __init__(self) -> None:
         self._char = ""
         self._len = 0
+        self.open_line = 0  # 1-based line where the currently-open fence started
 
-    def is_code(self, line: str) -> bool:
+    @property
+    def open(self) -> bool:
+        return bool(self._char)
+
+    def is_code(self, line: str, lineno: int = 0) -> bool:
         """Feed the next line; return True if it is a fence marker or inside a
         fenced block (i.e. not ordinary prose)."""
         m = FENCE_RE.match(line)
@@ -87,6 +97,7 @@ class Fences:
             if m:
                 self._char = m.group(1)[0]
                 self._len = len(m.group(1))
+                self.open_line = lineno
                 return True
             return False
         # Inside a fence: only a closing marker of the same char, >= the opening
@@ -126,21 +137,36 @@ def apply_outside_code(line: str, fn) -> str:
 def build_readme_pages(readme: str, err):
     """Split the README into (filename, title, body) pages at each `## ` heading,
     and build the anchor→filename map over every heading. The pre-first-section
-    content is the home page (index.md)."""
+    content is the home page (index.md).
+
+    Returns (pages, anchor_page, duplicate_slugs). duplicate_slugs are slugs that
+    occur on more than one heading/summary — a link to one is ambiguous after the
+    split, so rewrite_links treats it as an error rather than guessing.
+    """
     lines = readme.splitlines(keepends=True)
     pages: list[tuple[str, str, list[str]]] = []
     anchor_page: dict[str, str] = {}
+    slug_counts: dict[str, int] = {}
+
+    # Per-page reference-style link bookkeeping (see check below).
+    page_defs: dict[str, set[str]] = {}
+    page_uses: dict[str, set[str]] = {}
+    global_defs: set[str] = set()
 
     current_name = "index.md"
     current_title = "Home"
     current_body: list[str] = []
     fences = Fences()
 
+    def note_slug(slug: str) -> None:
+        slug_counts[slug] = slug_counts.get(slug, 0) + 1
+        anchor_page.setdefault(slug, current_name)
+
     def flush():
         pages.append((current_name, current_title, current_body))
 
-    for line in lines:
-        if fences.is_code(line):
+    for i, line in enumerate(lines, start=1):
+        if fences.is_code(line, i):
             current_body.append(line)
             continue
 
@@ -152,28 +178,69 @@ def build_readme_pages(readme: str, err):
             if current_name == ".md":
                 err(f"README section {current_title!r} slugifies to an empty page name")
             current_body = [line]
-            anchor_page.setdefault(heading_slug(current_title), current_name)
+            note_slug(heading_slug(current_title))
             continue
 
         mh = HEADING_RE.match(line)
         if mh:
-            anchor_page.setdefault(heading_slug(mh.group(2)), current_name)
+            note_slug(heading_slug(mh.group(2)))
 
         for ms in SUMMARY_RE.finditer(line):
-            anchor_page.setdefault(heading_slug(ms.group(2)), current_name)
+            note_slug(heading_slug(ms.group(2)))
 
+        # Reference-style link accounting (ignore matches inside inline code).
+        md = REF_DEF_RE.match(line)
+        if md:
+            label = md.group(1).strip().lower()
+            page_defs.setdefault(current_name, set()).add(label)
+            global_defs.add(label)
+
+        def collect_uses(text: str) -> str:
+            for mu in REF_USE_RE.finditer(text):
+                label = (mu.group(2) or mu.group(1)).strip().lower()
+                page_uses.setdefault(current_name, set()).add(label)
+            return text
+
+        apply_outside_code(line, collect_uses)
         current_body.append(line)
 
     flush()
-    return pages, anchor_page
+
+    if fences.open:
+        err(f"unclosed code fence opened at README line {fences.open_line}")
+
+    # A reference-style usage whose definition landed on a different page renders
+    # as plain text (no <a> for any downstream check to catch) — flag it.
+    for name, uses in page_uses.items():
+        for label in uses:
+            if label in global_defs and label not in page_defs.get(name, set()):
+                err(
+                    f"reference-style link [...][{label}] on page {name} is separated from its "
+                    f"[{label}]: definition by the section split — use an inline link or keep the "
+                    f"definition in the same section"
+                )
+
+    duplicate_slugs = {s for s, n in slug_counts.items() if n > 1}
+    return pages, anchor_page, duplicate_slugs
 
 
-def rewrite_links(body: str, anchor_page: dict[str, str], *, from_readme: bool, err) -> str:
+def rewrite_links(
+    body: str,
+    anchor_page: dict[str, str],
+    *,
+    from_readme: bool,
+    err,
+    duplicates: frozenset[str] = frozenset(),
+) -> str:
     """Rewrite cross-page links so they survive the split. Links inside fenced or
-    inline code are left untouched; an unmapped anchor is a hard error."""
+    inline code are left untouched; an unmapped or ambiguous anchor is an error."""
 
     def map_anchor(anchor: str, whole: str) -> str:
-        page = anchor_page.get(anchor.lower())
+        key = anchor.lower()
+        if key in duplicates:
+            err(f"ambiguous anchor #{anchor} in {whole!r}: the slug occurs on more than one heading")
+            return whole
+        page = anchor_page.get(key)
         if page is None:
             err(f"unmapped anchor #{anchor} in {whole!r}")
             return whole
@@ -264,19 +331,20 @@ def main() -> int:
     SRC.mkdir(parents=True)
 
     readme = (REPO / "README.md").read_text(encoding="utf-8")
-    pages, anchor_page = build_readme_pages(readme, err)
+    pages, anchor_page, duplicates = build_readme_pages(readme, err)
     anchor_page.setdefault("", "index.md")  # bare ../README.md -> home
+    dups = frozenset(duplicates)
 
     nav: list[tuple[str, str]] = []
     for name, title, body in pages:
         claim(name, f"README section {title!r}")
-        text = rewrite_links("".join(body), anchor_page, from_readme=True, err=err)
+        text = rewrite_links("".join(body), anchor_page, from_readme=True, err=err, duplicates=dups)
         (SRC / name).write_text(text, encoding="utf-8")
         nav.append((name, "Home" if name == "index.md" else title))
 
     for path, name, title in discover_doc_pages(err):
         claim(name, f"docs/{path.name}")
-        text = rewrite_links(path.read_text(encoding="utf-8"), anchor_page, from_readme=False, err=err)
+        text = rewrite_links(path.read_text(encoding="utf-8"), anchor_page, from_readme=False, err=err, duplicates=dups)
         (SRC / name).write_text(text, encoding="utf-8")
         nav.append((name, title))
 

--- a/scripts/build_docs_site.py
+++ b/scripts/build_docs_site.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Assemble the MkDocs source tree for the GitHub Pages site.
+
+The site is generated from the repo's existing Markdown — README.md plus
+docs/*.md — WITHOUT committing anything: this script writes a throwaway source
+tree under .site/src that `mkdocs build` (see mkdocs.yml) turns into .site/out.
+
+Because the README is large, it is split into one page per top-level `## `
+section (the content before the first section becomes the home page). Splitting
+would break the many intra-README anchor links (`#provider-selection`, …) and
+the docs' `../README.md#…` links, so an anchor→page map is built from every
+heading and used to rewrite those links to the page each section landed on. The
+heading slugs use the same GitHub-compatible slugifier MkDocs is configured with
+(pymdownx.slugs.slugify), so the rewritten anchors resolve.
+
+Run via `mise docs-build` / `mise docs-serve`, or directly; it is idempotent.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO / ".site" / "src"
+
+# Local assets referenced (by relative path) from the README intro, copied into
+# the site so those links resolve. Each entry is a path relative to the repo root.
+ASSETS = ["demo", "gui/build/appicon.png"]
+
+# The docs/*.md pages, in nav order, as (source filename, nav title).
+DOC_PAGES = [
+    ("aws.md", "AWS commands"),
+    ("azure.md", "Azure commands"),
+    ("gcloud.md", "Google Cloud commands"),
+    ("staging-state-transitions.md", "Staging state transitions"),
+]
+
+FENCE_RE = re.compile(r"^\s*(```|~~~)")
+H2_RE = re.compile(r"^## +(.*\S)\s*$")
+HEADING_RE = re.compile(r"^(#{1,6}) +(.*\S)\s*$")
+MD_LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")
+HTML_TAG_RE = re.compile(r"<[^>]+>")
+# A <details> summary is not a heading, so MkDocs (and GitHub) give it no anchor.
+# We map its text and inject a matching id so #anchor links to it still resolve.
+SUMMARY_RE = re.compile(r"<summary(\s[^>]*)?>(.*?)</summary>", re.IGNORECASE)
+
+
+def _load_slugify():
+    """Return the slugify used for anchors — pymdownx's GitHub-compatible one when
+    available (matches mkdocs.yml), else a close local fallback."""
+    try:
+        from pymdownx.slugs import slugify as _s  # type: ignore
+
+        return _s(case="lower")
+    except Exception:  # pragma: no cover - fallback for a bare environment
+
+        def _fallback(text: str, sep: str) -> str:
+            text = text.strip().lower()
+            text = re.sub(r"[^\w\s-]", "", text)
+            return re.sub(r"[\s]+", sep, text)
+
+        return _fallback
+
+
+_SLUGIFY = _load_slugify()
+
+
+def heading_slug(raw: str) -> str:
+    """Slug for a heading's raw Markdown text, mirroring how MkDocs slugifies the
+    rendered heading: strip HTML tags, reduce Markdown links to their text, drop
+    inline-formatting punctuation, then slugify."""
+    text = HTML_TAG_RE.sub("", raw)
+    text = MD_LINK_RE.sub(r"\1", text)
+    text = re.sub(r"[`*_~]", "", text)
+    return _SLUGIFY(text, "-")
+
+
+def section_filename(title: str) -> str:
+    return heading_slug(title) + ".md"
+
+
+def build_readme_pages(readme: str):
+    """Split the README into (filename, title, body) pages at each `## ` heading,
+    and build the anchor→filename map over every heading. The pre-first-section
+    content is the home page (index.md)."""
+    lines = readme.splitlines(keepends=True)
+    pages: list[tuple[str, str, list[str]]] = []
+    anchor_page: dict[str, str] = {}
+
+    current_name = "index.md"
+    current_title = "Home"
+    current_body: list[str] = []
+    in_fence = False
+
+    def flush():
+        pages.append((current_name, current_title, current_body))
+
+    for line in lines:
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            current_body.append(line)
+            continue
+
+        if not in_fence:
+            m2 = H2_RE.match(line)
+            if m2:
+                flush()
+                current_title = m2.group(1)
+                current_name = section_filename(current_title)
+                current_body = [line]
+                anchor_page[heading_slug(current_title)] = current_name
+                continue
+
+            mh = HEADING_RE.match(line)
+            if mh:
+                anchor_page.setdefault(heading_slug(mh.group(2)), current_name)
+
+            for ms in SUMMARY_RE.finditer(line):
+                anchor_page.setdefault(heading_slug(ms.group(2)), current_name)
+
+        current_body.append(line)
+
+    flush()
+    return pages, anchor_page
+
+
+def rewrite_links(body: str, anchor_page: dict[str, str], *, from_readme: bool, warn) -> str:
+    """Rewrite cross-page links so they survive the split. Links inside fenced code
+    are left untouched."""
+
+    def map_anchor(anchor: str, whole: str) -> str:
+        page = anchor_page.get(anchor)
+        if page is None:
+            warn(f"unmapped anchor #{anchor} in {whole!r}")
+            return whole
+        return f"]({page}#{anchor})"
+
+    def add_summary_id(m: re.Match) -> str:
+        attrs, inner = m.group(1) or "", m.group(2)
+        if re.search(r"\bid=", attrs, re.IGNORECASE):
+            return m.group(0)
+        return f'<summary{attrs} id="{heading_slug(inner)}">{inner}</summary>'
+
+    def rewrite_line(line: str) -> str:
+        if from_readme:
+            # README lives at the repo root; docs/ links become root-level siblings.
+            line = re.sub(r"\]\(docs/([^)]+)\)", r"](\1)", line)
+            # Give each <details> summary an id so #anchor links to it resolve.
+            line = SUMMARY_RE.sub(add_summary_id, line)
+            # Same-README anchors now live on whichever split page carries them.
+            line = re.sub(r"\]\(#([\w-]+)\)", lambda m: map_anchor(m.group(1), m.group(0)), line)
+        else:
+            # docs/*.md pages: rewrite their links back to the README.
+            line = re.sub(
+                r"\]\(\.\./README\.md#([\w-]+)\)",
+                lambda m: map_anchor(m.group(1), m.group(0)),
+                line,
+            )
+            line = re.sub(r"\]\(\.\./README\.md\)", "](index.md)", line)
+        return line
+
+    out: list[str] = []
+    in_fence = False
+    for line in body.splitlines(keepends=True):
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            out.append(line)
+            continue
+        out.append(line if in_fence else rewrite_line(line))
+    return "".join(out)
+
+
+def main() -> int:
+    warnings: list[str] = []
+    warn = warnings.append
+
+    if SRC.exists():
+        shutil.rmtree(SRC)
+    SRC.mkdir(parents=True)
+
+    readme = (REPO / "README.md").read_text(encoding="utf-8")
+    pages, anchor_page = build_readme_pages(readme)
+
+    # Home is always reachable even if the README ever loses its intro.
+    anchor_page.setdefault("", "index.md")
+
+    nav: list[tuple[str, str]] = []
+    for name, title, body in pages:
+        text = rewrite_links("".join(body), anchor_page, from_readme=True, warn=warn)
+        (SRC / name).write_text(text, encoding="utf-8")
+        nav.append((name, "Home" if name == "index.md" else title))
+
+    for filename, title in DOC_PAGES:
+        body = (REPO / "docs" / filename).read_text(encoding="utf-8")
+        text = rewrite_links(body, anchor_page, from_readme=False, warn=warn)
+        (SRC / filename).write_text(text, encoding="utf-8")
+        nav.append((filename, title))
+
+    for asset in ASSETS:
+        src = REPO / asset
+        dst = SRC / asset
+        if src.is_dir():
+            shutil.copytree(src, dst)
+        elif src.is_file():
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dst)
+        else:
+            warn(f"asset not found: {asset}")
+
+    # literate-nav reads this SUMMARY.md for page order/titles.
+    summary = "".join(f"- [{title}]({name})\n" for name, title in nav)
+    (SRC / "SUMMARY.md").write_text(summary, encoding="utf-8")
+
+    print(f"assembled {len(pages)} README pages + {len(DOC_PAGES)} doc pages into {SRC.relative_to(REPO)}")
+    for w in warnings:
+        print(f"  warning: {w}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/build_docs_site.py
+++ b/scripts/build_docs_site.py
@@ -231,6 +231,7 @@ def rewrite_links(
     from_readme: bool,
     err,
     duplicates: frozenset[str] = frozenset(),
+    label: str = "",
 ) -> str:
     """Rewrite cross-page links so they survive the split. Links inside fenced or
     inline code are left untouched; an unmapped or ambiguous anchor is an error."""
@@ -273,11 +274,13 @@ def rewrite_links(
 
     fences = Fences()
     out: list[str] = []
-    for line in body.splitlines(keepends=True):
-        if fences.is_code(line):
+    for i, line in enumerate(body.splitlines(keepends=True), start=1):
+        if fences.is_code(line, i):
             out.append(line)
             continue
         out.append(apply_outside_code(line, rewrite_prose))
+    if fences.open:
+        err(f"unclosed code fence in {label or 'page'} (opened at line {fences.open_line})")
     return "".join(out)
 
 
@@ -338,13 +341,15 @@ def main() -> int:
     nav: list[tuple[str, str]] = []
     for name, title, body in pages:
         claim(name, f"README section {title!r}")
-        text = rewrite_links("".join(body), anchor_page, from_readme=True, err=err, duplicates=dups)
+        text = rewrite_links("".join(body), anchor_page, from_readme=True, err=err, duplicates=dups, label=name)
         (SRC / name).write_text(text, encoding="utf-8")
         nav.append((name, "Home" if name == "index.md" else title))
 
     for path, name, title in discover_doc_pages(err):
         claim(name, f"docs/{path.name}")
-        text = rewrite_links(path.read_text(encoding="utf-8"), anchor_page, from_readme=False, err=err, duplicates=dups)
+        text = rewrite_links(
+            path.read_text(encoding="utf-8"), anchor_page, from_readme=False, err=err, duplicates=dups, label=f"docs/{path.name}"
+        )
         (SRC / name).write_text(text, encoding="utf-8")
         nav.append((name, title))
 

--- a/scripts/check_site_links.py
+++ b/scripts/check_site_links.py
@@ -30,11 +30,9 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 OUT = REPO / ".site" / "out"
 
-# Pages whose links are theme-generated against the absolute site_url base rather
-# than relative to the page, so they are not meaningfully checkable here.
-SKIP_FILES = {"404.html"}
-
-NON_HTTP_SCHEMES = ("mailto:", "tel:", "data:", "javascript:")
+# Pages excluded from checking. Empty: the resolver understands the site-base
+# absolute links (/suve/…) that the 404 page uses, so it is validated too.
+SKIP_FILES: set[str] = set()
 
 # Local URL-bearing element/attribute pairs to validate. srcset attributes are
 # comma-separated candidate lists and handled specially.
@@ -101,11 +99,13 @@ def to_out_relpath(page_rel: str, url: str) -> tuple[str | None, str, bool]:
     s = urllib.parse.urlsplit(url)
     frag = urllib.parse.unquote(s.fragment)
 
-    if s.scheme in ("http", "https"):
+    # Absolute (http(s)://host/…) or protocol-relative (//host/…): only same-site,
+    # under the site base, is checkable.
+    if s.scheme in ("http", "https") or (not s.scheme and s.netloc):
         if SITE_HOST and s.netloc == SITE_HOST and s.path.startswith(SITE_BASE):
-            return _from_root(s.path[len(SITE_BASE) :]), frag, False
+            return _from_root(urllib.parse.unquote(s.path[len(SITE_BASE) :])), frag, False
         return None, frag, True
-    if s.scheme or s.netloc:  # other scheme (mailto:, …) or //host
+    if s.scheme:  # mailto:, tel:, data:, javascript:, …
         return None, frag, True
 
     path = urllib.parse.unquote(s.path)

--- a/scripts/check_site_links.py
+++ b/scripts/check_site_links.py
@@ -2,22 +2,26 @@
 """Deterministically validate the built site's internal links, anchors and assets.
 
 Runs after `mkdocs build` over .site/out and, for every rendered page, checks
-that each local `<a href>` and `<img src>`:
+that each local URL-bearing HTML attribute (a/@href, img/@src+srcset, and the
+other asset-bearing elements below):
 
-  * resolves to a file that exists in the output (directory URLs → index.html),
-  * and, for `#fragment` links, that the target page actually contains an element
-    with that id/name.
+  * resolves to a file that exists in the output (directory URLs → index.html,
+    decided against the actual output tree), and
+  * for `#fragment` links, that the target page contains that id/name.
 
-External links (http(s)/mailto/tel/data/protocol-relative) and absolute-path
-links (theme-generated canonicals) are out of scope — network checks are
-non-deterministic, and this gate's job is to guarantee every REPOSITORY-LOCAL
-link/anchor/asset. Any broken local reference exits non-zero, so a documentation
-restructuring that breaks a link fails CI without any AI/human review.
+Same-site links — relative, root-absolute under the site base path (/suve/…), or
+fully-qualified under the site_url host — are all resolved and checked. Truly
+external links (other hosts, mailto/tel/data/js) are out of scope: network
+checks are non-deterministic, and this gate's job is to guarantee every
+REPOSITORY-LOCAL link/anchor/asset. Any broken local reference exits non-zero, so
+a documentation restructuring that breaks a reference fails CI without any
+AI/human review.
 """
 
 from __future__ import annotations
 
 import posixpath
+import re
 import sys
 import urllib.parse
 from html.parser import HTMLParser
@@ -30,16 +34,47 @@ OUT = REPO / ".site" / "out"
 # than relative to the page, so they are not meaningfully checkable here.
 SKIP_FILES = {"404.html"}
 
-EXTERNAL_SCHEMES = ("http:", "https:", "mailto:", "tel:", "data:", "javascript:")
+NON_HTTP_SCHEMES = ("mailto:", "tel:", "data:", "javascript:")
+
+# Local URL-bearing element/attribute pairs to validate. srcset attributes are
+# comma-separated candidate lists and handled specially.
+URL_ATTRS = {
+    ("a", "href"),
+    ("img", "src"),
+    ("source", "src"),
+    ("video", "src"),
+    ("video", "poster"),
+    ("audio", "src"),
+    ("script", "src"),
+    ("link", "href"),
+    ("object", "data"),
+    ("iframe", "src"),
+    ("embed", "src"),
+}
+SRCSET_TAGS = {"img", "source"}
+
+
+def load_site_base() -> tuple[str, str]:
+    """(host, base-path) parsed from mkdocs.yml's site_url, so same-site absolute
+    links can be resolved. base-path always ends with '/'."""
+    m = re.search(r"^site_url:\s*(\S+)", (REPO / "mkdocs.yml").read_text(encoding="utf-8"), re.M)
+    if not m:
+        return "", "/"
+    parts = urllib.parse.urlsplit(m.group(1))
+    base = parts.path if parts.path.endswith("/") else parts.path + "/"
+    return parts.netloc, base or "/"
+
+
+SITE_HOST, SITE_BASE = load_site_base()
 
 
 class PageParser(HTMLParser):
-    """Collects element ids/names and (a href / img src) references from a page."""
+    """Collects element ids/names and local URL references from a page."""
 
     def __init__(self) -> None:
         super().__init__(convert_charrefs=True)
         self.ids: set[str] = set()
-        self.refs: list[tuple[str, str]] = []  # (tag, url)
+        self.refs: list[str] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
         d = {k: (v or "") for k, v in attrs}
@@ -47,38 +82,60 @@ class PageParser(HTMLParser):
             self.ids.add(d["id"])
         if d.get("name"):
             self.ids.add(d["name"])
-        if tag == "a" and d.get("href"):
-            self.refs.append(("a", d["href"]))
-        elif tag == "img" and d.get("src"):
-            self.refs.append(("img", d["src"]))
+        for attr, value in d.items():
+            if (tag, attr) in URL_ATTRS and value:
+                self.refs.append(value)
+        if tag in SRCSET_TAGS and d.get("srcset"):
+            for candidate in d["srcset"].split(","):
+                url = candidate.strip().split(" ", 1)[0]
+                if url:
+                    self.refs.append(url)
 
 
-def is_external(url: str) -> bool:
-    u = url.strip()
-    return (
-        u.startswith("//")
-        or u.startswith("/")  # absolute-path (site-base) links: out of scope
-        or u.lower().startswith(EXTERNAL_SCHEMES)
-    )
+def to_out_relpath(page_rel: str, url: str) -> tuple[str | None, str, bool]:
+    """Map a URL found on page_rel to (output-relative path, fragment, external).
 
+    Returns external=True for links this gate does not check (other hosts,
+    mailto/tel/data/js, or absolute paths outside the site base). The path is a
+    normalized relpath from the output root, or None if it escapes the root."""
+    s = urllib.parse.urlsplit(url)
+    frag = urllib.parse.unquote(s.fragment)
 
-def resolve(page_rel: str, url: str) -> str | None:
-    """Resolve a page-relative link to an output file path (posix, relative to
-    OUT), or None if it points outside the tree."""
-    path = urllib.parse.unquote(urllib.parse.urldefrag(url)[0])
+    if s.scheme in ("http", "https"):
+        if SITE_HOST and s.netloc == SITE_HOST and s.path.startswith(SITE_BASE):
+            return _from_root(s.path[len(SITE_BASE) :]), frag, False
+        return None, frag, True
+    if s.scheme or s.netloc:  # other scheme (mailto:, …) or //host
+        return None, frag, True
+
+    path = urllib.parse.unquote(s.path)
     if path == "":
-        return page_rel  # same-page fragment
+        return page_rel, frag, False  # same-page fragment
+    if path.startswith("/"):
+        if SITE_BASE != "/" and path.startswith(SITE_BASE):
+            return _from_root(path[len(SITE_BASE) :]), frag, False
+        if SITE_BASE == "/":
+            return _from_root(path[1:]), frag, False
+        return None, frag, True  # absolute path outside the site base
 
     joined = posixpath.normpath(posixpath.join(posixpath.dirname(page_rel), path))
-    if joined == ".":
-        return "index.html"  # resolved to the site root (e.g. a `..`/`.` home link)
-    if joined.startswith(".."):
-        return None  # escaped the output root
+    return (None if joined.startswith("..") else joined), frag, False
 
-    # A directory URL (no filename extension) maps to its index.html.
-    if "." not in posixpath.basename(joined):
-        return joined + "/index.html"
-    return joined
+
+def _from_root(rel: str) -> str | None:
+    joined = posixpath.normpath(rel) if rel.strip("/") else "."
+    return None if joined.startswith("..") else joined
+
+
+def find_target(rel: str, existing: set[str]) -> str | None:
+    """Resolve a normalized relpath to an existing output file, trying it as a
+    file and then as a directory URL (rel/index.html). '.' is the site root."""
+    if rel in (".", ""):
+        return "index.html" if "index.html" in existing else None
+    if rel in existing:
+        return rel
+    idx = posixpath.normpath(posixpath.join(rel, "index.html"))
+    return idx if idx in existing else None
 
 
 def main() -> int:
@@ -88,14 +145,12 @@ def main() -> int:
 
     html_files = [p for p in OUT.rglob("*.html") if p.name not in SKIP_FILES]
     existing = {p.relative_to(OUT).as_posix() for p in OUT.rglob("*") if p.is_file()}
-
     ids_by_page: dict[str, set[str]] = {}
 
     def page_ids(rel: str) -> set[str]:
         if rel not in ids_by_page:
-            target = OUT / rel
             parser = PageParser()
-            parser.feed(target.read_text(encoding="utf-8", errors="replace"))
+            parser.feed((OUT / rel).read_text(encoding="utf-8", errors="replace"))
             ids_by_page[rel] = parser.ids
         return ids_by_page[rel]
 
@@ -107,19 +162,18 @@ def main() -> int:
         parser.feed(path.read_text(encoding="utf-8", errors="replace"))
         ids_by_page[page_rel] = parser.ids
 
-        for tag, url in parser.refs:
-            if not url.strip() or url.strip() == "#" or is_external(url):
+        for url in parser.refs:
+            if not url.strip() or url.strip() == "#":
                 continue
-
-            target = resolve(page_rel, url)
-            if target is None or target not in existing:
-                errors.append(f"{page_rel}: {tag} -> {url!r} (missing file {target!r})")
+            rel, fragment, external = to_out_relpath(page_rel, url)
+            if external:
                 continue
-
-            if tag == "a":
-                fragment = urllib.parse.unquote(urllib.parse.urldefrag(url)[1])
-                if fragment and fragment not in page_ids(target):
-                    errors.append(f"{page_rel}: link -> {url!r} (no anchor #{fragment} in {target})")
+            target = find_target(rel, existing) if rel is not None else None
+            if target is None:
+                errors.append(f"{page_rel}: {url!r} -> missing file (resolved {rel!r})")
+                continue
+            if fragment and fragment not in page_ids(target):
+                errors.append(f"{page_rel}: {url!r} -> no anchor #{fragment} in {target}")
 
     if errors:
         print(f"check_site_links: {len(errors)} broken local reference(s):", file=sys.stderr)

--- a/scripts/check_site_links.py
+++ b/scripts/check_site_links.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Deterministically validate the built site's internal links, anchors and assets.
+
+Runs after `mkdocs build` over .site/out and, for every rendered page, checks
+that each local `<a href>` and `<img src>`:
+
+  * resolves to a file that exists in the output (directory URLs → index.html),
+  * and, for `#fragment` links, that the target page actually contains an element
+    with that id/name.
+
+External links (http(s)/mailto/tel/data/protocol-relative) and absolute-path
+links (theme-generated canonicals) are out of scope — network checks are
+non-deterministic, and this gate's job is to guarantee every REPOSITORY-LOCAL
+link/anchor/asset. Any broken local reference exits non-zero, so a documentation
+restructuring that breaks a link fails CI without any AI/human review.
+"""
+
+from __future__ import annotations
+
+import posixpath
+import sys
+import urllib.parse
+from html.parser import HTMLParser
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+OUT = REPO / ".site" / "out"
+
+# Pages whose links are theme-generated against the absolute site_url base rather
+# than relative to the page, so they are not meaningfully checkable here.
+SKIP_FILES = {"404.html"}
+
+EXTERNAL_SCHEMES = ("http:", "https:", "mailto:", "tel:", "data:", "javascript:")
+
+
+class PageParser(HTMLParser):
+    """Collects element ids/names and (a href / img src) references from a page."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.ids: set[str] = set()
+        self.refs: list[tuple[str, str]] = []  # (tag, url)
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        d = {k: (v or "") for k, v in attrs}
+        if d.get("id"):
+            self.ids.add(d["id"])
+        if d.get("name"):
+            self.ids.add(d["name"])
+        if tag == "a" and d.get("href"):
+            self.refs.append(("a", d["href"]))
+        elif tag == "img" and d.get("src"):
+            self.refs.append(("img", d["src"]))
+
+
+def is_external(url: str) -> bool:
+    u = url.strip()
+    return (
+        u.startswith("//")
+        or u.startswith("/")  # absolute-path (site-base) links: out of scope
+        or u.lower().startswith(EXTERNAL_SCHEMES)
+    )
+
+
+def resolve(page_rel: str, url: str) -> str | None:
+    """Resolve a page-relative link to an output file path (posix, relative to
+    OUT), or None if it points outside the tree."""
+    path = urllib.parse.unquote(urllib.parse.urldefrag(url)[0])
+    if path == "":
+        return page_rel  # same-page fragment
+
+    joined = posixpath.normpath(posixpath.join(posixpath.dirname(page_rel), path))
+    if joined == ".":
+        return "index.html"  # resolved to the site root (e.g. a `..`/`.` home link)
+    if joined.startswith(".."):
+        return None  # escaped the output root
+
+    # A directory URL (no filename extension) maps to its index.html.
+    if "." not in posixpath.basename(joined):
+        return joined + "/index.html"
+    return joined
+
+
+def main() -> int:
+    if not OUT.is_dir():
+        print(f"check_site_links: {OUT} does not exist — build the site first", file=sys.stderr)
+        return 1
+
+    html_files = [p for p in OUT.rglob("*.html") if p.name not in SKIP_FILES]
+    existing = {p.relative_to(OUT).as_posix() for p in OUT.rglob("*") if p.is_file()}
+
+    ids_by_page: dict[str, set[str]] = {}
+
+    def page_ids(rel: str) -> set[str]:
+        if rel not in ids_by_page:
+            target = OUT / rel
+            parser = PageParser()
+            parser.feed(target.read_text(encoding="utf-8", errors="replace"))
+            ids_by_page[rel] = parser.ids
+        return ids_by_page[rel]
+
+    errors: list[str] = []
+
+    for path in sorted(html_files):
+        page_rel = path.relative_to(OUT).as_posix()
+        parser = PageParser()
+        parser.feed(path.read_text(encoding="utf-8", errors="replace"))
+        ids_by_page[page_rel] = parser.ids
+
+        for tag, url in parser.refs:
+            if not url.strip() or url.strip() == "#" or is_external(url):
+                continue
+
+            target = resolve(page_rel, url)
+            if target is None or target not in existing:
+                errors.append(f"{page_rel}: {tag} -> {url!r} (missing file {target!r})")
+                continue
+
+            if tag == "a":
+                fragment = urllib.parse.unquote(urllib.parse.urldefrag(url)[1])
+                if fragment and fragment not in page_ids(target):
+                    errors.append(f"{page_rel}: link -> {url!r} (no anchor #{fragment} in {target})")
+
+    if errors:
+        print(f"check_site_links: {len(errors)} broken local reference(s):", file=sys.stderr)
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        return 1
+
+    print(f"check_site_links: OK — {len(html_files)} pages, all local links/anchors/assets resolve")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/docs-requirements.txt
+++ b/scripts/docs-requirements.txt
@@ -1,0 +1,6 @@
+# Pinned dependencies for building the GitHub Pages site (see mkdocs.yml and
+# scripts/build_docs_site.py). Installed by `mise docs-build`/`docs-serve` and by
+# the Pages workflow. mkdocs-material pulls in mkdocs, Python-Markdown, and
+# pymdown-extensions (the GitHub-compatible slugifier the site relies on).
+mkdocs-material==9.7.6
+mkdocs-literate-nav==0.6.3

--- a/scripts/test_docs_pipeline.py
+++ b/scripts/test_docs_pipeline.py
@@ -1,9 +1,11 @@
 #!/usr/bin/env python3
 """Unit tests for the docs-site pipeline's fragile pure logic — the splitter's
-fence/heading handling and link rewriting, and the link checker's path resolver.
+fence/heading handling, link rewriting, fail-closed guards, and the link
+checker's URL resolution.
 
 Run: `python scripts/test_docs_pipeline.py` (used by the Pages workflow). These
-guard the behaviors most likely to break under a README/docs restructuring.
+guard the behaviors most likely to break — or to wrongly pass — under a
+README/docs restructuring.
 """
 
 from __future__ import annotations
@@ -18,28 +20,33 @@ import build_docs_site as b  # noqa: E402
 import check_site_links as c  # noqa: E402
 
 
+def resolve(page: str, url: str, existing: set[str]):
+    """Compose the checker's two steps to a final target (or None), ignoring
+    externals — the shape the checker uses per link."""
+    rel, _frag, external = c.to_out_relpath(page, url)
+    if external:
+        return "EXTERNAL"
+    return c.find_target(rel, existing) if rel is not None else None
+
+
 class FenceTests(unittest.TestCase):
     def test_h2_inside_fenced_block_is_not_a_split(self):
-        readme = (
-            "intro\n"
-            "```sh\n"
-            "## not a heading\n"
-            "~~~ still inside the ``` fence\n"
-            "```\n"
-            "## Real Section\n"
-            "body\n"
-        )
+        readme = "intro\n```sh\n## not a heading\n~~~ inside the ``` fence\n```\n## Real Section\nbody\n"
         errors: list[str] = []
-        pages, anchor_page = b.build_readme_pages(readme, errors.append)
-        names = [name for name, _, _ in pages]
-        self.assertEqual(names, ["index.md", "real-section.md"])
+        pages, anchor_page, _dups = b.build_readme_pages(readme, errors.append)
+        self.assertEqual([n for n, _, _ in pages], ["index.md", "real-section.md"])
         self.assertIn("real-section", anchor_page)
         self.assertNotIn("not-a-heading", anchor_page)
         self.assertEqual(errors, [])
 
+    def test_unclosed_fence_is_an_error(self):
+        errors: list[str] = []
+        b.build_readme_pages("## A\n```\nnever closed\n## B\nx\n", errors.append)
+        self.assertTrue(any("unclosed code fence" in e for e in errors))
+
     def test_mismatched_fence_marker_does_not_close(self):
         fences = b.Fences()
-        self.assertTrue(fences.is_code("```"))  # open with backticks
+        self.assertTrue(fences.is_code("```"))
         self.assertTrue(fences.is_code("~~~"))  # tildes do NOT close a ``` fence
         self.assertTrue(fences.is_code("## still code"))
         self.assertTrue(fences.is_code("```"))  # real close
@@ -61,11 +68,10 @@ class RewriteTests(unittest.TestCase):
         self.assertEqual(errors, [])
 
     def test_links_inside_inline_code_are_untouched(self):
-        amap = {"x": "page.md"}
         errors: list[str] = []
-        out = b.rewrite_links("real [a](#x) but `[a](#x)` code\n", amap, from_readme=True, err=errors.append)
-        self.assertIn("[a](page.md#x)", out)  # the real link rewritten
-        self.assertIn("`[a](#x)`", out)  # the inline-code one left verbatim
+        out = b.rewrite_links("real [a](#x) but `[a](#x)` code\n", {"x": "page.md"}, from_readme=True, err=errors.append)
+        self.assertIn("[a](page.md#x)", out)
+        self.assertIn("`[a](#x)`", out)
         self.assertEqual(errors, [])
 
     def test_unmapped_anchor_is_an_error(self):
@@ -73,14 +79,16 @@ class RewriteTests(unittest.TestCase):
         b.rewrite_links("[bad](#does-not-exist)\n", {}, from_readme=True, err=errors.append)
         self.assertTrue(any("does-not-exist" in e for e in errors))
 
+    def test_ambiguous_duplicate_anchor_is_an_error(self):
+        errors: list[str] = []
+        b.rewrite_links("[d](#dup)\n", {"dup": "a.md"}, from_readme=True, err=errors.append, duplicates=frozenset({"dup"}))
+        self.assertTrue(any("ambiguous anchor #dup" in e for e in errors))
+
     def test_doc_readme_backlinks_rewritten(self):
         amap = {"staging-workflow": "getting-started.md", "": "index.md"}
         errors: list[str] = []
         out = b.rewrite_links(
-            "[w](../README.md#staging-workflow) [home](../README.md)\n",
-            amap,
-            from_readme=False,
-            err=errors.append,
+            "[w](../README.md#staging-workflow) [home](../README.md)\n", amap, from_readme=False, err=errors.append
         )
         self.assertIn("(getting-started.md#staging-workflow)", out)
         self.assertIn("(index.md)", out)
@@ -92,22 +100,45 @@ class RewriteTests(unittest.TestCase):
         self.assertIn('id="building-from-source"', out)
 
 
+class GuardTests(unittest.TestCase):
+    def test_reference_link_split_from_definition_is_an_error(self):
+        readme = "## One\nSee [important][ref].\n## Two\n[ref]: #target\n### Target\ntext\n"
+        errors: list[str] = []
+        b.build_readme_pages(readme, errors.append)
+        self.assertTrue(any("reference-style link" in e for e in errors))
+
+    def test_reference_link_with_no_definition_is_ignored(self):
+        # e.g. `#VERSION][~SHIFT]` version-syntax notation, not a real ref link.
+        errors: list[str] = []
+        b.build_readme_pages("## One\nUse [#VERSION][~SHIFT] syntax.\n", errors.append)
+        self.assertEqual(errors, [])
+
+
 class ResolveTests(unittest.TestCase):
     def test_directory_url_maps_to_index(self):
-        self.assertEqual(c.resolve("command-reference/index.html", "../aws/"), "aws/index.html")
+        self.assertEqual(resolve("command-reference/index.html", "../aws/", {"aws/index.html"}), "aws/index.html")
 
     def test_dotdot_resolves_to_home(self):
-        self.assertEqual(c.resolve("aws/index.html", ".."), "index.html")
-        self.assertEqual(c.resolve("index.html", "."), "index.html")
+        self.assertEqual(resolve("aws/index.html", "..", {"index.html"}), "index.html")
+        self.assertEqual(resolve("index.html", ".", {"index.html"}), "index.html")
 
-    def test_asset_with_extension_kept(self):
-        self.assertEqual(c.resolve("index.html", "demo/cli-demo.gif"), "demo/cli-demo.gif")
+    def test_extensionless_file_not_mistaken_for_dir(self):
+        self.assertEqual(resolve("index.html", "LICENSE", {"LICENSE"}), "LICENSE")
+
+    def test_query_string_is_stripped(self):
+        self.assertEqual(resolve("index.html", "aws/?v=1", {"aws/index.html"}), "aws/index.html")
 
     def test_escape_above_root_is_rejected(self):
-        self.assertIsNone(c.resolve("index.html", "../../etc/passwd"))
+        self.assertIsNone(resolve("index.html", "../../etc/passwd", set()))
 
-    def test_same_page_fragment(self):
-        self.assertEqual(c.resolve("aws/index.html", "#frag"), "aws/index.html")
+    def test_same_site_absolute_and_qualified(self):
+        existing = {"aws/index.html"}
+        self.assertEqual(resolve("index.html", "/suve/aws/", existing), "aws/index.html")
+        self.assertEqual(resolve("index.html", "https://mpyw.github.io/suve/aws/", existing), "aws/index.html")
+
+    def test_external_is_skipped(self):
+        self.assertEqual(resolve("index.html", "https://example.com/x", set()), "EXTERNAL")
+        self.assertEqual(resolve("index.html", "mailto:x@y.z", set()), "EXTERNAL")
 
 
 if __name__ == "__main__":

--- a/scripts/test_docs_pipeline.py
+++ b/scripts/test_docs_pipeline.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Unit tests for the docs-site pipeline's fragile pure logic — the splitter's
+fence/heading handling and link rewriting, and the link checker's path resolver.
+
+Run: `python scripts/test_docs_pipeline.py` (used by the Pages workflow). These
+guard the behaviors most likely to break under a README/docs restructuring.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import build_docs_site as b  # noqa: E402
+import check_site_links as c  # noqa: E402
+
+
+class FenceTests(unittest.TestCase):
+    def test_h2_inside_fenced_block_is_not_a_split(self):
+        readme = (
+            "intro\n"
+            "```sh\n"
+            "## not a heading\n"
+            "~~~ still inside the ``` fence\n"
+            "```\n"
+            "## Real Section\n"
+            "body\n"
+        )
+        errors: list[str] = []
+        pages, anchor_page = b.build_readme_pages(readme, errors.append)
+        names = [name for name, _, _ in pages]
+        self.assertEqual(names, ["index.md", "real-section.md"])
+        self.assertIn("real-section", anchor_page)
+        self.assertNotIn("not-a-heading", anchor_page)
+        self.assertEqual(errors, [])
+
+    def test_mismatched_fence_marker_does_not_close(self):
+        fences = b.Fences()
+        self.assertTrue(fences.is_code("```"))  # open with backticks
+        self.assertTrue(fences.is_code("~~~"))  # tildes do NOT close a ``` fence
+        self.assertTrue(fences.is_code("## still code"))
+        self.assertTrue(fences.is_code("```"))  # real close
+        self.assertFalse(fences.is_code("## now a heading"))
+
+
+class RewriteTests(unittest.TestCase):
+    def test_readme_anchor_and_docs_prefix_rewrites(self):
+        amap = {"provider-selection": "command-reference.md"}
+        errors: list[str] = []
+        out = b.rewrite_links(
+            "See [sel](#provider-selection) and [aws](docs/aws.md#suve-aws-secret-log).\n",
+            amap,
+            from_readme=True,
+            err=errors.append,
+        )
+        self.assertIn("(command-reference.md#provider-selection)", out)
+        self.assertIn("(aws.md#suve-aws-secret-log)", out)
+        self.assertEqual(errors, [])
+
+    def test_links_inside_inline_code_are_untouched(self):
+        amap = {"x": "page.md"}
+        errors: list[str] = []
+        out = b.rewrite_links("real [a](#x) but `[a](#x)` code\n", amap, from_readme=True, err=errors.append)
+        self.assertIn("[a](page.md#x)", out)  # the real link rewritten
+        self.assertIn("`[a](#x)`", out)  # the inline-code one left verbatim
+        self.assertEqual(errors, [])
+
+    def test_unmapped_anchor_is_an_error(self):
+        errors: list[str] = []
+        b.rewrite_links("[bad](#does-not-exist)\n", {}, from_readme=True, err=errors.append)
+        self.assertTrue(any("does-not-exist" in e for e in errors))
+
+    def test_doc_readme_backlinks_rewritten(self):
+        amap = {"staging-workflow": "getting-started.md", "": "index.md"}
+        errors: list[str] = []
+        out = b.rewrite_links(
+            "[w](../README.md#staging-workflow) [home](../README.md)\n",
+            amap,
+            from_readme=False,
+            err=errors.append,
+        )
+        self.assertIn("(getting-started.md#staging-workflow)", out)
+        self.assertIn("(index.md)", out)
+        self.assertEqual(errors, [])
+
+    def test_summary_gets_an_id(self):
+        errors: list[str] = []
+        out = b.rewrite_links("<summary>Building From Source</summary>\n", {}, from_readme=True, err=errors.append)
+        self.assertIn('id="building-from-source"', out)
+
+
+class ResolveTests(unittest.TestCase):
+    def test_directory_url_maps_to_index(self):
+        self.assertEqual(c.resolve("command-reference/index.html", "../aws/"), "aws/index.html")
+
+    def test_dotdot_resolves_to_home(self):
+        self.assertEqual(c.resolve("aws/index.html", ".."), "index.html")
+        self.assertEqual(c.resolve("index.html", "."), "index.html")
+
+    def test_asset_with_extension_kept(self):
+        self.assertEqual(c.resolve("index.html", "demo/cli-demo.gif"), "demo/cli-demo.gif")
+
+    def test_escape_above_root_is_rejected(self):
+        self.assertIsNone(c.resolve("index.html", "../../etc/passwd"))
+
+    def test_same_page_fragment(self):
+        self.assertEqual(c.resolve("aws/index.html", "#frag"), "aws/index.html")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_docs_pipeline.py
+++ b/scripts/test_docs_pipeline.py
@@ -99,6 +99,12 @@ class RewriteTests(unittest.TestCase):
         out = b.rewrite_links("<summary>Building From Source</summary>\n", {}, from_readme=True, err=errors.append)
         self.assertIn('id="building-from-source"', out)
 
+    def test_unclosed_fence_in_a_doc_page_is_an_error(self):
+        # docs/*.md are not split, so their fences are checked in rewrite_links.
+        errors: list[str] = []
+        b.rewrite_links("intro\n```sh\nnever closed\n", {}, from_readme=False, err=errors.append, label="docs/x.md")
+        self.assertTrue(any("unclosed code fence in docs/x.md" in e for e in errors))
+
 
 class GuardTests(unittest.TestCase):
     def test_reference_link_split_from_definition_is_an_error(self):


### PR DESCRIPTION
Sets up **GitHub Pages** auto-generated from the existing Markdown (`README.md` + `docs/*.md`), deployed via a pipeline. **Nothing generated is committed** — no `gh-pages` branch, no built HTML; the assembled source (`.site/src`) and output (`.site/out`) are git-ignored and rebuilt each run.

Site: **https://mpyw.github.io/suve/** (enabled automatically on first run).

## How it works

- **Generator:** MkDocs + Material (light/dark toggle, search, nav, code copy).
- **README split:** `scripts/build_docs_site.py` splits the large README into one page per top-level `## ` section (intro → home), keeping `docs/*.md` as their own pages.
- **Links survive the split:** it builds an anchor→page map from every heading — and every `<details>` summary, which it also gives an `id` (so e.g. `#building-from-source`, previously a dead anchor even on GitHub, now resolves) — then rewrites README `#anchor` links and the docs' `../README.md#…` links to the page each section landed on. Slugs use the same GitHub-compatible slugifier MkDocs is configured with (`pymdownx.slugs.slugify`), so anchors match.
- **Assets:** README's demo GIFs + app icon are copied in; the workflow checks out **Git LFS** so they're real files.
- **Nav order:** a generated `SUMMARY.md` (literate-nav), kept out of the built pages.

## Pipeline — `.github/workflows/pages.yml`

- Build on push to `main` / PRs touching the site (**PRs validate the build only**); **deploy from `main`**.
- Standard Pages Actions flow: `configure-pages` (with `enablement: true`, so the first run turns Pages on with source = Actions) → `upload-pages-artifact` → `deploy-pages`. Least-privilege `pages: write` + `id-token: write`.

## Local

```bash
mise docs-serve   # http://127.0.0.1:8000  (bootstraps a venv from scripts/docs-requirements.txt)
mise docs-build   # build into .site/out
```

## Validation
Built locally end-to-end (`mise docs-build`): 12 README pages + 4 doc pages, cross-page anchors resolve (e.g. `azure/` → `../command-reference/#provider-selection`), assets served, `SUMMARY` excluded. No build errors.

**Pre-existing note (out of scope):** MkDocs' link checker flags that the README links `docs/azure.md#suve-azure-param-tag` / `-untag`, but `azure.md` has a single combined `## suve azure param tag / untag` heading — so those anchors are already dead on GitHub. Left for a separate docs fix.

> First-run requirement: the repo's **Pages** setting must allow the Actions source. `configure-pages enablement: true` sets this automatically on the first `main` run, provided Actions has the default `pages: write` permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)