### PR TITLE
docs: use a Documentation banner image for the GitHub-only docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
   <!-- site:skip -->
-  <p><a href="https://mpyw.me/suve"><strong>📖 Documentation</strong></a></p>
+  <p><a href="https://mpyw.me/suve"><img src="https://github.com/user-attachments/assets/69d90557-eacd-4480-8834-cf7f5f28d341" alt="Documentation on GitHub Pages" width="480"></a></p>
   <!-- /site:skip -->
 </div>
 


### PR DESCRIPTION
## Summary

Replace the plain **📖 Documentation** text link with the uploaded banner image, linked to the Pages site (https://mpyw.me/suve). The link lives in the README's `<!-- site:skip -->` block, so it appears **only on GitHub** (the Pages site has its own left-nav). Width is set explicitly (`width="480"`) since the source image is large.

```html
<a href="https://mpyw.me/suve"><img src="…/69d90557-…" alt="Documentation on GitHub Pages" width="480"></a>
```

## Verification

`mise docs-build` passes, and the banner stays GitHub-only (dropped from the built site by `site:skip`):

```
Ran 35 tests in 0.002s
OK
check_site_links: OK — 19 pages, all local links/anchors/assets resolve
absent from site ✓ (GitHub-only)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018WF6GrTWhfJKQeiXbyVV9B