### PR TITLE
fix(tui): fix CloudShell display corruption (continuous repaint + warn capture)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -523,6 +523,13 @@ jobs:
           CGO_ENABLED=0 go build -o suve-cli ./cmd/suve
           file suve-cli
 
+      - name: Upload CLI binary artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: suve-cli-linux-amd64
+          path: suve-cli
+          retention-days: 7
+
       - name: Verify binary runs correctly
         run: |
           ./suve-cli --help

--- a/internal/staging/store/file/store.go
+++ b/internal/staging/store/file/store.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -77,6 +78,35 @@ var mintKeyFunc = keyprovider.Mint
 //
 //nolint:gochecknoglobals // process-wide one-time warning guard.
 var plaintextWarnOnce sync.Once
+
+// warnWriter is the sink for the one-time plaintext-storage warning. It defaults
+// to os.Stderr, which is correct for plain CLI use. A full-screen frontend that
+// owns the terminal (the TUI's alt-screen) redirects it via SetWarnWriter so a
+// raw mid-render write cannot corrupt its display, then surfaces the collected
+// text after it exits. warnWriterMu guards it against the store's async callers.
+//
+//nolint:gochecknoglobals // process-wide, deliberately mutable warning sink.
+var (
+	warnWriter   io.Writer = os.Stderr
+	warnWriterMu sync.Mutex
+)
+
+// SetWarnWriter redirects the one-time plaintext-storage warning to w and returns
+// the previous writer so the caller can restore it. A frontend that owns the
+// terminal (the TUI) swaps in a buffer for the program's lifetime, then restores
+// os.Stderr and flushes the buffer once the screen is back — preventing the raw
+// warning write from landing in the middle of an alt-screen frame (which
+// corrupts the display, e.g. in a keychain-less cloud shell where the plaintext
+// fallback always fires). Safe to call concurrently with the store's warners.
+func SetWarnWriter(w io.Writer) io.Writer {
+	warnWriterMu.Lock()
+	defer warnWriterMu.Unlock()
+
+	prev := warnWriter
+	warnWriter = w
+
+	return prev
+}
 
 // isInteractiveFunc reports whether the process is attached to an interactive
 // terminal. It gates the unencrypted-write guard: an interactive session keeps
@@ -283,10 +313,16 @@ func warnPlaintextOnce(cause error) {
 			msg += "\nwarning: " + cause.Error()
 		}
 
-		// Direct stderr write: this low-level store package intentionally
-		// avoids depending on the cli/output package.
-		//nolint:forbidigo // one-time operator warning to stderr.
-		fmt.Fprintln(os.Stderr, msg)
+		// Write through the redirectable sink (default os.Stderr) so a
+		// full-screen frontend can capture it instead of having it corrupt the
+		// display; this low-level store package still avoids depending on the
+		// cli/output package.
+		warnWriterMu.Lock()
+		w := warnWriter
+		warnWriterMu.Unlock()
+
+		//nolint:forbidigo // low-level store writes to its own sink, not cli/output
+		_, _ = fmt.Fprintln(w, msg)
 	})
 }
 

--- a/internal/staging/store/file/store_split_internal_test.go
+++ b/internal/staging/store/file/store_split_internal_test.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
@@ -347,16 +348,37 @@ func TestNewWorkingStore_EncryptionCheckError(t *testing.T) {
 }
 
 // TestWarnPlaintextOnce_WithCause covers the branch that appends a non-nil
-// underlying cause to the one-time plaintext warning. It resets the package
-// once-guard (sync.Once cannot be copied, so it is reset to a fresh value rather
-// than saved/restored) so the warning body runs regardless of test ordering,
-// then leaves it fired — a valid terminal state, and the warning is a pure
-// stderr side effect no test asserts on.
+// underlying cause to the one-time plaintext warning, and pins that the warning
+// is written to the redirectable sink (SetWarnWriter) rather than straight to
+// os.Stderr — the seam the TUI uses to keep the warning out of its alt-screen.
+// It resets the package once-guard (sync.Once cannot be copied, so it is reset
+// to a fresh value rather than saved/restored) so the warning body runs
+// regardless of test ordering.
 //
 //nolint:paralleltest // mutates the package-level plaintextWarnOnce guard
