### PR TITLE
docs: recommend npm/npx for cloud shells in the install section

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ npx @mpyw/suve --version
 
 The right prebuilt binary is pulled in automatically per platform: the self-contained GUI build on macOS/Windows, and the dependency-free CLI/TUI-only static build on Linux (so **`--gui` is not available via npm on Linux**).
 
+> [!TIP]
+> **Ideal for cloud shells.** AWS CloudShell, Google Cloud Shell, and Azure Cloud Shell all ship Node.js, so `npx @mpyw/suve …` runs suve with nothing to download or install — and the dependency-free CLI/TUI-only build is exactly what you want there (no GUI). Each shell's ambient credentials are auto-detected too; see [Cloud Shell support](#cloud-shell-support).
+
 <details>
 <summary><a href="https://www.linux.org/"><img src="https://upload.wikimedia.org/wikipedia/commons/a/af/Tux.png" height="20" alt=""></a> Linux (.deb / .rpm)</summary>
 


### PR DESCRIPTION
## Summary

Add a `[!TIP]` to the **Using npm** install section pointing out that npm/npx is the easiest way to run suve in a browser-based cloud shell, linking to [Cloud Shell support](#cloud-shell-support).

Rationale: AWS CloudShell, Google Cloud Shell, and Azure Cloud Shell all ship Node.js out of the box, so `npx @mpyw/suve …` runs with nothing to download or install — and since those shells are Linux, the dependency-free CLI/TUI-only build (which npm installs there) is exactly what's needed (no GUI). suve also auto-detects each shell's ambient credentials.

Branched from `main`, independent of the docs restructure (#869).

## Verification

`mise docs-build`:

```
Ran 23 tests in 0.001s
OK
assembled 12 README pages + 4 doc pages into .site/src
check_site_links: OK — 17 pages, all local links/anchors/assets resolve
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WF6GrTWhfJKQeiXbyVV9B