### PR TITLE
ci(pages): fix site rendering, relocate scripts, align env-var docs

### DIFF
--- a/.github/scripts/build-docs-site.py
+++ b/.github/scripts/build-docs-site.py
@@ -16,7 +16,7 @@ site — an unmapped anchor, a missing asset, an output-path collision, an empty
 page slug, or a Git-LFS pointer left un-materialised — is collected and makes the
 script exit non-zero, so CI catches doc-restructuring breakage deterministically
 (no AI/human review). The rendered HTML is validated separately by
-scripts/check_site_links.py after the build.
+.github/scripts/check-site-links.py after the build.
 
 Run via `mise docs-build` / `mise docs-serve`, or directly; it is idempotent.
 """
@@ -28,7 +28,7 @@ import shutil
 import sys
 from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent
+REPO = Path(__file__).resolve().parents[2]  # .github/scripts/<file> → repo root
 SRC = REPO / ".site" / "src"
 
 # Local assets referenced (by relative path) from the README, copied into the
@@ -54,6 +54,19 @@ SUMMARY_RE = re.compile(r"<summary(\s[^>]*)?>(.*?)</summary>", re.IGNORECASE)
 # definition, which would silently render as plain text; we detect that.
 REF_DEF_RE = re.compile(r"^ {0,3}\[([^\]]+)\]:\s+\S")
 REF_USE_RE = re.compile(r"\[([^\]]+)\]\[([^\]]*)\]")
+# Material's stylesheet forces `.md-typeset img { height: auto }`, which overrides
+# the README's inline width=/height= attributes (logos blow up to full size). Move
+# those attributes into an inline style, which wins over the stylesheet.
+# Match a full <img …> / <div …> open tag, tolerating '>' inside quoted attribute
+# values (so an alt="a > b" cannot truncate the tag mid-attribute).
+IMG_TAG_RE = re.compile(r"""<img\b(?:[^>"']|"[^"]*"|'[^']*')*>""", re.IGNORECASE)
+DIV_OPEN_RE = re.compile(r"""<div\b(?:[^>"']|"[^"]*"|'[^']*')*>""", re.IGNORECASE)
+# Attribute matchers use a non-name lookbehind so data-width / data-style / …
+# are not mistaken for the bare attribute.
+IMG_WIDTH_RE = re.compile(r'(?<![-\w])width\s*=\s*"(\d+)"', re.IGNORECASE)
+IMG_HEIGHT_RE = re.compile(r'(?<![-\w])height\s*=\s*"(\d+)"', re.IGNORECASE)
+HAS_STYLE_RE = re.compile(r'(?<![-\w])style\s*=', re.IGNORECASE)
+HAS_MARKDOWN_ATTR_RE = re.compile(r'(?<![-\w])markdown\s*=', re.IGNORECASE)
 
 
 def _load_slugify():
@@ -120,6 +133,49 @@ def heading_slug(raw: str) -> str:
 
 def section_filename(title: str) -> str:
     return heading_slug(title) + ".md"
+
+
+def size_img(tag: str) -> str:
+    """Move an <img>'s width=/height= attributes into an inline style so Material's
+    `height: auto` rule cannot override them. Leaves tags with an explicit style
+    (or no numeric dimensions) untouched."""
+    if HAS_STYLE_RE.search(tag):
+        return tag
+    dims = []
+    w = IMG_WIDTH_RE.search(tag)
+    h = IMG_HEIGHT_RE.search(tag)
+    if w:
+        dims.append(f"width:{w.group(1)}px")
+    if h:
+        dims.append(f"height:{h.group(1)}px")
+    if not dims:
+        return tag
+    style = f' style="{";".join(dims)}"'
+    if tag.endswith("/>"):
+        return tag[:-2].rstrip() + style + " />"
+    return tag[:-1].rstrip() + style + ">"
+
+
+def add_div_markdown(m: re.Match) -> str:
+    """Add markdown="1" to a <div> open tag that lacks it, so md_in_html renders
+    Markdown inside it."""
+    tag = m.group(0)
+    if HAS_MARKDOWN_ATTR_RE.search(tag):
+        return tag
+    return '<div markdown="1"' + tag[len("<div") :]
+
+
+def promote_headings(text: str) -> str:
+    """Shift every ATX heading up one level (## → #, ### → ##, …) outside code, so
+    a split section page has a single top-level <h1> and MkDocs does not synthesize
+    a second title from the nav. Slugs are text-derived, so anchors are unchanged."""
+    fences = Fences()
+    out: list[str] = []
+    for i, line in enumerate(text.splitlines(keepends=True), start=1):
+        if not fences.is_code(line, i):
+            line = re.sub(r"^(#{2,6})( )", lambda m: "#" * (len(m.group(1)) - 1) + m.group(2), line)
+        out.append(line)
+    return "".join(out)
 
 
 def apply_outside_code(line: str, fn) -> str:
@@ -254,7 +310,12 @@ def rewrite_links(
         return f'<summary{attrs} id="{heading_slug(inner)}">{inner}</summary>'
 
     def rewrite_prose(text: str) -> str:
+        # Honor inline <img> dimensions on every page (README and docs).
+        text = IMG_TAG_RE.sub(lambda m: size_img(m.group(0)), text)
         if from_readme:
+            # Let Markdown inside raw <div> wrappers (centered badges/links) render:
+            # md_in_html only processes it when the block is marked markdown="1".
+            text = DIV_OPEN_RE.sub(add_div_markdown, text)
             # README lives at the repo root; docs/ links become root-level siblings.
             text = re.sub(r"\]\(docs/([^)#]+)((?:#[^)]*)?)\)", r"](\1\2)", text)
             # Give each <details> summary an id so #anchor links to it resolve.
@@ -342,6 +403,10 @@ def main() -> int:
     for name, title, body in pages:
         claim(name, f"README section {title!r}")
         text = rewrite_links("".join(body), anchor_page, from_readme=True, err=err, duplicates=dups, label=name)
+        # Split section pages open at `## `; promote so each has a single <h1>
+        # (the home page already carries the README's own top-level title).
+        if name != "index.md":
+            text = promote_headings(text)
         (SRC / name).write_text(text, encoding="utf-8")
         nav.append((name, "Home" if name == "index.md" else title))
 

--- a/.github/scripts/build-docs-site.py
+++ b/.github/scripts/build-docs-site.py
@@ -28,12 +28,17 @@ import shutil
 import sys
 from pathlib import Path
 
-REPO = Path(__file__).resolve().parents[2]  # .github/scripts/<file> → repo root
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[1]  # .github/scripts/<file> → repo root
 SRC = REPO / ".site" / "src"
 
 # Local assets referenced (by relative path) from the README, copied into the
 # site so those links resolve. Each entry is a path relative to the repo root.
 ASSETS = ["demo", "gui/build/appicon.png"]
+
+# Committed stylesheet copied into the docs source at assets/docs-extra.css and
+# wired via mkdocs.yml extra_css.
+EXTRA_CSS = HERE / "docs-extra.css"
 
 # A fenced code block opens with ``` or ~~~ (>=3), indented at most 3 spaces
 # (CommonMark), and closes with a marker of the SAME character and >= the opening
@@ -163,6 +168,32 @@ def add_div_markdown(m: re.Match) -> str:
     if HAS_MARKDOWN_ATTR_RE.search(tag):
         return tag
     return '<div markdown="1"' + tag[len("<div") :]
+
+
+BULLET_RE = re.compile(r"^[-*+] ")
+# A flush-left line that is NOT a paragraph (so a following list is already fine):
+# blank, a list item, heading, table row, blockquote, or raw HTML.
+NON_PARAGRAPH_RE = re.compile(r"^([-*+] |#{1,6} |\||>|<|\d+[.)] |\s*$)")
+
+
+def ensure_blank_before_lists(text: str) -> str:
+    """Insert the blank line Python-Markdown needs before a bullet list that opens
+    directly under a paragraph. GitHub renders such a list without the blank line;
+    MkDocs would otherwise fold the bullets into the paragraph as literal text."""
+    fences = Fences()
+    out: list[str] = []
+    prev_paragraph = False
+    for i, line in enumerate(text.splitlines(keepends=True), start=1):
+        if fences.is_code(line, i):
+            out.append(line)
+            prev_paragraph = False
+            continue
+        if prev_paragraph and BULLET_RE.match(line):
+            out.append("\n")
+        out.append(line)
+        # The next line is "under a paragraph" only if this one is flush-left prose.
+        prev_paragraph = bool(line.strip()) and not NON_PARAGRAPH_RE.match(line)
+    return "".join(out)
 
 
 def promote_headings(text: str) -> str:
@@ -407,6 +438,7 @@ def main() -> int:
         # (the home page already carries the README's own top-level title).
         if name != "index.md":
             text = promote_headings(text)
+        text = ensure_blank_before_lists(text)
         (SRC / name).write_text(text, encoding="utf-8")
         nav.append((name, "Home" if name == "index.md" else title))
 
@@ -415,6 +447,7 @@ def main() -> int:
         text = rewrite_links(
             path.read_text(encoding="utf-8"), anchor_page, from_readme=False, err=err, duplicates=dups, label=f"docs/{path.name}"
         )
+        text = ensure_blank_before_lists(text)
         (SRC / name).write_text(text, encoding="utf-8")
         nav.append((name, title))
 
@@ -433,6 +466,14 @@ def main() -> int:
                 err(f"asset is an un-materialised Git-LFS pointer: {asset}")
         else:
             err(f"asset not found: {asset}")
+
+    # Copy the extra stylesheet into the docs source (wired via mkdocs extra_css).
+    if EXTRA_CSS.is_file():
+        css_dst = SRC / "assets" / "docs-extra.css"
+        css_dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(EXTRA_CSS, css_dst)
+    else:
+        err(f"extra stylesheet not found: {EXTRA_CSS.relative_to(REPO)}")
 
     # literate-nav reads this SUMMARY.md for page order/titles.
     summary = "".join(f"- [{title}]({name})\n" for name, title in nav)

--- a/.github/scripts/check-site-links.py
+++ b/.github/scripts/check-site-links.py
@@ -27,7 +27,7 @@ import urllib.parse
 from html.parser import HTMLParser
 from pathlib import Path
 
-REPO = Path(__file__).resolve().parent.parent
+REPO = Path(__file__).resolve().parents[2]  # .github/scripts/<file> → repo root
 OUT = REPO / ".site" / "out"
 
 # Pages excluded from checking. Empty: the resolver understands the site-base

--- a/.github/scripts/docs-extra.css
+++ b/.github/scripts/docs-extra.css
@@ -1,0 +1,35 @@
+/* Extra site styles, copied into the assembled docs and wired via mkdocs.yml
+   extra_css. Kept minimal — overrides only what the Material defaults get wrong
+   for this project's content. Rules use CSS custom properties so they track the
+   light/dark theme. */
+
+/* Mermaid edge (transition) labels.
+
+   Material renders each mermaid diagram into a CLOSED shadow root
+   (attachShadow({mode:"closed"}) in the theme bundle), so descendant selectors
+   from page CSS can never reach the SVG — .edgeLabel/.labelBkg rules here are
+   silently inert. Custom properties DO inherit across the shadow boundary,
+   and Material's injected mermaid theme paints the edge-label background
+   (the HTML <span class="edgeLabel">/<p> inside the label's foreignObject) with
+   --md-mermaid-label-bg-color, which defaults to the opaque page background —
+   an invisible chip that still hides the arrow underneath.
+
+   Override just that variable, scoped to mermaid blocks, with a GitHub-like
+   semi-transparent chip: ~10% text colour over the page background at 0.8
+   alpha (the 8% + 72% mix weights leave 20% transparent). In the light scheme
+   this lands almost exactly on upstream mermaid's rgba(232,232,232,.8), and it
+   adapts to the slate scheme automatically. Browsers without color-mix() keep
+   Material's opaque default. */
+@supports (color: color-mix(in srgb, red 50%, blue)) {
+  .md-typeset .mermaid {
+    --md-mermaid-label-bg-color: color-mix(
+      in srgb,
+      var(--md-default-fg-color) 8%,
+      var(--md-default-bg-color) 72%
+    );
+  }
+}
+
+/* Mermaid notes need no override: Material's injected theme already recolours
+   them (node surface = --md-mermaid-node-bg-color), so they track light/dark
+   out of the box. */

--- a/.github/scripts/docs-requirements.txt
+++ b/.github/scripts/docs-requirements.txt
@@ -1,6 +1,8 @@
 # Pinned dependencies for building the GitHub Pages site (see mkdocs.yml and
-# scripts/build_docs_site.py). Installed by `mise docs-build`/`docs-serve` and by
+# .github/scripts/build-docs-site.py). Installed by `mise docs-build`/`docs-serve` and by
 # the Pages workflow. mkdocs-material pulls in mkdocs, Python-Markdown, and
 # pymdown-extensions (the GitHub-compatible slugifier the site relies on).
 mkdocs-material==9.7.6
 mkdocs-literate-nav==0.6.3
+# Converts GitHub-style callouts (> [!NOTE], [!TIP], …) into Material admonitions.
+mkdocs-callouts==1.16.1

--- a/.github/scripts/test-docs-pipeline.py
+++ b/.github/scripts/test-docs-pipeline.py
@@ -3,21 +3,31 @@
 fence/heading handling, link rewriting, fail-closed guards, and the link
 checker's URL resolution.
 
-Run: `python scripts/test_docs_pipeline.py` (used by the Pages workflow). These
+Run: `python .github/scripts/test-docs-pipeline.py` (used by the Pages workflow). These
 guard the behaviors most likely to break — or to wrongly pass — under a
 README/docs restructuring.
 """
 
 from __future__ import annotations
 
-import sys
+import importlib.util
 import unittest
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent))
+_HERE = Path(__file__).resolve().parent
 
-import build_docs_site as b  # noqa: E402
-import check_site_links as c  # noqa: E402
+
+def _load(mod_name: str, filename: str):
+    """Load a sibling script by path (their filenames use hyphens, so they can't
+    be imported by name)."""
+    spec = importlib.util.spec_from_file_location(mod_name, _HERE / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+b = _load("build_docs_site", "build-docs-site.py")
+c = _load("check_site_links", "check-site-links.py")
 
 
 def resolve(page: str, url: str, existing: set[str]):
@@ -93,6 +103,30 @@ class RewriteTests(unittest.TestCase):
         self.assertIn("(getting-started.md#staging-workflow)", out)
         self.assertIn("(index.md)", out)
         self.assertEqual(errors, [])
+
+    def test_img_size_moved_to_style(self):
+        errors: list[str] = []
+        out = b.rewrite_links('<img src="x.png" height="16" alt="">\n', {}, from_readme=True, err=errors.append)
+        self.assertIn('style="height:16px"', out)
+
+    def test_img_with_gt_in_quoted_attr_not_corrupted(self):
+        errors: list[str] = []
+        out = b.rewrite_links('<img alt="a > b" width="10" src="x.png">\n', {}, from_readme=True, err=errors.append)
+        self.assertIn('alt="a > b"', out)  # attribute preserved intact
+        self.assertIn("width:10px", out)
+
+    def test_data_width_not_mistaken_for_width(self):
+        errors: list[str] = []
+        out = b.rewrite_links('<img data-width="9" src="x.png">\n', {}, from_readme=True, err=errors.append)
+        self.assertNotIn("style=", out)  # no bogus dimension applied
+
+    def test_div_gets_markdown_attr_once(self):
+        errors: list[str] = []
+        out = b.rewrite_links('<div align="center">\n', {}, from_readme=True, err=errors.append)
+        self.assertIn('<div markdown="1" align="center">', out)
+        # A div that already declares markdown is left alone.
+        out2 = b.rewrite_links('<div markdown="span">\n', {}, from_readme=True, err=errors.append)
+        self.assertEqual(out2.count("markdown="), 1)
 
     def test_summary_gets_an_id(self):
         errors: list[str] = []

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,10 +11,10 @@ on:
       - demo/**
       - gui/build/appicon.png
       - mkdocs.yml
-      - scripts/build_docs_site.py
-      - scripts/check_site_links.py
-      - scripts/test_docs_pipeline.py
-      - scripts/docs-requirements.txt
+      - .github/scripts/build-docs-site.py
+      - .github/scripts/check-site-links.py
+      - .github/scripts/test-docs-pipeline.py
+      - .github/scripts/docs-requirements.txt
       - .github/workflows/pages.yml
   # Build + validate (no deploy) on PRs that touch the site, to catch breakage early.
   pull_request:
@@ -24,10 +24,10 @@ on:
       - demo/**
       - gui/build/appicon.png
       - mkdocs.yml
-      - scripts/build_docs_site.py
-      - scripts/check_site_links.py
-      - scripts/test_docs_pipeline.py
-      - scripts/docs-requirements.txt
+      - .github/scripts/build-docs-site.py
+      - .github/scripts/check-site-links.py
+      - .github/scripts/test-docs-pipeline.py
+      - .github/scripts/docs-requirements.txt
       - .github/workflows/pages.yml
   workflow_dispatch:
 
@@ -62,19 +62,19 @@ jobs:
         run: |
           python3 -m venv .venv
           .venv/bin/pip install --quiet --upgrade pip
-          .venv/bin/pip install --quiet -r scripts/docs-requirements.txt
+          .venv/bin/pip install --quiet -r .github/scripts/docs-requirements.txt
 
       - name: Unit-test the pipeline
-        run: .venv/bin/python scripts/test_docs_pipeline.py
+        run: .venv/bin/python .github/scripts/test-docs-pipeline.py
 
       - name: Assemble the site source (fails on broken/unmapped links, collisions, missing assets)
-        run: .venv/bin/python scripts/build_docs_site.py
+        run: .venv/bin/python .github/scripts/build-docs-site.py
 
       - name: Build with MkDocs (strict — link/anchor/nav problems fail)
         run: .venv/bin/mkdocs build --strict
 
       - name: Validate rendered links, anchors and assets
-        run: .venv/bin/python scripts/check_site_links.py
+        run: .venv/bin/python .github/scripts/check-site-links.py
 
       # Package the VALIDATED output as the github-pages artifact here, so the
       # privileged deploy job ships exactly what was validated (no rebuild).

--- a/README.md
+++ b/README.md
@@ -1003,6 +1003,8 @@ Each backend is selected and authenticated from its own environment variables (a
 |----------|-------------|
 | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` | Static credentials |
 | `AWS_PROFILE` | Shared-config profile to load |
+| `AWS_VAULT` | Set by [aws-vault](https://github.com/99designs/aws-vault); also marks AWS active for the bare aliases (see [Provider selection](#provider-selection)) |
+| `AWS_CONTAINER_CREDENTIALS_FULL_URI` / `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` / `AWS_WEB_IDENTITY_TOKEN_FILE` | Ambient credentials on AWS-managed compute (CloudShell, ECS/App Runner, EKS/IRSA); also mark AWS active — see [Cloud Shell support](#cloud-shell-support) |
 | `AWS_REGION` / `AWS_DEFAULT_REGION` | Region |
 
 #### Google Cloud

--- a/gui/go.mod
+++ b/gui/go.mod
@@ -81,7 +81,7 @@ require (
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
+	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/term v0.44.0 // indirect
 	golang.org/x/text v0.38.0 // indirect

--- a/gui/go.sum
+++ b/gui/go.sum
@@ -200,6 +200,7 @@ golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
 golang.org/x/sync v0.21.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
+golang.org/x/sync v0.22.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20200810151505-1b9f1253b3ed/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/mise.toml
+++ b/mise.toml
@@ -403,11 +403,11 @@ description = "Assemble, strictly build, and link-check the GitHub Pages site in
 run = '''
 python3 -m venv .site/venv
 .site/venv/bin/pip install --quiet --upgrade pip
-.site/venv/bin/pip install --quiet -r scripts/docs-requirements.txt
-.site/venv/bin/python scripts/test_docs_pipeline.py
-.site/venv/bin/python scripts/build_docs_site.py
+.site/venv/bin/pip install --quiet -r .github/scripts/docs-requirements.txt
+.site/venv/bin/python .github/scripts/test-docs-pipeline.py
+.site/venv/bin/python .github/scripts/build-docs-site.py
 DISABLE_MKDOCS_2_WARNING=true .site/venv/bin/mkdocs build --strict
-.site/venv/bin/python scripts/check_site_links.py
+.site/venv/bin/python .github/scripts/check-site-links.py
 '''
 
 [tasks.docs-serve]
@@ -415,8 +415,8 @@ description = "Assemble and serve the docs site locally at http://127.0.0.1:8000
 run = '''
 python3 -m venv .site/venv
 .site/venv/bin/pip install --quiet --upgrade pip
-.site/venv/bin/pip install --quiet -r scripts/docs-requirements.txt
-.site/venv/bin/python scripts/build_docs_site.py
+.site/venv/bin/pip install --quiet -r .github/scripts/docs-requirements.txt
+.site/venv/bin/python .github/scripts/build-docs-site.py
 DISABLE_MKDOCS_2_WARNING=true .site/venv/bin/mkdocs serve --strict
 '''
 
@@ -425,6 +425,6 @@ description = "Unit-test the docs-site pipeline (splitter + link checker)"
 run = '''
 python3 -m venv .site/venv
 .site/venv/bin/pip install --quiet --upgrade pip
-.site/venv/bin/pip install --quiet -r scripts/docs-requirements.txt
-.site/venv/bin/python scripts/test_docs_pipeline.py
+.site/venv/bin/pip install --quiet -r .github/scripts/docs-requirements.txt
+.site/venv/bin/python .github/scripts/test-docs-pipeline.py
 '''

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,7 @@ site_url: https://mpyw.github.io/suve/
 repo_url: https://github.com/mpyw/suve
 repo_name: mpyw/suve
 
-# The source tree is assembled by scripts/build_docs_site.py (README split into
+# The source tree is assembled by .github/scripts/build-docs-site.py (README split into
 # per-section pages + docs/*.md), and the built site goes to .site/out. Neither
 # directory is committed; both are produced fresh by `mise docs-build` / CI.
 docs_dir: .site/src
@@ -18,7 +18,7 @@ exclude_docs: |
 # --strict (see the Pages workflow and `mise docs-build`), which turns these
 # warnings into a non-zero exit — so a doc restructuring that breaks a Markdown
 # link or cross-page #anchor fails CI deterministically. Raw-HTML links/assets
-# (which MkDocs does not validate) are covered by scripts/check_site_links.py.
+# (which MkDocs does not validate) are covered by .github/scripts/check-site-links.py.
 validation:
   nav:
     omitted_files: warn
@@ -54,13 +54,16 @@ theme:
     - search.highlight
 
 plugins:
+  # Converts GitHub callouts (> [!NOTE]/[!TIP]/…) into Material admonitions;
+  # runs before rendering.
+  - callouts
   - search
   - literate-nav:
       nav_file: SUMMARY.md
 
 markdown_extensions:
   # GitHub-compatible heading slugs, so the README's existing #anchor links keep
-  # resolving after the split (scripts/build_docs_site.py uses the same slugifier).
+  # resolving after the split (.github/scripts/build-docs-site.py uses the same slugifier).
   - toc:
       slugify: !!python/object/apply:pymdownx.slugs.slugify
         kwds:
@@ -71,6 +74,12 @@ markdown_extensions:
   - md_in_html
   - tables
   - pymdownx.details
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      # Render ```mermaid fenced blocks (e.g. the staging state diagram) as
+      # diagrams instead of code; Material loads mermaid.js for the .mermaid class.
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.highlight:
       anchor_linenums: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,11 @@ repo_name: mpyw/suve
 docs_dir: .site/src
 site_dir: .site/out
 
+# Small style overrides (see .github/scripts/docs-extra.css); the assembler copies
+# the file into the docs source at assets/docs-extra.css.
+extra_css:
+  - assets/docs-extra.css
+
 # literate-nav reads SUMMARY.md for the nav; keep it out of the built pages.
 exclude_docs: |
   SUMMARY.md


### PR DESCRIPTION
Follow-up to the merged Pages pipeline (#863). Fixes the rendering issues visible on the built site, tidies the script layout, and reconciles the env-var docs. **Rendering fixes live in the assembler / MkDocs config** — the README/docs source is unchanged except the one consistency edit below.

## Rendering fixes
| Issue | Fix |
|---|---|
| Section pages showed the title **twice** | Heading-promote split pages (`##`→`#`) so each has a single `<h1>`; MkDocs no longer synthesizes a duplicate title from the nav |
| Images rendered at **full size** | Move inline `width`/`height` attrs into an inline `style` (beats Material's `.md-typeset img{height:auto}`). Tag matchers tolerate `>` in quoted attrs; attribute detection ignores `data-*` look-alikes |
| **Badges / image-links** printed literally | Inject `markdown="1"` into raw `<div>` wrappers so `md_in_html` renders the Markdown inside |
| `> [!NOTE]` / `[!TIP]` printed literally | `mkdocs-callouts` → Material admonitions |
| **State diagram** not rendered | `mermaid` superfences custom fence → rendered diagrams |

## Layout
- Moved the docs-site scripts out of `scripts/` (now only `seed.sh`) into `.github/scripts/`, renamed to the hyphenated house style: `build-docs-site.py`, `check-site-links.py`, `test-docs-pipeline.py`, `docs-requirements.txt`. Updated `REPO` path, `mise` tasks, the workflow, and the tests (hyphenated modules loaded by path).

## Docs consistency
- `Environment Variables > Providers > AWS` now lists `AWS_VAULT` and the ambient-credential vars (`AWS_CONTAINER_CREDENTIALS_*` / `AWS_WEB_IDENTITY_TOKEN_FILE`), matching Provider selection / Cloud Shell support.

## Gate unchanged
The deterministic gate (fail-closed assembler + `mkdocs build --strict` + `validation` + `check-site-links` + unit tests) is intact; the unit suite is now **23 tests**. Reviewed by Codex `gpt-5.6-sol`.

Local: 23 tests + strict build + link-check all green (17 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)