-func TestWarnPlaintextOnce_WithCause(_ *testing.T) {
+func TestWarnPlaintextOnce_WithCause(t *testing.T) {
 	plaintextWarnOnce = sync.Once{}
 
-	// Must not panic; exercises the cause != nil message branch.
+	var buf bytes.Buffer
+
+	prev := SetWarnWriter(&buf)
+	defer SetWarnWriter(prev)
+
 	warnPlaintextOnce(errors.New("keychain unavailable"))
+
+	out := buf.String()
+	assert.Contains(t, out, "stored UNENCRYPTED", "the primary warning must reach the sink")
+	assert.Contains(t, out, "keychain unavailable", "the underlying cause must be appended")
+}
+
+// TestSetWarnWriter_SwapAndRestore pins that SetWarnWriter returns the previous
+// writer so a caller (tui.Run) can capture during a program and restore after.
+func TestSetWarnWriter_SwapAndRestore(t *testing.T) { //nolint:paralleltest // mutates package-level warnWriter
+	var a, b bytes.Buffer
+
+	orig := SetWarnWriter(&a)
+	defer SetWarnWriter(orig)
+
+	got := SetWarnWriter(&b)
+	assert.Same(t, &a, got, "SetWarnWriter must return the writer it replaced")
 }

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"time"
 
 	"charm.land/bubbles/v2/cursor"
 	"charm.land/bubbles/v2/help"
@@ -28,7 +29,31 @@ import (
 	"github.com/mpyw/suve/internal/tui/keys"
 	"github.com/mpyw/suve/internal/tui/nav"
 	"github.com/mpyw/suve/internal/tui/styles"
+	"github.com/mpyw/suve/internal/tui/termquirk"
 )
+
+// cloudShellRepaintMsg drives the continuous full-repaint loop used in browser
+// cloud shells (see cloudShellRepaintCmd).
+type cloudShellRepaintMsg struct{}
+
+// cloudShellRepaintInterval is how often the TUI forces a full repaint in a
+// browser cloud shell. Fast enough that any transient corruption is wiped within
+// a frame or two, slow enough to stay readable.
+const cloudShellRepaintInterval = 120 * time.Millisecond
+
+// cloudShellRepaintCmd schedules the next full-repaint tick. In AWS/Google/Azure
+// browser cloud shells (xterm.js, often inside tmux) the terminal mishandles
+// Bubble Tea's incremental cell writes and corrupts the display on any content
+// change — the loading spinner, arriving data, or scrolling — where only a full
+// repaint (what a manual window resize triggers) clears it. #859's per-scroll
+// ClearScreen was too narrow: it never fired during loading and only on scroll.
+// This drives a full repaint continuously instead. Gated to affected terminals
+// so native terminals keep the optimized path.
+func cloudShellRepaintCmd() tea.Cmd {
+	return tea.Tick(cloudShellRepaintInterval, func(time.Time) tea.Msg {
+		return cloudShellRepaintMsg{}
+	})
+}
 
 // forceQuitKey is the one global escape that survives even while a page captures
 // text input: ctrl+c always quits, so a focused filter can never trap the user.
@@ -235,6 +260,10 @@ func (m *App) Init() tea.Cmd {
 		cmds = append(cmds, cmd)
 	}
 
+	if termquirk.ScrollNeedsFullRepaint() {
+		cmds = append(cmds, cloudShellRepaintCmd())
+	}
+
 	return tea.Batch(cmds...)
 }
 
