### PR TITLE
ci: split npm publishing into its own release-npm.yml workflow

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,101 @@
+name: Release npm
+
+# Show the target version in the run title, e.g. "Release npm v1.2.3".
+run-name: "Release npm ${{ inputs.version }}"
+
+# npm trusted publishing (OIDC) matches on the workflow filename of the OIDC
+# token's workflow claim. This workflow must therefore only ever run directly
+# via workflow_dispatch — never as a reusable workflow_call — so the claim is
+# always release-npm.yml, the filename configured as the trusted publisher on
+# npmjs.com.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish to npm (e.g., v1.2.3) - GitHub release must already exist"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  # ===========================================================================
+  # Validate that the tag exists before publishing
+  # ===========================================================================
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate version format
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [[ ! "$VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Invalid version format '$VERSION'"
+            echo "Expected format: vX.Y.Z (e.g., v1.2.3)"
+            exit 1
+          fi
+          echo "Version format valid: $VERSION"
+
+      - name: Check tag exists
+        env:
+          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! git ls-remote --tags https://github.com/${{ github.repository }} | grep -q "refs/tags/${VERSION}$"; then
+            echo "Error: Tag '$VERSION' does not exist"
+            echo "Please create the tag first using the 'Tag' workflow"
+            exit 1
+          fi
+          echo "Tag exists: $VERSION"
+
+  # ===========================================================================
+  # Publish to npm: no rebuild. Publish from the tag's already-released
+  # binaries (downloaded from its GitHub Release), using the current tooling
+  # from this workflow's ref.
+  # ===========================================================================
+  publish-npm:
+    needs: [validate]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm provenance / OIDC trusted publishing
+    steps:
+      # Default checkout ref = the ref this workflow runs on (current main), so
+      # .github/npm and the publish script are the current tooling — not the tag.
+      # This is the same effect as the release job's "restore npm tooling from
+      # the workflow ref" overlay: an older tag (created before npm support) can
+      # still be published with the current tooling.
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v6.0.0
+        with:
+          node-version: "22"
+
+      - name: Download released archives for the tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.version }}
+        run: |
+          mkdir -p .github/releases
+          # Only the archives npm-publish.sh consumes: macOS/Windows self-contained
+          # builds and the Linux CLI-only static build.
+          gh release download "$TAG" \
+            --repo "${{ github.repository }}" \
+            -D .github/releases \
+            -p 'suve_*_darwin_*.tar.gz' \
+            -p 'suve_*_windows_*.zip' \
+            -p 'suve-cli_*_linux_*.tar.gz'
+          ls -la .github/releases
+
+      - name: Publish to npm
+        env:
+          TAG: ${{ inputs.version }}
+        run: |
+          # Tokenless OIDC trusted publishing (id-token: write); provenance auto.
+          # A recent npm is required for both. Each package must have a trusted
+          # publisher configured on npmjs.com (owner mpyw/suve, this workflow).
+          npm install -g npm@latest
+          .github/scripts/npm-publish.sh "${TAG#v}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,12 @@
 name: Release
 
-# Show the target version and selected mode in the run title, e.g.
-# "Release v1.2.3 · Release Only NPM".
-run-name: "Release ${{ inputs.version }} · ${{ inputs.mode }}"
+# Show the target version in the run title, e.g. "Release v1.2.3".
+run-name: "Release ${{ inputs.version }}"
 
+# npm publishing lives in release-npm.yml (dispatch-only): npm trusted
+# publishing (OIDC) matches on the top-level workflow filename, and this
+# workflow is also called as a reusable workflow by tag_and_release.yml —
+# in that path the OIDC claim would be tag_and_release.yml, not release.yml.
 on:
   workflow_dispatch:
     inputs:
@@ -11,26 +14,12 @@ on:
         description: "Version to release (e.g., v1.2.3) - tag must already exist"
         required: true
         type: string
-      mode:
-        description: "What to release for this tag"
-        required: true
-        type: choice
-        default: Release All
-        options:
-          - Release All
-          - Release Without NPM
-          - Release Only NPM
   workflow_call:
     inputs:
       version:
         description: "Version to release (e.g., v1.2.3) - tag must already exist"
         required: true
         type: string
-      mode:
-        description: "Release All | Release Without NPM | Release Only NPM"
-        required: false
-        type: string
-        default: Release All
 
 permissions:
   contents: write
