### PR TITLE
docs: add Open Graph / Twitter Card meta to the Pages site

### DIFF
--- a/.github/scripts/build-docs-site.py
+++ b/.github/scripts/build-docs-site.py
@@ -46,7 +46,9 @@ SRC = REPO / ".site" / "src"
 
 # Local assets referenced (by relative path) from the README, copied into the
 # site so those links resolve. Each entry is a path relative to the repo root.
-ASSETS = ["demo", "gui/build/appicon.png"]
+# social-preview.png is not linked from the README; it is copied so the OG/Twitter
+# card image wired in the theme override (see mkdocs.yml theme.custom_dir) resolves.
+ASSETS = ["demo", "gui/build/appicon.png", "social-preview.png"]
 
 # docs/*.md nav placement. By default a doc page is appended at the end of the
 # nav, top-level. An entry here instead nests the page under `group` and inserts

--- a/.github/scripts/overrides/main.html
+++ b/.github/scripts/overrides/main.html
@@ -1,0 +1,43 @@
+{#-
+  Theme override wired via mkdocs.yml `theme.custom_dir`. It injects Open Graph /
+  Twitter Card meta tags into every page's <head> so links to the site unfurl with
+  a preview card. The image is the repo's social-preview.png (1280x640), copied
+  into the site by .github/scripts/build-docs-site.py (ASSETS).
+-#}
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {#- Per-page title (home page keeps the bare site name), site description as the
+      default, and any page-level `description:` front matter as an override. -#}
+  {% set og_title = config.site_name %}
+  {% if page and page.title and not page.is_homepage %}
+    {% set og_title = (page.title | striptags) ~ " · " ~ config.site_name %}
+  {% endif %}
+  {% set og_description = config.site_description %}
+  {% if page and page.meta and page.meta.description %}
+    {% set og_description = page.meta.description %}
+  {% endif %}
+  {#- site_url ends with a trailing slash, so this yields an absolute image URL. -#}
+  {% set og_image = config.site_url ~ "social-preview.png" %}
+  {% set og_image_alt = config.site_name ~ " — " ~ config.site_description %}
+
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="{{ config.site_name }}">
+  <meta property="og:locale" content="en_US">
+  <meta property="og:title" content="{{ og_title }}">
+  <meta property="og:description" content="{{ og_description }}">
+  <meta property="og:image" content="{{ og_image }}">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:image:width" content="1280">
+  <meta property="og:image:height" content="640">
+  <meta property="og:image:alt" content="{{ og_image_alt }}">
+  {% if page and page.canonical_url %}
+  <meta property="og:url" content="{{ page.canonical_url }}">
+  {% endif %}
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ og_title }}">
+  <meta name="twitter:description" content="{{ og_description }}">
+  <meta name="twitter:image" content="{{ og_image }}">
+  <meta name="twitter:image:alt" content="{{ og_image_alt }}">
+{% endblock %}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,7 +10,9 @@ on:
       - docs/**
       - demo/**
       - gui/build/appicon.png
+      - social-preview.png
       - mkdocs.yml
+      - .github/scripts/overrides/**
       - .github/scripts/build-docs-site.py
       - .github/scripts/check-site-links.py
       - .github/scripts/test-docs-pipeline.py
@@ -23,7 +25,9 @@ on:
       - docs/**
       - demo/**
       - gui/build/appicon.png
+      - social-preview.png
       - mkdocs.yml
+      - .github/scripts/overrides/**
       - .github/scripts/build-docs-site.py
       - .github/scripts/check-site-links.py
       - .github/scripts/test-docs-pipeline.py

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,10 @@ validation:
 
 theme:
   name: material
+  # Committed template override (extends base.html) that injects Open Graph /
+  # Twitter Card meta tags so links to the site unfurl with a preview card; the
+  # card image is social-preview.png, copied into the site by build-docs-site.py.
+  custom_dir: .github/scripts/overrides
   # The app icon (copied into the docs source by build-docs-site.py via ASSETS)
   # doubles as the header logo and the browser-tab favicon.
   logo: gui/build/appicon.png


### PR DESCRIPTION
## What

Links to the GitHub Pages docs site previously unfurled with no preview card. This adds a Material theme override (extending `base.html`) that injects Open Graph / Twitter Card meta tags into every page's `<head>`. The card image is the repo's existing `social-preview.png` (1280×640).

## Changes

- **`.github/scripts/overrides/main.html`** (new): `extrahead` block emitting `og:*` / `twitter:*` tags.
  - Title is per-page (home keeps the bare site name; sub-pages use `Page Title · suve`)
  - Description falls back to `site_description` (overridable per page via a `description:` front matter)
  - `og:image` is built from `site_url`, so it stays absolute and in sync with the canonical URL
  - `og:image:alt` / `twitter:image:alt` are generated from `site name — site_description`
- **`mkdocs.yml`**: wire `theme.custom_dir` to the override
- **`build-docs-site.py`**: copy `social-preview.png` into the site so the card image resolves (`ASSETS`)
- **`pages.yml`**: rebuild when the override or the image changes (added to the trigger paths)

## Notes

- `twitter:site` / `twitter:creator` are intentionally omitted (no active handle)
- `<link rel="canonical">` is left to Material's default output (not duplicated)

## Verification

`mise docs-build` (36 unit tests → assemble → `mkdocs build --strict` → link check) passes. Verified the rendered `<head>`:

- home: `og:title=suve` / `og:url=https://mpyw.github.io/suve/`
- aws sub-page: `og:title=AWS Commands … · suve` / `og:url=…/aws/`
- image: `https://mpyw.github.io/suve/social-preview.png` on every page, with width/height/type/alt, and `twitter:card=summary_large_image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)