@@ -258,6 +287,11 @@ func (m *App) fetchIdentityCmd() tea.Cmd {
 // bar.
 func (m *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
+	case cloudShellRepaintMsg:
+		// Continuous full repaint for browser cloud shells: clear the screen and
+		// arm the next tick. The tick is a 120ms timer, so batching (concurrent)
+		// vs sequencing is immaterial to ordering here.
+		return m, tea.Batch(tea.ClearScreen, cloudShellRepaintCmd())
 	case tea.WindowSizeMsg:
 		m.width, m.height = msg.Width, msg.Height
 		// Give the help bar the terminal width so it can self-truncate its short

--- a/internal/tui/cloudshell_repaint_test.go
+++ b/internal/tui/cloudshell_repaint_test.go
@@ -1,0 +1,79 @@
+//nolint:testpackage // white-box: exercises the unexported cloud-shell repaint loop
+package tui
+
+import (
+	"reflect"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mpyw/suve/internal/provider"
+)
+
+// drainBatch runs cmd (recursing into batches) and returns every leaf message.
+// It blocks on timer commands (e.g. tea.Tick), so callers accept that latency.
+func drainBatch(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+
+	msg := cmd()
+	if msg == nil {
+		return nil
+	}
+
+	if batch, ok := msg.(tea.BatchMsg); ok {
+		var out []tea.Msg
+		for _, c := range batch {
+			out = append(out, drainBatch(c)...)
+		}
+
+		return out
+	}
+
+	return []tea.Msg{msg}
+}
+
+// clearScreenType is the reflected type of tea's (unexported) clear-screen msg.
+//
+//nolint:gochecknoglobals // test-only type sentinel
+var clearScreenType = reflect.TypeOf(tea.ClearScreen())
+
+// TestCloudShellRepaintCmd_ProducesRepaintMsg pins that the repaint ticker fires
+// a cloudShellRepaintMsg (so the loop keeps rescheduling itself).
+func TestCloudShellRepaintCmd_ProducesRepaintMsg(t *testing.T) {
+	t.Parallel()
+
+	msg := cloudShellRepaintCmd()()
+	assert.IsType(t, cloudShellRepaintMsg{}, msg)
+}
+
+// TestUpdate_CloudShellRepaint_ClearsAndReschedules pins that handling a repaint
+// tick both forces a full repaint (tea.ClearScreen) and arms the next tick.
+func TestUpdate_CloudShellRepaint_ClearsAndReschedules(t *testing.T) {
+	t.Parallel()
+
+	m := newApp(config{scope: provider.Scope{Provider: provider.ProviderAWS}})
+
+	_, cmd := m.Update(cloudShellRepaintMsg{})
+	require.NotNil(t, cmd)
+
+	msgs := drainBatch(cmd)
+
+	var sawClear, sawReschedule bool
+
+	for _, msg := range msgs {
+		if reflect.TypeOf(msg) == clearScreenType {
+			sawClear = true
+		}
+
+		if _, ok := msg.(cloudShellRepaintMsg); ok {
+			sawReschedule = true
+		}
+	}
+
+	assert.True(t, sawClear, "a repaint tick must force a full ClearScreen")
+	assert.True(t, sawReschedule, "a repaint tick must arm the next tick")
+}

--- a/internal/tui/run.go
+++ b/internal/tui/run.go
@@ -1,8 +1,11 @@
 package tui
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"os"
+	"sync"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -11,6 +14,7 @@ import (
 	"github.com/mpyw/suve/internal/provider/aws/infra"
 	"github.com/mpyw/suve/internal/provider/azure"
 	"github.com/mpyw/suve/internal/provider/gcloud"
+	"github.com/mpyw/suve/internal/staging/store/file"
 	"github.com/mpyw/suve/internal/tui/components"
 )
 
@@ -42,12 +46,53 @@ func Run(ctx context.Context, scope provider.Scope, service string) error {
 		return err
 	}
 
+	// The staging store's plaintext-fallback warning writes straight to stderr;
+	// firing during the alt-screen (it always does in a keychain-less cloud
+	// shell) would corrupt the display. Capture it for the program's lifetime and
+	// replay it to stderr once the normal screen is restored.
+	warnings := &lockedBuffer{}
+	prevWarn := file.SetWarnWriter(warnings)
+
+	defer func() {
+		file.SetWarnWriter(prevWarn)
+
+		if s := warnings.String(); s != "" {
+			// Deliberate stderr write: replay the captured staging warning now
+			// that the alt-screen is closed and the normal screen is restored.
+			//nolint:forbidigo // one-off warning replay after the TUI exits
+			_, _ = fmt.Fprint(os.Stderr, s)
+		}
+	}()
+
 	// Alt-screen and mouse capture are requested through the model's returned
 	// tea.View (Bubble Tea v2 reads them there each frame), so the program needs
-	// only the context here.
+	// only the context here. Browser cloud-shell corruption is handled in the
+	// model via a continuous full-repaint loop (see cloudShellRepaintCmd).
 	_, err = tea.NewProgram(model, tea.WithContext(ctx)).Run()
 
 	return err
+}
+
+// lockedBuffer is a concurrency-safe bytes.Buffer: the staging store may emit its
+// plaintext warning from an async data-load goroutine while Run reads the
+// captured text after the program exits.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.String()
 }
 
 // newModel builds the root app model for a launched scope and initial service,


### PR DESCRIPTION
## Problem

The TUI corrupted in AWS CloudShell (a browser xterm.js terminal running **inside tmux**) — from the first loading frame and on scroll. Earlier scroll fixes (#859/#862) did not resolve it.

Two independent causes:

1. **Warning bled into the alt-screen.** The staging store's plaintext-fallback warning wrote straight to `os.Stderr`. CloudShell has no OS keychain, so the fallback *always* fires — mid-render during async load — scrolling raw text into the alt-screen. (On macOS a keychain exists, so it never fired — hence "CloudShell-only".)
2. **xterm.js mishandles incremental cell writes.** The browser terminal corrupts the display on **any** content change — the loading spinner, arriving data, or scrolling — where only a full repaint (what a manual window resize triggers) clears it. Confirmed: `tmux capture-pane` (tmux's own model) stays clean, and native terminals render the same byte stream fine, so this is purely a browser-side quirk. #859's per-scroll `ClearScreen` was too narrow — it never fired during loading and missed the initial corruption entirely.

## Fix

1. Redirectable warning sink (`file.SetWarnWriter`); `tui.Run` captures it for the program's lifetime and replays to stderr only after the normal screen is restored.
2. Drive a **continuous full repaint** (120ms tick) while in a browser cloud shell, gated by `termquirk.ScrollNeedsFullRepaint()` — so both auto-detection (AWS/Google/Azure) and the `SUVE_TUI_FULL_REPAINT` override apply. Native terminals keep the optimized path untouched.

No dependency changes — pure suve, upstream Bubble Tea `v2.0.8`.

## Verification

- Built via CI, verified in real AWS CloudShell: initial load, entry-list scroll, and history scroll all render cleanly (previously corrupted from the first frame).
- `go test ./...` green; new tests: warn-sink redirect (`file`), repaint tick clears + reschedules (`tui`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)