@@ -70,7 +59,6 @@ jobs:
   # ===========================================================================
   build-darwin:
     needs: [validate]
-    if: ${{ inputs.mode != 'Release Only NPM' }}
     runs-on: macos-latest
     steps:
       - name: Checkout
@@ -132,7 +120,6 @@ jobs:
   # ===========================================================================
   build-linux-amd64:
     needs: [validate]
-    if: ${{ inputs.mode != 'Release Only NPM' }}
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -178,7 +165,6 @@ jobs:
 
   build-linux-arm64:
     needs: [validate]
-    if: ${{ inputs.mode != 'Release Only NPM' }}
     runs-on: ubuntu-22.04-arm
     steps:
       - name: Checkout
@@ -227,7 +213,6 @@ jobs:
   # ===========================================================================
   build-linux-amd64-webkit2_41:
     needs: [validate]
-    if: ${{ inputs.mode != 'Release Only NPM' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -271,7 +256,6 @@ jobs:
 
   build-linux-arm64-webkit2_41:
     needs: [validate]
-    if: ${{ inputs.mode != 'Release Only NPM' }}
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
@@ -318,7 +302,6 @@ jobs:
   # ===========================================================================
   build-linux-cli:
     needs: [validate]
-    if: ${{ inputs.mode != 'Release Only NPM' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -354,7 +337,6 @@ jobs:
   # ===========================================================================
   build-windows:
     needs: [validate]
-    if: ${{ inputs.mode != 'Release Only NPM' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -420,9 +402,6 @@ jobs:
   # Release: Combine all artifacts and publish
   # ===========================================================================
   release:
-    # Full build/assemble/publish path. Release Only NPM skips this entirely and
-    # uses publish-npm-only below (download the tag's released binaries instead).
-    if: ${{ inputs.mode != 'Release Only NPM' }}
     needs:
       - build-darwin
       - build-linux-amd64
@@ -434,7 +413,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write # npm provenance
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -632,7 +610,6 @@ jobs:
           cat checksums.txt
 
       - name: Create GitHub Release
-        if: ${{ inputs.mode != 'Release Only NPM' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ inputs.version }}
@@ -658,7 +635,6 @@ jobs:
             .github/releases/*
 
       - name: Update Homebrew formulas
-        if: ${{ inputs.mode != 'Release Only NPM' }}
         env:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           TAG: ${{ inputs.version }}
@@ -693,7 +669,6 @@ jobs:
           git push
 
       - name: Update Scoop manifest
-        if: ${{ inputs.mode != 'Release Only NPM' }}
         env:
           SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}
           TAG: ${{ inputs.version }}
@@ -724,81 +699,3 @@ jobs:
           git add suve.json
           git commit -m "Update suve to ${VERSION}"
           git push
-
-      - name: Restore npm tooling from the workflow ref
-        if: ${{ inputs.mode != 'Release Without NPM' }}
-        env:
-          SHA: ${{ github.sha }}
-        run: |
-          # The build/release steps operate on inputs.version (the tag). A tag
-          # created before npm support lacks .github/npm and the publish script,
-          # so overlay them from the ref this workflow runs on (github.sha =
-          # current main). This lets an older tag be published to npm using the
-          # current tooling with that tag's freshly built binaries.
-          git fetch --no-tags --depth=1 origin "$SHA"
-          git checkout "$SHA" -- .github/scripts/npm-publish.sh .github/npm
-
-      - name: Set up Node.js (npm publish)
-        if: ${{ inputs.mode != 'Release Without NPM' }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v6.0.0
-        with:
-          node-version: "22"
-
-      - name: Publish to npm
-        if: ${{ inputs.mode != 'Release Without NPM' }}
-        env:
-          TAG: ${{ inputs.version }}
-        run: |
-          # Authenticates tokenlessly via GitHub OIDC trusted publishing
-          # (id-token: write on this job); provenance is attached automatically.
-          # A recent npm is required for both. Each package must have a trusted
-          # publisher configured on npmjs.com (owner mpyw/suve, this workflow).
-          npm install -g npm@latest
-          .github/scripts/npm-publish.sh "${TAG#v}"
-
-  # ===========================================================================
-  # Release Only NPM: no rebuild. Publish to npm from the tag's already-released
-  # binaries (downloaded from its GitHub Release), using the current tooling
-  # from this workflow's ref. Runs independently of the build matrix.
-  # ===========================================================================
-  publish-npm-only:
-    if: ${{ inputs.mode == 'Release Only NPM' }}
-    needs: [validate]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write # npm provenance / OIDC trusted publishing
-    steps:
-      # Default checkout ref = the ref this workflow runs on (current main), so
-      # .github/npm and the publish script are the current tooling — not the tag.
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-
-      - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v6.0.0
-        with:
-          node-version: "22"
-
-      - name: Download released archives for the tag
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TAG: ${{ inputs.version }}
-        run: |
-          mkdir -p .github/releases
-          # Only the archives npm-publish.sh consumes: macOS/Windows self-contained
-          # builds and the Linux CLI-only static build.
-          gh release download "$TAG" \
-            --repo "${{ github.repository }}" \
-            -D .github/releases \
-            -p 'suve_*_darwin_*.tar.gz' \
-            -p 'suve_*_windows_*.zip' \
-            -p 'suve-cli_*_linux_*.tar.gz'
-          ls -la .github/releases
-
-      - name: Publish to npm
-        env:
-          TAG: ${{ inputs.version }}
-        run: |
-          # Tokenless OIDC trusted publishing (id-token: write); provenance auto.
-          npm install -g npm@latest
-          .github/scripts/npm-publish.sh "${TAG#v}"

--- a/.github/workflows/tag_and_release.yml
+++ b/.github/workflows/tag_and_release.yml
@@ -1,7 +1,6 @@
 name: Tag and Release
 
 # Show the target version in the run title, e.g. "Tag and Release v1.2.3".
-# This flow always releases everything (mode: Release All below).
 run-name: "Tag and Release ${{ inputs.version }}"
 
 on:
@@ -23,17 +22,7 @@ jobs:
 
   release:
     needs: [tag]
-    # release.yml mints OIDC tokens (npm trusted publishing / provenance), so its
-    # jobs request id-token: write. In a reusable-workflow call the callee's
-    # permissions can only be a subset of the caller job's, and the top-level
-    # `permissions: contents: write` block zeroes every unlisted scope
-    # (id-token: none) — which fails workflow validation at startup. Grant
-    # id-token here (only the release path needs it; the tag job does not).
-    permissions:
-      contents: write
-      id-token: write
     uses: ./.github/workflows/release.yml
     with:
       version: ${{ inputs.version }}
-      mode: Release All
     secrets: inherit


### PR DESCRIPTION
## Problem
npm **Trusted Publishing (OIDC)** matches a single **"Workflow filename"**. npm was published from `release.yml`, but `release.yml` is also called as a reusable workflow by `tag_and_release.yml`. In that path the OIDC token's `workflow` claim is the **top-level** `tag_and_release.yml`, not `release.yml`, so npm's trusted publisher (configured for `release.yml`) rejects it → `ENEEDAUTH`. A trusted publisher can only name one file, so the direct-`release.yml` path and the `tag_and_release.yml`→`release.yml` path can't both match.

## Fix — dedicated, dispatch-only npm workflow
Move npm publishing to its own workflow whose OIDC claim is always itself:

- **New `release-npm.yml`** — `workflow_dispatch` only (never `workflow_call`), `version` input, `permissions: contents: read` + `id-token: write`. Validates the tag, downloads the tag's already-released binaries, runs `.github/scripts/npm-publish.sh` — a faithful move of `release.yml`'s old `publish-npm-only` job.
- **`release.yml`** — drop the `mode` input and all npm: remove the `publish-npm-only` job, the npm steps + `id-token` from the `release` job, and every `mode != 'Release Only NPM'` guard (build jobs + GitHub release now always run). It's binaries + GitHub release only.
- **`tag_and_release.yml`** — drop `mode: Release All` from the `release` call; it no longer needs or grants `id-token` (release.yml no longer mints OIDC). This also removes the reusable-workflow permissions-subset startup failure that #865 was patching, so **#865 is superseded and closed**.

## ⚠️ Manual follow-up (npm side)
On npmjs.com, set each package's Trusted Publisher **"Workflow filename"** from `release.yml` → **`release-npm.yml`** (owner `mpyw/suve`). npm publishing will `ENEEDAUTH` until this is done.

## Notes
- No remaining `inputs.mode` / `Release All` / `publish-npm-only` references.
- `actionlint` clean on all three files (only pre-existing shellcheck style warnings in untouched release.yml scripts).
- Refactor implemented by a Fable subagent; permissions verified (`id-token: write` only on `release-npm.yml`'s publish job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)