### PR TITLE
fix(ci): grant id-token to the release caller so Tag and Release starts

### DIFF
--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -23,6 +23,15 @@ jobs:
 
   release:
     needs: [tag]
+    # release.yml mints OIDC tokens (npm trusted publishing / provenance), so its
+    # jobs request id-token: write. In a reusable-workflow call the callee's
+    # permissions can only be a subset of the caller job's, and the top-level
+    # `permissions: contents: write` block zeroes every unlisted scope
+    # (id-token: none) — which fails workflow validation at startup. Grant
+    # id-token here (only the release path needs it; the tag job does not).
+    permissions:
+      contents: write
+      id-token: write
     uses: ./.github/workflows/release.yml
     with:
       version: ${{ inputs.version }}


### PR DESCRIPTION
## Problem
The **Tag and Release** workflow fails with **Startup Failure** (before any job runs). The run annotation:

> Error calling workflow `…/release.yml`. The nested job 'release' is requesting `id-token: write`, but is only allowed `id-token: none`. `.github/workflows/tag_and_release.yml (Line: 24)`

## Cause
`release.yml`'s jobs request `id-token: write` for npm trusted publishing / provenance (added in #853 / #856). `tag_and_release.yml` calls `release.yml` via `workflow_call`, but its top-level `permissions: contents: write` block sets every **unlisted** scope to `none` — so the caller grants `id-token: none`. In a reusable-workflow call the callee's job permissions can only be a **subset** of the caller job's grant, so the workflow graph fails validation at startup.

(Direct `workflow_dispatch` of **Release** was unaffected — job-level permissions apply directly with no caller ceiling — which is why this only surfaced on the `Tag and Release` path, on the first tag since those PRs.)

## Fix
Grant `id-token: write` on the `release` caller job (least privilege — the `tag` job doesn't need OIDC):

```yaml
  release:
    needs: [tag]
    permissions:
      contents: write
      id-token: write
    uses: ./.github/workflows/release.yml
    ...
```

Both nested jobs are covered (`release`: `contents: write` + `id-token: write`; `publish-npm-only`: `contents: read` + `id-token: write` — subsets of the grant). No other workflow changes needed.

_Diagnosed via a Fable subagent against the actual startup-failure annotation._

🤖 Generated with [Claude Code](https://claude.com/claude-code)