### PR TITLE
docs: hide synthesized "Home" title and set site logo/favicon

### DIFF
--- a/.claude/skills/docs-site-pages/SKILL.md
+++ b/.claude/skills/docs-site-pages/SKILL.md
@@ -36,6 +36,12 @@ The site renders with python-markdown (mkdocs), stricter than GitHub's CommonMar
 - **Blank line before a list or table.** A list/table directly under a paragraph line is folded into it: bullets become literal text, and a heading placed right after a table row with no blank line becomes an extra one-cell **table row** (a real PR #869 bug — the "Behavior & Diagnostics" heading was swallowed by the preceding Staging table).
 - **Nested list = 4-space indent.** GitHub nests at 2 spaces; python-markdown needs 4. Inside a blockquote, count the indent *after* the `> `.
 - **Exactly one `<h1>` per page.** Multiple `<h1>` (a page title plus `# service` dividers) breaks Material's "on this page" ToC — it renders empty (real PR #869 bug on the Azure page). Use one `<h1>` (the title) with `##`/`###` below.
+- **A page with *no* in-content `<h1>` gets a synthesized title.** The home page's banner is `.hero-title` (a styled `<p>`, deliberately not a heading), so Material synthesizes a bare, id-less `<h1>Home</h1>` from the nav entry. It is not in the source (so `site:skip` can't touch it); hide it with CSS — every real page heading carries an `id`, so `.md-typeset h1:not([id]) { display: none }` in `docs-extra.css` drops just the synthesized title.
+
+## Site chrome (mkdocs.yml + docs-extra.css)
+
+- **Logo & favicon** come from the app icon `gui/build/appicon.png` — copied into the source tree by `build-docs-site.py`'s `ASSETS`, then wired as `theme.logo` / `theme.favicon` (paths relative to `docs_dir`).
+- **`docs-extra.css`** (committed at `.github/scripts/`, copied to `assets/` and wired via `extra_css`) holds the small overrides: hide the redundant sidebar site title (`.md-nav--primary > .md-nav__title`), style `.hero-title`, hide the synthesized home `<h1>`, and the mermaid edge-label tweak. `mkdocs.yml` also sets `navigation.expand` so nav groups open by default.
 - `--strict` will **not** catch these — they produce valid HTML, just wrong structure. **Verify the rendered HTML** (`curl` the served page, or read `.site/out/<page>/index.html`) after any structural change, not just the source Markdown.
 
 ## Editorial conventions for a restructure

--- a/.github/scripts/docs-extra.css
+++ b/.github/scripts/docs-extra.css
@@ -52,3 +52,11 @@
   font-weight: 700;
   line-height: 1.25;
 }
+
+/* Because the home page has no in-content <h1> (its banner is .hero-title, not a
+   heading), Material synthesizes a page-title <h1>Home</h1> from the nav entry —
+   a bare, id-less heading. Every other page has a real content heading (which
+   carries an id), so hiding id-less <h1>s drops just that synthesized "Home". */
+.md-typeset h1:not([id]) {
+  display: none;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,10 @@ validation:
 
 theme:
   name: material
+  # The app icon (copied into the docs source by build-docs-site.py via ASSETS)
+  # doubles as the header logo and the browser-tab favicon.
+  logo: gui/build/appicon.png
+  favicon: gui/build/appicon.png
   icon:
     repo: fontawesome/brands/github
   palette:


### PR DESCRIPTION
## Summary

Two home-page/site polish items:

- **Hide the synthesized "Home" heading.** The home page has no in-content `<h1>` (its banner is the `.hero-title` paragraph, deliberately not a heading so it gets no toc anchor), so Material synthesizes a bare, id-less `<h1>Home</h1>` from the nav entry. It's not in the source, so `site:skip` can't remove it — every real page heading carries an `id`, so `.md-typeset h1:not([id]) { display: none }` drops just that synthesized title.
- **Site logo & favicon.** Wire the existing app icon (`gui/build/appicon.png`, already copied into the source tree by `build-docs-site.py`) as `theme.logo` (header) and `theme.favicon` (browser tab).

`docs-site-pages` skill updated with the synthesized-title gotcha and a short "site chrome" note.

Branched from `main` (after #873 merged).

## Verification

`mise docs-build`, plus confirming the icon links and the hide rule ship:

```
Ran 35 tests in 0.001s
OK
check_site_links: OK — 19 pages, all local links/anchors/assets resolve

<link rel="icon" href="gui/build/appicon.png">     # favicon
src="gui/build/appicon.png"                        # header logo
.md-typeset h1:not([id]) { display: none; }        # in served docs-extra.css
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WF6GrTWhfJKQeiXbyVV9B